### PR TITLE
SRResNet config maturation (PR-C, closes SR base-classes arc)

### DIFF
--- a/sisr/models/srresnet/__init__.py
+++ b/sisr/models/srresnet/__init__.py
@@ -1,4 +1,11 @@
 """SRResNet architecture (the residual generator from Ledig et al., 2017)."""
+from .config import SRResNetEvalConfig, SRResNetTrainingConfig
 from .model import SRResidualBlock, SRResNet, SRUpsampleBlock
 
-__all__ = ["SRResNet", "SRResidualBlock", "SRUpsampleBlock"]
+__all__ = [
+    "SRResNet",
+    "SRResidualBlock",
+    "SRUpsampleBlock",
+    "SRResNetTrainingConfig",
+    "SRResNetEvalConfig",
+]

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -1,0 +1,55 @@
+"""SRResNet-paper-faithful training and evaluation defaults.
+
+Subclassing :class:`~sisr.training.config.SRTrainingConfig` /
+:class:`~sisr.training.config.SREvalConfig` lets the SRResNet recipe live
+alongside the model architecture, so an SRResNet experiment YAML only has
+to point at these classes via ``class_path`` to inherit defaults.
+
+Reference: Photo-Realistic Single Image Super-Resolution Using a
+Generative Adversarial Network (https://arxiv.org/pdf/1609.04802),
+Section 3.2 (SRResNet baseline).
+"""
+from dataclasses import dataclass, field
+from typing import Literal
+
+from sisr.training.config import SREvalConfig, SRTrainingConfig
+
+
+@dataclass
+class SRResNetTrainingConfig(SRTrainingConfig):
+    """SRResNet-paper-faithful training defaults.
+
+    The paper trains on full RGB (selected at the YAML layer by pairing
+    with :class:`~sisr.processors.RGBProcessor`) using Adam (lr 1e-4) and
+    no per-layer LRs.
+
+    Weight initialization in the paper is implicit (Kaiming-style for PReLU
+    activations). ``init_strategy='paper'`` is reserved for a future PR
+    that wires this up via :meth:`SRResNet.reset_parameters`. Today the
+    field defaults to ``'default'`` so SRResNet ships with PyTorch's
+    built-in init; flipping to ``'paper'`` is currently a no-op because
+    :meth:`SRModel.reset_parameters` (the inherited base) does nothing.
+    The field exists now so a future PR can add the implementation without
+    a YAML schema change.
+    """
+
+    init_strategy: Literal['default', 'paper'] = 'default'
+
+
+@dataclass
+class SRResNetEvalConfig(SREvalConfig):
+    """SRResNet-paper-faithful eval defaults.
+
+    Reports PSNR on RGB and YCbCr (literature typically quotes Y-channel
+    for SRResNet too); excludes the outer ``scale=4`` pixels before
+    computing PSNR / SSIM, matching the standard SR-evaluation convention.
+
+    Args:
+        crop_border: Overrides the base default to ``4`` (outer pixels
+            excluded before PSNR / SSIM at the standard ``x4`` scale).
+        psnr_channels: Overrides the base default to
+            ``['RGB', 'YCbCr']`` (the literature reports both).
+    """
+
+    crop_border: int = 4
+    psnr_channels: list[str] = field(default_factory=lambda: ['RGB', 'YCbCr'])

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -18,14 +18,11 @@ model:
   processor:
     class_path: sisr.processors.RGBProcessor
   training_config:
-    class_path: sisr.training.SRTrainingConfig
+    class_path: sisr.models.srresnet.SRResNetTrainingConfig
     init_args:
       example_input_shape: [3, 24, 24]   # For TensorBoard graph
   eval_config:
-    class_path: sisr.training.SREvalConfig
-    init_args:
-      crop_border: 4
-      psnr_channels: [RGB, YCbCr]
+    class_path: sisr.models.srresnet.SRResNetEvalConfig
 
 data:
   train_dataset:

