### PR TITLE
Strengthen weak tests: reference-tensor assertions + callback spies (P3.3, P3.4, P3.5)

### DIFF
--- a/tests/datasets/test_srresnet.py
+++ b/tests/datasets/test_srresnet.py
@@ -11,13 +11,37 @@ from sisr.datasets.srresnet import TrainDataset, ValidationDataset
 # ---------------------------------------------------------------------------
 
 def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
+    """LR must be the cv2 INTER_CUBIC downscale of the SAME HR crop the item
+    returned — not merely a (3, h/scale, w/scale) tensor in [0, 1]. Recovers the
+    returned HR crop as uint8 and re-runs the dataset's own LR pipeline as the
+    reference; the crop is random, but LR and HR come from one call, so the
+    reference is exact. A regression to bilinear/nearest downscaling fails here."""
+    import cv2
+    import numpy as np
+    import albumentations as A
+    from albumentations.pytorch import ToTensorV2
+
     ds = TrainDataset(img_dir=tiny_rgb_image_dir, scale=4, hr_crop_size=16)
     lr, hr = ds[0]
+
+    # Shape / dtype / range (retained smoke coverage).
     assert hr.shape == (3, 16, 16)
     assert lr.shape == (3, 4, 4)  # 16 // 4
     assert lr.dtype == torch.float32 and hr.dtype == torch.float32
     assert 0.0 <= lr.min() <= lr.max() <= 1.0
     assert 0.0 <= hr.min() <= hr.max() <= 1.0
+
+    # Reference: recover the HR crop as uint8 HWC and re-run the dataset's own
+    # LR pipeline (A.Resize INTER_CUBIC -> ToFloat -> ToTensorV2).
+    hr_uint8 = (hr.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
+    lr_size = 16 // 4
+    ref_pipeline = A.Compose([
+        A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
+        A.ToFloat(max_value=255.0),
+        ToTensorV2(),
+    ])
+    lr_expected = ref_pipeline(image=hr_uint8)["image"]
+    torch.testing.assert_close(lr, lr_expected, atol=1e-6, rtol=0)
 
 
 def test_train_dataset_len_scales_with_crops_per_image(tiny_rgb_image_dir: Path):

--- a/tests/models/srcnn/test_model.py
+++ b/tests/models/srcnn/test_model.py
@@ -131,3 +131,25 @@ def test_hparams_architectural_only():
         padding=0,
     )
     assert set(model.hparams.keys()) == {"num_channels", "num_filters", "kernel_sizes", "padding"}
+
+
+def test_forward_multilayer_mapping_builds_extra_conv_and_preserves_shape():
+    """A 3-entry num_filters (64, 32, 16) exercises the mapping comprehension
+    for TWO hidden convs — every other valid config uses (64, 32) -> a single
+    mapping conv, so the loop over range(len(num_filters) - 1) is untested for
+    >1 layer. Asserts the deep net builds exactly 4 Conv2d (feat + 2 mapping +
+    recon), that `mapping` holds 2 of them, and that same padding preserves the
+    spatial size through the forward pass."""
+    model = SRCNN(
+        num_channels=3,
+        num_filters=(64, 32, 16),
+        kernel_sizes=(9, 1, 3, 5),   # len == len(num_filters) + 1
+        padding="same",
+    )
+    n_convs = sum(1 for m in model.modules() if isinstance(m, torch.nn.Conv2d))
+    assert n_convs == 4
+    # (64,32) would give a single mapping conv; (64,32,16) must give two.
+    assert sum(1 for m in model.mapping if isinstance(m, torch.nn.Conv2d)) == 2
+    x = torch.zeros(2, 3, 16, 16)
+    out = model(x)
+    assert out.shape == (2, 3, 16, 16)

--- a/tests/models/srresnet/test_model.py
+++ b/tests/models/srresnet/test_model.py
@@ -80,15 +80,22 @@ def test_residual_block_preserves_shape():
     assert out.shape == x.shape
 
 
-def test_residual_block_adds_identity():
-    """With BatchNorm in eval and zero input, the residual addition should
-    surface even tiny non-zero contributions from biases."""
+def test_residual_block_is_identity_when_branch_zeroed():
+    """block(x) = x + branch(x), where branch = conv->BN->PReLU->conv->BN.
+    Zero the SECOND conv's weight+bias so its output is 0; in eval mode the
+    trailing BatchNorm maps 0 -> 0 (running_mean=0, bias=0), collapsing the whole
+    residual branch to 0. The block must then reproduce its (random, non-zero)
+    input exactly. The old test fed zeros and only asserted the shape, so a
+    dropped/renamed skip connection would have passed unnoticed."""
+    torch.manual_seed(0)
     block = SRResidualBlock(channels=16, kernel_size=3).eval()
