### PR TITLE
refactor/04: docstring cleanup and library-style coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,27 @@ pip install -e ".[dev]"
 
 ## Usage
 
-Training is configured entirely through YAML. Copy a template from [`templates/`](templates/), fill in the `TODO` placeholders (dataset directories, experiment output paths), then:
+Training is configured entirely through YAML. Copy a template from [`templates/`](templates/), edit the dataset directories and experiment output paths, then:
 
 ```bash
 # Train SRCNN (x3):
-python -m sisr.cli fit --config templates/config.srcnn.template.yaml
+sisr fit --config templates/config.srcnn.template.yaml
 
 # Train SRResNet (x4):
-python -m sisr.cli fit --config templates/config.srresnet.template.yaml
+sisr fit --config templates/config.srresnet.template.yaml
 ```
 
 Per-run overrides can be passed on the CLI without editing the YAML:
 
 ```bash
-python -m sisr.cli fit --config templates/config.srcnn.template.yaml \
+sisr fit --config templates/config.srcnn.template.yaml \
     --trainer.max_steps=500000 --optimizer.init_args.lr=1e-3
 ```
 
 After training, evaluate a checkpoint against the test sets (Set5, Set14, …):
 
 ```bash
-python -m sisr.cli test --config templates/config.srcnn.template.yaml \
+sisr test --config templates/config.srcnn.template.yaml \
     --ckpt_path path/to/best.ckpt
 ```
 

--- a/sisr/__init__.py
+++ b/sisr/__init__.py
@@ -1,1 +1,6 @@
+"""PyTorch Lightning framework for single-image super-resolution.
+
+See :class:`sisr.training.SRLightning` for the generic Lightning wrapper
+and :mod:`sisr.cli` for the LightningCLI entrypoint.
+"""
 __version__ = "0.1.0"

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -34,16 +34,26 @@ class SRLightningCLI(LightningCLI):
     """
 
     def add_arguments_to_parser(self, parser):
-        # Non-subclass mode (model_class=SRLightning fixed): SRLightning's
-        # init args land at model.<arg>, not model.init_args.<arg>.
+        """Wire top-level ``optimizer:`` / ``lr_scheduler:`` YAML keys into the model.
+
+        Non-subclass mode (``model_class=SRLightning`` fixed) means
+        ``SRLightning``'s init args land at ``model.<arg>``, not
+        ``model.init_args.<arg>`` — that's why the link targets omit
+        ``init_args``.
+        """
         parser.add_optimizer_args(link_to="model.optimizer")
         parser.add_lr_scheduler_args(link_to="model.lr_scheduler")
 
 
 def main() -> None:
-    # `freeze_support` lives inside `main` (not the __main__ block) so it
-    # also runs when invoked via the `sisr` console script declared in
-    # pyproject.toml — that entry point bypasses __main__.
+    """Console-script entrypoint.
+
+    Invoked as ``sisr ...`` via the entry point registered in
+    ``pyproject.toml``, and also as ``python -m sisr.cli ...``.
+    ``freeze_support`` lives inside ``main`` (not the ``__main__`` block)
+    so it also runs under the console-script path, which bypasses
+    ``__main__``.
+    """
     if sys.platform == 'win32':
         from multiprocessing import freeze_support
         freeze_support()

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -1,9 +1,12 @@
 """LightningCLI entrypoint for SR training.
 
 Usage:
-    python -m sisr.cli fit --config templates/config.srcnn.template.yaml
-    python -m sisr.cli test --config templates/config.srcnn.template.yaml \\
-                            --ckpt_path <best.ckpt>
+    sisr fit --config templates/config.srcnn.template.yaml
+    sisr test --config templates/config.srcnn.template.yaml \\
+              --ckpt_path <best.ckpt>
+
+The ``sisr`` console script is registered by ``pyproject.toml``; ``python -m
+sisr.cli ...`` also works.
 
 Top-level YAML keys ``optimizer:`` / ``lr_scheduler:`` are linked into
 ``model.init_args.optimizer`` / ``model.init_args.lr_scheduler`` by

--- a/sisr/datasets/__init__.py
+++ b/sisr/datasets/__init__.py
@@ -1,0 +1,5 @@
+"""Per-architecture data pipelines (SRCNN, SRResNet).
+
+Each submodule exposes ``TrainDataset`` and ``ValidationDataset`` classes
+that share the contract used by :class:`~sisr.training.SRDataModule`.
+"""

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -15,8 +15,7 @@ def _process_subimages(
     blur_sigma: float,
     base_idx: int,
 ) -> list[tuple[str, bytes]]:
-    """
-    Extracts all LR/HR sub-image pairs from a single image and returns
+    """Extracts all LR/HR sub-image pairs from a single image and returns
     them as keyed pairs ready for LMDB insertion.
 
     This is a top-level function (not a method) so that it can be
@@ -82,8 +81,7 @@ def _process_subimages(
 
 
 class TrainDataset(torch.utils.data.Dataset):
-    """
-    Dataset that serves precomputed LR/HR sub-image pairs from an LMDB cache.
+    """Dataset that serves precomputed LR/HR sub-image pairs from an LMDB cache.
 
     On first instantiation with a given set of parameters the dataset
     extracts every sliding-window sub-image from every image, generates the
@@ -161,8 +159,7 @@ class TrainDataset(torch.utils.data.Dataset):
         )
 
     def _compute_checksum(self) -> str:
-        """
-        Computes a SHA-256 checksum over the file manifest and dataset
+        """Computes a SHA-256 checksum over the file manifest and dataset
         parameters.
 
         The manifest includes every file name and its size (via ``stat``),
@@ -185,8 +182,7 @@ class TrainDataset(torch.utils.data.Dataset):
         return hashlib.sha256(canonical.encode('utf-8')).hexdigest()
 
     def _compute_offsets(self) -> tuple[list[int], int]:
-        """
-        Reads image dimensions (without decoding pixels) to compute
+        """Reads image dimensions (without decoding pixels) to compute
         per-image cumulative sub-image offsets.
 
         Returns:
@@ -209,8 +205,7 @@ class TrainDataset(torch.utils.data.Dataset):
         return offsets, offset
 
     def _build(self, ctx: LMDBCacheBuildContext) -> None:
-        """
-        Populates the LMDB cache using parallel image processing.
+        """Populates the LMDB cache using parallel image processing.
 
         Each image is submitted to a worker process which extracts
         sub-images and returns keyed byte pairs.  Results are written
