### PR TITLE
Add SRDataset contract and public predict_rgb inference seam (P3.6, P5.4, P2.1)

### DIFF
--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -1,0 +1,94 @@
+"""Shared base for SR datasets — enforces the ``.img_paths`` contract.
+
+All four architecture datasets (SRCNN / SRResNet train + validation) subclass
+:class:`SRDataset`. It centralises the file discovery (extension-allowlisted
+glob + empty-directory guard), the RGB image load, and the AlbumentationsX
+``uint8`` HWC → ``float32`` CHW ``[0, 1]`` tensor adapter, and declares the
+``.img_paths`` filename contract that :class:`~sisr.training.SRDataModule`
+and :class:`~sisr.training.callbacks.BenchmarkImageLogger` rely on.
+"""
+import abc
+from pathlib import Path
+
+import albumentations as A
+import numpy as np
+import torch
+from albumentations.pytorch import ToTensorV2
+from PIL import Image
+
+
+class SRDataset(torch.utils.data.Dataset, abc.ABC):
+    """Abstract base for single-image super-resolution datasets.
+
+    Subclasses call :meth:`_index_images` in ``__init__`` to populate
+    :attr:`img_paths`, and implement :meth:`__len__` / :meth:`__getitem__`.
+    HR is always discovered and loaded as RGB; colorspace selection happens
+    downstream in :class:`~sisr.training.SRLightning` via the processor.
+
+    Attributes:
+        IMAGE_EXTENSIONS: Allowlisted lower-case file suffixes. Files with any
+            other suffix (or none) are skipped by :meth:`_index_images` so a
+            stray ``notes.txt`` / ``checksum.json`` never enters the manifest.
+        img_dir: Directory the images were discovered in.
+        img_paths: Sorted list of image file paths — the filename contract
+            consumed by the datamodule and the benchmark logger.
+    """
+
+    IMAGE_EXTENSIONS: frozenset[str] = frozenset({
+        '.png', '.jpg', '.jpeg', '.bmp', '.tif', '.tiff', '.webp', '.ppm', '.pgm',
+    })
+
+    img_dir: Path
+    img_paths: list[Path]
+
+    def _index_images(self, img_dir: str | Path) -> None:
+        """Discover image files under ``img_dir`` and store the sorted manifest.
+
+        Only files whose lower-cased suffix is in :attr:`IMAGE_EXTENSIONS`
+        are kept — an allowlist rather than the old ``glob('*.*')``, which
+        matched non-image files and dropped extensionless ones by accident.
+
+        Args:
+            img_dir (str | Path): Directory containing the high-resolution
+                images.
+
+        Raises:
+            ValueError: If no allowlisted image files are found in ``img_dir``.
+        """
+        self.img_dir = Path(img_dir)
+        self.img_paths = sorted(
+            p for p in self.img_dir.iterdir()
+            if p.is_file() and p.suffix.lower() in self.IMAGE_EXTENSIONS
+        )
+        if not self.img_paths:
+            raise ValueError(f"No images found in {img_dir}")
+
+    @staticmethod
+    def _load_rgb(path: str | Path) -> np.ndarray:
+        """Load an image file as an ``(H, W, 3)`` uint8 RGB array.
+
+        Args:
+            path (str | Path): Image file path.
+
+        Returns:
+            The decoded image as an HWC uint8 RGB ``numpy`` array.
+        """
+        return np.array(Image.open(path).convert('RGB'))
+
+    @staticmethod
+    def _to_tensor_transform() -> A.Compose:
+        """Build the AlbumentationsX uint8-HWC → float32-CHW-``[0, 1]`` adapter.
+
+        Returns:
+            An :class:`albumentations.Compose` of ``ToFloat(max_value=255.0)``
+            followed by :class:`~albumentations.pytorch.ToTensorV2`.
+        """
+        return A.Compose([A.ToFloat(max_value=255.0), ToTensorV2()])
+
+    @abc.abstractmethod
+    def __len__(self) -> int:
+        """Return the number of items the dataset serves."""
+
+    @abc.abstractmethod
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return the ``(lr_tensor, hr_tensor)`` pair at ``idx``."""

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -12,11 +12,11 @@ import cv2
 import numpy as np
 import torch
 import albumentations as A
-from albumentations.pytorch import ToTensorV2
 from PIL import Image
 from pathlib import Path
 from collections.abc import Iterator
 from ..utils import LMDBCache, LMDBCacheBuildContext
+from .base import SRDataset
 
 
 def _iter_patch_origins(
@@ -121,7 +121,7 @@ def _process_subimages(
     return keyed_pairs
 
 
-class TrainDataset(torch.utils.data.Dataset):
+class TrainDataset(SRDataset):
     """Dataset that serves precomputed LR/HR sub-image pairs from an LMDB cache.
 
     On first instantiation with a given set of parameters the dataset