--- a/tests/models/srresnet/test_config.py
+++ b/tests/models/srresnet/test_config.py
@@ -1,0 +1,37 @@
+"""Defaults, subclass, and isolation tests for SRResNet's paper-faithful configs."""
+from sisr.models.srresnet import SRResNetEvalConfig, SRResNetTrainingConfig
+from sisr.training import SREvalConfig, SRTrainingConfig
+
+
+def test_srresnet_training_config_paper_defaults():
+    """SRResNet ships init_strategy='default' (reserved-but-no-op)."""
+    cfg = SRResNetTrainingConfig()
+    # Paper-faithful Kaiming/PReLU init is future work; current default is PyTorch's built-in init.
+    assert cfg.init_strategy == "default"
+    assert cfg.init_mean == 0.0
+    assert cfg.init_std == 0.01
+    assert cfg.layer_lrs is None              # SRResNet has BatchNorm/PReLU; layer_lrs would error
+
+
+def test_srresnet_eval_config_paper_defaults():
+    """SRResNet paper defaults: x4 border crop; RGB+YCbCr PSNR breakdown."""
+    cfg = SRResNetEvalConfig()
+    assert cfg.crop_border == 4
+    assert cfg.psnr_channels == ["RGB", "YCbCr"]
+    assert cfg.separate_psnr is False
+
+
+def test_srresnet_training_config_subclass():
+    assert issubclass(SRResNetTrainingConfig, SRTrainingConfig)
+
+
+def test_srresnet_eval_config_subclass():
+    assert issubclass(SRResNetEvalConfig, SREvalConfig)
+
+
+def test_srresnet_eval_config_psnr_channels_independent_per_instance():
+    """`default_factory` produces a fresh list per instance — guards against mutable-default bug."""
+    a = SRResNetEvalConfig()
+    b = SRResNetEvalConfig()
+    a.psnr_channels.append("X")
+    assert b.psnr_channels == ["RGB", "YCbCr"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,16 +42,18 @@ def test_cli_print_config_resolves():
 
 def test_cli_srresnet_print_config_resolves():
     """`cli fit --print_config` exits 0 and resolves the SRResNet template
-    (model + base configs + random-crop dataset classes)."""
+    (model + paper-faithful configs + random-crop dataset classes)."""
     proc = _cli("fit", "--config", str(SRRESNET_TEMPLATE), "--print_config")
     assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
     out = proc.stdout
     assert "class_path: sisr.models.srresnet.SRResNet" in out
     assert "class_path: sisr.processors.RGBProcessor" in out
+    assert "class_path: sisr.models.srresnet.SRResNetTrainingConfig" in out
+    assert "class_path: sisr.models.srresnet.SRResNetEvalConfig" in out
     assert "class_path: sisr.datasets.srresnet.TrainDataset" in out
     assert "class_path: sisr.datasets.srresnet.ValidationDataset" in out
     assert "hr_crop_size: 96" in out
-    assert "crop_border: 4" in out
+    assert "crop_border: 4" in out                  # still present — inherited default
     # The removed model_colorspace field must not reappear.
     assert "model_colorspace" not in out
 


### PR DESCRIPTION
## Summary
Final PR of the SR base-classes refactor arc (follows #11 PR-A and #12 PR-B). Gives SRResNet structural parity with SRCNN's paper-faithful config pattern.

- Add `sisr/models/srresnet/config.py` with `SRResNetTrainingConfig` (overrides `init_strategy` default — reserved-but-no-op slot for future Kaiming/PReLU paper-init implementation; leaves `layer_lrs=None` inherited because SRResNet has BatchNorm/PReLU) and `SRResNetEvalConfig` (`crop_border=4`, `psnr_channels=['RGB','YCbCr']` matching standard x4 SR evaluation convention).
- Re-export the new classes from `sisr.models.srresnet`.
- Switch `templates/config.srresnet.template.yaml` `training_config` and `eval_config` `class_path`s to the new subclasses; drop the inline `crop_border: 4` and `psnr_channels: [RGB, YCbCr]` overrides now baked into `SRResNetEvalConfig` defaults.
- Extend `tests/test_cli.py::test_cli_srresnet_print_config_resolves` to assert the new class_paths appear in resolved `--print_config` output and that `crop_border: 4` is still present (inherited).

## Test Plan
- [x] CI: `pytest tests/` green (177 tests; +5 new dataclass-defaults tests in `tests/models/srresnet/test_config.py`)
- [x] SRResNet template resolves: `python -m sisr.cli fit --config templates/config.srresnet.template.yaml --print_config` shows `class_path: sisr.models.srresnet.SRResNetTrainingConfig`, `class_path: sisr.models.srresnet.SRResNetEvalConfig`, `crop_border: 4`, and `psnr_channels` containing `RGB`/`YCbCr`

## Arc complete
This closes the 3-PR SR base-classes refactor: PR-A introduced `SRModel` + `SRProcessor` abstract bases, PR-B wired them through `SRLightning` and removed the `model_colorspace` string field, and PR-C completes structural parity for SRResNet's config layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)