@@ -238,8 +233,7 @@ class TrainDataset(torch.utils.data.Dataset):
         return self._cache.length
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Retrieves the LR/HR sub-image pair at the given index.
+        """Retrieves the LR/HR sub-image pair at the given index.
 
         Reads the raw uint8 bytes from LMDB, reshapes them into
         ``(C, H, W)`` arrays, and converts to ``float32`` tensors
@@ -279,8 +273,7 @@ class TrainDataset(torch.utils.data.Dataset):
 
 
 class ValidationDataset(torch.utils.data.Dataset):
-    """
-    Dataset that serves full-image LR/HR pairs for validation.
+    """Dataset that serves full-image LR/HR pairs for validation.
 
     Unlike :class:`TrainDataset` this dataset does not extract sub-images.
     Each item is a full image pair where the low-resolution version is
@@ -320,8 +313,7 @@ class ValidationDataset(torch.utils.data.Dataset):
         return len(self.img_paths)
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Retrieves the LR/HR image pair at the given index.
+        """Retrieves the LR/HR image pair at the given index.
 
         Args:
             idx (int): Zero-based image index.

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -1,3 +1,11 @@
+"""SRCNN-style data pipeline.
+
+LR is generated from HR via blur → bicubic-down → bicubic-up so the LR
+patches share the spatial size of the HR patches (pre-upsampled SRCNN
+formulation). :class:`TrainDataset` caches sliding-window sub-images
+through :class:`~sisr.utils.LMDBCache`; :class:`ValidationDataset`
+generates LR pairs on the fly for full images.
+"""
 import torch
 import torchvision
 import hashlib

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -73,11 +73,12 @@ class TrainDataset(torch.utils.data.Dataset):
         return len(self.img_paths) * self.crops_per_image
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Returns a ``(lr_tensor, hr_tensor)`` pair where ``hr_tensor`` is a
-        random ``hr_crop_size`` square crop and ``lr_tensor`` is its bicubic
-        downscale by ``scale`` (side ``hr_crop_size // scale``).  Both are
-        ``float32`` in ``[0, 1]`` with shape ``(3, H, W)``.
+        """Returns a ``(lr_tensor, hr_tensor)`` pair where ``hr_tensor`` is a random crop.
+
+        ``hr_tensor`` is a random ``hr_crop_size`` square crop and
+        ``lr_tensor`` is its bicubic downscale by ``scale`` (side
+        ``hr_crop_size // scale``). Both are ``float32`` in ``[0, 1]``
+        with shape ``(3, H, W)``.
         """
         path = self.img_paths[idx % len(self.img_paths)]
         hr_img = Image.open(path).convert('RGB')
@@ -133,10 +134,11 @@ class ValidationDataset(torch.utils.data.Dataset):
         return len(self.img_paths)
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Returns a ``(lr_tensor, hr_tensor)`` pair: ``hr_tensor`` is the HR
-        image cropped to a multiple of ``scale``, and ``lr_tensor`` is its
-        bicubic downscale by ``scale``. Both are ``float32`` in ``[0, 1]``.
+        """Returns a ``(lr_tensor, hr_tensor)`` pair for the image at ``idx``.
+
+        ``hr_tensor`` is the HR image cropped to a multiple of ``scale``,
+        and ``lr_tensor`` is its bicubic downscale by ``scale``. Both are
+        ``float32`` in ``[0, 1]``.
         """
         path = self.img_paths[idx]
         hr_img = Image.open(path).convert('RGB')

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -1,3 +1,11 @@
+"""SRResNet-style data pipeline.
+
+LR is the bicubic downscale of HR by ``scale`` (no upsample round-trip);
+the model is responsible for the ×``scale`` upsampling. :class:`TrainDataset`
+serves random ``hr_crop_size`` crops without caching (random crops aren't
+cacheable); :class:`ValidationDataset` serves full images cropped to a
+multiple of ``scale``.
+"""
 import random
 
 import torch

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -7,8 +7,7 @@ from pathlib import Path
 
 
 class TrainDataset(torch.utils.data.Dataset):
-    """
-    Random-crop HR/LR pairs for SRResNet-style training.
+    """Random-crop HR/LR pairs for SRResNet-style training.
 
     Each ``__getitem__`` takes a random ``hr_crop_size`` square crop from an
     HR image and bicubic-downsamples it by ``scale`` to form the LR input.
@@ -96,8 +95,7 @@ class TrainDataset(torch.utils.data.Dataset):
 
 
 class ValidationDataset(torch.utils.data.Dataset):
-    """
-    Full-image HR with bicubic-downsampled LR for SRResNet validation/test.
+    """Full-image HR with bicubic-downsampled LR for SRResNet validation/test.
 
     Each item is a full image pair. The HR image is cropped to a multiple of
     ``scale`` so the model's ×``scale`` output lands exactly on the HR size;

--- a/sisr/models/__init__.py
+++ b/sisr/models/__init__.py
@@ -1,0 +1,7 @@
+"""Per-architecture network implementations.
+
+Each subpackage (``srcnn``, ``srresnet``) exports its top-level
+``nn.Module`` and any per-architecture config dataclasses for use under
+``model.model.class_path`` and ``model.training_config.class_path`` in
+experiment YAMLs.
+"""

--- a/sisr/models/srcnn/__init__.py
+++ b/sisr/models/srcnn/__init__.py
@@ -1,3 +1,4 @@
+"""SRCNN architecture and paper-faithful config defaults."""
 from .config import SRCNNEvalConfig, SRCNNTrainingConfig
 from .model import SRCNN
 

--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -21,10 +21,24 @@ class SRCNNTrainingConfig(SRTrainingConfig):
     The paper trains on the Y channel of YCbCr only and uses a per-layer
     learning rate of ``1e-4`` for the feature-extraction and non-linear-
     mapping layers and ``1e-5`` for the reconstruction layer — i.e. the
-    last layer learns 10× slower.  Weight initialization follows the
+    last layer learns 10× slower. Weight initialization follows the
     paper's Gaussian schedule (``N(0, 0.01)`` with zero biases); set
     ``init_strategy='default'`` to fall back to PyTorch's built-in init.
     Override any field in YAML to deviate.
+
+    Args:
+        model_colorspace: Overrides the base default to ``'Y'``
+            (SRCNN's Y-channel training).
+        layer_lrs: Per-``Conv2d`` LRs ``[1e-4, 1e-4, 1e-5]`` matching the
+            paper's recipe. Set to ``None`` to disable per-layer LRs.
+        init_strategy: ``'paper'`` (default) triggers the Gaussian
+            init via :meth:`SRCNN.reset_parameters` in
+            :class:`~sisr.training.SRLightning`'s constructor;
+            ``'default'`` skips it and uses PyTorch's defaults.
+        init_mean: Mean of the Gaussian used by ``init_strategy='paper'``.
+            Defaults to ``0.0``.
+        init_std: Std of the Gaussian used by ``init_strategy='paper'``.
+            Defaults to ``0.01``.
     """
 
     model_colorspace: Literal['RGB', 'Y', 'YCbCr'] = 'Y'
@@ -40,9 +54,15 @@ class SRCNNTrainingConfig(SRTrainingConfig):
 class SRCNNEvalConfig(SREvalConfig):
     """SRCNN-paper-faithful eval defaults.
 
-    Reports PSNR on both RGB and the YCbCr triplet (the literature usually
-    quotes Y-channel PSNR for SRCNN), and excludes the outer ``scale=3``
-    pixels per the standard SR-evaluation convention.
+    Reports PSNR on both RGB and the YCbCr triplet (the literature
+    usually quotes Y-channel PSNR for SRCNN), and excludes the outer
+    ``scale=3`` pixels per the standard SR-evaluation convention.
+
+    Args:
+        crop_border: Overrides the base default to ``3`` (outer pixels
+            excluded before PSNR / SSIM at the standard ``x3`` scale).
+        psnr_channels: Overrides the base default to
+            ``['RGB', 'YCbCr']`` (the literature reports both).
     """
 
     crop_border: int = 3

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -1,3 +1,8 @@
+"""SRCNN — the 3-layer CNN from Dong et al. (2014).
+
+Reference: Image Super-Resolution Using Deep Convolutional Networks
+(https://arxiv.org/pdf/1501.00092).
+"""
 import torch
 
 

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -83,6 +83,16 @@ class SRCNN(torch.nn.Module):
 
     @property
     def hparams(self) -> dict:
+        """Return the model architecture hyperparameters as a dict.
+
+        Merged into Lightning's HParams by :class:`~sisr.training.SRLightning`
+        so the architecture spec appears alongside training params in
+        TensorBoard.
+
+        Returns:
+            Dict with keys ``num_channels``, ``num_filters``,
+            ``kernel_sizes``, ``padding``.
+        """
         return self._hparams
 
     def reset_parameters(self, mean: float = 0.0, std: float = 0.01):

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -57,9 +57,8 @@ class SRCNN(torch.nn.Module):
         Validates the architecture parameters for the SRCNN model.
 
         Args:
-            num_filters (tuple[int, ...]): A tuple containing the number of filters for each convolutional layer
-            kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each convolutional layer
-            padding (str | int): The padding type or size for the convolutional layers
+            num_filters (tuple[int, ...]): A tuple containing the number of filters for each convolutional layer.
+            kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each convolutional layer.
 
         Raises:
             ValueError: If num_filters or kernel_sizes are not tuples, if they have different lengths, or if any of their elements are not positive integers.

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -2,8 +2,7 @@ import torch
 
 
 class SRCNN(torch.nn.Module):
-    """
-    SRCNN (Super-Resolution Convolutional Neural Network) model for single image super-resolution.
+    """SRCNN (Super-Resolution Convolutional Neural Network) model for single image super-resolution.
     The architecture consists of three main parts: feature extraction, non-linear mapping, and reconstruction.
 
     Reference:
@@ -53,8 +52,7 @@ class SRCNN(torch.nn.Module):
             num_filters[-1], num_channels, kernel_size=kernel_sizes[-1], padding=padding)
 
     def _check_architecture(self, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...]):
-        """
-        Validates the architecture parameters for the SRCNN model.
+        """Validates the architecture parameters for the SRCNN model.
 
         Args:
             num_filters (tuple[int, ...]): A tuple containing the number of filters for each convolutional layer.
@@ -88,8 +86,7 @@ class SRCNN(torch.nn.Module):
         return self._hparams
 
     def reset_parameters(self, mean: float = 0.0, std: float = 0.01):
-        """
-        Initializes the weights of the convolutional layers using a normal distribution and sets the biases to zero.
+        """Initializes the weights of the convolutional layers using a normal distribution and sets the biases to zero.
         Following the initialization method described in the original SRCNN paper (https://arxiv.org/pdf/1501.00092).
 
         Args:
@@ -102,8 +99,7 @@ class SRCNN(torch.nn.Module):
                 torch.nn.init.constant_(module.bias, 0.0)
 
     def forward(self, x: torch.Tensor, clamp_output: bool = False, clamp_minmax: tuple[float, float] = (0.0, 1.0)) -> torch.Tensor:
-        """
-        Forward pass of the SRCNN model.
+        """Forward pass of the SRCNN model.
 
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, num_channels, height, width)

--- a/sisr/models/srresnet/__init__.py
+++ b/sisr/models/srresnet/__init__.py
@@ -1,3 +1,4 @@
+"""SRResNet architecture (the residual generator from Ledig et al., 2017)."""
 from .model import SRResidualBlock, SRResNet, SRUpsampleBlock
 
 __all__ = ["SRResNet", "SRResidualBlock", "SRUpsampleBlock"]

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -3,8 +3,7 @@ import math
 
 
 class SRResidualBlock(torch.nn.Module):
-    """
-    A single residual block used in SRResNet.
+    """A single residual block used in SRResNet.
     Each block applies two convolutional layers with batch normalization,
     and adds the input (identity) as a skip connection.
 
@@ -29,8 +28,7 @@ class SRResidualBlock(torch.nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Forward pass of the residual block.
+        """Forward pass of the residual block.
 
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, channels, height, width).
@@ -45,8 +43,7 @@ class SRResidualBlock(torch.nn.Module):
 
 
 class SRUpsampleBlock(torch.nn.Module):
-    """
-    An upsampling block used in SRResNet that increases spatial resolution using sub-pixel convolution.
+    """An upsampling block used in SRResNet that increases spatial resolution using sub-pixel convolution.
 
     Args:
         channels (int): Number of input channels.
@@ -64,8 +61,7 @@ class SRUpsampleBlock(torch.nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Forward pass of the upsample block.
+        """Forward pass of the upsample block.
 
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, channels, height, width).
@@ -77,8 +73,7 @@ class SRUpsampleBlock(torch.nn.Module):
 
 
 class SRResNet(torch.nn.Module):
-    """
-    SRResNet (Super-Resolution Residual Network) model for single image super-resolution.
+    """SRResNet (Super-Resolution Residual Network) model for single image super-resolution.
     The architecture consists of an initial feature extraction block, a series of residual blocks
     with a skip connection, sub-pixel upsample blocks, and a final reconstruction layer.
 
@@ -129,8 +124,7 @@ class SRResNet(torch.nn.Module):
         self.tail = torch.nn.Conv2d(hidden_channel, in_out_channels, kernel_size=kernel_sizes[2], padding=padding)
 
     def _check_scale(self, scale: int):
-        """
-        Validates that the scale factor is a power of 2.
+        """Validates that the scale factor is a power of 2.
 
         Args:
             scale (int): The upscaling factor.
@@ -153,8 +147,7 @@ class SRResNet(torch.nn.Module):
         return self._hparams
 
     def forward(self, x: torch.Tensor, clamp_output: bool = False, clamp_minmax: tuple[float, float] = (0.0, 1.0)) -> torch.Tensor:
-        """
-        Forward pass of the SRResNet model.
+        """Forward pass of the SRResNet model.
 
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, in_out_channels, height, width).

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -1,3 +1,8 @@
+"""SRResNet — the residual generator from Ledig et al. (2017).
+
+Reference: Photo-Realistic Single Image Super-Resolution Using a Generative
+Adversarial Network (https://arxiv.org/pdf/1609.04802).
+"""
 import torch
 import math
 

--- a/sisr/training/__init__.py
+++ b/sisr/training/__init__.py
@@ -1,3 +1,8 @@
+"""Generic Lightning training plumbing — SRLightning, SRDataModule, callbacks.
+
+Re-exports are flat so experiment YAMLs can use short class paths like
+``sisr.training.SRLightning`` instead of ``sisr.training.lightning_module.SRLightning``.
+"""
 from .callbacks import (
     BenchmarkImageLogger,
     GradNormLogger,

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -171,6 +171,7 @@ class BenchmarkImageLogger(Callback):
         )
 
     def _on_image_log_interval(self) -> bool:
+        """Return True when this val run should also log image strips."""
         return self._val_run_count % self.log_every_n_val_runs == 0
 
     def _collect_batch(
@@ -184,6 +185,27 @@ class BenchmarkImageLogger(Callback):
         dataloader_idx: int,
         should_log_images: bool,
     ):
+        """Forward one batch, compute per-image metrics, and buffer the results.
+
+        Shared between :meth:`on_validation_batch_end` and
+        :meth:`on_test_batch_end`. Border cropping is sourced from
+        ``pl_module.eval_config.crop_border`` at the use site.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being evaluated.
+            batch (Any): ``(lr_img, hr_img)`` tuple from the loader.
+            batch_idx (int): Index of the batch within the current
+                dataloader.
+            dataset_name (str): Name of the test set this batch comes from.
+            source_dataloaders: ``trainer.val_dataloaders`` or
+                ``trainer.test_dataloaders`` — used to recover the
+                underlying dataset for filename resolution.
+            dataloader_idx (int): Index into ``source_dataloaders``.
+            should_log_images (bool): When True the LR/SR/HR tensors are
+                cached for image-strip emission in :meth:`_flush_buffer`;
+                otherwise only scalar metrics are buffered.
+        """
         lr_img, hr_img = batch
 
         with torch.no_grad():
@@ -230,6 +252,21 @@ class BenchmarkImageLogger(Callback):
         pl_module: lightning.LightningModule,
         should_log_images: bool,
     ):
+        """Log per-set means and (optionally) image strips for buffered batches.
+
+        Shared between :meth:`on_validation_epoch_end` and
+        :meth:`on_test_epoch_end`. Looks up the TensorBoard logger from
+        ``trainer.loggers``; silently skips image emission for sets whose
+        logger is missing.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer (used for
+                ``global_step`` and the TensorBoard logger lookup).
+            pl_module (lightning.LightningModule): Receives ``log()`` calls
+                for the per-set mean metrics.
+            should_log_images (bool): When True, LR|SR|HR image strips are
+                emitted to TensorBoard alongside the scalar means.
+        """
         step = trainer.global_step
 
         for dataset_name, samples in self._buffer.items():

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -73,8 +73,17 @@ class BenchmarkImageLogger(Callback):
         pl_module: lightning.LightningModule,
         stage: str,
     ):
-        """Resolve ``dataset_names`` (auto-discover from the datamodule when
-        not supplied) and build both stage-specific dataloader_idx mappings.
+        """Resolve ``dataset_names`` and build both dataloader_idx mappings.
+
+        Auto-discovers ``dataset_names`` from ``trainer.datamodule.test_names``
+        when not supplied at construction time.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being trained
+                (unused).
+            stage (str): Lightning trainer stage (unused — both val and
+                test mappings are built up-front).
         """
         if self.dataset_names is None:
             dm = getattr(trainer, "datamodule", None)
@@ -86,7 +95,13 @@ class BenchmarkImageLogger(Callback):
     def on_validation_epoch_start(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
     ):
-        """Clear buffers and bump the val-run counter."""
+        """Clear buffers and bump the val-run counter.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer (unused).
+            pl_module (lightning.LightningModule): The model being
+                evaluated (unused).
+        """
         self._val_run_count += 1
         self._buffer = {name: [] for name in self.dataset_names}
 
@@ -101,8 +116,21 @@ class BenchmarkImageLogger(Callback):
     ):
         """Collect LR/SR/HR + per-image metrics for one test loader's batch.
 
-        Only runs for ``dataloader_idx`` in ``_val_mapping`` (i.e. test sets,
-        not the primary val loader at idx 0).
+        Only runs for ``dataloader_idx`` in ``_val_mapping`` (i.e. test
+        sets, not the primary val loader at idx 0).
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being
+                evaluated.
+            outputs (Any): The value returned by ``validation_step``
+                (unused — :class:`~sisr.training.SRLightning.validation_step`
+                returns ``None`` for idx >= 1).
+            batch (Any): ``(lr_img, hr_img)`` tuple from the test loader.
+            batch_idx (int): Index of the batch within the current
+                dataloader.
+            dataloader_idx (int): Index of the loader within
+                ``trainer.val_dataloaders``.
         """
         if dataloader_idx not in self._val_mapping:
             return
@@ -120,7 +148,13 @@ class BenchmarkImageLogger(Callback):
     def on_validation_epoch_end(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
     ):
-        """Log per-set means every val epoch; image strips every N val runs."""
+        """Log per-set means every val epoch; image strips every N val runs.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being
+                evaluated.
+        """
         self._flush_buffer(
             trainer=trainer,
             pl_module=pl_module,
@@ -130,7 +164,13 @@ class BenchmarkImageLogger(Callback):
     def on_test_epoch_start(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
     ):
-        """Clear buffers ahead of a test run."""
+        """Clear buffers ahead of a test run.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer (unused).
+            pl_module (lightning.LightningModule): The model being
+                evaluated (unused).
+        """
         self._buffer = {name: [] for name in self.dataset_names}
 
     def on_test_batch_end(
@@ -146,6 +186,19 @@ class BenchmarkImageLogger(Callback):
 
         ``cli test`` runs the test loaders only, so all dataloader indices
         are test sets (no primary loader at idx 0).
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being
+                evaluated.
+            outputs (Any): The value returned by ``test_step`` (unused —
+                :class:`~sisr.training.SRLightning.test_step` returns
+                ``None``).
+            batch (Any): ``(lr_img, hr_img)`` tuple from the test loader.
+            batch_idx (int): Index of the batch within the current
+                dataloader.
+            dataloader_idx (int): Index of the loader within
+                ``trainer.test_dataloaders``.
         """
         if dataloader_idx not in self._test_mapping:
             return
@@ -163,7 +216,13 @@ class BenchmarkImageLogger(Callback):
     def on_test_epoch_end(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
     ):
-        """Log per-set means and image strips at the end of `cli test`."""
+        """Log per-set means and image strips at the end of ``cli test``.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being
+                evaluated.
+        """
         self._flush_buffer(
             trainer=trainer,
             pl_module=pl_module,

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -1,3 +1,12 @@
+"""Lightning callbacks for SR training.
+
+:class:`BenchmarkImageLogger` logs per-image LR|SR|HR strips and PSNR/SSIM
+for held-out test sets (Set5, Set14, ...) during both ``cli fit`` (every
+N val cycles) and ``cli test`` (one-shot final eval).
+:class:`GradNormLogger` and :class:`WeightHistogramLogger` log diagnostic
+training signals; :class:`SRCheckpoint` is a thin
+:class:`~lightning.pytorch.callbacks.ModelCheckpoint` preset for SR metrics.
+"""
 import math
 import torch
 import torch.nn.functional

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -9,8 +9,7 @@ from typing import Any
 
 
 class BenchmarkImageLogger(Callback):
-    """
-    Log per-image LR|SR|HR composites and scalar PSNR/SSIM to TensorBoard for
+    """Log per-image LR|SR|HR composites and scalar PSNR/SSIM to TensorBoard for
     one or more held-out test/benchmark dataloaders (Set5, Set14, …).
 
     Fires during *both* validation and test stages:
@@ -277,9 +276,7 @@ class BenchmarkImageLogger(Callback):
 
     @staticmethod
     def _pad_to_match(img: torch.Tensor, target_hw: tuple) -> torch.Tensor:
-        """
-        Zero-pad a ``(C, H, W)`` tensor to *target_hw* spatial size.
-
+        """Zero-pad a ``(C, H, W)`` tensor to *target_hw* spatial size.
 
         Args:
             img (torch.Tensor): Image tensor of shape ``(C, H, W)``.
@@ -305,8 +302,7 @@ class BenchmarkImageLogger(Callback):
 
 
 class GradNormLogger(Callback):
-    """
-    Log the total gradient L2 norm to TensorBoard periodically.
+    """Log the total gradient L2 norm to TensorBoard periodically.
 
     Computes ``sqrt(sum(p.grad.norm() ** 2))`` across all model parameters
     after the backward pass and logs it as the ``"grad_norm"`` scalar.
@@ -323,8 +319,7 @@ class GradNormLogger(Callback):
     def on_after_backward(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
     ):
-        """
-        Compute and log gradient norm if on the right step cadence.
+        """Compute and log gradient norm if on the right step cadence.
 
         Args:
             trainer (lightning.Trainer): The trainer instance.
@@ -343,8 +338,7 @@ class GradNormLogger(Callback):
 
 
 class WeightHistogramLogger(Callback):
-    """
-    Log the weights of the model as histograms to TensorBoard periodically,
+    """Log the weights of the model as histograms to TensorBoard periodically,
     grouped by parameter prefixes (e.g., model.feat, model.mapping, model.recon).
 
     Args:
@@ -359,8 +353,7 @@ class WeightHistogramLogger(Callback):
     def on_train_batch_end(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule, outputs: Any, batch: Any, batch_idx: int
     ):
-        """
-        Log grouped weights as histograms if on the right step cadence.
+        """Log grouped weights as histograms if on the right step cadence.
 
         Args:
             trainer (lightning.Trainer): The trainer instance.
@@ -389,8 +382,7 @@ class WeightHistogramLogger(Callback):
 
 
 class SRCheckpoint(ModelCheckpoint):
-    """
-    Model checkpoint that monitors a super-resolution quality metric.
+    """Model checkpoint that monitors a super-resolution quality metric.
 
     A thin convenience wrapper around
     :class:`~lightning.pytorch.callbacks.ModelCheckpoint` that

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -6,8 +6,7 @@ from torch.utils.data import DataLoader, Dataset
 
 
 class SRDataModule(lightning.LightningDataModule):
-    """
-    Generic LightningDataModule for single-image super-resolution.
+    """Generic LightningDataModule for single-image super-resolution.
 
     Owns the train / validation / test Dataset constructions and exposes them
     as DataLoaders. Datasets are described by ``{class_path, init_args}`` specs

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -81,6 +81,15 @@ class SRDataModule(lightning.LightningDataModule):
             self._val_ds = instantiate_class((), self._val_spec)
 
     def train_dataloader(self) -> DataLoader:
+        """Build the training DataLoader.
+
+        ``shuffle=True`` is forced — any ``shuffle`` entry the user supplies
+        in ``train_dataloader_kwargs`` would be a TypeError (duplicate
+        kwarg) and the YAML schema does not expose ``shuffle``.
+
+        Returns:
+            DataLoader over the train spec, shuffled.
+        """
         return DataLoader(self._train_ds, shuffle=True, **self._train_dl_kwargs)
 
     def val_dataloader(self) -> list:

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -1,3 +1,11 @@
+"""Generic Lightning DataModule for SR training.
+
+Dataset specs (``{class_path, init_args}``) are materialized lazily in
+:meth:`SRDataModule.setup` so expensive constructors (LMDB cache builds)
+only run for the stages that need them. Test sets are surfaced through
+*both* :meth:`val_dataloader` (for ``cli fit`` monitoring) and
+:meth:`test_dataloader` (for ``cli test --ckpt_path`` final eval).
+"""
 from typing import Any
 
 import lightning

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -65,11 +65,27 @@ class SRDataModule(lightning.LightningDataModule):
 
     @property
     def test_names(self) -> list:
-        """Ordered list of test dataset names — drives BenchmarkImageLogger auto-discovery."""
+        """Ordered list of test dataset names — drives BenchmarkImageLogger auto-discovery.
+
+        Returns:
+            List of names in the order they appear in
+            ``test_datasets``. Empty when no test sets are configured.
+        """
         return list(self._test_specs.keys())
 
     def setup(self, stage: str | None = None) -> None:
-        """Instantiate datasets lazily based on the trainer stage."""
+        """Instantiate datasets lazily based on the trainer stage.
+
+        Called by Lightning at the start of every subcommand. Specs are
+        materialized via :func:`lightning.pytorch.cli.instantiate_class`
+        so expensive constructors (LMDB cache builds, etc.) only run for
+        the stages that need them.
+
+        Args:
+            stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
+                ``'test'``, or ``None`` (for all). Determines which
+                datasets get instantiated.
+        """
         if stage in ('fit', None) and self._train_ds is None:
             self._train_ds = instantiate_class((), self._train_spec)
         if stage in ('fit', 'validate', 'test', None) and not self._test_ds and self._test_specs:
@@ -95,9 +111,13 @@ class SRDataModule(lightning.LightningDataModule):
     def val_dataloader(self) -> list:
         """Primary validation loader followed by every test loader.
 
-        Index 0 is the held-out primary val set; indices 1+ are the test sets,
-        which lets `BenchmarkImageLogger` log Set5/Set14 progress during
-        every val cycle of `cli fit`.
+        Index 0 is the held-out primary val set; indices 1+ are the test
+        sets, which lets :class:`~sisr.training.callbacks.BenchmarkImageLogger`
+        log Set5 / Set14 progress during every val cycle of ``cli fit``.
+
+        Returns:
+            List ``[primary_val_loader, test_loader_1, test_loader_2,
+            ...]``. Length is ``1 + len(test_names)``.
         """
         loaders = [DataLoader(self._val_ds, shuffle=False, **self._val_dl_kwargs)]
         for ds in self._test_ds.values():
@@ -105,7 +125,12 @@ class SRDataModule(lightning.LightningDataModule):
         return loaders
 
     def test_dataloader(self) -> list:
-        """Test loaders only — for `cli test --ckpt_path <path>` final eval."""
+        """Test loaders only — for ``cli test --ckpt_path <path>`` final eval.
+
+        Returns:
+            List of one DataLoader per entry in ``test_datasets``, in
+            insertion order. Empty when no test sets are configured.
+        """
         return [
             DataLoader(ds, shuffle=False, **self._test_dl_kwargs)
             for ds in self._test_ds.values()

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -109,6 +109,14 @@ class SRLightning(lightning.LightningModule):
 
         None values are dropped (they add noise without aiding comparison).
         Class objects are reduced to their ``__name__``.
+
+        Args:
+            hparams: Nested mapping of hparams (may contain dicts, lists,
+                tuples, scalars, or class objects).
+            sep: Separator used to join nested keys. Defaults to ``'/'``.
+
+        Returns:
+            Flat dict with ``sep``-joined keys and scalar leaves.
         """
         result = {}
 
@@ -139,6 +147,15 @@ class SRLightning(lightning.LightningModule):
         """Pre-compute (sr, hr) tensor pairs for every tracked PSNR key.
 
         Colorspace conversions are performed at most once per call.
+
+        Args:
+            sr: SR tensor of shape ``(B, 3, H, W)`` in RGB.
+            hr: HR tensor of shape ``(B, 3, H, W)`` in RGB.
+
+        Returns:
+            Mapping from PSNR key (``'RGB'``, ``'Y'``, ``'Cb'``, ...) to
+            ``(sr_subset, hr_subset)`` tensor pair ready for PSNR
+            computation.
         """
         keys = set(self.val_psnr_metrics.keys())
         tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
@@ -182,10 +199,18 @@ class SRLightning(lightning.LightningModule):
     ]:
         """Shared forward + loss for training and validation steps.
 
-        Returns ``(loss, lr_img, hr_img, sr_rgb, hr_cropped)``.  Loss is
-        computed in :attr:`SRTrainingConfig.model_colorspace`; metrics
-        downstream consume ``sr_rgb`` / ``hr_cropped`` (both full RGB,
-        spatially aligned).
+        Loss is computed in :attr:`SRTrainingConfig.model_colorspace`;
+        metrics downstream consume ``sr_rgb`` / ``hr_cropped`` (both
+        full RGB, spatially aligned).
+
+        Args:
+            batch: ``(lr_img, hr_img)`` tuple from a loader. Both RGB,
+                ``float32`` in ``[0, 1]``.
+
+        Returns:
+            ``(loss, lr_img, hr_img, sr_rgb, hr_cropped)``. ``loss`` is a
+            scalar tensor; ``sr_rgb`` and ``hr_cropped`` are RGB tensors
+            with matching spatial size.
         """
         lr_img, hr_img = batch
         cs = self.training_config.model_colorspace
@@ -233,6 +258,13 @@ class SRLightning(lightning.LightningModule):
 
         Benchmark / test loaders (idx >= 1) are handled by
         :class:`~sisr.training.callbacks.BenchmarkImageLogger`.
+
+        Args:
+            batch: ``(lr_img, hr_img)`` tuple from the val loader.
+            batch_idx: Index of the batch within the current val epoch.
+            dataloader_idx: Index of the loader within the list returned
+                by :meth:`SRDataModule.val_dataloader`. ``0`` is the
+                primary val set; anything else is skipped.
         """
         if dataloader_idx != 0:
             return
@@ -265,22 +297,40 @@ class SRLightning(lightning.LightningModule):
     ) -> None:
         """No-op so Lightning iterates ``trainer.test_dataloaders``.
 
-        All metric computation, per-image logging, and image-strip emission
-        for the test sets happens in
+        All metric computation, per-image logging, and image-strip
+        emission for the test sets happens in
         :class:`~sisr.training.callbacks.BenchmarkImageLogger.on_test_*`.
+
+        Args:
+            batch: ``(lr_img, hr_img)`` tuple from the test loader
+                (unused).
+            batch_idx: Index of the batch within the current test epoch
+                (unused).
+            dataloader_idx: Index of the test loader (unused).
         """
         return None
 
     def configure_optimizers(self):
         """Build optimizer (and optional scheduler) from top-level YAML.
 
-        Uniform LR by default — ``self.optimizer(self.parameters())`` exactly
-        matches what LightningCLI's ``auto_configure_optimizers`` would do.
+        Uniform LR by default — ``self.optimizer(self.parameters())``
+        exactly matches what LightningCLI's ``auto_configure_optimizers``
+        would do.
 
         When ``training_config.layer_lrs`` is set, builds per-``Conv2d``
-        ``param_groups`` with explicit absolute LRs.  This requires every
+        ``param_groups`` with explicit absolute LRs. This requires every
         trainable parameter to live inside a ``Conv2d`` (SRCNN-style — no
         BatchNorm / PReLU); the validation below makes that explicit.
+
+        Returns:
+            The constructed optimizer, or a ``([optimizer], [scheduler])``
+            tuple if ``self.lr_scheduler`` is set. Lightning accepts both.
+
+        Raises:
+            ValueError: If ``training_config.layer_lrs`` length does not
+                match the model's ``Conv2d`` count, or if any trainable
+                parameter lives outside a ``Conv2d`` while ``layer_lrs``
+                is set.
         """
         lrs = self.training_config.layer_lrs
         if lrs is None:

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -1,3 +1,12 @@
+"""Generic Lightning wrapper for SR models — :class:`SRLightning`.
+
+The Lightning module is architecture-agnostic: per-paper behavior lives
+in :class:`~sisr.training.config.SRTrainingConfig` /
+:class:`~sisr.training.config.SREvalConfig` subclasses (e.g.
+:class:`~sisr.models.srcnn.SRCNNTrainingConfig`), not in the module
+itself. Optimizer / LR scheduler are wired in from top-level YAML keys by
+:class:`~sisr.cli.SRLightningCLI`.
+"""
 import torch
 import torchvision
 import torchmetrics

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -160,6 +160,21 @@ class SRLightning(lightning.LightningModule):
         return tensors
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the wrapped SR model on ``x`` and return its raw output.
+
+        Pure inference path — no colorspace conversion, no metrics, no
+        cropping. Used by ``trainer.predict`` and direct ``module(x)``
+        calls. The training / validation paths go through :meth:`_step`,
+        which adds the colorspace pipeline.
+
+        Args:
+            x: LR input tensor of shape ``(B, C, H, W)``.
+
+        Returns:
+            SR tensor as produced by the wrapped model. Shape depends on
+            the architecture (same as ``x`` for SRCNN; ``(B, C, H*scale,
+            W*scale)`` for SRResNet).
+        """
         return self.model(x)
 
     def _step(self, batch: tuple[torch.Tensor, torch.Tensor]) -> tuple[
@@ -193,6 +208,20 @@ class SRLightning(lightning.LightningModule):
         return loss, lr_img, hr_img, sr_rgb, hr_cropped
 
     def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
+        """Compute training loss for one batch and log it.
+
+        Delegates the forward + colorspace + loss pipeline to :meth:`_step`
+        and logs ``train_loss`` on every step for the progress bar.
+
+        Args:
+            batch: ``(lr_img, hr_img)`` tuple as produced by the
+                :class:`SRDataModule` train loader. Both are ``float32`` in
+                ``[0, 1]``.
+            batch_idx: Index of the batch within the current epoch.
+
+        Returns:
+            Scalar loss tensor for the optimizer.
+        """
         loss, *_ = self._step(batch)
         self.log('train_loss', loss, prog_bar=True, on_step=True)
         return loss

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -14,8 +14,7 @@ from .config import SREvalConfig, SRTrainingConfig
 
 
 class SRLightning(lightning.LightningModule):
-    """
-    Generic Lightning wrapper for single-image super-resolution models.
+    """Generic Lightning wrapper for single-image super-resolution models.
 
     Architecture-agnostic: any ``torch.nn.Module`` that accepts an LR tensor
     of shape ``(B, C, H, W)`` and returns an SR tensor can be plugged in.

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -29,7 +29,16 @@ _YCBCR_TO_B = 1.772                     # cb coefficient
 
 
 def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
-    """Convert a normalised RGB tensor ``(B, 3, H, W)`` to YCbCr (BT.601 full-range)."""
+    """Convert a normalised RGB tensor to YCbCr (BT.601 full-range).
+
+    Args:
+        img (torch.Tensor): RGB tensor of shape ``(B, 3, H, W)`` with
+            values in ``[0, 1]``.
+
+    Returns:
+        torch.Tensor: YCbCr tensor of shape ``(B, 3, H, W)`` in
+        ``[0, 1]`` with Cb/Cr offset by +0.5.
+    """
     r, g, b = img[:, 0:1], img[:, 1:2], img[:, 2:3]
     y  = _RGB_TO_Y[0]  * r + _RGB_TO_Y[1]  * g + _RGB_TO_Y[2]  * b
     cb = _RGB_TO_CB[0] * r + _RGB_TO_CB[1] * g + _RGB_TO_CB[2] * b + 0.5
@@ -38,7 +47,16 @@ def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
 
 
 def ycbcr_to_rgb(img: torch.Tensor) -> torch.Tensor:
-    """Convert a YCbCr tensor ``(B, 3, H, W)`` to RGB (BT.601 full-range, clamped to [0, 1])."""
+    """Convert a YCbCr tensor to RGB (BT.601 full-range, clamped to [0, 1]).
+
+    Args:
+        img (torch.Tensor): YCbCr tensor of shape ``(B, 3, H, W)`` with
+            Cb/Cr offset by +0.5.
+
+    Returns:
+        torch.Tensor: RGB tensor of shape ``(B, 3, H, W)`` clamped to
+        ``[0, 1]``.
+    """
     y, cb, cr = img[:, 0:1], img[:, 1:2] - 0.5, img[:, 2:3] - 0.5
     r = y + _YCBCR_TO_R * cr
     g = y + _YCBCR_TO_G_CB * cb + _YCBCR_TO_G_CR * cr
@@ -52,9 +70,20 @@ def extract_model_input(
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Prepare the model input from a full-RGB LR tensor.
 
-    Returns ``(model_input, lr_ycbcr)`` where ``lr_ycbcr`` is the full LR
-    YCbCr tensor retained for chroma reconstruction (only when
-    ``model_colorspace='Y'``); ``None`` otherwise.
+    Args:
+        lr_img (torch.Tensor): RGB LR tensor of shape ``(B, 3, H, W)``.
+        model_colorspace (Literal['RGB', 'Y', 'YCbCr']): Colorspace the
+            model expects.
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor | None]: ``(model_input,
+        lr_ycbcr)`` where ``lr_ycbcr`` is the full LR YCbCr tensor
+        retained for chroma reconstruction (only when
+        ``model_colorspace='Y'``); ``None`` otherwise.
+
+    Raises:
+        ValueError: If ``model_colorspace`` is not one of ``'RGB'``,
+            ``'Y'``, or ``'YCbCr'``.
     """
     if model_colorspace == 'RGB':
         return lr_img, None
@@ -78,6 +107,24 @@ def reconstruct_sr_rgb(
     For ``model_colorspace='Y'``, stitches SR-Y with bicubic Cb/Cr from the
     LR YCbCr tensor (centre-cropped to match the SR spatial size) and
     converts to RGB.
+
+    Args:
+        sr_model (torch.Tensor): The model's raw output. Shape matches
+            ``model_colorspace`` (``(B, 1, H, W)`` for ``'Y'``,
+            ``(B, 3, H, W)`` for ``'RGB'`` and ``'YCbCr'``).
+        lr_ycbcr (torch.Tensor | None): Full LR YCbCr tensor used to
+            recover Cb/Cr for ``model_colorspace='Y'``; ignored
+            otherwise.
+        model_colorspace (Literal['RGB', 'Y', 'YCbCr']): Colorspace the
+            model produced.
+
+    Returns:
+        torch.Tensor: Full-RGB SR tensor of shape ``(B, 3, H, W)``.
+
+    Raises:
+        ValueError: If ``model_colorspace`` is not one of ``'RGB'``,
+            ``'Y'``, or ``'YCbCr'``, or if ``model_colorspace='Y'`` is
+            passed without ``lr_ycbcr``.
     """
     if model_colorspace == 'RGB':
         return sr_model

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -95,8 +95,7 @@ def reconstruct_sr_rgb(
 
 
 class LMDBCacheBuildContext:
-    """
-    Context object passed to the ``build_fn`` callback of :class:`LMDBCache`.
+    """Context object passed to the ``build_fn`` callback of :class:`LMDBCache`.
 
     Provides helpers for writing data into the LMDB being built.
 
@@ -110,8 +109,7 @@ class LMDBCacheBuildContext:
         self.use_tqdm = use_tqdm
 
     def write_batch(self, pairs: Sequence[tuple[str, bytes]]) -> None:
-        """
-        Writes a batch of key-value pairs in a single transaction.
+        """Writes a batch of key-value pairs in a single transaction.
 
         Args:
             pairs (Sequence[tuple[str, bytes]]): Sequence of ``(key, value)`` tuples to write.
@@ -129,8 +127,7 @@ class LMDBCacheBuildContext:
         num_workers: int = 8,
         desc: str = "Building LMDB cache",
     ):
-        """
-        Processes *items* in parallel and writes results to LMDB.
+        """Processes *items* in parallel and writes results to LMDB.
 
         Each item is submitted to a ``ProcessPoolExecutor``.  The worker
         function *process_fn* must be a top-level (picklable) callable
@@ -189,8 +186,7 @@ class LMDBCacheBuildContext:
 
 
 class LMDBCache:
-    """
-    A checksum-validated LMDB key-value store with parallel build support.
+    """A checksum-validated LMDB key-value store with parallel build support.
 
     On construction the cache checks whether a valid LMDB database
     already exists (matched by *checksum*).  If not, it calls
@@ -247,8 +243,7 @@ class LMDBCache:
 
     @property
     def path(self) -> Path:
-        """
-        Path to the LMDB database directory.
+        """Path to the LMDB database directory.
 
         Returns:
             The path where the LMDB database is stored.
@@ -257,8 +252,7 @@ class LMDBCache:
 
     @property
     def length(self) -> int:
-        """
-        Number of entries stored in the cache.
+        """Number of entries stored in the cache.
 
         Returns:
             The number of entries.
@@ -266,8 +260,7 @@ class LMDBCache:
         return self._length
 
     def get_env(self) -> lmdb.Environment:
-        """
-        Returns the LMDB environment, opening it lazily on first call.
+        """Returns the LMDB environment, opening it lazily on first call.
 
         Each ``DataLoader`` worker process must call this independently
         because LMDB memory-mapped environments cannot be shared across
@@ -282,8 +275,7 @@ class LMDBCache:
         return self._env
 
     def get(self, key: str) -> bytes | None:
-        """
-        Reads a single value from the cache.
+        """Reads a single value from the cache.
 
         Args:
             key (str): The string key to look up.
@@ -299,8 +291,7 @@ class LMDBCache:
             return bytes(buf)
 
     def get_batch(self, keys: Sequence[str]) -> list[bytes | None]:
-        """
-        Reads multiple values from the cache in a single transaction.
+        """Reads multiple values from the cache in a single transaction.
 
         Args:
             keys (Sequence[str]): Sequence of string keys to look up.
@@ -318,8 +309,7 @@ class LMDBCache:
         return results
 
     def _try_load(self, checksum: str) -> bool:
-        """
-        Validates an existing LMDB by comparing its stored checksum.
+        """Validates an existing LMDB by comparing its stored checksum.
 
         Args:
             checksum (str): The expected checksum to validate against.
@@ -356,8 +346,7 @@ class LMDBCache:
         build_fn: Callable[[LMDBCacheBuildContext], None],
         use_tqdm: bool,
     ):
-        """
-        Creates a fresh LMDB and delegates population to *build_fn*.
+        """Creates a fresh LMDB and delegates population to *build_fn*.
 
         Args:
             checksum (str): The checksum to store for future validation.

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -1,3 +1,13 @@
+"""Colorspace conversions and the LMDB cache infrastructure.
+
+BT.601 full-range YCbCr is the project's working chroma space (see
+:mod:`sisr.training.config`); pure conversion functions live here so the
+:class:`~sisr.training.SRLightning` module stays paper-agnostic.
+
+:class:`LMDBCache` is a checksum-validated key-value store used by
+:class:`~sisr.datasets.srcnn.TrainDataset` to persist precomputed
+LR/HR sub-image pairs.
+"""
 import shutil
 import lmdb
 import torch
@@ -9,15 +19,12 @@ from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
 
-# ----------------------------------------------------------------------------
 # BT.601 full-range RGB <-> YCbCr conversion (ITU-R Rec. BT.601-7).
-#
-# Both colorspaces are normalised to [0, 1].  Cb and Cr have a +0.5 offset on
+# Both colorspaces are normalised to [0, 1]. Cb and Cr have a +0.5 offset on
 # their stored representation so that signed chroma values in [-0.5, +0.5]
-# map onto unsigned [0, 1].  This is the *full-range* (a.k.a. "JPEG") variant
+# map onto unsigned [0, 1]. This is the *full-range* (a.k.a. "JPEG") variant
 # of BT.601 — distinct from the studio-range variant which scales Y to
 # [16/255, 235/255] and Cb/Cr to [16/255, 240/255].
-# ----------------------------------------------------------------------------
 
 _RGB_TO_Y  = (0.299, 0.587, 0.114)
 _RGB_TO_CB = (-0.169, -0.331, 0.500)   # output offset +0.5


### PR DESCRIPTION
## Summary

Doc-only PR bringing every public symbol in `sisr/` up to library-author quality. No behavior, signature, or test logic changes. Existing 145-test suite passes throughout.

- **Stale `python -m sisr.cli` refs purged** from `sisr/cli.py` module docstring and `README.md` (4 invocation examples) in favor of the `sisr <subcmd>` console script registered in `pyproject.toml`. Also drops `README.md`'s "TODO placeholders" wording (the placeholders themselves were stripped in refactor/03) and removes a stale `padding` Args entry on `SRCNN._check_architecture` (the method doesn't take `padding`).
- **Docstring opener standardized** to PEP 257 / Google-style `"""Summary on first line` across the package — 43 docstrings converted (41 in the main sweep + 2 missed openers in `sisr/datasets/srresnet.py` `__getitem__`s caught by an AST-level audit). An AST scan now reports zero docstrings whose content starts with a newline.
- **9 previously-bare public symbols** gained docstrings: `SRLightning.forward` / `.training_step`, `SRLightningCLI.add_arguments_to_parser`, `sisr.cli.main`, `SRDataModule.train_dataloader`, `SRCNN.hparams` property, and three `BenchmarkImageLogger` internals (`_on_image_log_interval`, `_collect_batch`, `_flush_buffer`).
- **23 docstrings gained formal `Args:` / `Returns:` / `Raises:` blocks** — `configure_optimizers` documents its `ValueError` on `layer_lrs` misuse; `extract_model_input` / `reconstruct_sr_rgb` document their colorspace `ValueError`s; all Lightning callback hooks now document `trainer` / `pl_module` / `outputs` / `batch` / `batch_idx` / `dataloader_idx`; `SRCNNTrainingConfig` / `SRCNNEvalConfig` gain class-level Args blocks for their overridden / new fields.
- **Module docstrings on every `.py` file under `sisr/`** — including the two previously-empty `sisr/datasets/__init__.py` and `sisr/models/__init__.py`. `sisr/utils.py`'s BT.601 boxed-comment is converted into a module docstring (plus a plain-comment BT.601 explanation above `_RGB_TO_Y`).

YAML templates were re-audited (Task 6) — no stale comments survived refactor/03; no template changes in this PR.

## Test plan

- [x] `pytest` passes (145 tests) at every commit
- [x] `sisr fit --print_config --config templates/config.srcnn.template.yaml` exits 0
- [x] `sisr fit --print_config --config templates/config.srresnet.template.yaml` exits 0
- [x] `grep -rn 'python -m sisr.cli' sisr/ README.md templates/` returns only the deliberate documentation note inside `main()`'s docstring (`sisr/cli.py:52`)
- [x] AST audit: no docstring in `sisr/` opens with a newline before its summary
- [x] CI `test` + `build` checks green on this PR

## Commits

1. `adb54b0` Fix stale CLI references in cli.py and README
2. `03fb14b` Standardize docstring opener style across sisr/
3. `937ff14` Add missing public-API docstrings
4. `bcb117a` Complete Google-style Args/Returns/Raises blocks
5. `9ba8905` Add module docstrings across sisr/
6. `7a961ec` Convert two missed docstring openers in srresnet.py