### PR TITLE
refactor/02: template & model schema cleanup

### DIFF
--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -21,15 +21,19 @@ class SRCNNTrainingConfig(SRTrainingConfig):
     The paper trains on the Y channel of YCbCr only and uses a per-layer
     learning rate of ``1e-4`` for the feature-extraction and non-linear-
     mapping layers and ``1e-5`` for the reconstruction layer — i.e. the
-    last layer learns 10× slower.  Override any field in YAML to deviate
-    (e.g. ``layer_lrs: null`` for uniform LR, or ``model_colorspace: RGB``
-    for full-RGB training).
+    last layer learns 10× slower.  Weight initialization follows the
+    paper's Gaussian schedule (``N(0, 0.01)`` with zero biases); set
+    ``init_strategy='default'`` to fall back to PyTorch's built-in init.
+    Override any field in YAML to deviate.
     """
 
     model_colorspace: Literal['RGB', 'Y', 'YCbCr'] = 'Y'
     layer_lrs: list[float] | None = field(
         default_factory=lambda: [1.0e-4, 1.0e-4, 1.0e-5]
     )
+    init_strategy: Literal['default', 'paper'] = 'paper'
+    init_mean: float = 0.0
+    init_std: float = 0.01
 
 
 @dataclass

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -17,13 +17,9 @@ class SRCNN(torch.nn.Module):
             (e.g., (9, 1, 5) for the original SRCNN architecture).
         padding (str | int): The padding type or size for the convolutional layers.
             Can be 'valid', 'same', or an integer specifying the number of pixels to pad. Default is 'valid'.
-        custom_init (bool): Whether to use custom weight initialization for the convolutional layers. Default
-            is False, which uses the default initialization method in PyTorch.
-        init_mean (float): The mean of the normal distribution for custom weight initialization. Default is 0.0. Only used if custom_init is True.
-        init_std (float): The standard deviation of the normal distribution for custom weight initialization. Default is 0.01. Only used if custom_init is True.
     """
 
-    def __init__(self, num_channels: int, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...], padding: str | int = 'valid', custom_init: bool = False, init_mean: float = 0.0, init_std: float = 0.01):
+    def __init__(self, num_channels: int, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...], padding: str | int = 'valid'):
         super().__init__()
 
         self._check_architecture(num_filters, kernel_sizes)
@@ -33,9 +29,6 @@ class SRCNN(torch.nn.Module):
             'num_filters': num_filters,
             'kernel_sizes': kernel_sizes,
             'padding': padding,
