### PR TITLE
Migrate SRCNN/SRResNet + Lightning to SR base classes (PR-B)

### DIFF
--- a/sisr/models/base.py
+++ b/sisr/models/base.py
@@ -1,6 +1,7 @@
 """Abstract base class for single-image super-resolution architectures."""
 import abc
 
+import torch
 import torch.nn as nn
 
 
@@ -20,7 +21,7 @@ class SRModel(nn.Module, abc.ABC):
         return self._hparams
 
     @abc.abstractmethod
-    def forward(self, x: "torch.Tensor") -> "torch.Tensor":
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the model on input ``x`` and return the SR output tensor."""
 
     def reset_parameters(self, **kwargs) -> None:

--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -18,36 +18,28 @@ from sisr.training.config import SREvalConfig, SRTrainingConfig
 class SRCNNTrainingConfig(SRTrainingConfig):
     """SRCNN-paper-faithful training defaults.
 
-    The paper trains on the Y channel of YCbCr only and uses a per-layer
-    learning rate of ``1e-4`` for the feature-extraction and non-linear-
-    mapping layers and ``1e-5`` for the reconstruction layer — i.e. the
-    last layer learns 10× slower. Weight initialization follows the
-    paper's Gaussian schedule (``N(0, 0.01)`` with zero biases); set
+    The paper trains on the Y channel of YCbCr only (selected at the YAML
+    layer by pairing with :class:`~sisr.processors.YChannelProcessor`) and
+    uses a per-layer learning rate of ``1e-4`` for the feature-extraction
+    and non-linear-mapping layers and ``1e-5`` for the reconstruction layer
+    — i.e. the last layer learns 10× slower. Weight initialization follows
+    the paper's Gaussian schedule (``N(0, 0.01)`` with zero biases); set
     ``init_strategy='default'`` to fall back to PyTorch's built-in init.
     Override any field in YAML to deviate.
 
     Args:
-        model_colorspace: Overrides the base default to ``'Y'``
-            (SRCNN's Y-channel training).
         layer_lrs: Per-``Conv2d`` LRs ``[1e-4, 1e-4, 1e-5]`` matching the
             paper's recipe. Set to ``None`` to disable per-layer LRs.
         init_strategy: ``'paper'`` (default) triggers the Gaussian
             init via :meth:`SRCNN.reset_parameters` in
             :class:`~sisr.training.SRLightning`'s constructor;
             ``'default'`` skips it and uses PyTorch's defaults.
-        init_mean: Mean of the Gaussian used by ``init_strategy='paper'``.
-            Defaults to ``0.0``.
-        init_std: Std of the Gaussian used by ``init_strategy='paper'``.
-            Defaults to ``0.01``.
     """
 
-    model_colorspace: Literal['RGB', 'Y', 'YCbCr'] = 'Y'
     layer_lrs: list[float] | None = field(
         default_factory=lambda: [1.0e-4, 1.0e-4, 1.0e-5]
     )
     init_strategy: Literal['default', 'paper'] = 'paper'
-    init_mean: float = 0.0
-    init_std: float = 0.01
 
 
 @dataclass

--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -34,6 +34,11 @@ class SRCNNTrainingConfig(SRTrainingConfig):
             init via :meth:`SRCNN.reset_parameters` in
             :class:`~sisr.training.SRLightning`'s constructor;
             ``'default'`` skips it and uses PyTorch's defaults.
+        init_mean / init_std: Gaussian parameters used by
+            ``init_strategy='paper'``; inherited from
+            :class:`~sisr.training.config.SRTrainingConfig` with defaults
+            ``0.0`` / ``0.01`` matching the SRCNN paper. Override in YAML
+            to deviate.
     """
 
     layer_lrs: list[float] | None = field(

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -5,8 +5,10 @@ Reference: Image Super-Resolution Using Deep Convolutional Networks
 """
 import torch
 
+from sisr.models.base import SRModel
 
-class SRCNN(torch.nn.Module):
+
+class SRCNN(SRModel):
     """SRCNN (Super-Resolution Convolutional Neural Network) model for single image super-resolution.
     The architecture consists of three main parts: feature extraction, non-linear mapping, and reconstruction.
 
@@ -85,20 +87,6 @@ class SRCNN(torch.nn.Module):
         if len(num_filters) + 1 != len(kernel_sizes):
             raise ValueError(
                 f"num_filters must have exactly one less element than kernel_sizes. Got num_filters={num_filters} and kernel_sizes={kernel_sizes}.")
-
-    @property
-    def hparams(self) -> dict:
-        """Return the model architecture hyperparameters as a dict.
-
-        Merged into Lightning's HParams by :class:`~sisr.training.SRLightning`
-        so the architecture spec appears alongside training params in
-        TensorBoard.
-
-        Returns:
-            Dict with keys ``num_channels``, ``num_filters``,
-            ``kernel_sizes``, ``padding``.
-        """
-        return self._hparams
 
     def reset_parameters(self, mean: float = 0.0, std: float = 0.01):
         """Initializes the weights of the convolutional layers using a normal distribution and sets the biases to zero.

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -6,6 +6,8 @@ Adversarial Network (https://arxiv.org/pdf/1609.04802).
 import torch
 import math
 
+from sisr.models.base import SRModel
+
 
 class SRResidualBlock(torch.nn.Module):
     """A single residual block used in SRResNet.
@@ -77,7 +79,7 @@ class SRUpsampleBlock(torch.nn.Module):
         return self.upsample(x)
 
 
-class SRResNet(torch.nn.Module):
+class SRResNet(SRModel):
     """SRResNet (Super-Resolution Residual Network) model for single image super-resolution.
     The architecture consists of an initial feature extraction block, a series of residual blocks
     with a skip connection, sub-pixel upsample blocks, and a final reconstruction layer.
@@ -141,15 +143,6 @@ class SRResNet(torch.nn.Module):
             raise ValueError(f"scale must be a positive integer. Got {scale}.")
         if (scale & (scale - 1)) != 0:
             raise ValueError(f"scale must be a power of 2. Got {scale}.")
-
-    @property
-    def hparams(self) -> dict:
-        """Returns the model architecture hyperparameters as a dict.
-
-        Merged into Lightning's HParams by :class:`~sisr.training.SRLightning`
-        so the architecture spec appears alongside training params in TensorBoard.
-        """
-        return self._hparams
 
     def forward(self, x: torch.Tensor, clamp_output: bool = False, clamp_minmax: tuple[float, float] = (0.0, 1.0)) -> torch.Tensor:
         """Forward pass of the SRResNet model.

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -277,7 +277,9 @@ class BenchmarkImageLogger(Callback):
         lr_img, hr_img = batch
 
         with torch.no_grad():
-            sr = pl_module(lr_img)
+            model_in = pl_module.processor.extract(lr_img)
+            sr_model_out = pl_module.model(model_in)
+            sr = pl_module.processor.reconstruct(sr_model_out, lr_img)
 
         hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr.shape[-2:])
 

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -2,9 +2,9 @@
 
 Split into two classes by lifecycle:
 
-* :class:`SRTrainingConfig` controls behaviour during ``cli fit`` — model
-  input/output colorspace, per-Conv2d learning rates, and the example input
-  shape used to log the model graph to TensorBoard.
+* :class:`SRTrainingConfig` controls behaviour during ``cli fit`` — per-Conv2d
+  learning rates, paper-init knobs, and the example input shape used to log
+  the model graph to TensorBoard.
 * :class:`SREvalConfig` controls validation/test metric computation —
   boundary-pixel exclusion (``crop_border``) and which colorspaces PSNR is
   reported in.
@@ -13,6 +13,9 @@ Per-architecture defaults live in subclasses next to the model code (e.g.
 ``sisr.models.srcnn.SRCNNTrainingConfig``); a YAML user picks them via
 ``class_path`` on ``model.training_config`` / ``model.eval_config`` and
 overrides individual fields with ``init_args``.
+
+The colorspace the model trains in is no longer a string field here; it is
+expressed by the choice of processor (see :mod:`sisr.processors`).
 """
 from dataclasses import dataclass, field
 from typing import Literal
@@ -20,21 +23,9 @@ from typing import Literal
 
 @dataclass
 class SRTrainingConfig:
-    """How to train the SR model — affects forward pass, loss, and optimizer setup.
+    """How to train the SR model — affects optimizer setup and weight init.
 
     Args:
-        model_colorspace: Colorspace the inner model trains on.
-
-            * ``'RGB'`` (default) — model receives and emits RGB directly.
-            * ``'Y'`` — Y channel of LR YCbCr is fed to the model; the SR
-              output is stitched with bicubic Cb/Cr taken from the LR image
-              and converted back to RGB before metrics are computed.
-            * ``'YCbCr'`` — model trains on full YCbCr; output converted
-              back to RGB for metrics.
-
-            The dataset always serves RGB; conversion happens inside
-            :class:`SRLightning` via :mod:`sisr.utils`.
-
         layer_lrs: Absolute per-``Conv2d`` learning rates (one entry per
             ``Conv2d`` in the model, in module-traversal order).  When
             ``None`` (default), training uses the optimizer's base ``lr``
@@ -44,14 +35,30 @@ class SRTrainingConfig:
             raises ``ValueError`` otherwise.
 
         example_input_shape: Shape of a single input sample *excluding* the
-            batch dimension (e.g. ``(3, 33, 33)`` for a 33×33 RGB patch).
+            batch dimension (e.g. ``(1, 33, 33)`` for a 33×33 Y-channel patch).
             When provided, ``self.example_input_array`` is set so the
             TensorBoard logger can capture the model graph.
+
+        init_strategy: ``'paper'`` triggers a paper-faithful weight init via
+            :meth:`SRModel.reset_parameters` in :class:`SRLightning`'s constructor;
+            ``'default'`` (the default) skips it and uses PyTorch's defaults.
+            Subclasses pin a paper-faithful default (e.g. ``SRCNNTrainingConfig``
+            uses ``'paper'``).
+
+        init_mean: Mean of the Gaussian used by SRCNN's
+            ``init_strategy='paper'``. Other paper-init implementations may
+            ignore this. Defaults to ``0.0``.
+
+        init_std: Std of the Gaussian used by SRCNN's
+            ``init_strategy='paper'``. Other paper-init implementations may
+            ignore this. Defaults to ``0.01``.
     """
 
-    model_colorspace: Literal['RGB', 'Y', 'YCbCr'] = 'RGB'
     layer_lrs: list[float] | None = None
     example_input_shape: tuple[int, ...] | None = None
+    init_strategy: Literal['default', 'paper'] = 'default'
+    init_mean: float = 0.0
+    init_std: float = 0.01
 
 
 @dataclass

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -14,50 +14,41 @@ import lightning
 from lightning.pytorch.cli import OptimizerCallable, LRSchedulerCallable
 from typing import Any
 
-from ..utils import (
-    extract_model_input,
-    reconstruct_sr_rgb,
-    rgb_to_ycbcr,
-)
+from ..models.base import SRModel
+from ..processors import SRProcessor
+from ..utils import rgb_to_ycbcr
 from .config import SREvalConfig, SRTrainingConfig
 
 
 class SRLightning(lightning.LightningModule):
     """Generic Lightning wrapper for single-image super-resolution models.
 
-    Architecture-agnostic: any ``torch.nn.Module`` that accepts an LR tensor
-    of shape ``(B, C, H, W)`` and returns an SR tensor can be plugged in.
-    The wrapped model is passed in pre-instantiated (jsonargparse / LightningCLI
-    handle the construction via ``class_path`` / ``init_args``).
-
-    Per-architecture training and evaluation knobs live in
-    :class:`~sisr.training.config.SRTrainingConfig` and
-    :class:`~sisr.training.config.SREvalConfig` (and their subclasses next to
-    each model, e.g. :class:`~sisr.models.srcnn.SRCNNTrainingConfig`).
-    Optimizer and LR scheduler are wired from top-level YAML keys (``optimizer:``,
-    ``lr_scheduler:``) by :class:`~sisr.cli.SRLightningCLI` via
-    ``link_arguments``; the user does not pass them explicitly under
-    ``model.init_args``.
+    Composes an :class:`~sisr.models.base.SRModel` with an
+    :class:`~sisr.processors.SRProcessor`. The model is a pure tensor function;
+    the processor handles per-batch colorspace conversion between the dataset's
+    RGB format and the model's input/output colorspace. Both are wired
+    independently in YAML via ``class_path``.
 
     Args:
-        model: An initialised SR model instance.  If it exposes an
-            ``hparams`` mapping (as :class:`~sisr.models.srcnn.SRCNN` does),
-            those values are merged into the Lightning hparams so model
-            specs appear alongside training params in TensorBoard HParams.
-        training_config: Per-architecture training settings (model_colorspace,
-            layer_lrs, example_input_shape).  Defaults to
-            :class:`SRTrainingConfig`'s base defaults (RGB, uniform LR).
+        model: An initialised :class:`SRModel` subclass (e.g. :class:`SRCNN`,
+            :class:`SRResNet`). Required.
+        processor: An :class:`SRProcessor` subclass (e.g.
+            :class:`~sisr.processors.RGBProcessor`,
+            :class:`~sisr.processors.YChannelProcessor`,
+            :class:`~sisr.processors.YCbCrProcessor`). Required.
+        training_config: Per-architecture training settings (layer_lrs,
+            example_input_shape, init_*). Defaults to base
+            :class:`SRTrainingConfig` (uniform LR, no paper init).
         eval_config: Per-architecture evaluation settings (crop_border,
-            psnr_channels, separate_psnr).  Defaults to
-            :class:`SREvalConfig`'s base defaults (no crop, RGB-only PSNR).
-        criterion: Loss instance.  Defaults to :class:`torch.nn.MSELoss`
-            when ``None``.
-        optimizer: ``OptimizerCallable`` (``functools.partial(optimizer_cls,
-            **init_args)``-style) — populated from top-level YAML
-            ``optimizer:``.  Defaults to :class:`torch.optim.Adam`.
-        lr_scheduler: ``LRSchedulerCallable`` or ``None`` — populated from
-            top-level YAML ``lr_scheduler:``.  Defaults to ``None``
-            (constant LR).
+            psnr_channels, separate_psnr). Defaults to base :class:`SREvalConfig`.
+        criterion: Loss instance. Defaults to :class:`torch.nn.MSELoss`.
+        optimizer: ``OptimizerCallable`` populated from top-level YAML
+            ``optimizer:``. Defaults to :class:`torch.optim.Adam`.
+        lr_scheduler: ``LRSchedulerCallable`` or ``None``. Defaults to ``None``.
+
+    Raises:
+        TypeError: If ``model`` is not an :class:`SRModel` subclass, or
+            if ``processor`` is not an :class:`SRProcessor` subclass.
     """
 
     _CS_CHANNEL_NAMES: dict[str, tuple[str, ...]] = {
@@ -67,7 +58,8 @@ class SRLightning(lightning.LightningModule):
 
     def __init__(
         self,
-        model: torch.nn.Module,
+        model: SRModel,
+        processor: SRProcessor,
         training_config: SRTrainingConfig | None = None,
         eval_config: SREvalConfig | None = None,
         criterion: torch.nn.Module | None = None,
@@ -75,26 +67,41 @@ class SRLightning(lightning.LightningModule):
         lr_scheduler: LRSchedulerCallable | None = None,
     ):
         super().__init__()
-        self.save_hyperparameters(ignore=['model', 'criterion', 'optimizer', 'lr_scheduler'])
+        if not isinstance(model, SRModel):
+            raise TypeError(
+                f"SRLightning requires an SRModel subclass; got "
+                f"{type(model).__name__}. Update your YAML to point at a "
+                f"class under sisr.models.* that inherits from SRModel."
+            )
+        if not isinstance(processor, SRProcessor):
+            raise TypeError(
+                f"SRLightning requires an SRProcessor subclass; got "
+                f"{type(processor).__name__}. Update your YAML to point "
+                f"at a class under sisr.processors.* that inherits from "
+                f"SRProcessor."
+            )
+
+        self.save_hyperparameters(ignore=['model', 'processor', 'criterion', 'optimizer', 'lr_scheduler'])
 
         self.model = model
+        self.processor = processor
         self.training_config = training_config or SRTrainingConfig()
         self.eval_config = eval_config or SREvalConfig()
         self.criterion = criterion if criterion is not None else torch.nn.MSELoss()
         self.optimizer = optimizer
         self.lr_scheduler = lr_scheduler
 
-        strategy = getattr(self.training_config, 'init_strategy', 'default')
-        if strategy == 'paper' and hasattr(model, 'reset_parameters'):
-            mean = getattr(self.training_config, 'init_mean', 0.0)
-            std = getattr(self.training_config, 'init_std', 0.01)
-            model.reset_parameters(mean=mean, std=std)
+        if self.training_config.init_strategy == 'paper':
+            model.reset_parameters(
+                mean=self.training_config.init_mean,
+                std=self.training_config.init_std,
+            )
 
-        # Merge model.hparams into Lightning hparams for TensorBoard HParams.
-        model_hparams = getattr(model, 'hparams', {})
+        # Merge model.hparams + processor identity into Lightning hparams for TensorBoard HParams.
         self._hparams = self._flatten_hparams({
             **self._hparams,
-            'model': model_hparams,
+            'model': model.hparams,
+            'processor': type(processor).__name__,
             'criterion': type(self.criterion).__name__,
         })
 
@@ -208,9 +215,10 @@ class SRLightning(lightning.LightningModule):
     ]:
         """Shared forward + loss for training and validation steps.
 
-        Loss is computed in :attr:`SRTrainingConfig.model_colorspace`;
-        metrics downstream consume ``sr_rgb`` / ``hr_cropped`` (both
-        full RGB, spatially aligned).
+        The processor handles all colorspace conversion; loss is computed in
+        the model's IO colorspace (against HR converted to the same space
+        via ``processor.extract``). Metrics downstream consume ``sr_rgb`` /
+        ``hr_cropped`` (both full RGB, spatially aligned).
 
         Args:
             batch: ``(lr_img, hr_img)`` tuple from a loader. Both RGB,
@@ -222,22 +230,14 @@ class SRLightning(lightning.LightningModule):
             with matching spatial size.
         """
         lr_img, hr_img = batch
-        cs = self.training_config.model_colorspace
 
-        model_input, lr_ycbcr = extract_model_input(lr_img, cs)
-        sr_model = self.model(model_input)
-        sr_rgb = reconstruct_sr_rgb(sr_model, lr_ycbcr, cs)
+        model_input = self.processor.extract(lr_img)
+        sr_model_out = self.model(model_input)
+        sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
 
         hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_rgb.shape[-2:])
