### PR TITLE
Render bicubic baseline at HR scale in BenchmarkImageLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ sisr test --config templates/config.srcnn.template.yaml \
     --ckpt_path path/to/best.ckpt
 ```
 
-Test sets are also surfaced during `fit` (monitored each validation cycle), and PSNR/SSIM plus LR│SR│HR image strips are logged to TensorBoard.
+Test sets are also surfaced during `fit` (monitored each validation cycle), and PSNR/SSIM plus bicubic│SR│HR image strips are logged to TensorBoard.
 
 ## Tests
 

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -1,6 +1,6 @@
 """Lightning callbacks for SR training.
 
-:class:`BenchmarkImageLogger` logs per-image LR|SR|HR strips and PSNR/SSIM
+:class:`BenchmarkImageLogger` logs per-image bicubic|SR|HR strips and PSNR/SSIM
 for held-out test sets (Set5, Set14, ...) during both ``cli fit`` (every
 N val cycles) and ``cli test`` (one-shot final eval).
 :class:`GradNormLogger` and :class:`WeightHistogramLogger` log diagnostic
@@ -18,8 +18,8 @@ from typing import Any
 
 
 class BenchmarkImageLogger(Callback):
-    """Log per-image LR|SR|HR composites and scalar PSNR/SSIM to TensorBoard for
-    one or more held-out test/benchmark dataloaders (Set5, Set14, …).
+    """Log per-image bicubic|SR|HR composites and scalar PSNR/SSIM to TensorBoard
+    for one or more held-out test/benchmark dataloaders (Set5, Set14, …).
 
     Fires during *both* validation and test stages:
 
@@ -34,9 +34,10 @@ class BenchmarkImageLogger(Callback):
       ``dataset_names``.  Images are logged every test run (no throttle —
       ``cli test`` is typically a one-shot final-eval invocation).
 
-    Each image lands as a horizontal **LR | SR | HR** strip; when the model
-    uses ``padding='valid'`` the SR output is zero-padded so all three panels
-    share the same spatial size.
+    Each image lands as a horizontal **bicubic | SR | HR** strip at HR scale:
+    the LR is bicubic-upsampled to HR size (the standard SR baseline), and the
+    SR output is center-padded when smaller than HR (``padding='valid'``) so
+    all three panels share the same spatial size.
 
     Per-image PSNR/SSIM scalars go under ``"{name}_psnr/{filename}"`` and
     ``"{name}_ssim/{filename}"``; per-set means under
@@ -334,8 +335,8 @@ class BenchmarkImageLogger(Callback):
                 ``global_step`` and the TensorBoard logger lookup).
             pl_module (lightning.LightningModule): Receives ``log()`` calls
                 for the per-set mean metrics.
-            should_log_images (bool): When True, LR|SR|HR image strips are
-                emitted to TensorBoard alongside the scalar means.
+            should_log_images (bool): When True, bicubic|SR|HR image strips
+                are emitted to TensorBoard alongside the scalar means.
         """
         step = trainer.global_step
 
@@ -366,20 +367,45 @@ class BenchmarkImageLogger(Callback):
                         experiment.add_scalar(f"{dataset_name}_psnr({key})/{filename}", psnr_val, global_step=step)
                     experiment.add_scalar(f"{dataset_name}_ssim/{filename}", ssim, global_step=step)
 
-                    # Pad LR and SR up to the HR size so all three tile cleanly.
-                    # For SRCNN (lr/sr/hr already equal) this is a no-op; for
-                    # upscaling models (SRResNet) the small LR is zero-padded up
-                    # to the HR size rather than crashing make_grid on a size
-                    # mismatch.
+                    # Triptych: bicubic | SR | HR, all at HR size.
+                    # The bicubic panel is the LR upsampled to HR via bicubic
+                    # interpolation — the standard SR baseline.  For SRCNN the
+                    # LR is already at HR size (pre-upsampled in the dataset),
+                    # so this resamples at 1:1 and is near-identity.  For
+                    # SRResNet (LR < HR) it upscales to HR for direct visual
+                    # comparison against SR.  SR is center-padded only when
+                    # smaller than HR (SRCNN with padding='valid') to preserve
+                    # full HR context on the right.
                     target_hw = hr.shape[-2:]
-                    lr_padded = self._pad_to_match(lr, target_hw)
+                    bicubic = self._bicubic_to(lr, target_hw)
                     sr_padded = self._pad_to_match(sr, target_hw)
                     strip = torchvision.utils.make_grid(
-                        [lr_padded, sr_padded, hr], nrow=3, padding=2, pad_value=0.5
+                        [bicubic, sr_padded, hr], nrow=3, padding=2, pad_value=0.5
                     )
                     experiment.add_image(f"{dataset_name}/{filename}", strip, global_step=step)
 
         self._buffer.clear()
+
+    @staticmethod
+    def _bicubic_to(img: torch.Tensor, target_hw: tuple) -> torch.Tensor:
+        """Bicubic-upsample a ``(C, H, W)`` tensor to *target_hw*, clamped to [0, 1].
+
+        Used to render the bicubic baseline panel of the triptych at HR size.
+        Bicubic can overshoot for high-contrast inputs, so the output is
+        clamped to the unit interval to keep the panel renderable as a
+        normalized image.
+
+        Args:
+            img (torch.Tensor): Image tensor of shape ``(C, H, W)``.
+            target_hw (tuple): Target ``(H, W)`` spatial dimensions.
+
+        Returns:
+            torch.Tensor: Bicubic-resampled tensor of shape ``(C, target_H, target_W)``.
+        """
+        out = torch.nn.functional.interpolate(
+            img.unsqueeze(0), size=target_hw, mode="bicubic", align_corners=False
+        ).squeeze(0)
+        return out.clamp(0.0, 1.0)
 
     @staticmethod
     def _pad_to_match(img: torch.Tensor, target_hw: tuple) -> torch.Tensor:

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -57,6 +57,38 @@ def test_benchmark_setup_datamodule_without_test_names_is_safe():
 
 
 # ---------------------------------------------------------------------------
+# BenchmarkImageLogger._bicubic_to
+# ---------------------------------------------------------------------------
+
+def test_bicubic_to_returns_target_shape():
+    """LR (3, 4, 4) -> (3, 16, 16) for a 4x upscaling model."""
+    lr = torch.rand(3, 4, 4)
+    out = BenchmarkImageLogger._bicubic_to(lr, (16, 16))
+    assert out.shape == (3, 16, 16)
+
+
+def test_bicubic_to_clamps_to_unit_interval():
+    """Bicubic overshoots on high-contrast inputs; the helper clamps so the
+    panel renders cleanly as a normalized image."""
+    lr = torch.zeros(3, 4, 4)
+    lr[:, 0, 0] = 1.0
+    out = BenchmarkImageLogger._bicubic_to(lr, (16, 16))
+    assert out.min().item() >= 0.0
+    assert out.max().item() <= 1.0
+
+
+def test_bicubic_to_matches_torch_interpolate_bicubic():
+    """Lock the helper to bicubic mode (not bilinear/nearest)."""
+    torch.manual_seed(0)
+    lr = torch.rand(3, 4, 4)
+    expected = torch.nn.functional.interpolate(
+        lr.unsqueeze(0), size=(16, 16), mode="bicubic", align_corners=False
+    ).squeeze(0).clamp(0.0, 1.0)
+    out = BenchmarkImageLogger._bicubic_to(lr, (16, 16))
+    torch.testing.assert_close(out, expected)
+
+
+# ---------------------------------------------------------------------------
 # BenchmarkImageLogger._pad_to_match
 # ---------------------------------------------------------------------------
 
@@ -309,10 +341,48 @@ def test_benchmark_validation_epoch_end_logs_image_strips_when_on_interval(tmp_p
     tb_logger.finalize("success")  # flush
 
 
+def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path, monkeypatch):
+    """The first triptych panel must be the bicubic-upsampled LR at HR size,
+    not the original LR or a zero-padded LR. Locks the Bicubic|SR|HR layout."""
+    import lightning.pytorch.loggers as pl_loggers
+    import torchvision.utils
+
+    captured: list[list[torch.Tensor]] = []
+    real_make_grid = torchvision.utils.make_grid
+
+    def spy_make_grid(tensors, *args, **kwargs):
+        captured.append(list(tensors))
+        return real_make_grid(tensors, *args, **kwargs)
+
+    monkeypatch.setattr(torchvision.utils, "make_grid", spy_make_grid)
+
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    pl_module = MagicMock()
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    lr = torch.rand(3, 4, 4)
+    sr = torch.rand(3, 16, 16)
+    hr = torch.rand(3, 16, 16)
+    cb._buffer["Set5"] = [("img_0", lr, sr, hr, {"RGB": 30.0}, 0.9)]
+    tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
+    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
+    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    tb_logger.finalize("success")
+
+    assert len(captured) == 1
+    panels = captured[0]
+    assert len(panels) == 3
+    expected_bicubic = BenchmarkImageLogger._bicubic_to(lr, hr.shape[-2:])
+    torch.testing.assert_close(panels[0], expected_bicubic)
+    # SR is already HR-sized so _pad_to_match is a no-op; HR is untouched.
+    torch.testing.assert_close(panels[1], sr)
+    torch.testing.assert_close(panels[2], hr)
+
+
 def test_benchmark_image_strips_handle_upscaling_sizes(tmp_path: Path):
     """For an upscaling model (SRResNet) the LR is smaller than SR/HR; the
-    strip must pad LR up to the HR size rather than crash make_grid on a size
-    mismatch."""
+    strip must bicubic-upsample LR to HR size rather than crash make_grid on
+    a size mismatch."""
     import lightning.pytorch.loggers as pl_loggers
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")


### PR DESCRIPTION
## Summary
- Replace the first triptych panel (zero-padded LR) with a **bicubic-upsampled LR at HR size** so the strip is a true `Bicubic | SR | HR` comparison at consistent scale.
- Extract `_bicubic_to` as a static method (mirrors `_pad_to_match`) so the resample is unit-testable in isolation.
- SR continues to be center-padded only when smaller than HR (SRCNN with `padding='valid'`); HR is untouched.

## Why
Previously LR was zero-padded up to HR size — for SRResNet (x4) this rendered LR as a tiny 4×4 thumbnail inside a 16×16 black canvas next to a full-size HR panel, defeating the side-by-side visual comparison. Backlog item from the AlbumentationsX migration arc.

## Test Plan
- [x] `pytest tests/training/test_callbacks.py` — 32 passed (28 baseline + 4 new)
- [x] Full suite: 185 passed (181 baseline + 4 new)
- [x] Visual: rerun an SRResNet val/test cycle and confirm Set5 strips now show `Bicubic | SR | HR` at matched dimensions

## New tests
- `test_bicubic_to_returns_target_shape` — shape correctness
- `test_bicubic_to_clamps_to_unit_interval` — bicubic overshoot is clamped to [0, 1]
- `test_bicubic_to_matches_torch_interpolate_bicubic` — locks the helper to bicubic mode (not bilinear)
- `test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size` — integration: `make_grid` receives `[bicubic, sr_padded, hr]`, all three at HR size