@@ -172,17 +172,12 @@ class TrainDataset(torch.utils.data.Dataset):
     ):
         super().__init__()
 
-        self.img_dir = Path(img_dir)
+        self._index_images(img_dir)
         self.sub_img_size = subimg_size
         self.stride = stride
         self.scale = scale
         self.blur_sigma = blur_sigma
         self.build_num_workers = build_num_workers
-
-        self.img_paths = sorted(
-            [p for p in self.img_dir.glob('*.*') if p.is_file()])
-        if not self.img_paths:
-            raise ValueError(f"No images found in {img_dir}")
 
         cache_dir = Path(cache_dir) if cache_dir else self.img_dir / '.lmdb_cache'
         checksum = self._compute_checksum()
@@ -319,7 +314,7 @@ class TrainDataset(torch.utils.data.Dataset):
         return lr_tensor, hr_tensor
 
 
-class ValidationDataset(torch.utils.data.Dataset):
+class ValidationDataset(SRDataset):
     """Dataset that serves full-image LR/HR pairs for validation.
 
     Unlike :class:`TrainDataset` this dataset does not extract sub-images.
@@ -347,20 +342,12 @@ class ValidationDataset(torch.utils.data.Dataset):
     ):
         super().__init__()
 
-        self.img_dir = Path(img_dir)
+        self._index_images(img_dir)
         self.scale = scale
         self.blur_sigma = blur_sigma
 
-        self.img_paths = sorted(
-            [p for p in self.img_dir.glob('*.*') if p.is_file()])
-        if not self.img_paths:
-            raise ValueError(f"No images found in {img_dir}")
-
         self._kernel = 2 * math.ceil(3.0 * blur_sigma) + 1  # odd, covers ±3σ
-        self._to_tensor = A.Compose([
-            A.ToFloat(max_value=255.0),
-            ToTensorV2(),
-        ])
+        self._to_tensor = self._to_tensor_transform()
 
     def __len__(self) -> int:
         return len(self.img_paths)
@@ -376,7 +363,7 @@ class ValidationDataset(torch.utils.data.Dataset):
             with shape ``(C, H, W)`` and values in ``[0, 1]``.
         """
         path = self.img_paths[idx]
-        arr = np.array(Image.open(path).convert('RGB'))  # HWC uint8 RGB
+        arr = self._load_rgb(path)  # HWC uint8 RGB
         h, w = arr.shape[:2]
         lr_h = h // self.scale
         lr_w = w // self.scale

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -7,15 +7,14 @@ cacheable); :class:`ValidationDataset` serves full images cropped to a
 multiple of ``scale``.
 """
 import cv2
-import numpy as np
 import torch
 import albumentations as A
 from albumentations.pytorch import ToTensorV2
-from PIL import Image
 from pathlib import Path
+from .base import SRDataset
 
 
-class TrainDataset(torch.utils.data.Dataset):
+class TrainDataset(SRDataset):
     """Random-crop HR/LR pairs for SRResNet-style training (AlbumentationsX backend).
 
     Each ``__getitem__`` takes a random ``hr_crop_size`` square crop from an
@@ -62,15 +61,10 @@ class TrainDataset(torch.utils.data.Dataset):
                 f"hr_crop_size ({hr_crop_size}) must be divisible by scale ({scale})."
             )
 
-        self.img_dir = Path(img_dir)
+        self._index_images(img_dir)
         self.scale = scale
         self.hr_crop_size = hr_crop_size
         self.crops_per_image = crops_per_image
-
-        self.img_paths = sorted(
-            [p for p in self.img_dir.glob('*.*') if p.is_file()])
-        if not self.img_paths:
-            raise ValueError(f"No images found in {img_dir}")
 
         lr_size = hr_crop_size // scale
         self._hr_crop = A.Compose([A.RandomCrop(hr_crop_size, hr_crop_size)])