-    x = torch.zeros(1, 16, 4, 4)
+    with torch.no_grad():
+        block.block2[0].weight.zero_()   # block2 = Sequential(Conv2d, BatchNorm2d)
+        block.block2[0].bias.zero_()
+    x = torch.rand(1, 16, 4, 4)           # random, non-zero: identity must survive
     with torch.no_grad():
         out = block(x)
-    # block(x) = x + branch(x); for x=0, out = branch(0). Just check it ran.
-    assert out.shape == x.shape
+    torch.testing.assert_close(out, x, atol=1e-6, rtol=0)
 
 
 def test_upsample_block_doubles_spatial():

--- a/tests/processors/test_y_channel.py
+++ b/tests/processors/test_y_channel.py
@@ -2,7 +2,7 @@
 import torch
 
 from sisr.processors import YChannelProcessor, SRProcessor
-from sisr.utils import rgb_to_ycbcr
+from sisr.utils import rgb_to_ycbcr, ycbcr_to_rgb
 
 
 def test_y_channel_processor_is_srprocessor():
@@ -19,21 +19,43 @@ def test_y_channel_extract_returns_single_y_channel():
     assert torch.allclose(out, expected, atol=1e-6)
 
 
-def test_y_channel_reconstruct_same_size_lr_and_sr():
-    """SR-Y same spatial size as LR (SRCNN-style): output shape [B,3,H,W], valid RGB."""
+def test_y_channel_reconstruct_same_size_roundtrips_to_lr():
+    """SRCNN-style (SR-Y same size as LR): feeding the LR's own Y back through
+    reconstruct must roundtrip to the original RGB. Same-size bicubic Cb/Cr
+    resampling is exact identity, so out == ycbcr_to_rgb(rgb_to_ycbcr(lr)) ~= lr.
+    The old assertion only checked out was in [0, 1] (always true after the
+    clamp); this pins that the stitch + inverse actually recover the input."""
+    import torch.nn.functional as F
     p = YChannelProcessor()
     lr = torch.rand(2, 3, 16, 16)
-    sr_y = rgb_to_ycbcr(lr)[:, 0:1]    # SR-Y exactly the LR-Y (round-trip)
+    sr_y = rgb_to_ycbcr(lr)[:, 0:1]        # SR-Y is exactly the LR-Y
     out = p.reconstruct(sr_y, lr)
     assert out.shape == (2, 3, 16, 16)
-    assert out.min() >= 0.0 and out.max() <= 1.0
+    # Same-size interpolate is an exact no-op, so the whole path is a roundtrip.
+    same = F.interpolate(rgb_to_ycbcr(lr)[:, 1:], size=(16, 16),
+                         mode="bicubic", align_corners=False)
+    assert torch.equal(same, rgb_to_ycbcr(lr)[:, 1:])  # bicubic@same-size == identity
+    # Tolerance 1e-3: the BT.601 coeffs in sisr.utils are truncated to 3 dp, so
+    # the forward/inverse matrices aren't perfect inverses (worst-case ~5e-4).
+    assert torch.allclose(out, lr, atol=1e-3)
 
 
-def test_y_channel_reconstruct_upscaled_sr():
-    """SR-Y larger than LR (SRResNet-style): bicubic Cb/Cr is interpolated up to SR-Y size."""
+def test_y_channel_reconstruct_upscaled_stitches_bicubic_chroma():
+    """SRResNet-style (SR-Y larger than LR): the Y passes through untouched and
+    the LR Cb/Cr are bicubic-upsampled to the SR-Y size, then converted to RGB.
+    The old test asserted shape only. This re-derives the exact reconstruction
+    from the same primitives, so switching the interpolation mode/target size or
+    dropping the Y pass-through fails."""
+    import torch.nn.functional as F
     p = YChannelProcessor()
     lr = torch.rand(2, 3, 8, 8)
-    sr_y = torch.rand(2, 1, 32, 32)    # 4x upscale
+    sr_y = torch.rand(2, 1, 32, 32)        # 4x upscale
     out = p.reconstruct(sr_y, lr)
     assert out.shape == (2, 3, 32, 32)
