### PR TITLE
Simplify .gitignore and trim pyproject comments (P4.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,14 @@
 # Extra files to ignore
 data
-cache/
 .lmdb_cache/
-lightning_logs/
-checkpoints/
 experiments/
 templates/*
 !templates/*template*
-
-# Old notebook-era artifacts (root-anchored so they don't match the
-# sisr/models package): trained checkpoints, prototype notebooks, TB logs
-/models/
-/notebooks/
-/runs/
 
 # Claude's local working notes (codebase index, triage, session history)
 .claude/
 
 # LLM agentic coding artifacts (brainstorming specs, implementation plans).
-# Same rationale as .claude/ — kept off the codebase's git tracking.
 docs/superpowers/
 
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,21 +34,17 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-# Abstract runtime dependencies with compatible lower bounds. The CUDA-built
-# torch / torchvision wheels live on PyTorch's own index (not PyPI), so users
-# who need GPU support install them from that index first; `pip install .`
-# then sees torch already satisfied and resolves everything else from PyPI.
 dependencies = [
     "torch>=2.4",
     "torchvision>=0.19",
     "lightning>=2.4",
     "torchmetrics>=1.4",
-    "jsonargparse[signatures]>=4.27",  # required by lightning's LightningCLI
+    "jsonargparse[signatures]>=4.27",
     "lmdb>=1.4",
     "pillow>=10",
     "numpy>=1.26",
     "tqdm>=4.66",
-    "tensorboard>=2.16",  # default logger in the experiment templates
+    "tensorboard>=2.16",
     # AGPL-3.0; provides A.Compose, A.GaussianBlur, A.Resize, A.RandomCrop, A.ToFloat, and albumentations.pytorch.ToTensorV2.
     # Capped at <=2.1.0 to stay on albucore<0.1.0 (simsimd-backed). albucore 0.1.0 switched its native
     # backend to numkong, whose .pyd depends on libomp140.x86_64.dll (LLVM OpenMP runtime, not bundled


### PR DESCRIPTION
Drop dead ignore rules (cache/, lightning_logs/, checkpoints/, notebook-era paths) and trailing comments; trim pyproject dependency-rationale comments. No functional dependency change.

**Stacked PR** - base: `main` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code