### PR TITLE
Fix val-metric statefulness, HParams expansion, per-image PSNR, config validation (P2.2, P2.3, P2.4, P2.6)

### DIFF
--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -84,3 +84,19 @@ class SREvalConfig:
     crop_border: int = 0
     psnr_channels: list[str] = field(default_factory=lambda: ['RGB'])
     separate_psnr: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate ``psnr_channels`` at construction.
+
+        Raises:
+            ValueError: If any entry is not a supported colorspace
+                (``'RGB'`` or ``'YCbCr'``).
+        """
+        valid = ('RGB', 'YCbCr')
+        invalid = [c for c in self.psnr_channels if c not in valid]
+        if invalid:
+            raise ValueError(
+                f"SREvalConfig.psnr_channels entries must be one of "
+                f"{list(valid)}; got unsupported {invalid}. Fix "
+                f"model.eval_config.init_args.psnr_channels in your YAML."
+            )

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -9,7 +9,7 @@ itself. Optimizer / LR scheduler are wired in from top-level YAML keys by
 """
 import torch
 import torchvision
-import torchmetrics
+import torchmetrics.functional
 import lightning
 from lightning.pytorch.cli import OptimizerCallable, LRSchedulerCallable
 from typing import Any
@@ -114,10 +114,6 @@ class SRLightning(lightning.LightningModule):
                 metric_keys.extend(self._CS_CHANNEL_NAMES[cs])
             metric_keys.append(cs)
         self._psnr_keys = metric_keys
-        self.val_metrics = torchmetrics.MetricCollection({
-            **{f'psnr({k})': torchmetrics.image.PeakSignalNoiseRatio(data_range=1.0) for k in metric_keys},
-            'ssim': torchmetrics.image.StructuralSimilarityIndexMeasure(data_range=1.0),
-        })
 
     @staticmethod
     def _flatten_hparams(hparams: dict[str, Any], sep: str = '/') -> dict:
@@ -340,12 +336,14 @@ class SRLightning(lightning.LightningModule):
         for key in self._psnr_keys:
             sr_t, hr_t = psnr_tensors[key]
             self.log(
-                f'val_psnr({key})', self.val_metrics[f'psnr({key})'](sr_t, hr_t),
+                f'val_psnr({key})',
+                torchmetrics.functional.image.peak_signal_noise_ratio(sr_t, hr_t, data_range=1.0),
                 prog_bar=(key == primary),
                 on_step=False, add_dataloader_idx=False,
             )
         self.log(
-            'val_ssim', self.val_metrics['ssim'](sr, hr_cropped),
+            'val_ssim',
+            torchmetrics.functional.image.structural_similarity_index_measure(sr, hr_cropped, data_range=1.0),
             prog_bar=True, on_step=False, add_dataloader_idx=False,
         )
 

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -192,6 +192,26 @@ class SRLightning(lightning.LightningModule):
 
         return tensors
 