+
+    lr_ycbcr = rgb_to_ycbcr(lr)
+    cbcr = F.interpolate(lr_ycbcr[:, 1:], size=(32, 32),
+                        mode="bicubic", align_corners=False)
+    expected = ycbcr_to_rgb(torch.cat([sr_y, cbcr], dim=1))
+    torch.testing.assert_close(out, expected, atol=1e-6, rtol=0)
 

--- a/tests/processors/test_ycbcr.py
+++ b/tests/processors/test_ycbcr.py
@@ -18,14 +18,28 @@ def test_ycbcr_extract_returns_full_ycbcr():
     assert torch.allclose(out, rgb_to_ycbcr(lr), atol=1e-6)
 
 
-def test_ycbcr_reconstruct_converts_back_to_rgb():
-    """reconstruct converts YCbCr SR output to RGB."""
+def test_ycbcr_reconstruct_matches_bt601_inverse_not_just_clamp():
+    """reconstruct must apply the real BT.601 full-range inverse, not merely
+    land in [0, 1]. The old assertion (out.min() >= 0, out.max() <= 1) passed
+    even for wrong coefficients because ycbcr_to_rgb clamps to [0, 1]. Here the
+    chroma is mid-range so the correct RGB is strictly inside (0, 1) — the clamp
+    is a genuine no-op, and a coefficient/sign/offset regression changes the
+    values instead of being hidden."""
     p = YCbCrProcessor()
-    lr = torch.rand(2, 3, 8, 8)
-    sr_ycbcr = rgb_to_ycbcr(lr)        # use a known-valid YCbCr tensor
-    out = p.reconstruct(sr_ycbcr, lr)
-    assert out.shape == (2, 3, 8, 8)
-    assert out.min() >= 0.0 and out.max() <= 1.0
+    # Stored Y=0.5, Cb=0.6, Cr=0.4 -> signed cb=+0.1, cr=-0.1 (the +0.5 offset).
+    ycbcr = torch.tensor([0.5, 0.6, 0.4]).view(1, 3, 1, 1).expand(1, 3, 2, 2).clone()
+    lr = torch.rand(1, 3, 2, 2)  # only its shape matters to reconstruct
+    out = p.reconstruct(ycbcr, lr)
+
+    # Hand-computed BT.601 full-range inverse (coefficients from sisr.utils).
+    cb, cr = 0.1, -0.1
+    r = 0.5 + 1.402 * cr
+    g = 0.5 - 0.344 * cb - 0.714 * cr
+    b = 0.5 + 1.772 * cb
+    expected = torch.tensor([r, g, b]).view(1, 3, 1, 1).expand(1, 3, 2, 2)
+
+    assert out.min() > 0.0 and out.max() < 1.0  # clamp is a genuine no-op here
+    torch.testing.assert_close(out, expected, atol=1e-6, rtol=0)
 
 
 def test_ycbcr_roundtrip_recovers_input():

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -323,22 +323,39 @@ def test_benchmark_validation_epoch_end_logs_means():
     assert psnr_call.args[1] == pytest.approx(31.0)
 
 
-def test_benchmark_validation_epoch_end_logs_image_strips_when_on_interval(tmp_path: Path):
-    """When _val_run_count hits the log interval, image strips are emitted to
-    a TensorBoardLogger via experiment.add_image / add_scalar."""
+def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path: Path, monkeypatch):
+    """When on the log interval, _flush_buffer must actually call
+    experiment.add_image once (the bicubic|SR|HR strip) and experiment.add_scalar
+    for the per-image psnr + ssim. The old test only checked it didn't raise, so
+    a silently-skipped emit would have passed."""
     import lightning.pytorch.loggers as pl_loggers
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    # SRCNN-style: LR already at HR size (4x4). One image, one psnr key.
     cb._buffer["Set5"] = [
         ("img_0", torch.rand(3, 4, 4), torch.rand(3, 4, 4), torch.rand(3, 4, 4),
          {"RGB": 30.0}, 0.9),
     ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
+    experiment = tb_logger.experiment  # materialize the SummaryWriter before wrapping
+    add_image = MagicMock(wraps=experiment.add_image)
+    add_scalar = MagicMock(wraps=experiment.add_scalar)
+    monkeypatch.setattr(experiment, "add_image", add_image)
+    monkeypatch.setattr(experiment, "add_scalar", add_scalar)
+
     trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
     cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
-    tb_logger.finalize("success")  # flush
+    tb_logger.finalize("success")
+
+    add_image.assert_called_once()
+    tag, strip = add_image.call_args.args[0], add_image.call_args.args[1]
+    assert tag == "Set5/img_0"
+    assert strip.ndim == 3 and strip.shape[0] == 3   # (C, H, W) triptych
+    # One psnr scalar (RGB) + one ssim scalar for the single buffered image.
+    scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
+    assert scalar_tags == ["Set5_psnr(RGB)/img_0", "Set5_ssim/img_0"]
 
 
 def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path, monkeypatch):