-            'custom_init': custom_init,
-            'init_mean': init_mean,
-            'init_std': init_std,
         }
 
         self.feat = torch.nn.Sequential(
@@ -47,7 +40,6 @@ class SRCNN(torch.nn.Module):
         self.mapping = torch.nn.Sequential(
             *[
                 layer
-                # Skip 1st and last layer, defined separately
                 for i in range(len(num_filters) - 1)
                 for layer in (
                     torch.nn.Conv2d(
@@ -59,9 +51,6 @@ class SRCNN(torch.nn.Module):
 
         self.recon = torch.nn.Conv2d(
             num_filters[-1], num_channels, kernel_size=kernel_sizes[-1], padding=padding)
-
-        if custom_init:
-            self.reset_parameters(mean=init_mean, std=init_std)
 
     def _check_architecture(self, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...]):
         """

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -34,6 +34,9 @@ class BenchmarkImageLogger(Callback):
     ``"{name}_ssim/{filename}"``; per-set means under
     ``"{name}_psnr({key})"`` and ``"{name}_ssim"``.
 
+    Border cropping is sourced from ``pl_module.eval_config.crop_border`` at
+    the use site; this avoids dual-knob configuration drift.
+
     Args:
         dataset_names: Ordered list of test set names (e.g.
             ``["Set5", "Set14"]``) matching the order of
@@ -45,21 +48,16 @@ class BenchmarkImageLogger(Callback):
             ``max_steps=100_000``) val fires ~100 times, so logging every 5
             runs gives ~20 image snapshots — enough to track visual
             progress without flooding TensorBoard storage.  Default ``5``.
-        crop_border: Pixels to crop on each border before metric
-            computation; matches the standard SR-evaluation convention of
-            ignoring the outer ``scale`` pixels.
     """
 
     def __init__(
         self,
         dataset_names: list[str] | None = None,
         log_every_n_val_runs: int = 5,
-        crop_border: int = 0,
     ):
         super().__init__()
         self.dataset_names = list(dataset_names) if dataset_names else None
         self.log_every_n_val_runs = log_every_n_val_runs
-        self.crop_border = crop_border
 
         # Val: primary val is at idx 0, test sets at 1..N → {1: 'Set5', ...}
         # Test: only test sets present, at idx 0..N-1     → {0: 'Set5', ...}
@@ -204,8 +202,8 @@ class BenchmarkImageLogger(Callback):
 
             sr_4d = sr[i].unsqueeze(0).cpu()
             hr_4d = hr_cropped[i].unsqueeze(0).cpu()
-            if self.crop_border > 0:
-                n = self.crop_border
+            n = pl_module.eval_config.crop_border
+            if n > 0:
                 sr_4d = sr_4d[..., n:-n, n:-n]
                 hr_4d = hr_4d[..., n:-n, n:-n]
             psnr_tensors = pl_module._build_psnr_tensors(sr_4d, hr_4d)

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -1,9 +1,8 @@
 from typing import Any
 
 import lightning
+from lightning.pytorch.cli import instantiate_class
 from torch.utils.data import DataLoader, Dataset
-
-from ..datasets.srcnn import TrainDataset, ValidationDataset
 
 
 class SRDataModule(lightning.LightningDataModule):
@@ -11,9 +10,10 @@ class SRDataModule(lightning.LightningDataModule):
     Generic LightningDataModule for single-image super-resolution.
 
     Owns the train / validation / test Dataset constructions and exposes them
-    as DataLoaders.  Datasets are instantiated lazily in :meth:`setup` so that
-    expensive work (e.g. LMDB cache builds in :class:`TrainDataset`) only runs
-    once trainer subcommands are dispatched.
+    as DataLoaders. Datasets are described by ``{class_path, init_args}`` specs
+    and instantiated lazily in :meth:`setup` so that expensive work (e.g. LMDB
+    cache builds in ``TrainDataset``) only runs once trainer subcommands are
+    dispatched.
 
     Test sets (Set5, Set14, …) are surfaced through *both* dataloader hooks:
 
@@ -25,28 +25,22 @@ class SRDataModule(lightning.LightningDataModule):
     * :meth:`test_dataloader` returns the test loaders only, for
       ``cli test --ckpt_path <path>`` final evaluation.
 
-    Architecture-agnostic: the dataset classes themselves are constructor
-    parameters, so swapping in an alternative pipeline (e.g. random-crop
-    style for SRResNet) only requires pointing the YAML at a different class.
+    Architecture-agnostic: each dataset spec carries its own ``class_path``,
+    so swapping in an alternative pipeline (e.g. SRResNet's random-crop dataset)
+    only requires pointing the YAML at a different class.
 
     Args:
-        train_dataset: Keyword arguments forwarded to ``train_dataset_class``
-            in :meth:`setup` (``stage='fit'``).
-        val_dataset: Keyword arguments forwarded to ``val_dataset_class``.
-        test_datasets: Mapping ``{name: dataset_kwargs}`` for held-out test
-            sets (Set5, Set14, …).  ``None`` disables test evaluation.
+        train_dataset: ``{class_path, init_args}`` spec for the training dataset.
+        val_dataset: ``{class_path, init_args}`` spec for the primary
+            held-out validation dataset.
+        test_datasets: ``{name: {class_path, init_args}}`` mapping for held-out
+            test sets (Set5, Set14, …). ``None`` disables test evaluation.
         train_dataloader_kwargs: DataLoader kwargs for the training loader
             (excluding ``shuffle``, which is forced to ``True``).
         val_dataloader_kwargs: DataLoader kwargs for the primary validation
-            loader.  Defaults to ``{'batch_size': 1, 'num_workers': 1}``.
+            loader. Defaults to ``{'batch_size': 1, 'num_workers': 1}``.
         test_dataloader_kwargs: DataLoader kwargs reused for every test
-            loader.  Defaults to the same as the validation loader.
-        train_dataset_class: Dataset class used for training.  Defaults to
-            :class:`sisr.datasets.srcnn.TrainDataset`.
-        val_dataset_class: Dataset class used for validation.  Defaults to
-            :class:`sisr.datasets.srcnn.ValidationDataset`.
-        test_dataset_class: Dataset class used for test sets.  When ``None``,
-            falls back to ``val_dataset_class``.
+            loader. Defaults to the same as the validation loader.
     """
 
     def __init__(
@@ -57,20 +51,14 @@ class SRDataModule(lightning.LightningDataModule):
         train_dataloader_kwargs: dict[str, Any] | None = None,
         val_dataloader_kwargs: dict[str, Any] | None = None,
         test_dataloader_kwargs: dict[str, Any] | None = None,
-        train_dataset_class: type = TrainDataset,
-        val_dataset_class: type = ValidationDataset,
-        test_dataset_class: type | None = None,
     ):
         super().__init__()
-        self._train_kwargs = train_dataset
-        self._val_kwargs = val_dataset
-        self._test_kwargs = test_datasets or {}
+        self._train_spec = train_dataset
+        self._val_spec = val_dataset
+        self._test_specs = test_datasets or {}
         self._train_dl_kwargs = train_dataloader_kwargs or {}
         self._val_dl_kwargs = val_dataloader_kwargs or {'batch_size': 1, 'num_workers': 1}
         self._test_dl_kwargs = test_dataloader_kwargs or self._val_dl_kwargs
-        self._train_cls = train_dataset_class
-        self._val_cls = val_dataset_class
-        self._test_cls = test_dataset_class or val_dataset_class
 
         self._train_ds: Dataset | None = None
         self._val_ds: Dataset | None = None
@@ -79,19 +67,19 @@ class SRDataModule(lightning.LightningDataModule):
     @property
     def test_names(self) -> list:
         """Ordered list of test dataset names — drives BenchmarkImageLogger auto-discovery."""
-        return list(self._test_kwargs.keys())
+        return list(self._test_specs.keys())
 
     def setup(self, stage: str | None = None) -> None:
         """Instantiate datasets lazily based on the trainer stage."""
         if stage in ('fit', None) and self._train_ds is None:
-            self._train_ds = self._train_cls(**self._train_kwargs)
-        if stage in ('fit', 'validate', 'test', None) and not self._test_ds and self._test_kwargs:
+            self._train_ds = instantiate_class((), self._train_spec)
+        if stage in ('fit', 'validate', 'test', None) and not self._test_ds and self._test_specs:
             self._test_ds = {
-                name: self._test_cls(**kwargs)
-                for name, kwargs in self._test_kwargs.items()
+                name: instantiate_class((), spec)
+                for name, spec in self._test_specs.items()
             }
         if stage in ('fit', 'validate', None) and self._val_ds is None:
-            self._val_ds = self._val_cls(**self._val_kwargs)
+            self._val_ds = instantiate_class((), self._val_spec)
 
     def train_dataloader(self) -> DataLoader:
         return DataLoader(self._train_ds, shuffle=True, **self._train_dl_kwargs)

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -76,6 +76,12 @@ class SRLightning(lightning.LightningModule):
         self.optimizer = optimizer
         self.lr_scheduler = lr_scheduler
 
+        strategy = getattr(self.training_config, 'init_strategy', 'default')
+        if strategy == 'paper' and hasattr(model, 'reset_parameters'):
+            mean = getattr(self.training_config, 'init_mean', 0.0)
+            std = getattr(self.training_config, 'init_std', 0.01)
+            model.reset_parameters(mean=mean, std=std)
+
         # Merge model.hparams into Lightning hparams for TensorBoard HParams.
         model_hparams = getattr(model, 'hparams', {})
         self._hparams = self._flatten_hparams({

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -100,8 +100,8 @@ trainer:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
         log_every_n_val_runs: 1
-        crop_border: 3
         # dataset_names is auto-discovered from data.test_datasets
+        # crop_border is sourced from model.eval_config.crop_border
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_psnr(RGB)

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -25,16 +25,17 @@ model:
       num_filters: [64, 32]
       kernel_sizes: [9, 1, 5]
       padding: 0
-      custom_init: true
   training_config:
     class_path: sisr.models.srcnn.SRCNNTrainingConfig
     # Defaults match the SRCNN paper:
-    #   model_colorspace=Y, layer_lrs=[1e-4, 1e-4, 1e-5]
+    #   model_colorspace=Y, layer_lrs=[1e-4, 1e-4, 1e-5],
+    #   init_strategy=paper, init_mean=0.0, init_std=0.01
     init_args:
       example_input_shape: [3, 224, 224]   # for TensorBoard model graph
       # Override per experiment, e.g.:
       # model_colorspace: RGB              # train on RGB instead of Y
       # layer_lrs: null                    # uniform LR from optimizer.init_args.lr
+      # init_strategy: default             # skip paper-faithful weight init
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig
     # Defaults: crop_border=3, psnr_channels=[RGB, YCbCr], separate_psnr=false

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -1,12 +1,3 @@
-# SRCNN x3 experiment template. One self-contained YAML — no layering.
-#   python -m sisr.cli fit --config templates/config.srcnn.template.yaml
-#
-# Fill in placeholders flagged with TODO before running. Per-run tweaks can
-# also be applied on the CLI:
-#   --trainer.max_steps=500000
-#   --optimizer.init_args.lr=1e-3
-#   --data.train_dataset.subimg_size=33
-
 seed_everything: 42
 
 # Top-level optimizer / lr_scheduler — linked into model.init_args by

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -40,29 +40,35 @@ model:
     # Defaults: crop_border=3, psnr_channels=[RGB, YCbCr], separate_psnr=false
 
 data:
-  train_dataset_class: sisr.datasets.srcnn.TrainDataset
-  val_dataset_class: sisr.datasets.srcnn.ValidationDataset
   train_dataset:
-    img_dir: data/DIV2K_train_HR
-    subimg_size: 33
-    stride: 14
-    scale: 3
-    blur_sigma: 1.0
-    use_tqdm: true
-    cache_dir: ./.lmdb_cache/DIV2K_train_HR   # TODO: set or accept default
+    class_path: sisr.datasets.srcnn.TrainDataset
+    init_args:
+      img_dir: data/DIV2K_train_HR
+      subimg_size: 33
+      stride: 14
+      scale: 3
+      blur_sigma: 1.0
+      use_tqdm: true
+      cache_dir: ./.lmdb_cache/DIV2K_train_HR   # TODO: set or accept default
   val_dataset:
-    img_dir: data/DIV2K_valid_HR
-    scale: 3
-    blur_sigma: 1.0                       # keep in sync with train_dataset.blur_sigma
-  test_datasets:                         # surface as both val_dataloader (monitor during fit)
-    Set5:                                # and test_dataloader (final eval via `cli test`)
-      img_dir: data/Set5_HR
+    class_path: sisr.datasets.srcnn.ValidationDataset
+    init_args:
+      img_dir: data/DIV2K_valid_HR
       scale: 3
-      blur_sigma: 1.0
+      blur_sigma: 1.0                           # keep in sync with train_dataset.init_args.blur_sigma
+  test_datasets:                                # surface as both val_dataloader (monitor during fit)
+    Set5:                                       # and test_dataloader (final eval via `cli test`)
+      class_path: sisr.datasets.srcnn.ValidationDataset
+      init_args:
+        img_dir: data/Set5_HR
+        scale: 3
+        blur_sigma: 1.0
     Set14:
-      img_dir: data/Set14_HR
-      scale: 3
-      blur_sigma: 1.0
+      class_path: sisr.datasets.srcnn.ValidationDataset
+      init_args:
+        img_dir: data/Set14_HR
+        scale: 3
+        blur_sigma: 1.0
   train_dataloader_kwargs:
     batch_size: 64
     num_workers: 16

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -37,23 +37,29 @@ model:
       psnr_channels: [RGB, YCbCr]
 
 data:
-  train_dataset_class: sisr.datasets.srresnet.TrainDataset
-  val_dataset_class: sisr.datasets.srresnet.ValidationDataset
   train_dataset:
-    img_dir: data/DIV2K_train_HR
-    scale: 4
-    hr_crop_size: 96            # LR crop is 96 / 4 = 24; must be divisible by scale
-    crops_per_image: 1          # raise to draw more random crops per image per epoch
+    class_path: sisr.datasets.srresnet.TrainDataset
+    init_args:
+      img_dir: data/DIV2K_train_HR
+      scale: 4
+      hr_crop_size: 96            # LR crop is 96 / 4 = 24; must be divisible by scale
+      crops_per_image: 1          # raise to draw more random crops per image per epoch
   val_dataset:
-    img_dir: data/DIV2K_valid_HR
-    scale: 4
-  test_datasets:                # surface as both val_dataloader (monitor during fit)
-    Set5:                       # and test_dataloader (final eval via `cli test`)
-      img_dir: data/Set5_HR
+    class_path: sisr.datasets.srresnet.ValidationDataset
+    init_args:
+      img_dir: data/DIV2K_valid_HR
       scale: 4
+  test_datasets:                  # surface as both val_dataloader (monitor during fit)
+    Set5:                         # and test_dataloader (final eval via `cli test`)
+      class_path: sisr.datasets.srresnet.ValidationDataset
+      init_args:
+        img_dir: data/Set5_HR
+        scale: 4
     Set14:
-      img_dir: data/Set14_HR
-      scale: 4
+      class_path: sisr.datasets.srresnet.ValidationDataset
+      init_args:
+        img_dir: data/Set14_HR
+        scale: 4
   train_dataloader_kwargs:
     batch_size: 16
     num_workers: 16

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -1,12 +1,3 @@
-# SRResNet x4 experiment template. One self-contained YAML — no layering.
-#   python -m sisr.cli fit --config templates/config.srresnet.template.yaml
-#
-# Fill in placeholders flagged with TODO before running. Per-run tweaks can
-# also be applied on the CLI:
-#   --trainer.max_steps=1000000
-#   --optimizer.init_args.lr=1e-4
-#   --data.train_dataset.hr_crop_size=96
-
 seed_everything: 42
 
 # Top-level optimizer / lr_scheduler — linked into model.init_args by

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -90,8 +90,8 @@ trainer:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
         log_every_n_val_runs: 1
-        crop_border: 4
         # dataset_names is auto-discovered from data.test_datasets
+        # crop_border is sourced from model.eval_config.crop_border
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_psnr(RGB)

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -37,3 +37,11 @@ def test_srcnn_eval_config_psnr_channels_independent_per_instance():
     b = SRCNNEvalConfig()
     a.psnr_channels.append("X")
     assert b.psnr_channels == ["RGB", "YCbCr"]
+
+
+def test_srcnn_training_config_init_defaults():
+    """Paper-faithful init lives on SRCNNTrainingConfig after migration."""
+    cfg = SRCNNTrainingConfig()
+    assert cfg.init_strategy == "paper"
+    assert cfg.init_mean == 0.0
+    assert cfg.init_std == 0.01

--- a/tests/models/srcnn/test_model.py
+++ b/tests/models/srcnn/test_model.py
@@ -85,34 +85,49 @@ def test_hparams_property_round_trips():
         num_filters=(64, 32),
         kernel_sizes=(9, 1, 5),
         padding=0,
-        custom_init=True,
-        init_mean=0.1,
-        init_std=0.05,
     )
     h = model.hparams
     assert h["num_channels"] == 3
     assert h["num_filters"] == (64, 32)
     assert h["kernel_sizes"] == (9, 1, 5)
     assert h["padding"] == 0
-    assert h["custom_init"] is True
-    assert h["init_mean"] == 0.1
-    assert h["init_std"] == 0.05
 
 
 def test_reset_parameters_zeroes_bias_and_sets_weight_std():
-    """Verifies the SRCNN-paper init: weights ~ N(mean, std), biases = 0."""
+    """Verifies the SRCNN-paper init: weights ~ N(mean, std), biases = 0.
+    After the init-args migration, reset_parameters is invoked explicitly."""
     torch.manual_seed(0)
     model = SRCNN(
         num_channels=3,
         num_filters=(64, 32),
         kernel_sizes=(9, 1, 5),
         padding=0,
-        custom_init=True,
-        init_mean=0.0,
-        init_std=0.01,
     )
+    model.reset_parameters(mean=0.0, std=0.01)
     for m in model.modules():
         if isinstance(m, torch.nn.Conv2d):
             assert torch.allclose(m.bias, torch.zeros_like(m.bias))
-            # Weight std is approximately 0.01; loose bound for finite-sample variance.
             assert 0.005 < m.weight.std().item() < 0.02
+
+
+def test_init_only_args_rejected():
+    """custom_init / init_mean / init_std were moved to SRCNNTrainingConfig."""
+    with pytest.raises(TypeError):
+        SRCNN(
+            num_channels=3,
+            num_filters=(64, 32),
+            kernel_sizes=(9, 1, 5),
+            padding=0,
+            custom_init=True,
+        )
+
+
+def test_hparams_architectural_only():
+    """After the init-args migration, SRCNN.hparams holds only architectural keys."""
+    model = SRCNN(
+        num_channels=3,
+        num_filters=(64, 32),
+        kernel_sizes=(9, 1, 5),
+        padding=0,
+    )
+    assert set(model.hparams.keys()) == {"num_channels", "num_filters", "kernel_sizes", "padding"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE = REPO_ROOT / "templates" / "config.srcnn.template.yaml"
@@ -75,3 +76,16 @@ def test_cli_help_lists_subcommands():
     assert proc.returncode == 0
     for sub in ("fit", "validate", "test", "predict"):
         assert sub in proc.stdout
+
+
+TEMPLATE_PATHS = sorted((REPO_ROOT / "templates").glob("config.*.template.yaml"))
+assert TEMPLATE_PATHS, "No templates found — check REPO_ROOT"
+
+
+@pytest.mark.parametrize("template_path", TEMPLATE_PATHS, ids=[p.name for p in TEMPLATE_PATHS])
+def test_template_yaml_parses(template_path: Path):
+    """Every template YAML file must be valid YAML and have required keys."""
+    with template_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"{template_path} did not parse as a mapping"
+    assert "trainer" in data and "model" in data and "data" in data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,8 +45,8 @@ def test_cli_srresnet_print_config_resolves():
     assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
     out = proc.stdout
     assert "class_path: sisr.models.srresnet.SRResNet" in out
-    assert "train_dataset_class: sisr.datasets.srresnet.TrainDataset" in out
-    assert "val_dataset_class: sisr.datasets.srresnet.ValidationDataset" in out
+    assert "class_path: sisr.datasets.srresnet.TrainDataset" in out
+    assert "class_path: sisr.datasets.srresnet.ValidationDataset" in out
     assert "model_colorspace: RGB" in out
     assert "hr_crop_size: 96" in out
     assert "crop_border: 4" in out

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -376,3 +376,43 @@ def test_weight_histogram_logger_emits_on_cadence(tmp_path: Path):
     trainer = SimpleNamespace(global_step=1, loggers=[tb_logger])
     cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
     tb_logger.finalize("success")
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkImageLogger crop_border migration to eval_config
+# ---------------------------------------------------------------------------
+
+def test_crop_border_init_arg_rejected():
+    """crop_border was dropped from BenchmarkImageLogger; now lives on eval_config."""
+    with pytest.raises(TypeError):
+        BenchmarkImageLogger(crop_border=3)
+
+
+def test_benchmark_collect_batch_crops_per_eval_config():
+    """When eval_config.crop_border=3, _collect_batch crops 3 pixels per edge
+    before computing per-image PSNR/SSIM."""
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    # Real SRLightning with crop_border=3 in eval_config.
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    pl_module = SRLightning(
+        model=model,
+        training_config=SRTrainingConfig(model_colorspace="RGB"),
+        eval_config=SREvalConfig(crop_border=3),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer = SimpleNamespace(
+        val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)],
+    )
+    # 16x16 input; after crop_border=3 sides, the inner 10x10 region drives PSNR/SSIM.
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer, pl_module=pl_module, outputs=None,
+        batch=batch, batch_idx=0, dataloader_idx=1,
+    )
+    assert len(cb._buffer["Set5"]) == 1
+    _, _, _, _, psnr_dict, ssim = cb._buffer["Set5"][0]
+    assert "RGB" in psnr_dict
+    assert isinstance(ssim, float)

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -8,21 +8,30 @@ from sisr.training import SRDataModule
 
 def _make_dm(image_dir: Path, *, with_train: bool = True) -> SRDataModule:
     """SRDataModule pointing at a single tiny image dir for train/val/test."""
-    train_kwargs = {
-        "img_dir": str(image_dir),
-        "subimg_size": 33,
-        "stride": 14,
-        "scale": 2,
-        "blur_sigma": 1.0,
-        "use_tqdm": False,
-        "cache_dir": str(image_dir / ".lmdb_cache_train"),
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "blur_sigma": 1.0,
+            "use_tqdm": False,
+            "cache_dir": str(image_dir / ".lmdb_cache_train"),
+        },
     }
-    val_kwargs = {"img_dir": str(image_dir), "scale": 2}
-    test_kwargs = {"img_dir": str(image_dir), "scale": 2}
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(image_dir), "scale": 2},
+    }
+    test_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(image_dir), "scale": 2},
+    }
     return SRDataModule(
-        train_dataset=train_kwargs,
-        val_dataset=val_kwargs,
-        test_datasets={"Set5": test_kwargs, "Set14": test_kwargs},
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        test_datasets={"Set5": test_spec, "Set14": test_spec},
         train_dataloader_kwargs={"batch_size": 2, "num_workers": 0},
         val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
         test_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
@@ -91,20 +100,26 @@ def test_test_dataloader_returns_test_only(tiny_rgb_image_dir: Path):
 def test_test_dataloader_kwargs_falls_back_to_val(tiny_rgb_image_dir: Path):
     """When test_dataloader_kwargs is omitted, the datamodule reuses
     val_dataloader_kwargs."""
-    train_kwargs = {
-        "img_dir": str(tiny_rgb_image_dir),
-        "subimg_size": 33,
-        "stride": 14,
-        "scale": 2,
-        "blur_sigma": 1.0,
-        "use_tqdm": False,
-        "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_train_fb"),
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "blur_sigma": 1.0,
+            "use_tqdm": False,
+            "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_train_fb"),
+        },
     }
-    val_kwargs = {"img_dir": str(tiny_rgb_image_dir), "scale": 2}
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
     dm = SRDataModule(
-        train_dataset=train_kwargs,
-        val_dataset=val_kwargs,
-        test_datasets={"Set5": val_kwargs},
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        test_datasets={"Set5": val_spec},
         train_dataloader_kwargs={"batch_size": 2, "num_workers": 0},
         val_dataloader_kwargs={"batch_size": 7, "num_workers": 0},
         test_dataloader_kwargs=None,
@@ -114,19 +129,25 @@ def test_test_dataloader_kwargs_falls_back_to_val(tiny_rgb_image_dir: Path):
 
 
 def test_no_test_datasets_val_dataloader_returns_only_primary(tiny_rgb_image_dir: Path):
-    train_kwargs = {
-        "img_dir": str(tiny_rgb_image_dir),
-        "subimg_size": 33,
-        "stride": 14,
-        "scale": 2,
-        "blur_sigma": 1.0,
-        "use_tqdm": False,
-        "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_only_primary"),
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "blur_sigma": 1.0,
+            "use_tqdm": False,
+            "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_only_primary"),
+        },
     }
-    val_kwargs = {"img_dir": str(tiny_rgb_image_dir), "scale": 2}
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
     dm = SRDataModule(
-        train_dataset=train_kwargs,
-        val_dataset=val_kwargs,
+        train_dataset=train_spec,
+        val_dataset=val_spec,
         test_datasets=None,
         train_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
         val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
@@ -134,3 +155,66 @@ def test_no_test_datasets_val_dataloader_returns_only_primary(tiny_rgb_image_dir
     dm.setup(stage="fit")
     loaders = dm.val_dataloader()
     assert len(loaders) == 1
+
+
+def test_old_class_params_rejected(tiny_rgb_image_dir: Path):
+    """The legacy `train_dataset_class` etc. params no longer exist."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "blur_sigma": 1.0,
+            "use_tqdm": False,
+            "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_train_legacy"),
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    with pytest.raises(TypeError):
+        SRDataModule(
+            train_dataset=train_spec,
+            val_dataset=val_spec,
+            train_dataset_class=object,  # legacy param — must not exist
+        )
+
+
+def test_train_dataset_built_from_class_path_spec(tiny_rgb_image_dir: Path):
+    """train_dataset accepts {class_path, init_args} and setup() instantiates it."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "blur_sigma": 1.0,
+            "use_tqdm": False,
+            "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_train_cp"),
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    test_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    dm = SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        test_datasets={"Set5": test_spec},
+        train_dataloader_kwargs={"batch_size": 2, "num_workers": 0},
+        val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+        test_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+    )
+    dm.setup(stage="fit")
+    from sisr.datasets.srcnn import TrainDataset, ValidationDataset
+    assert isinstance(dm._train_ds, TrainDataset)
+    assert isinstance(dm._val_ds, ValidationDataset)
+    assert isinstance(dm._test_ds["Set5"], ValidationDataset)

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from sisr.models.srcnn import SRCNN
+from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
 from sisr.models.srresnet.model import SRResNet
 from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
 
@@ -254,3 +254,47 @@ def test_flatten_hparams_handles_nested():
         "b/y/1": 4,
         "d": "SRCNN",
     }
+
+
+# ---------------------------------------------------------------------------
+# init strategy
+# ---------------------------------------------------------------------------
+
+
+def test_paper_init_calls_reset_parameters():
+    """init_strategy='paper' → SRLightning calls model.reset_parameters(...)."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    model.reset_parameters = MagicMock()
+    SRLightning(
+        model=model,
+        training_config=SRCNNTrainingConfig(init_strategy="paper", init_mean=0.5, init_std=0.02),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    model.reset_parameters.assert_called_once_with(mean=0.5, std=0.02)
+
+
+def test_default_init_skips_reset_parameters():
+    """init_strategy='default' → SRLightning does NOT call model.reset_parameters(...)."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    model.reset_parameters = MagicMock()
+    SRLightning(
+        model=model,
+        training_config=SRCNNTrainingConfig(init_strategy="default"),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    model.reset_parameters.assert_not_called()
+
+
+def test_base_training_config_skips_reset_parameters():
+    """Plain SRTrainingConfig (no init_strategy attr) → no call, no crash."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    model.reset_parameters = MagicMock()
+    SRLightning(
+        model=model,
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    model.reset_parameters.assert_not_called()


### PR DESCRIPTION
## Summary

Four bundled schema/surface cleanups across the YAML templates and the model/config split. Clean break per project convention (no backward-compat shims).

- **Template preamble strip** — drop the file-header comment block from both `.template.yaml` files (duplicated README Usage).
- **Data section unification** — replace the two-key `train_dataset_class` + `train_dataset` schema with a single `class_path`/`init_args` spec per dataset. `SRDataModule` materializes specs lazily in `setup()` via `lightning.pytorch.cli.instantiate_class`, preserving the no-LMDB-at-parse-time guarantee for `cli test`.
- **SRCNN init-args migration** — move `custom_init` / `init_mean` / `init_std` from `SRCNN.__init__` to `SRCNNTrainingConfig.{init_strategy, init_mean, init_std}`. `SRCNN` is now purely architectural; `SRLightning` applies the strategy post-construction via feature-detected `model.reset_parameters(...)`.
- **`crop_border` dedupe** — drop the `BenchmarkImageLogger.crop_border` init arg; the callback reads `pl_module.eval_config.crop_border` at metric-computation time. One source of truth, no drift.

## Commits

- `df4894f` Strip template-preamble file-headers (duplicates README Usage)
- `f3efff4` Unify data section to class_path/init_args spec
- `619d2df` Move SRCNN init-only args to SRCNNTrainingConfig
- `aaf1de9` Dedupe crop_border to eval_config (single source of truth)

## Test plan

- [x] `pytest` green locally (145 passed in worktree, was 133 baseline; +12 new tests)
- [ ] CI `test` workflow passes
- [ ] CI `build` workflow passes
- [ ] Codecov delta is non-regressive
- [ ] Manual smoke: \`python -m sisr.cli fit --config templates/config.srcnn.template.yaml --trainer.fast_dev_run=true\` against a tiny dataset (user-verified before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)