-
-        # Loss is computed in model colorspace against HR in that same space.
-        if cs == 'Y':
-            hr_for_loss = rgb_to_ycbcr(hr_cropped)[:, 0:1]
-        elif cs == 'YCbCr':
-            hr_for_loss = rgb_to_ycbcr(hr_cropped)
-        else:
-            hr_for_loss = hr_cropped
-        loss = self.criterion(sr_model, hr_for_loss)
+        hr_for_loss = self.processor.extract(hr_cropped)
+        loss = self.criterion(sr_model_out, hr_for_loss)
 
         return loss, lr_img, hr_img, sr_rgb, hr_cropped
 

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -1,8 +1,9 @@
 """Colorspace conversions and the LMDB cache infrastructure.
 
-BT.601 full-range YCbCr is the project's working chroma space (see
-:mod:`sisr.training.config`); pure conversion functions live here so the
-:class:`~sisr.training.SRLightning` module stays paper-agnostic.
+BT.601 full-range YCbCr is the project's working chroma space. Pure
+conversion functions live here so the :class:`~sisr.processors.SRProcessor`
+subclasses and any external callers can use them without depending on
+Lightning or model code.
 
 :class:`LMDBCache` is a checksum-validated key-value store used by
 :class:`~sisr.datasets.srcnn.TrainDataset` to persist precomputed
@@ -11,12 +12,11 @@ LR/HR sub-image pairs.
 import shutil
 import lmdb
 import torch
-import torchvision
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from tqdm.auto import tqdm
 from collections.abc import Callable, Sequence
-from typing import Any, Literal
+from typing import Any
 
 
 # BT.601 full-range RGB <-> YCbCr conversion (ITU-R Rec. BT.601-7).
@@ -69,83 +69,6 @@ def ycbcr_to_rgb(img: torch.Tensor) -> torch.Tensor:
     g = y + _YCBCR_TO_G_CB * cb + _YCBCR_TO_G_CR * cr
     b = y + _YCBCR_TO_B * cb
     return torch.cat([r, g, b], dim=1).clamp(0.0, 1.0)
-
-
-def extract_model_input(
-    lr_img: torch.Tensor,
-    model_colorspace: Literal['RGB', 'Y', 'YCbCr'],
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Prepare the model input from a full-RGB LR tensor.
-
-    Args:
-        lr_img (torch.Tensor): RGB LR tensor of shape ``(B, 3, H, W)``.
-        model_colorspace (Literal['RGB', 'Y', 'YCbCr']): Colorspace the
-            model expects.
-
-    Returns:
-        tuple[torch.Tensor, torch.Tensor | None]: ``(model_input,
-        lr_ycbcr)`` where ``lr_ycbcr`` is the full LR YCbCr tensor
-        retained for chroma reconstruction (only when
-        ``model_colorspace='Y'``); ``None`` otherwise.
-
-    Raises:
-        ValueError: If ``model_colorspace`` is not one of ``'RGB'``,
-            ``'Y'``, or ``'YCbCr'``.
-    """
-    if model_colorspace == 'RGB':
-        return lr_img, None
-    lr_ycbcr = rgb_to_ycbcr(lr_img)
-    if model_colorspace == 'Y':
-        return lr_ycbcr[:, 0:1], lr_ycbcr
-    if model_colorspace == 'YCbCr':
-        return lr_ycbcr, None
-    raise ValueError(
-        f"Unknown model_colorspace {model_colorspace!r}. Expected 'RGB', 'Y', or 'YCbCr'."
-    )
-
-
-def reconstruct_sr_rgb(
-    sr_model: torch.Tensor,
-    lr_ycbcr: torch.Tensor | None,
-    model_colorspace: Literal['RGB', 'Y', 'YCbCr'],
-) -> torch.Tensor:
-    """Reconstruct a full-RGB SR image from the model output.
-
-    For ``model_colorspace='Y'``, stitches SR-Y with bicubic Cb/Cr from the
-    LR YCbCr tensor (centre-cropped to match the SR spatial size) and
-    converts to RGB.
-
-    Args:
-        sr_model (torch.Tensor): The model's raw output. Shape matches
-            ``model_colorspace`` (``(B, 1, H, W)`` for ``'Y'``,
-            ``(B, 3, H, W)`` for ``'RGB'`` and ``'YCbCr'``).
-        lr_ycbcr (torch.Tensor | None): Full LR YCbCr tensor used to
-            recover Cb/Cr for ``model_colorspace='Y'``; ignored
-            otherwise.
-        model_colorspace (Literal['RGB', 'Y', 'YCbCr']): Colorspace the
-            model produced.
-
-    Returns:
-        torch.Tensor: Full-RGB SR tensor of shape ``(B, 3, H, W)``.
-
-    Raises:
-        ValueError: If ``model_colorspace`` is not one of ``'RGB'``,
-            ``'Y'``, or ``'YCbCr'``, or if ``model_colorspace='Y'`` is
-            passed without ``lr_ycbcr``.
-    """
-    if model_colorspace == 'RGB':
-        return sr_model
-    if model_colorspace == 'Y':
-        if lr_ycbcr is None:
-            raise ValueError("model_colorspace='Y' requires lr_ycbcr to reconstruct chroma.")
-        cb = torchvision.transforms.functional.center_crop(lr_ycbcr[:, 1:2], sr_model.shape[-2:])
-        cr = torchvision.transforms.functional.center_crop(lr_ycbcr[:, 2:3], sr_model.shape[-2:])
-        return ycbcr_to_rgb(torch.cat([sr_model, cb, cr], dim=1))
-    if model_colorspace == 'YCbCr':
-        return ycbcr_to_rgb(sr_model)
-    raise ValueError(
-        f"Unknown model_colorspace {model_colorspace!r}. Expected 'RGB', 'Y', or 'YCbCr'."
-    )
 
 
 class LMDBCacheBuildContext:

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -10,14 +10,16 @@ model:
   model:
     class_path: sisr.models.srcnn.SRCNN
     init_args:
-      num_channels: 3
+      num_channels: 1                    # Y-channel only (was 3 — latent bug fix)
       num_filters: [64, 32]
       kernel_sizes: [9, 1, 5]
       padding: 0
+  processor:
+    class_path: sisr.processors.YChannelProcessor
   training_config:
     class_path: sisr.models.srcnn.SRCNNTrainingConfig
     init_args:
-      example_input_shape: [3, 224, 224]   # For TensorBoard graph
+      example_input_shape: [1, 224, 224]  # For TensorBoard graph (1-channel Y)
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig
 

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -15,10 +15,11 @@ model:
       kernel_sizes: [9, 3, 9]
       num_residual_blocks: 16
       padding: same
+  processor:
+    class_path: sisr.processors.RGBProcessor
   training_config:
     class_path: sisr.training.SRTrainingConfig
     init_args:
-      model_colorspace: RGB
       example_input_shape: [3, 24, 24]   # For TensorBoard graph
   eval_config:
     class_path: sisr.training.SREvalConfig

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -4,7 +4,8 @@ from sisr.training import SREvalConfig, SRTrainingConfig
 
 def test_srcnn_training_config_paper_defaults():
     cfg = SRCNNTrainingConfig()
-    assert cfg.model_colorspace == "Y"
+    # model_colorspace was removed in the SR base-classes refactor;
+    # colorspace intent is now expressed by pairing with sisr.processors.YChannelProcessor.
     assert cfg.layer_lrs == [1.0e-4, 1.0e-4, 1.0e-5]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,11 +29,13 @@ def test_cli_print_config_resolves():
     out = proc.stdout
     # Sanity markers — confirm config-class wiring resolved correctly.
     assert "class_path: sisr.models.srcnn.SRCNN" in out