+    @staticmethod
+    def _mean_psnr(sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
+        """Mean of the per-image PSNRs across the batch (SR-standard reduction).
+
+        Scores each image independently (``dim=(1, 2, 3)``) before the batch
+        mean, so the result is invariant to the val ``batch_size``. This differs
+        from pooling the whole batch into one PSNR — the deviation a stateful
+        ``PeakSignalNoiseRatio`` with default ``dim`` would introduce.
+
+        Args:
+            sr: SR tensor of shape ``(B, C, H, W)`` in ``[0, 1]``.
+            hr: HR tensor of the same shape.
+
+        Returns:
+            Scalar tensor — the batch mean of the per-image PSNRs.
+        """
+        return torchmetrics.functional.image.peak_signal_noise_ratio(
+            sr, hr, data_range=1.0, dim=(1, 2, 3), reduction='elementwise_mean'
+        )
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the wrapped SR model on ``x`` and return its raw output.
 
@@ -341,7 +361,7 @@ class SRLightning(lightning.LightningModule):
             sr_t, hr_t = psnr_tensors[key]
             self.log(
                 f'val_psnr({key})',
-                torchmetrics.functional.image.peak_signal_noise_ratio(sr_t, hr_t, data_range=1.0),
+                self._mean_psnr(sr_t, hr_t),
                 prog_bar=(key == primary),
                 on_step=False, add_dataloader_idx=False,
             )

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -7,6 +7,7 @@ in :class:`~sisr.training.config.SRTrainingConfig` /
 itself. Optimizer / LR scheduler are wired in from top-level YAML keys by
 :class:`~sisr.cli.SRLightningCLI`.
 """
+import dataclasses
 import torch
 import torchvision
 import torchmetrics.functional
@@ -98,8 +99,11 @@ class SRLightning(lightning.LightningModule):
             )
 
         # Merge model.hparams + processor identity into Lightning hparams for TensorBoard HParams.
+        # Configs are expanded via dataclasses.asdict so each field becomes its own HParams column.
         self._hparams = self._flatten_hparams({
             **self._hparams,
+            'training_config': dataclasses.asdict(self.training_config),
+            'eval_config': dataclasses.asdict(self.eval_config),
             'model': model.hparams,
             'processor': type(processor).__name__,
             'criterion': type(self.criterion).__name__,

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -1,5 +1,7 @@
 from dataclasses import fields
 
+import pytest
+
 from sisr.training import SREvalConfig, SRTrainingConfig
 
 
@@ -36,3 +38,12 @@ def test_sr_training_config_field_names():
 def test_sr_eval_config_field_names():
     names = {f.name for f in fields(SREvalConfig)}
     assert names == {"crop_border", "psnr_channels", "separate_psnr"}
+
+
+def test_eval_config_rejects_unknown_psnr_channel():
+    """Regression (P2.3): a colorspace outside {RGB, YCbCr} fails fast at
+    construction with an actionable message — not an opaque KeyError deep in
+    SRLightning."""
+    SREvalConfig(psnr_channels=["RGB", "YCbCr"])  # valid — must not raise
+    with pytest.raises(ValueError, match="psnr_channels"):
+        SREvalConfig(psnr_channels=["RGB", "HSV"])

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -524,3 +524,29 @@ def test_hparams_expand_nested_config_fields():
     # regression guard: no stringified dataclass blob under the bare key
     assert "eval_config" not in flat
     assert "training_config" not in flat
+
+
+# ---------------------------------------------------------------------------
+# P2.6 — val PSNR is the per-image mean, invariant to batch size
+# ---------------------------------------------------------------------------
+
+def test_val_psnr_is_per_image_mean_not_batch_pooled():
+    """Regression (P2.6): PSNR for a batch equals the mean of the per-image
+    PSNRs (SR-standard reduction, invariant to val batch_size), not the
+    batch-pooled PSNR that a default-dim PeakSignalNoiseRatio would give."""
+    from torchmetrics.functional.image import peak_signal_noise_ratio as psnr_fn
+
+    g = torch.Generator().manual_seed(1)
+    hr = torch.rand(2, 3, 8, 8, generator=g) * 0.8   # keep values in [0, 0.8]
+    sr = hr.clone()
+    sr[0] = sr[0] + 0.01                             # image 0: small error
+    sr[1] = sr[1] + 0.15                             # image 1: larger error
+
+    per_image = torch.stack([
+        psnr_fn(sr[i:i + 1], hr[i:i + 1], data_range=1.0) for i in range(2)
+    ]).mean()
+    pooled = psnr_fn(sr, hr, data_range=1.0)          # dim=None -> pools the batch
+
+    batch_val = SRLightning._mean_psnr(sr, hr)
+    assert torch.allclose(batch_val, per_image, atol=1e-5)
+    assert not torch.allclose(batch_val, pooled, atol=1e-3)

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -500,3 +500,27 @@ def test_val_metrics_hold_no_stateful_accumulators(srcnn_y_lit: SRLightning):
     assert stateful == [], (
         f"expected no stateful torchmetrics.Metric accumulators; found {stateful}"
     )
+
+
+# ---------------------------------------------------------------------------
+# P2.4 — nested config dataclasses expand into HParams columns
+# ---------------------------------------------------------------------------
+
+def test_hparams_expand_nested_config_fields():
+    """Regression (P2.4): training_config/eval_config dataclasses expand into
+    individual HParams columns (via dataclasses.asdict) using the '/' separator,
+    instead of a single stringified blob under the bare key."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(crop_border=7),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    flat = dict(lit.hparams)
+    assert flat.get("eval_config/crop_border") == 7
+    assert flat.get("training_config/init_strategy") == "default"
+    # regression guard: no stringified dataclass blob under the bare key
+    assert "eval_config" not in flat
+    assert "training_config" not in flat

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import lightning
 import pytest
 import torch
+import torchmetrics
 
 from sisr.models.base import SRModel
 from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
@@ -485,3 +486,17 @@ def test_predict_rgb_matches_step_forward_path_y_channel(srcnn_y_lit: SRLightnin
     pred_sr, pred_hr = srcnn_y_lit.predict_rgb(lr, hr)
     torch.testing.assert_close(pred_sr, step_sr)
     torch.testing.assert_close(pred_hr, step_hr)
+
+
+# ---------------------------------------------------------------------------
+# P2.2 — no dead stateful metric accumulator
+# ---------------------------------------------------------------------------
+
+def test_val_metrics_hold_no_stateful_accumulators(srcnn_y_lit: SRLightning):
+    """Regression (P2.2): PSNR/SSIM are computed via torchmetrics.functional,
+    so SRLightning registers no stateful torchmetrics.Metric accumulators that
+    would grow unread and unreset across a validation run."""
+    stateful = [m for m in srcnn_y_lit.modules() if isinstance(m, torchmetrics.Metric)]
+    assert stateful == [], (
+        f"expected no stateful torchmetrics.Metric accumulators; found {stateful}"
+    )


### PR DESCRIPTION
Compute val PSNR/SSIM via torchmetrics.functional to remove dead accumulator state (P2.2), validate psnr_channels (P2.3), expand nested dataclass configs into individual HParams via asdict (P2.4), and make val PSNR a per-image mean invariant to batch size (P2.6).

**Stacked PR** - base: `stack/04-pr4` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code