@@ -379,10 +396,11 @@ def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path,
     torch.testing.assert_close(panels[2], hr)
 
 
-def test_benchmark_image_strips_handle_upscaling_sizes(tmp_path: Path):
-    """For an upscaling model (SRResNet) the LR is smaller than SR/HR; the
-    strip must bicubic-upsample LR to HR size rather than crash make_grid on
-    a size mismatch."""
+def test_benchmark_image_strips_upsample_lr_to_hr_size(tmp_path: Path, monkeypatch):
+    """For an upscaling model (SRResNet) LR (4x4) is smaller than SR/HR (16x16);
+    the strip must bicubic-upsample LR to HR size, so add_image is called once
+    with a panel taller than the LR (not crash make_grid on a size mismatch, and
+    not log at LR size). The old test only asserted it didn't raise."""
     import lightning.pytorch.loggers as pl_loggers
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
@@ -394,9 +412,20 @@ def test_benchmark_image_strips_handle_upscaling_sizes(tmp_path: Path):
          {"RGB": 30.0}, 0.9),
     ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
+    experiment = tb_logger.experiment
+    add_image = MagicMock(wraps=experiment.add_image)
+    monkeypatch.setattr(experiment, "add_image", add_image)
+
     trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
     cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)  # must not raise
     tb_logger.finalize("success")
+
+    add_image.assert_called_once()
+    strip = add_image.call_args.args[1]
+    # make_grid pads each panel by 2px per side -> HR-sized panels give height
+    # 16 + 4 = 20; the point is it is upsampled to HR (>> the 4px LR).
+    assert strip.shape[-2] == 20
+    assert strip.shape[-2] > 4
 
 
 def test_benchmark_test_batch_end_collects_with_zero_indexed_mapping():
@@ -436,7 +465,11 @@ def test_benchmark_test_epoch_end_logs_means():
 # WeightHistogramLogger on-cadence path
 # ---------------------------------------------------------------------------
 
-def test_weight_histogram_logger_emits_on_cadence(tmp_path: Path):
+def test_weight_histogram_logger_calls_add_histogram_for_model_params_only(tmp_path: Path, monkeypatch):
+    """On-cadence, the logger must call experiment.add_histogram exactly once for
+    the single `model.`-prefixed parameter (the non-model param is filtered out),
+    with the prefix-grouped tag. The old test only checked it didn't raise, so a
+    broken `model.` filter or a missing emit would have passed."""
     import lightning.pytorch.loggers as pl_loggers
     cb = WeightHistogramLogger(log_every_n_steps=1)
     pl_module = MagicMock()
@@ -445,9 +478,17 @@ def test_weight_histogram_logger_emits_on_cadence(tmp_path: Path):
         ("non_model_param", torch.nn.Parameter(torch.rand(4))),  # filtered out
     ])
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
+    experiment = tb_logger.experiment
+    add_histogram = MagicMock(wraps=experiment.add_histogram)
+    monkeypatch.setattr(experiment, "add_histogram", add_histogram)
+
     trainer = SimpleNamespace(global_step=1, loggers=[tb_logger])
     cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
     tb_logger.finalize("success")
+
+    add_histogram.assert_called_once()
+    # name.split('.', 2) -> ["model","feat","0.weight"]; tag = "model" + "." + "feat/0.weight"
+    assert add_histogram.call_args.args[0] == "model.feat/0.weight"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace clamp/shape-only assertions with reference-tensor checks, add a multi-layer SRCNN forward + conv-count test, and spy on the callback add_image/add_scalar/add_histogram calls (P3.3, P3.4, P3.5). Test-only.

**Stacked PR** - base: `stack/05-pr5` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code