+    assert "class_path: sisr.processors.YChannelProcessor" in out
     assert "class_path: sisr.models.srcnn.SRCNNTrainingConfig" in out
     assert "class_path: sisr.models.srcnn.SRCNNEvalConfig" in out
     assert "layer_lrs:" in out
     assert "crop_border: 3" in out
-    assert "model_colorspace: Y" in out
+    # The removed model_colorspace field must not reappear.
+    assert "model_colorspace" not in out
     # Top-level optimizer block linked from YAML.
     assert "optimizer:" in out
 
@@ -45,11 +47,13 @@ def test_cli_srresnet_print_config_resolves():
     assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
     out = proc.stdout
     assert "class_path: sisr.models.srresnet.SRResNet" in out
+    assert "class_path: sisr.processors.RGBProcessor" in out
     assert "class_path: sisr.datasets.srresnet.TrainDataset" in out
     assert "class_path: sisr.datasets.srresnet.ValidationDataset" in out
-    assert "model_colorspace: RGB" in out
     assert "hr_crop_size: 96" in out
     assert "crop_border: 4" in out
+    # The removed model_colorspace field must not reappear.
+    assert "model_colorspace" not in out
 
 
 def test_cli_test_subcommand_exposes_ckpt_path():

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -23,8 +23,6 @@ def test_public_exports():
     from sisr.utils import (  # noqa: F401
         LMDBCache,
         LMDBCacheBuildContext,
-        extract_model_input,
         rgb_to_ycbcr,
-        reconstruct_sr_rgb,
         ycbcr_to_rgb,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,6 @@ import torch
 from sisr.utils import (
     LMDBCache,
     LMDBCacheBuildContext,
-    extract_model_input,
-    reconstruct_sr_rgb,
     rgb_to_ycbcr,
     ycbcr_to_rgb,
 )
@@ -64,69 +62,6 @@ def test_round_trip_within_coefficient_precision():
     y = ycbcr_to_rgb(rgb_to_ycbcr(x))
     err = (y - x).abs().max().item()
     assert err < 5e-4
-
-
-def test_extract_model_input_rgb_passthrough():
-    x = torch.rand(1, 3, 4, 4)
-    inp, aux = extract_model_input(x, "RGB")
-    assert torch.equal(inp, x)
-    assert aux is None
-
-
-def test_extract_model_input_y_returns_y_and_full_ycbcr():
-    x = torch.rand(1, 3, 4, 4)
-    inp, aux = extract_model_input(x, "Y")
-    assert inp.shape == (1, 1, 4, 4)
-    assert aux is not None
-    assert aux.shape == (1, 3, 4, 4)
-
-
-def test_extract_model_input_ycbcr():
-    x = torch.rand(1, 3, 4, 4)
-    inp, aux = extract_model_input(x, "YCbCr")
-    assert inp.shape == (1, 3, 4, 4)
-    assert aux is None
-
-
-def test_extract_model_input_unknown_raises():
-    x = torch.rand(1, 3, 4, 4)
-    with pytest.raises(ValueError):
-        extract_model_input(x, "XYZ")
-
-
-def test_reconstruct_sr_rgb_rgb_passthrough():
-    sr = torch.rand(1, 3, 4, 4)
-    out = reconstruct_sr_rgb(sr, lr_ycbcr=None, model_colorspace="RGB")
-    assert torch.equal(out, sr)
-
-
-def test_reconstruct_sr_rgb_y_requires_lr_ycbcr():
-    sr_y = torch.rand(1, 1, 4, 4)
-    with pytest.raises(ValueError):
-        reconstruct_sr_rgb(sr_y, lr_ycbcr=None, model_colorspace="Y")
-
-
-def test_reconstruct_sr_rgb_y_centre_crops_chroma():
-    """When SR is spatially smaller than LR (valid padding), reconstruct must
-    centre-crop the LR's Cb/Cr to match SR's spatial size."""
-    lr_ycbcr = torch.rand(1, 3, 8, 8)
-    sr_y = torch.zeros(1, 1, 4, 4)
-    out = reconstruct_sr_rgb(sr_y, lr_ycbcr=lr_ycbcr, model_colorspace="Y")
-    assert out.shape == (1, 3, 4, 4)
-
-
-def test_reconstruct_sr_rgb_ycbcr_converts_to_rgb():
-    sr = torch.rand(1, 3, 4, 4)
-    out = reconstruct_sr_rgb(sr, lr_ycbcr=None, model_colorspace="YCbCr")
-    assert out.shape == (1, 3, 4, 4)
-    # ycbcr_to_rgb clamps to [0, 1].
-    assert out.min() >= 0.0 and out.max() <= 1.0
-
-
-def test_reconstruct_sr_rgb_unknown_raises():
-    sr = torch.rand(1, 3, 4, 4)
-    with pytest.raises(ValueError):
-        reconstruct_sr_rgb(sr, lr_ycbcr=None, model_colorspace="XYZ")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from sisr.models.srcnn import SRCNN
+from sisr.processors import RGBProcessor
 from sisr.training import (
     BenchmarkImageLogger,
     GradNormLogger,
@@ -201,7 +202,8 @@ def _make_real_pl_module() -> SRLightning:
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     return SRLightning(
         model=model,
-        training_config=SRTrainingConfig(model_colorspace="RGB"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(crop_border=0),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -397,7 +399,8 @@ def test_benchmark_collect_batch_crops_per_eval_config():
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     pl_module = SRLightning(
         model=model,
-        training_config=SRTrainingConfig(model_colorspace="RGB"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(crop_border=3),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from sisr.models.srcnn import SRCNN
-from sisr.processors import RGBProcessor
+from sisr.processors import RGBProcessor, YChannelProcessor
 from sisr.training import (
     BenchmarkImageLogger,
     GradNormLogger,
@@ -418,4 +418,41 @@ def test_benchmark_collect_batch_crops_per_eval_config():
     assert len(cb._buffer["Set5"]) == 1
     _, _, _, _, psnr_dict, ssim = cb._buffer["Set5"][0]
     assert "RGB" in psnr_dict
+    assert isinstance(ssim, float)
+
+
+def test_benchmark_collect_batch_routes_through_processor():
+    """SRCNN+YChannelProcessor: _collect_batch must extract Y from RGB LR before the
+    model forward, then reconstruct SR back to RGB. Bypassing the processor would
+    feed 3-channel RGB to a 1-channel Conv2d and crash with a shape mismatch."""
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    # 1-channel SRCNN paired with YChannelProcessor — production SRCNN template shape.
+    model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    pl_module = SRLightning(
+        model=model,
+        processor=YChannelProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(crop_border=0, psnr_channels=["RGB", "YCbCr"]),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer = SimpleNamespace(
+        val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)],
+    )
+    # Batch is 3-channel RGB (dataset-format); the processor must extract Y before the model.
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer, pl_module=pl_module, outputs=None,
+        batch=batch, batch_idx=0, dataloader_idx=1,
+    )
+    assert len(cb._buffer["Set5"]) == 1
+    _, lr_cached, sr_cached, hr_cached, psnr_dict, ssim = cb._buffer["Set5"][0]
+    # All cached tensors are full RGB (reconstruct stitched SR-Y with bicubic Cb/Cr).
+    assert lr_cached.shape == (3, 16, 16)
+    assert sr_cached.shape == (3, 16, 16)
+    assert hr_cached.shape == (3, 16, 16)
+    assert "RGB" in psnr_dict
+    assert "YCbCr" in psnr_dict
     assert isinstance(ssim, float)

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -5,9 +5,11 @@ from sisr.training import SREvalConfig, SRTrainingConfig
 
 def test_sr_training_config_defaults():
     cfg = SRTrainingConfig()
-    assert cfg.model_colorspace == "RGB"
     assert cfg.layer_lrs is None
     assert cfg.example_input_shape is None
+    assert cfg.init_strategy == 'default'
+    assert cfg.init_mean == 0.0
+    assert cfg.init_std == 0.01
 
 
 def test_sr_eval_config_defaults():
@@ -28,7 +30,7 @@ def test_sr_eval_config_psnr_channels_isolated_per_instance():
 def test_sr_training_config_field_names():
     """Reduced surface check — guards against accidental field renames."""
     names = {f.name for f in fields(SRTrainingConfig)}
-    assert names == {"model_colorspace", "layer_lrs", "example_input_shape"}
+    assert names == {"layer_lrs", "example_input_shape", "init_strategy", "init_mean", "init_std"}
 
 
 def test_sr_eval_config_field_names():

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -372,3 +372,83 @@ def test_on_train_start_multiple_tb_loggers_each_receive_call(srcnn_rgb_lit: SRL
 
     tb1.log_hyperparams.assert_called_once()
     tb2.log_hyperparams.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# new: isinstance guards and processor flow
+# ---------------------------------------------------------------------------
+
+def test_srlightning_rejects_non_srmodel():
+    """SRLightning(model=<plain nn.Module>) raises TypeError with a readable message."""
+    model = torch.nn.Conv2d(3, 3, 1)              # plain nn.Module, not SRModel
+    with pytest.raises(TypeError, match="SRModel subclass"):
+        SRLightning(
+            model=model,
+            processor=RGBProcessor(),
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+        )
+
+
+def test_srlightning_rejects_non_srprocessor():
+    """SRLightning(processor=<not SRProcessor>) raises TypeError with a readable message."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    with pytest.raises(TypeError, match="SRProcessor subclass"):
+        SRLightning(
+            model=model,
+            processor=object(),                    # not an SRProcessor
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+        )
+
+
+def test_step_calls_processor_extract_and_reconstruct():
+    """_step routes through processor.extract (twice — input and HR) and processor.reconstruct."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    processor = MagicMock(spec=SRProcessor)
+    # extract returns 3-channel passthrough; reconstruct returns its first arg.
+    processor.extract.side_effect = lambda x: x
+    processor.reconstruct.side_effect = lambda sr, lr: sr
+
+    lit = SRLightning(
+        model=model,
+        processor=processor,
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    lr = torch.rand(2, 3, 33, 33)
+    hr = torch.rand(2, 3, 33, 33)
+    lit._step((lr, hr))
+
+    # extract called twice: once for LR input, once for HR-for-loss.
+    assert processor.extract.call_count == 2
+    # reconstruct called once with (sr_model_out, lr_img).
+    assert processor.reconstruct.call_count == 1
+
+
+def test_paper_init_polymorphic_on_non_overriding_subclass():
+    """init_strategy='paper' on a SRModel subclass without paper init is a no-op (not a crash)."""
+    # SRResNet doesn't override reset_parameters; the base SRModel.reset_parameters
+    # accepts **kwargs and does nothing.
+    model = SRResNet(scale=2, num_residual_blocks=1)
+    SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(init_strategy="paper", init_mean=0.5, init_std=0.02),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    # No exception = success. (The actual weights are whatever PyTorch's default init produced.)
+
+
+def test_saved_hparams_contain_processor_name():
+    """The processor's class name is saved into Lightning hparams for TensorBoard distinction."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    # Lightning's self.hparams is a flat dict after the _flatten_hparams step.
+    assert lit.hparams.get("processor") == "RGBProcessor"

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -6,8 +6,15 @@ import lightning
 import pytest
 import torch
 
+from sisr.models.base import SRModel
 from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
 from sisr.models.srresnet.model import SRResNet
+from sisr.processors import (
+    RGBProcessor,
+    SRProcessor,
+    YChannelProcessor,
+    YCbCrProcessor,
+)
 from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
 
 
@@ -17,11 +24,12 @@ from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
 
 @pytest.fixture
 def srcnn_rgb_lit() -> SRLightning:
-    """SRLightning wrapping a 3-channel SRCNN (RGB training)."""
+    """SRLightning wrapping a 3-channel SRCNN with the RGB pass-through processor."""
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     return SRLightning(
         model=model,
-        training_config=SRTrainingConfig(model_colorspace="RGB"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(crop_border=0),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -29,11 +37,12 @@ def srcnn_rgb_lit() -> SRLightning:
 
 @pytest.fixture
 def srcnn_y_lit() -> SRLightning:
-    """SRLightning wrapping a 1-channel SRCNN trained on Y (paper-faithful)."""
+    """SRLightning wrapping a 1-channel SRCNN with the Y-channel processor (paper-faithful)."""
     model = SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     return SRLightning(
         model=model,
-        training_config=SRTrainingConfig(model_colorspace="Y"),
+        processor=YChannelProcessor(),
+        training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(crop_border=0, psnr_channels=["RGB", "YCbCr"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -79,12 +88,13 @@ def test_step_y_path_reconstructs_rgb(srcnn_y_lit: SRLightning, rgb_lr_hr_batch)
 
 
 def test_step_y_path_loss_on_y_only():
-    """When model_colorspace='Y', criterion sees 1-channel inputs."""
+    """With YChannelProcessor, criterion sees 1-channel inputs."""
     model = SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     criterion = MagicMock(return_value=torch.tensor(0.0, requires_grad=True))
     lit = SRLightning(
         model=model,
-        training_config=SRTrainingConfig(model_colorspace="Y"),
+        processor=YChannelProcessor(),
+        training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(),
         criterion=criterion,
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -99,11 +109,12 @@ def test_step_y_path_loss_on_y_only():
 
 
 def test_step_ycbcr_path():
-    """3-channel YCbCr training path."""
+    """3-channel YCbCr training path via YCbCrProcessor."""
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
-        training_config=SRTrainingConfig(model_colorspace="YCbCr"),
+        processor=YCbCrProcessor(),
+        training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -129,6 +140,7 @@ def test_configure_optimizers_per_layer_lrs():
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRTrainingConfig(layer_lrs=[1.0e-4, 1.0e-4, 1.0e-5]),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4, momentum=0.9),
@@ -143,6 +155,7 @@ def test_configure_optimizers_per_layer_count_mismatch_raises():
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRTrainingConfig(layer_lrs=[1e-4, 1e-4]),  # 2 vs 3
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -158,6 +171,7 @@ def test_configure_optimizers_per_layer_with_non_conv_params_raises():
     n_convs = sum(1 for m in model.modules() if isinstance(m, torch.nn.Conv2d))
     lit = SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRTrainingConfig(layer_lrs=[1e-4] * n_convs),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -171,6 +185,7 @@ def test_configure_optimizers_with_lr_scheduler(srcnn_rgb_lit: SRLightning):
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -214,6 +229,7 @@ def test_build_psnr_tensors_with_separate_psnr_includes_per_channel():
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(psnr_channels=["RGB"], separate_psnr=True),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -228,6 +244,7 @@ def test_build_psnr_tensors_ycbcr_does_conversion():
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRTrainingConfig(),
         eval_config=SREvalConfig(psnr_channels=["YCbCr"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -269,6 +286,7 @@ def test_paper_init_calls_reset_parameters():
     model.reset_parameters = MagicMock()
     SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRCNNTrainingConfig(init_strategy="paper", init_mean=0.5, init_std=0.02),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -282,6 +300,7 @@ def test_default_init_skips_reset_parameters():
     model.reset_parameters = MagicMock()
     SRLightning(
         model=model,
+        processor=RGBProcessor(),
         training_config=SRCNNTrainingConfig(init_strategy="default"),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -290,12 +309,13 @@ def test_default_init_skips_reset_parameters():
 
 
 def test_base_training_config_skips_reset_parameters():
-    """Plain SRTrainingConfig (no init_strategy attr) → no call, no crash."""
+    """Base SRTrainingConfig defaults init_strategy='default' → no call, no crash."""
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     model.reset_parameters = MagicMock()
     SRLightning(
         model=model,
-        training_config=SRTrainingConfig(),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),    # init_strategy='default' by default
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )


### PR DESCRIPTION
## Summary
**BREAKING.** Structural-break PR of the SR base-classes refactor arc (follows #11; one more PR — SRResNet config maturation — to come). Six commits:

- `SRCNN` and `SRResNet` now inherit from `SRModel` (PR-A's abstract base); their local `hparams` properties are removed in favor of the inherited one. `sisr/models/base.py` also gets a missed `import torch` so the abstract `forward` annotation resolves under `typing.get_type_hints`.
- `SRLightning.__init__` adds a required `processor: SRProcessor` arg and tightens `model: SRModel`; both are guarded with runtime `isinstance` checks that produce readable errors on YAML misconfiguration. `_step` delegates colorspace conversion to `processor.extract` / `processor.reconstruct` — no more string-dispatched colorspace logic. The `hasattr(model, 'reset_parameters')` defensive branch goes away (now polymorphic via `SRModel`).
- `SRTrainingConfig.model_colorspace` is **removed**. Colorspace intent is now expressed by the choice of processor `class_path` in YAML. `init_strategy` / `init_mean` / `init_std` are promoted from `SRCNNTrainingConfig` into the base.
- Templates wire the new `processor:` block (`YChannelProcessor` for SRCNN, `RGBProcessor` for SRResNet). The SRCNN template's `num_channels: 3` (a latent bug that paired wrongly with implicit Y colorspace) is corrected to `num_channels: 1`.
- `BenchmarkImageLogger._collect_batch` no longer bypasses the processor (final-reviewer-caught crash that the `num_channels: 1` template fix activated).
- `sisr.utils.extract_model_input` and `sisr.utils.reconstruct_sr_rgb` are **deleted** (their logic is now in the processor subclasses).

### Migration notes for downstream users
- YAML configs that set `model.init_args.training_config.init_args.model_colorspace` must remove that field; the colorspace decision is now expressed by `model.init_args.processor.class_path`.
- YAML configs that wire `SRLightning` must add a `processor:` block alongside `model:`.
- Old Lightning checkpoints will not load via `SRLightning.load_from_checkpoint(...)` — the new `__init__` requires `processor`, which old `hyper_parameters` lack. Manual migration: construct `SRLightning(...)` directly, then `model.load_state_dict(ckpt['state_dict'])` on the inner model.
- **Behavioral note (Cb/Cr reconstruction):** `YChannelProcessor.reconstruct` uses `F.interpolate(..., mode='bicubic')` for the chroma channels where the legacy `reconstruct_sr_rgb` used `torchvision.transforms.functional.center_crop`. Output shape is identical; chroma values differ slightly (max ~0.7 in a synthetic worst-case). For SRCNN's same-size case the change is a small chroma quality shift; for SRResNet+Y the change is a correctness fix (`center_crop` was wrong on upscaling). PSNR/SSIM numbers on existing SRCNN checkpoints may shift very slightly after this PR.

## Test Plan
- [ ] CI: `pytest tests/` green (172 tests; +5 new isinstance/processor-flow tests in `test_lightning_module.py`, +1 new regression test in `test_callbacks.py`, -9 deleted utils helper tests)
- [ ] Both templates resolve under `--print_config`: `python -m sisr.cli fit --config templates/config.srcnn.template.yaml --print_config` and same for SRResNet — neither output contains `model_colorspace:`; SRCNN shows `class_path: sisr.processors.YChannelProcessor`; SRResNet shows `class_path: sisr.processors.RGBProcessor`
- [ ] `python -c "import typing; from sisr.models.base import SRModel; print(typing.get_type_hints(SRModel.forward))"` succeeds (PR-A's deferred typing fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)