### PR TITLE
Harden SRCNN LMDB build: configurable workers + shared patch helper (P4.1, P4.7, P4.11, P2.5, P3.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ dependencies = [
 dev = [
     "pytest>=8",
     "pytest-cov>=5",
+    # tests/test_cli.py parses/emits config YAML directly; PyYAML otherwise
+    # resolves only transitively (via jsonargparse/lightning), which is fragile.
+    "pyyaml>=6",
 ]
 
 [project.scripts]

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -15,7 +15,40 @@ import albumentations as A
 from albumentations.pytorch import ToTensorV2
 from PIL import Image
 from pathlib import Path
+from collections.abc import Iterator
 from ..utils import LMDBCache, LMDBCacheBuildContext
+
+
+def _iter_patch_origins(
+    height: int,
+    width: int,
+    scale: int,
+    sub_img_size: int,
+    stride: int,
+) -> Iterator[tuple[int, int]]:
+    """Yields the ``(top, left)`` origin of every sliding-window sub-image.
+
+    Each axis is first cropped to a multiple of *scale* (so the bicubic LR
+    downsample is exact), then a *sub_img_size* window is walked across the
+    cropped grid in *stride* steps.  Both :meth:`TrainDataset._compute_offsets`
+    and :func:`_process_subimages` consume this, so the patch count and ordering
+    can never disagree and misalign the LMDB ``lr_``/``hr_`` keys.
+
+    Args:
+        height (int): Full image height in pixels.
+        width (int): Full image width in pixels.
+        scale (int): Downscaling factor; each axis is cropped to a multiple of it.
+        sub_img_size (int): Side length of the square sub-image window.
+        stride (int): Step size of the sliding window.
+
+    Yields:
+        ``(top, left)`` pixel offsets of each sub-image's top-left corner.
+    """
+    h_crop = height - (height % scale)
+    w_crop = width - (width % scale)
+    for top in range(0, h_crop - sub_img_size + 1, stride):
+        for left in range(0, w_crop - sub_img_size + 1, stride):
+            yield top, left
 
 
 def _process_subimages(
@@ -35,7 +68,8 @@ def _process_subimages(
     than at module level so that workers spawned on Windows do not need
     to pickle the Compose object across the process boundary.
 
-    For each sliding-window position the function:
+    For each sliding-window position (from the shared
+    :func:`_iter_patch_origins` grid) the function:
       1. Crops the HR sub-image with a direct numpy slice (deterministic,
          pixel-exact — no need for ``A.Crop`` overhead).
       2. Generates the LR sub-image by Gaussian-blurring then
@@ -61,9 +95,6 @@ def _process_subimages(
     """
     arr = np.array(Image.open(path).convert('RGB'))
     h, w = arr.shape[:2]
-    w_crop = w - (w % scale)
-    h_crop = h - (h % scale)
-    arr = arr[:h_crop, :w_crop, :]
 
     lr_size = sub_img_size // scale
     kernel = 2 * math.ceil(3.0 * blur_sigma) + 1  # odd, covers ±3σ
@@ -74,19 +105,18 @@ def _process_subimages(
     ])
 
     keyed_pairs = []
-    idx = base_idx
+    for offset, (top, left) in enumerate(
+        _iter_patch_origins(h, w, scale, sub_img_size, stride)
+    ):
+        idx = base_idx + offset
+        hr_subimg = arr[top:top + sub_img_size, left:left + sub_img_size, :]
+        lr_subimg = lr_pipeline(image=hr_subimg)['image']
 
-    for top in range(0, h_crop - sub_img_size + 1, stride):
-        for left in range(0, w_crop - sub_img_size + 1, stride):
-            hr_subimg = arr[top:top + sub_img_size, left:left + sub_img_size, :]
-            lr_subimg = lr_pipeline(image=hr_subimg)['image']
+        hr_chw = hr_subimg.transpose(2, 0, 1)
+        lr_chw = lr_subimg.transpose(2, 0, 1)
 
-            hr_chw = hr_subimg.transpose(2, 0, 1)
-            lr_chw = lr_subimg.transpose(2, 0, 1)
-
-            keyed_pairs.append((f'lr_{idx:08d}', lr_chw.tobytes()))
-            keyed_pairs.append((f'hr_{idx:08d}', hr_chw.tobytes()))
-            idx += 1
+        keyed_pairs.append((f'lr_{idx:08d}', lr_chw.tobytes()))
+        keyed_pairs.append((f'hr_{idx:08d}', hr_chw.tobytes()))
 
     return keyed_pairs
 
@@ -215,12 +245,10 @@ class TrainDataset(torch.utils.data.Dataset):
             img = Image.open(path)
             w, h = img.size
             img.close()
-            w_crop = w - (w % self.scale)
-            h_crop = h - (h % self.scale)
-            n_h = max(0, (h_crop - self.sub_img_size) // self.stride + 1)
-            n_w = max(0, (w_crop - self.sub_img_size) // self.stride + 1)
+            n = sum(1 for _ in _iter_patch_origins(
+                h, w, self.scale, self.sub_img_size, self.stride))
             offsets.append(offset)
-            offset += n_h * n_w
+            offset += n
         return offsets, offset
 
     def _build(self, ctx: LMDBCacheBuildContext) -> None:

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -119,6 +119,11 @@ class TrainDataset(torch.utils.data.Dataset):
             build.  Defaults to ``False``.
         cache_dir (str | Path | None): Directory in which to store the
             LMDB cache.  Defaults to ``img_dir / '.lmdb_cache'``.
+        build_num_workers (int | None): Number of worker processes for the
+            one-time LMDB build.  ``None`` (default) uses
+            ``min(os.cpu_count() or 1, num_images)``; a value that resolves to
+            ``<= 1`` effective workers runs an inline, no-subprocess build.
+            Only affects cache construction, not data loading.
 
     Raises:
         ValueError: If no image files are found in ``img_dir``.
@@ -133,6 +138,7 @@ class TrainDataset(torch.utils.data.Dataset):
         blur_sigma: float = 1.0,
         use_tqdm: bool = False,
         cache_dir: str | Path | None = None,
+        build_num_workers: int | None = None,
     ):
         super().__init__()
 
@@ -141,6 +147,7 @@ class TrainDataset(torch.utils.data.Dataset):
         self.stride = stride
         self.scale = scale
         self.blur_sigma = blur_sigma
+        self.build_num_workers = build_num_workers
 
         self.img_paths = sorted(
             [p for p in self.img_dir.glob('*.*') if p.is_file()])
@@ -237,7 +244,7 @@ class TrainDataset(torch.utils.data.Dataset):
             items=self.img_paths,
             process_fn=_process_subimages,
             process_args=process_args,
-            num_workers=8,
+            num_workers=self.build_num_workers,
             desc="Building LMDB cache",
         )
 

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -12,7 +12,7 @@ LR/HR sub-image pairs.
 import shutil
 import lmdb
 import torch
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from pathlib import Path
 from tqdm.auto import tqdm
 from collections.abc import Callable, Sequence
@@ -132,7 +132,7 @@ class LMDBCacheBuildContext:
             pbar = tqdm(total=len(items), desc=desc, unit="item")
 
         with ProcessPoolExecutor(max_workers=num_workers) as executor:
-            pending: dict[Any, int] = {}
+            pending: set[Future] = set()
 
             def _submit():
                 nonlocal next_submit
@@ -140,23 +140,20 @@ class LMDBCacheBuildContext:
                     args = (items[next_submit],)
                     if process_args is not None:
                         args = args + tuple(process_args[next_submit])
-                    f = executor.submit(process_fn, *args)
-                    pending[f] = next_submit
+                    pending.add(executor.submit(process_fn, *args))
                     next_submit += 1
 
-            for _ in range(min(num_workers, len(items))):
+            for _ in range(num_workers):
                 _submit()
 
             while pending:
-                done = next(iter(as_completed(pending)))
-                pending.pop(done)
-
-                self.write_batch(done.result())
-
-                if pbar is not None:
-                    pbar.update(1)
-
-                _submit()
+                done, _ = wait(pending, return_when=FIRST_COMPLETED)
+                for future in done:
+                    pending.discard(future)
+                    self.write_batch(future.result())
+                    if pbar is not None:
+                        pbar.update(1)
+                    _submit()
 
         if pbar is not None:
             pbar.close()

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -9,6 +9,7 @@ Lightning or model code.
 :class:`~sisr.datasets.srcnn.TrainDataset` to persist precomputed
 LR/HR sub-image pairs.
 """
+import os
 import shutil
 import lmdb
 import torch
@@ -101,17 +102,17 @@ class LMDBCacheBuildContext:
         items: Sequence[Any],
         process_fn: Callable[..., list[tuple[str, bytes]]],
         process_args: Sequence[Sequence[Any]] | None = None,
-        num_workers: int = 8,
+        num_workers: int | None = None,
         desc: str = "Building LMDB cache",
     ):
-        """Processes *items* in parallel and writes results to LMDB.
+        """Processes *items* and writes the results to LMDB.
 
-        Each item is submitted to a ``ProcessPoolExecutor``.  The worker
-        function *process_fn* must be a top-level (picklable) callable
-        that returns a list of ``(key, value_bytes)`` tuples.
-
-        A sliding window of *num_workers* in-flight jobs keeps workers
-        busy while the main process writes completed results.
+        The worker function *process_fn* must be a top-level (picklable)
+        callable returning a list of ``(key, value_bytes)`` tuples.  With more
+        than one effective worker a ``ProcessPoolExecutor`` runs a sliding
+        window of *num_workers* in-flight jobs while the main process writes
+        completed results; with ``<= 1`` effective worker the jobs run inline in
+        the calling process (no subprocess).
 
         Args:
             items (Sequence[Any]): One item per job (e.g. a list of image paths).
@@ -121,22 +122,42 @@ class LMDBCacheBuildContext:
                 If ``None``, each job calls ``process_fn(item)``.
                 If provided, must have the same length as *items* and
                 each element is unpacked as positional args.
-            num_workers (int): Maximum number of parallel worker processes.
+            num_workers (int | None): Maximum number of parallel worker
+                processes.  ``None`` resolves to ``min(os.cpu_count() or 1,
+                len(items))``.  When the effective count is ``<= 1`` (a single
+                core, a lone item, or an explicit ``1``) the build runs inline
+                with no ``ProcessPoolExecutor``.
             desc (str): Description shown in the ``tqdm`` progress bar.
         """
-        num_workers = min(num_workers, len(items))
+        n_items = len(items)
+        if num_workers is None:
+            num_workers = min(os.cpu_count() or 1, n_items)
+        num_workers = min(num_workers, n_items)
+
+        pbar = tqdm(total=n_items, desc=desc, unit="item") if self.use_tqdm else None
+
+        # Inline (no-pool) build. With <= 1 effective worker the
+        # ProcessPoolExecutor spawn/import cost — plus the hazard of nesting a
+        # pool inside a test/xdist worker — isn't worth it, so run jobs here.
+        if num_workers <= 1:
+            for i in range(n_items):
+                args = (items[i],)
+                if process_args is not None:
+                    args = args + tuple(process_args[i])
+                self.write_batch(process_fn(*args))
+                if pbar is not None:
+                    pbar.update(1)
+            if pbar is not None:
+                pbar.close()
+            return
+
         next_submit = 0
-
-        pbar = None
-        if self.use_tqdm:
-            pbar = tqdm(total=len(items), desc=desc, unit="item")
-
         with ProcessPoolExecutor(max_workers=num_workers) as executor:
             pending: set[Future] = set()
 
             def _submit():
                 nonlocal next_submit
-                if next_submit < len(items):
+                if next_submit < n_items:
                     args = (items[next_submit],)
                     if process_args is not None:
                         args = args + tuple(process_args[next_submit])

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -118,6 +118,20 @@ def test_train_dataset_rejects_channels_param(tiny_rgb_image_dir: Path):
         _make_train(tiny_rgb_image_dir, channels="L", subimg_size=20, stride=8)
 
 
+def test_train_dataset_build_num_workers_1_builds_inline(tiny_rgb_image_dir: Path):
+    """build_num_workers=1 must thread through to an inline LMDB build (no
+    ProcessPoolExecutor), so the one-time build is safe inside a test/xdist
+    worker instead of nesting an 8-process pool."""
+    with patch("sisr.utils.ProcessPoolExecutor") as mock_pool:
+        ds = _make_train(
+            tiny_rgb_image_dir, subimg_size=20, stride=8, build_num_workers=1)
+    mock_pool.assert_not_called()
+    assert len(ds) > 0
+    lr, hr = ds[0]
+    assert lr.shape == (3, 20, 20)
+    assert hr.shape == (3, 20, 20)
+
+
 # ---------------------------------------------------------------------------
 # ValidationDataset
 # ---------------------------------------------------------------------------

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -132,6 +132,32 @@ def test_train_dataset_build_num_workers_1_builds_inline(tiny_rgb_image_dir: Pat
     assert hr.shape == (3, 20, 20)
 
 
+def test_patch_grid_derived_from_shared_helper(tiny_rgb_image_dir: Path):
+    """_compute_offsets and the worker must derive the sliding-window grid from
+    one shared helper, so their patch counts can never silently disagree and
+    misalign the LMDB lr_/hr_ keys."""
+    from sisr.datasets.srcnn import _iter_patch_origins, _process_subimages
+
+    ds = _make_train(
+        tiny_rgb_image_dir, subimg_size=20, stride=8, build_num_workers=1)
+    _, total = ds._compute_offsets()
+
+    # The worker's actual emitted pairs (one lr + one hr per patch) across every
+    # image must sum to exactly the offset total.
+    worker_total = 0
+    for i, path in enumerate(ds.img_paths):
+        pairs = _process_subimages(path, 20, 8, 2, 1.0, ds._img_offsets[i])
+        worker_total += len(pairs) // 2
+    assert worker_total == total
+
+    # And the helper enumerates the expected grid for the 36x36 fixture:
+    # crop 36 -> 36 (divisible by scale=2); (36-20)//8 + 1 = 3 positions per axis.
+    origins = list(_iter_patch_origins(36, 36, 2, 20, 8))
+    assert len(origins) == 9
+    assert origins[0] == (0, 0)
+    assert (16, 16) in origins
+
+
 # ---------------------------------------------------------------------------
 # ValidationDataset
 # ---------------------------------------------------------------------------

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,17 @@
+"""Packaging-contract checks that don't need the app imported."""
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pyyaml_declared_in_dev_extra():
+    """tests/test_cli.py imports `yaml`; PyYAML must be an explicit dev
+    dependency, not a transitive accident of jsonargparse/lightning that could
+    vanish on a resolver bump."""
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dev = pyproject["project"]["optional-dependencies"]["dev"]
+    assert any(re.match(r"pyyaml(\[|[<>=!~ ]|$)", spec.strip(), re.IGNORECASE) for spec in dev), (
+        f"PyYAML missing from the dev extra: {dev}"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -236,3 +236,35 @@ def test_lmdb_try_load_propagates_unexpected_error(tmp_path: Path):
     with patch("sisr.utils.lmdb.open", side_effect=ValueError("unexpected")):
         with pytest.raises(ValueError, match="unexpected"):
             cache._try_load("abc")
+
+
+# ---------------------------------------------------------------------------
+# LMDBCacheBuildContext.parallel_build
+# ---------------------------------------------------------------------------
+
+def _sq_process_fn(item: int) -> list[tuple[str, bytes]]:
+    """Top-level (picklable) worker: squares *item* into one keyed pair.
+
+    Must be module-level so ProcessPoolExecutor can pickle it on spawn platforms.
+    """
+    return [(f"n_{item}", str(item * item).encode())]
+
+
+def test_parallel_build_persists_every_submitted_item(tmp_path: Path):
+    """parallel_build must submit every item to the pool and persist each
+    worker's returned pairs — previously only write_batch was covered, so the
+    submit/collect loop was untested."""
+    def build(ctx: LMDBCacheBuildContext) -> None:
+        ctx.parallel_build(items=[2, 3, 4, 5], process_fn=_sq_process_fn, num_workers=2)
+
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="pb",
+        checksum="c",
+        length=4,
+        map_size=_MAP_SIZE,
+        build_fn=build,
+    )
+    assert cache.length == 4
+    assert cache.get("n_2") == b"4"
+    assert cache.get("n_5") == b"25"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -268,3 +268,42 @@ def test_parallel_build_persists_every_submitted_item(tmp_path: Path):
     assert cache.length == 4
     assert cache.get("n_2") == b"4"
     assert cache.get("n_5") == b"25"
+
+
+def test_parallel_build_single_worker_skips_process_pool(tmp_path: Path):
+    """num_workers=1 must run the build inline (no ProcessPoolExecutor), so it
+    is safe to nest inside a test/xdist worker without oversubscribing cores."""
+    def build(ctx: LMDBCacheBuildContext) -> None:
+        ctx.parallel_build(items=[2, 3, 4], process_fn=_sq_process_fn, num_workers=1)
+
+    with patch("sisr.utils.ProcessPoolExecutor") as mock_pool:
+        cache = LMDBCache(
+            cache_dir=tmp_path,
+            name="pb1",
+            checksum="c",
+            length=3,
+            map_size=_MAP_SIZE,
+            build_fn=build,
+        )
+    mock_pool.assert_not_called()
+    assert cache.get("n_2") == b"4"
+    assert cache.get("n_4") == b"16"
+
+
+def test_parallel_build_none_workers_builds_single_item_inline(tmp_path: Path):
+    """num_workers=None must resolve to min(os.cpu_count() or 1, n_items); a lone
+    item yields <= 1 effective worker and therefore an inline build."""
+    def build(ctx: LMDBCacheBuildContext) -> None:
+        ctx.parallel_build(items=[7], process_fn=_sq_process_fn, num_workers=None)
+
+    with patch("sisr.utils.ProcessPoolExecutor") as mock_pool:
+        cache = LMDBCache(
+            cache_dir=tmp_path,
+            name="pbn",
+            checksum="c",
+            length=1,
+            map_size=_MAP_SIZE,
+            build_fn=build,
+        )
+    mock_pool.assert_not_called()
+    assert cache.get("n_7") == b"49"


### PR DESCRIPTION
Make the SRCNN LMDB build worker count configurable with an inline no-pool path (P4.11), tidy parallel_build to a set + wait(FIRST_COMPLETED) (P4.7), derive the patch grid from one shared helper (P2.5), add a parallel_build test (P3.2), and declare pyyaml in the dev extra (P4.1).

**Stacked PR** - base: `stack/01-pr0` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code