@@ -79,10 +73,7 @@ class TrainDataset(torch.utils.data.Dataset):
             A.ToFloat(max_value=255.0),
             ToTensorV2(),
         ])
-        self._hr_to_tensor = A.Compose([
-            A.ToFloat(max_value=255.0),
-            ToTensorV2(),
-        ])
+        self._hr_to_tensor = self._to_tensor_transform()
 
     def __len__(self) -> int:
         return len(self.img_paths) * self.crops_per_image
@@ -96,7 +87,7 @@ class TrainDataset(torch.utils.data.Dataset):
         with shape ``(3, H, W)``.
         """
         path = self.img_paths[idx % len(self.img_paths)]
-        arr = np.array(Image.open(path).convert('RGB'))  # HWC uint8 RGB
+        arr = self._load_rgb(path)  # HWC uint8 RGB
 
         h, w = arr.shape[:2]
         if w < self.hr_crop_size or h < self.hr_crop_size:
@@ -112,7 +103,7 @@ class TrainDataset(torch.utils.data.Dataset):
         return lr_tensor, hr_tensor
 
 
-class ValidationDataset(torch.utils.data.Dataset):
+class ValidationDataset(SRDataset):
     """Full-image HR with bicubic-downsampled LR for SRResNet validation/test
     (AlbumentationsX backend).
 
@@ -132,18 +123,10 @@ class ValidationDataset(torch.utils.data.Dataset):
     def __init__(self, img_dir: str | Path, scale: int):
         super().__init__()
 
-        self.img_dir = Path(img_dir)
+        self._index_images(img_dir)
         self.scale = scale
 
-        self.img_paths = sorted(
-            [p for p in self.img_dir.glob('*.*') if p.is_file()])
-        if not self.img_paths:
-            raise ValueError(f"No images found in {img_dir}")
-
-        self._to_tensor = A.Compose([
-            A.ToFloat(max_value=255.0),
-            ToTensorV2(),
-        ])
+        self._to_tensor = self._to_tensor_transform()
 
     def __len__(self) -> int:
         return len(self.img_paths)
@@ -156,7 +139,7 @@ class ValidationDataset(torch.utils.data.Dataset):
         ``float32`` in ``[0, 1]``.
         """
         path = self.img_paths[idx]
-        arr = np.array(Image.open(path).convert('RGB'))  # HWC uint8 RGB
+        arr = self._load_rgb(path)  # HWC uint8 RGB
 
         h, w = arr.shape[:2]
         h_crop = h - (h % self.scale)

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -278,11 +278,7 @@ class BenchmarkImageLogger(Callback):
         lr_img, hr_img = batch
 
         with torch.no_grad():
-            model_in = pl_module.processor.extract(lr_img)
-            sr_model_out = pl_module.model(model_in)
-            sr = pl_module.processor.reconstruct(sr_model_out, lr_img)
-
-        hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr.shape[-2:])
+            sr, hr_cropped = pl_module.predict_rgb(lr_img, hr_img)
 
         # Resolve filenames from the underlying dataset for use as TB tags.
         dataset = source_dataloaders[dataloader_idx].dataset

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -210,6 +210,56 @@ class SRLightning(lightning.LightningModule):
         """
         return self.model(x)
 
