### PR TITLE
refactor/05: strip narrating template comments and normalize ./ path prefixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,13 @@
 {
-    // Test discovery uses the pyproject.toml `[tool.pytest.ini_options]`
-    // testpaths, so we don't need pytestArgs here.
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
 
-    // Skip the OS file watcher for the heavy dirs the current code produces:
-    // user-provided HR images, the LMDB training cache, and the TensorBoard /
-    // CSV / checkpoint output tree. Root-anchored (no leading "**/") so they
-    // only match the top-level dirs.
     "files.watcherExclude": {
         "data/**": true,
         ".lmdb_cache/**": true,
         "experiments/**": true
     },
 
-    // Keep project-wide search + Quick Open fast and free of binary noise
-    // (LMDB pages, .pt checkpoints, tfevents).
     "search.exclude": {
         "data": true,
         ".lmdb_cache": true,

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -17,7 +17,7 @@ model:
   training_config:
     class_path: sisr.models.srcnn.SRCNNTrainingConfig
     init_args:
-      example_input_shape: [3, 224, 224]   # for TensorBoard model graph
+      example_input_shape: [3, 224, 224]   # For TensorBoard graph
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig
 
@@ -31,15 +31,15 @@ data:
       scale: 3
       blur_sigma: 1.0
       use_tqdm: true
-      cache_dir: ./.lmdb_cache/DIV2K_train_HR
+      cache_dir: .lmdb_cache/DIV2K_train_HR
   val_dataset:
     class_path: sisr.datasets.srcnn.ValidationDataset
     init_args:
       img_dir: data/DIV2K_valid_HR
       scale: 3
-      blur_sigma: 1.0                           # keep in sync with train_dataset.init_args.blur_sigma
-  test_datasets:                                # surface as both val_dataloader (monitor during fit)
-    Set5:                                       # and test_dataloader (final eval via `cli test`)
+      blur_sigma: 1.0
+  test_datasets:
+    Set5:
       class_path: sisr.datasets.srcnn.ValidationDataset
       init_args:
         img_dir: data/Set5_HR
@@ -81,18 +81,16 @@ trainer:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
         log_every_n_val_runs: 1
-        # dataset_names is auto-discovered from data.test_datasets
-        # crop_border is sourced from model.eval_config.crop_border
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_psnr(RGB)
         save_top_k: 3
-        dirpath: ./experiments/SRCNN/baseline
+        dirpath: experiments/SRCNN/baseline
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_ssim
         save_top_k: 3
-        dirpath: ./experiments/SRCNN/baseline
+        dirpath: experiments/SRCNN/baseline
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
@@ -102,12 +100,12 @@ trainer:
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:
-        save_dir: ./experiments
+        save_dir: experiments
         name: SRCNN
         version: baseline
         log_graph: true
     - class_path: lightning.pytorch.loggers.CSVLogger
       init_args:
-        save_dir: ./experiments
+        save_dir: experiments
         name: SRCNN
         version: baseline

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -9,7 +9,7 @@ model:
   model:
     class_path: sisr.models.srresnet.SRResNet
     init_args:
-      scale: 4                  # must be a power of 2
+      scale: 4
       in_out_channels: 3
       hidden_channel: 64
       kernel_sizes: [9, 3, 9]
@@ -18,12 +18,12 @@ model:
   training_config:
     class_path: sisr.training.SRTrainingConfig
     init_args:
-      model_colorspace: RGB     # SRResNet trains on RGB (SRGAN convention)
-      example_input_shape: [3, 24, 24]   # LR patch (96 / 4) for the TensorBoard graph
+      model_colorspace: RGB
+      example_input_shape: [3, 24, 24]   # For TensorBoard graph
   eval_config:
     class_path: sisr.training.SREvalConfig
     init_args:
-      crop_border: 4            # exclude the outer `scale` pixels (x4)
+      crop_border: 4
       psnr_channels: [RGB, YCbCr]
 
 data:
@@ -32,15 +32,15 @@ data:
     init_args:
       img_dir: data/DIV2K_train_HR
       scale: 4
-      hr_crop_size: 96            # LR crop is 96 / 4 = 24; must be divisible by scale
-      crops_per_image: 1          # raise to draw more random crops per image per epoch
+      hr_crop_size: 96
+      crops_per_image: 1
   val_dataset:
     class_path: sisr.datasets.srresnet.ValidationDataset
     init_args:
       img_dir: data/DIV2K_valid_HR
       scale: 4
-  test_datasets:                  # surface as both val_dataloader (monitor during fit)
-    Set5:                         # and test_dataloader (final eval via `cli test`)
+  test_datasets:
+    Set5:
       class_path: sisr.datasets.srresnet.ValidationDataset
       init_args:
         img_dir: data/Set5_HR
@@ -80,18 +80,16 @@ trainer:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
         log_every_n_val_runs: 1
-        # dataset_names is auto-discovered from data.test_datasets
-        # crop_border is sourced from model.eval_config.crop_border
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_psnr(RGB)
         save_top_k: 3
-        dirpath: ./experiments/SRResNet/baseline
+        dirpath: experiments/SRResNet/baseline
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_ssim
         save_top_k: 3
-        dirpath: ./experiments/SRResNet/baseline
+        dirpath: experiments/SRResNet/baseline
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
@@ -101,12 +99,12 @@ trainer:
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:
-        save_dir: ./experiments
+        save_dir: experiments
         name: SRResNet
         version: baseline
         log_graph: true
     - class_path: lightning.pytorch.loggers.CSVLogger
       init_args:
-        save_dir: ./experiments
+        save_dir: experiments
         name: SRResNet
         version: baseline


### PR DESCRIPTION
## Summary

Continues the refactor/03 tidy thread — strips the remaining "what"-style narrating comments in both YAML templates and `.vscode/settings.json`, and normalizes `./experiments/…` and `./.lmdb_cache/…` to bare relative paths.

- **Both YAML templates**: drop `# keep in sync with train_dataset.init_args.blur_sigma`, `# surface as both val_dataloader…`, `# must be a power of 2`, `# SRResNet trains on RGB (SRGAN convention)`, `# exclude the outer scale pixels (x4)`, `# LR crop is 96 / 4 = 24; must be divisible by scale`, `# raise to draw more random crops per image per epoch`, `# dataset_names is auto-discovered from data.test_datasets`, `# crop_border is sourced from model.eval_config.crop_border`. Shorten `# for TensorBoard model graph` → `# For TensorBoard graph`.
- **`.vscode/settings.json`**: drop the three explanatory comment blocks (test discovery / watcherExclude / search.exclude). The settings themselves are unchanged.
- **Path-prefix normalization**: `./experiments/...` → `experiments/...` and `./.lmdb_cache/...` → `.lmdb_cache/...` across both templates. Both forms resolve identically at runtime; bare form matches the README's example-invocation style.

Net diff: 21 insertions / 33 deletions across 3 files.

## Test plan

- [x] `pytest tests/test_cli.py` — 7 pass (including the parametrized `test_template_yaml_parses` covering both templates)
- [x] `sisr fit --print_config --config templates/config.srcnn.template.yaml` exits 0
- [x] `sisr fit --print_config --config templates/config.srresnet.template.yaml` exits 0
- [ ] CI `test` + `build` checks green on this PR