+    def _forward_sr(
+        self, lr_img: torch.Tensor, hr_img: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Canonical SR forward: extract → model → reconstruct → crop HR.
+
+        The single source of truth for the forward pipeline. Shared by
+        :meth:`_step` (which also needs the model-space output for the loss)
+        and :meth:`predict_rgb` (the public scoring seam), so the training and
+        benchmark-logging paths cannot silently diverge.
+
+        Args:
+            lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
+                ``(B, 3, H, W)``.
+            hr_img: HR batch, RGB ``float32`` in ``[0, 1]``.
+
+        Returns:
+            ``(sr_model_out, sr_rgb, hr_cropped)`` — the raw model output in
+            the model IO colorspace, the reconstructed SR RGB, and HR
+            center-cropped to the SR spatial size.
+        """
+        model_input = self.processor.extract(lr_img)
+        sr_model_out = self.model(model_input)
+        sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
+        hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_rgb.shape[-2:])
+        return sr_model_out, sr_rgb, hr_cropped
+
+    def predict_rgb(
+        self, lr_img: torch.Tensor, hr_img: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run the SR forward and return spatially-aligned SR / HR RGB tensors.
+
+        Public scoring seam consumed by the training path (via :meth:`_step`)
+        and by :class:`~sisr.training.callbacks.BenchmarkImageLogger`, so
+        neither re-implements the ``extract → model → reconstruct →
+        center_crop`` pipeline nor reaches into ``.model`` / ``.processor``.
+        Gradient tracking follows the caller's context — wrap in
+        ``torch.no_grad()`` for pure inference.
+
+        Args:
+            lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
+                ``(B, 3, H, W)``.
+            hr_img: HR batch, RGB ``float32`` in ``[0, 1]``.
+
+        Returns:
+            ``(sr_rgb, hr_cropped)`` — SR RGB and HR center-cropped to the SR
+            spatial size, both RGB ``float32``.
+        """
+        _, sr_rgb, hr_cropped = self._forward_sr(lr_img, hr_img)
+        return sr_rgb, hr_cropped
+
     def _step(self, batch: tuple[torch.Tensor, torch.Tensor]) -> tuple[
         torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
     ]:
@@ -231,11 +281,7 @@ class SRLightning(lightning.LightningModule):
         """
         lr_img, hr_img = batch
 
-        model_input = self.processor.extract(lr_img)
-        sr_model_out = self.model(model_input)
-        sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
-
-        hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_rgb.shape[-2:])
+        sr_model_out, sr_rgb, hr_cropped = self._forward_sr(lr_img, hr_img)
         hr_for_loss = self.processor.extract(hr_cropped)
         loss = self.criterion(sr_model_out, hr_for_loss)
 

--- a/tests/datasets/test_base.py
+++ b/tests/datasets/test_base.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from sisr.datasets.base import SRDataset
+
+
+def _write_png(path: Path, size: int = 8) -> None:
+    rng = np.random.default_rng(seed=abs(hash(path.name)) % (2**32))
+    arr = rng.integers(0, 256, size=(size, size, 3), dtype=np.uint8)
+    Image.fromarray(arr).save(path)
+
+
+class _Mini(SRDataset):
+    """Minimal concrete SRDataset used to exercise the shared base helpers."""
+
+    def __init__(self, img_dir):
+        super().__init__()
+        self._index_images(img_dir)
+
+    def __len__(self) -> int:
+        return len(self.img_paths)
+
+    def __getitem__(self, idx):
+        return self.img_paths[idx]
+
+
+def test_srdataset_subclass_missing_abstract_methods_fails_at_construction():
+    """A mis-shaped dataset (no __len__/__getitem__) must fail clearly at
+    construction time via the ABC, not silently at first runtime access."""
+    class Bad(SRDataset):
+        pass
+
+    with pytest.raises(TypeError, match="abstract"):
+        Bad()
+
+
+def test_index_images_populates_img_paths_as_paths(tmp_path: Path):
+    _write_png(tmp_path / "a.png")
+    _write_png(tmp_path / "b.png")
+    ds = _Mini(tmp_path)
+    assert [p.name for p in ds.img_paths] == ["a.png", "b.png"]  # sorted
+    assert all(isinstance(p, Path) for p in ds.img_paths)
+    assert ds.img_dir == tmp_path
+
+
+def test_index_images_skips_non_image_and_extensionless_files(tmp_path: Path):
+    """P5.4: the allowlist keeps only real image extensions — a .txt file and
+    an extensionless file are excluded (the old glob('*.*') matched the .txt
+    and dropped the extensionless one silently)."""
+    _write_png(tmp_path / "img_00.png")
+    _write_png(tmp_path / "img_01.png")
+    (tmp_path / "notes.txt").write_text("not an image")
+    (tmp_path / "README").write_text("extensionless")
+    (tmp_path / "checksum.json").write_text("{}")
+    ds = _Mini(tmp_path)
+    assert [p.name for p in ds.img_paths] == ["img_00.png", "img_01.png"]
+
+
+def test_index_images_no_images_raises(tmp_path: Path):
+    (tmp_path / "notes.txt").write_text("not an image")
+    with pytest.raises(ValueError, match="No images"):
+        _Mini(tmp_path)
+
+
+def test_load_rgb_returns_hwc_uint8_rgb(tmp_path: Path):
+    _write_png(tmp_path / "a.png", size=8)
+    arr = SRDataset._load_rgb(tmp_path / "a.png")
+    assert arr.shape == (8, 8, 3)
+    assert arr.dtype == np.uint8
+
+
+def test_to_tensor_transform_produces_chw_float01(tmp_path: Path):
+    arr = np.full((4, 4, 3), 255, dtype=np.uint8)
+    t = SRDataset._to_tensor_transform()(image=arr)["image"]
+    assert t.shape == (3, 4, 4)
+    assert t.dtype == torch.float32
+    assert torch.allclose(t, torch.ones(3, 4, 4))

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -195,3 +195,23 @@ def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):
     lr_b, hr_b = ds[0]
     assert torch.equal(lr_a, lr_b), "validation LR must be deterministic"
     assert torch.equal(hr_a, hr_b), "validation HR must be deterministic"
+
+
+# ---------------------------------------------------------------------------
+# SRDataset contract (P3.6 / P5.4)
+# ---------------------------------------------------------------------------
+
+def test_srcnn_datasets_are_srdataset_subclasses():
+    from sisr.datasets.base import SRDataset
+    assert issubclass(TrainDataset, SRDataset)
+    assert issubclass(ValidationDataset, SRDataset)
+
+
+def test_srcnn_validation_skips_non_image_files(tiny_rgb_image_dir: Path):
+    """A stray .txt/extensionless file in the image dir must not enter
+    img_paths — the old glob('*.*') would have matched the .txt."""
+    (tiny_rgb_image_dir / "notes.txt").write_text("not an image")
+    (tiny_rgb_image_dir / "MANIFEST").write_text("extensionless")
+    ds = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2)
+    assert len(ds) == 3  # only the 3 PNGs
+    assert all(p.suffix == ".png" for p in ds.img_paths)

--- a/tests/datasets/test_srresnet.py
+++ b/tests/datasets/test_srresnet.py
@@ -87,3 +87,21 @@ def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):
     lr_b, hr_b = ds[0]
     assert torch.equal(lr_a, lr_b), "validation LR must be deterministic"
     assert torch.equal(hr_a, hr_b), "validation HR must be deterministic"
+
+
+# ---------------------------------------------------------------------------
+# SRDataset contract (P3.6 / P5.4)
+# ---------------------------------------------------------------------------
+
+def test_srresnet_datasets_are_srdataset_subclasses():
+    from sisr.datasets.base import SRDataset
+    assert issubclass(TrainDataset, SRDataset)
+    assert issubclass(ValidationDataset, SRDataset)
+
+
+def test_srresnet_validation_skips_non_image_files(tiny_rgb_image_dir: Path):
+    (tiny_rgb_image_dir / "notes.txt").write_text("not an image")
+    (tiny_rgb_image_dir / "MANIFEST").write_text("extensionless")
+    ds = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2)
+    assert len(ds) == 3
+    assert all(p.suffix == ".png" for p in ds.img_paths)

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -526,3 +526,68 @@ def test_benchmark_collect_batch_routes_through_processor():
     assert "RGB" in psnr_dict
     assert "YCbCr" in psnr_dict
     assert isinstance(ssim, float)
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkImageLogger consumes the public predict_rgb seam + SRDataset (P2.1)
+# ---------------------------------------------------------------------------
+
+def test_benchmark_collect_batch_routes_through_predict_rgb():
+    """_collect_batch must call the public pl_module.predict_rgb, and the
+    buffered SR/HR must equal its output — proving no re-implemented, divergent
+    forward path remains in the callback."""
+    from unittest.mock import MagicMock
+
+    pl_module = _make_real_pl_module()  # SRCNN + RGBProcessor, crop_border=0
+    batch = (torch.rand(2, 3, 16, 16), torch.rand(2, 3, 16, 16))
+    with torch.no_grad():
+        ref_sr, ref_hr = pl_module.predict_rgb(*batch)
+
+    spy = MagicMock(wraps=pl_module.predict_rgb)
+    pl_module.predict_rgb = spy
+
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    ds = _stub_dataset_with_img_paths(n=2, name="Set5")
+    trainer = SimpleNamespace(
+        val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)],
+    )
+    cb.on_validation_batch_end(
+        trainer=trainer, pl_module=pl_module, outputs=None,
+        batch=batch, batch_idx=0, dataloader_idx=1,
+    )
+
+    spy.assert_called_once()
+    call_args, _ = spy.call_args
+    torch.testing.assert_close(call_args[0], batch[0])
+    torch.testing.assert_close(call_args[1], batch[1])
+    # Buffered SR/HR (uncropped, crop_border=0) match the public forward output.
+    _, _, sr0, hr0, _, _ = cb._buffer["Set5"][0]
+    torch.testing.assert_close(sr0, ref_sr[0].cpu())
+    torch.testing.assert_close(hr0, ref_hr[0].cpu())
+
+
+def test_benchmark_collect_batch_consumes_srdataset_img_paths(tiny_rgb_image_dir: Path):
+    """The callback resolves filenames from a real SRDataset's declared
+    .img_paths contract (not a duck-typed attr)."""
+    from sisr.datasets.base import SRDataset
+    from sisr.datasets.srresnet import ValidationDataset
+
+    ds = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2)
+    assert isinstance(ds, SRDataset)
+
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    pl_module = _make_real_pl_module()
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    trainer = SimpleNamespace(
+        val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)],
+    )
+    batch = (torch.rand(2, 3, 16, 16), torch.rand(2, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer, pl_module=pl_module, outputs=None,
+        batch=batch, batch_idx=0, dataloader_idx=1,
+    )
+    fnames = [entry[0] for entry in cb._buffer["Set5"]]
+    assert fnames == [p.stem for p in ds.img_paths[:2]]  # e.g. ["img_00", "img_01"]

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -452,3 +452,36 @@ def test_saved_hparams_contain_processor_name():
     )
     # Lightning's self.hparams is a flat dict after the _flatten_hparams step.
     assert lit.hparams.get("processor") == "RGBProcessor"
+
+
+# ---------------------------------------------------------------------------
+# predict_rgb public inference seam (P2.1)
+# ---------------------------------------------------------------------------
+
+def test_predict_rgb_returns_sr_and_hr_pair(srcnn_rgb_lit: SRLightning, rgb_lr_hr_batch):
+    lr, hr = rgb_lr_hr_batch
+    sr_rgb, hr_cropped = srcnn_rgb_lit.predict_rgb(lr, hr)
+    # SRCNN with valid padding: 33 -> 21; HR center-cropped to match.
+    assert sr_rgb.shape == (2, 3, 21, 21)
+    assert hr_cropped.shape == (2, 3, 21, 21)
+
+
+def test_predict_rgb_matches_step_forward_path(srcnn_rgb_lit: SRLightning, rgb_lr_hr_batch):
+    """predict_rgb must produce the exact sr_rgb / hr_cropped that _step
+    returns — both route through the single _forward_sr core, so the training
+    and benchmark-logging paths cannot diverge."""
+    lr, hr = rgb_lr_hr_batch
+    _, _, _, step_sr, step_hr = srcnn_rgb_lit._step((lr, hr))
+    pred_sr, pred_hr = srcnn_rgb_lit.predict_rgb(lr, hr)
+    torch.testing.assert_close(pred_sr, step_sr)
+    torch.testing.assert_close(pred_hr, step_hr)
+
+
+def test_predict_rgb_matches_step_forward_path_y_channel(srcnn_y_lit: SRLightning, rgb_lr_hr_batch):
+    """Same invariant on the Y-channel path (reconstruct stitches SR-Y with
+    bicubic Cb/Cr) — the reconstructed RGB must be identical across paths."""
+    lr, hr = rgb_lr_hr_batch
+    _, _, _, step_sr, step_hr = srcnn_y_lit._step((lr, hr))
+    pred_sr, pred_hr = srcnn_y_lit.predict_rgb(lr, hr)
+    torch.testing.assert_close(pred_sr, step_sr)
+    torch.testing.assert_close(pred_hr, step_hr)


### PR DESCRIPTION
Introduce an SRDataset ABC with shared extension-allowlist glob / RGB-load / ToTensor and a declared .img_paths contract (P3.6, P5.4), and add a public SRLightning.predict_rgb backed by a shared _forward_sr core so the module and BenchmarkImageLogger cannot diverge (P2.1).

**Stacked PR** - base: `stack/03-pr2` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code