### PR TITLE
Speed up test suite ~6.5x via pytest-xdist + shared LMDB fixture (P4.10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install
         run: pip install -e ".[dev]"
       - name: Run tests with coverage
-        run: pytest --cov=sisr --cov-report=xml --cov-report=term --cov-fail-under=90
+        run: pytest -n 8 --cov=sisr --cov-report=xml --cov-report=term --cov-fail-under=90
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,10 @@ testpaths = ["tests"]
 # subdirs (e.g. tests/models/srcnn/test_model.py vs
 # tests/models/srresnet/test_model.py) without requiring __init__.py files.
 # -n 8 is the measured-clean xdist worker count; -n auto (=16 here) oversubscribed.
-# Capped so it merely time-slices on smaller CI runners.
-addopts = "-ra --strict-markers --import-mode=importlib -n 8"
+# Capped so it merely time-slices on smaller CI runners. --dist=loadscope keeps
+# same-module tests on one worker so module-scoped fixtures (e.g. the shared
+# SRCNN LMDB cache) build once instead of once per worker.
+addopts = "-ra --strict-markers --import-mode=importlib -n 8 --dist=loadscope"
 filterwarnings = [
     "error",
     # Lightning 2.6.5 constructs torch 2.12's deprecated pytree `LeafSpec` at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ dependencies = [
 dev = [
     "pytest>=8",
     "pytest-cov>=5",
+    # Parallelizes the suite (see addopts `-n 8`); execnet is pulled in transitively.
+    "pytest-xdist>=3.6",
     # tests/test_cli.py parses/emits config YAML directly; PyYAML otherwise
     # resolves only transitively (via jsonargparse/lightning), which is fragile.
     "pyyaml>=6",
@@ -88,7 +90,9 @@ testpaths = ["tests"]
 # --import-mode=importlib avoids duplicate-basename collisions across test
 # subdirs (e.g. tests/models/srcnn/test_model.py vs
 # tests/models/srresnet/test_model.py) without requiring __init__.py files.
-addopts = "-ra --strict-markers --import-mode=importlib"
+# -n 8 is the measured-clean xdist worker count; -n auto (=16 here) oversubscribed.
+# Capped so it merely time-slices on smaller CI runners.
+addopts = "-ra --strict-markers --import-mode=importlib -n 8"
 filterwarnings = [
     "error",
     # Lightning 2.6.5 constructs torch 2.12's deprecated pytree `LeafSpec` at

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -13,6 +13,32 @@ from sisr.datasets.srcnn import TrainDataset, ValidationDataset
 # TrainDataset
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(scope="module")
+def shared_srcnn_train_ds(tmp_path_factory) -> TrainDataset:
+    """One inline-built SRCNN train cache (subimg_size=20, stride=8) shared by
+    every read-only test in this module.
+
+    Module-scoped so the LMDB build runs once instead of once per test;
+    build_num_workers=1 forces PR 1's inline (no ProcessPool) build path, which
+    keeps it safe when the whole run is under pytest-xdist workers.
+    """
+    img_dir = tmp_path_factory.mktemp("shared_srcnn_hr")
+    rng = np.random.default_rng(seed=0)
+    for i in range(3):
+        arr = rng.integers(0, 256, size=(36, 36, 3), dtype=np.uint8)
+        Image.fromarray(arr).save(img_dir / f"img_{i:02d}.png")
+    return TrainDataset(
+        img_dir=img_dir,
+        subimg_size=20,
+        stride=8,
+        scale=2,
+        blur_sigma=1.0,
+        use_tqdm=False,
+        cache_dir=img_dir / ".lmdb_cache_shared",
+        build_num_workers=1,
+    )
+
+
 def _make_train(image_dir: Path, **overrides) -> TrainDataset:
     defaults = {
         "img_dir": image_dir,
@@ -22,19 +48,18 @@ def _make_train(image_dir: Path, **overrides) -> TrainDataset:
         "blur_sigma": 1.0,
         "use_tqdm": False,
         "cache_dir": image_dir / ".lmdb_cache_train",
+        "build_num_workers": 1,
     }
     defaults.update(overrides)
     return TrainDataset(**defaults)
 
 
-def test_train_dataset_builds_and_len_positive(tiny_rgb_image_dir: Path):
-    ds = _make_train(tiny_rgb_image_dir)
-    assert len(ds) > 0
+def test_train_dataset_builds_and_len_positive(shared_srcnn_train_ds: TrainDataset):
+    assert len(shared_srcnn_train_ds) > 0
 
 
-def test_train_dataset_getitem_shape_dtype_range(tiny_rgb_image_dir: Path):
-    ds = _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8)
-    lr, hr = ds[0]
+def test_train_dataset_getitem_shape_dtype_range(shared_srcnn_train_ds: TrainDataset):
+    lr, hr = shared_srcnn_train_ds[0]
     assert lr.shape == (3, 20, 20)
     assert hr.shape == (3, 20, 20)
     assert lr.dtype == torch.float32
@@ -43,12 +68,11 @@ def test_train_dataset_getitem_shape_dtype_range(tiny_rgb_image_dir: Path):
     assert 0.0 <= hr.min() <= hr.max() <= 1.0
 
 
-def test_train_dataset_missing_key_raises_keyerror(tiny_rgb_image_dir: Path):
+def test_train_dataset_missing_key_raises_keyerror(shared_srcnn_train_ds: TrainDataset):
     """A missing LMDB key (here, an out-of-range index) surfaces as a KeyError
     naming the key, not a cryptic numpy TypeError from np.frombuffer(None)."""
-    ds = _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8)
     with pytest.raises(KeyError, match=r"lr_\d{8}"):
-        ds[len(ds) + 100]
+        shared_srcnn_train_ds[len(shared_srcnn_train_ds) + 100]
 
 
 def test_train_dataset_cache_reuse_skips_rebuild(tiny_rgb_image_dir: Path):
@@ -72,14 +96,11 @@ def test_train_dataset_checksum_change_triggers_rebuild(tiny_rgb_image_dir: Path
     assert len(ds_a) != len(ds_b), "different subimg_size must yield different patch counts"
 
 
-def test_train_dataset_checksum_includes_transforms_impl_tag(tiny_rgb_image_dir: Path):
+def test_train_dataset_checksum_includes_transforms_impl_tag(shared_srcnn_train_ds: TrainDataset):
     """The checksum input must include 'transforms_impl=albumentations' so caches
     built under the old PIL implementation invalidate automatically on upgrade."""
-    ds = _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8)
-    # The canonical hash input is built inside _compute_checksum from these
-    # fields plus the tag. We verify by recomputing what _compute_checksum
-    # should produce and comparing.
     import hashlib
+    ds = shared_srcnn_train_ds
     file_manifest = ','.join(
         f'{p.name}:{p.stat().st_size}' for p in ds.img_paths
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,14 @@
-"""End-to-end CLI smoke tests via subprocess."""
+"""CLI tests: mostly in-process config resolution, plus two subprocess smokes.
+
+Config-resolution / matmul / override / subcommand-help assertions run in-process
+via ``SRLightningCLI(args=..., run=False)`` (see ``_resolve``); only
+``test_cli_print_config_resolves`` and ``test_cli_help_lists_subcommands`` still
+spawn the installed ``sisr`` console script to exercise the real entry point.
+"""
 import subprocess
 import sys
 import sysconfig
+import warnings
 from pathlib import Path
 
 import pytest
@@ -35,6 +42,48 @@ def _cli(*args: str, timeout: int = 60) -> subprocess.CompletedProcess:
     )
 
 
+def _resolve(*args: str):
+    """Resolve a config fully in-process via ``SRLightningCLI(run=False)``.
+
+    No subprocess, no CUDA: jsonargparse merges the YAML + CLI overrides +
+    dataclass defaults and instantiates the classes, but never runs a training
+    loop. ``--trainer.accelerator=cpu --trainer.devices=1`` is appended because
+    ``run=False`` instantiates the Trainer, and both shipped templates request
+    CUDA — the override lets resolution succeed on any machine without touching
+    the model/processor/config fields the tests assert on.
+    """
+    from sisr.cli import SRLightningCLI
+    from sisr.training import SRDataModule, SRLightning
+
+    # LightningCLI warns when both `args=` and sys.argv[1:] are set (it sees
+    # pytest's own argv). The strict `filterwarnings=["error"]` would turn that
+    # into an error, so blank sys.argv for the duration of the parse.
+    saved_argv = sys.argv
+    sys.argv = saved_argv[:1]
+    try:
+        # Two framework-internal warnings fire only on the in-process path (the
+        # subprocess --print_config path never surfaced them) and would trip the
+        # global strict "error" filter, so suppress them locally — leaving the
+        # strict filter intact for our own code:
+        #   * jsonargparse DeprecationWarning: lightning's _add_instantiators
+        #     calls add_instantiator / instantiate_classes, deprecated in 4.49.
+        #   * "GPU available but not used": run=False instantiates the Trainer and
+        #     we force accelerator=cpu; harmless on a GPU dev box, absent on CI.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", message="GPU available but not used.*")
+            return SRLightningCLI(
+                model_class=SRLightning,
+                datamodule_class=SRDataModule,
+                auto_configure_optimizers=False,
+                save_config_kwargs={"overwrite": True},
+                args=[*args, "--trainer.accelerator=cpu", "--trainer.devices=1"],
+                run=False,
+            )
+    finally:
+        sys.argv = saved_argv
+
+
 def test_cli_print_config_resolves():
     """`cli fit --print_config` exits 0 and resolves the SRCNN template."""
     proc = _cli("fit", "--config", str(TEMPLATE), "--print_config")
@@ -53,41 +102,63 @@ def test_cli_print_config_resolves():
     assert "optimizer:" in out
 
 
-def test_cli_srresnet_print_config_resolves():
-    """`cli fit --print_config` exits 0 and resolves the SRResNet template
-    (model + paper-faithful configs + random-crop dataset classes)."""
-    proc = _cli("fit", "--config", str(SRRESNET_TEMPLATE), "--print_config")
-    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
-    out = proc.stdout
-    assert "class_path: sisr.models.srresnet.SRResNet" in out
-    assert "class_path: sisr.processors.RGBProcessor" in out
-    assert "class_path: sisr.models.srresnet.SRResNetTrainingConfig" in out
-    assert "class_path: sisr.models.srresnet.SRResNetEvalConfig" in out
-    assert "class_path: sisr.datasets.srresnet.TrainDataset" in out
-    assert "class_path: sisr.datasets.srresnet.ValidationDataset" in out
-    assert "hr_crop_size: 96" in out
-    assert "crop_border: 4" in out                  # still present — inherited default
-    # The removed model_colorspace field must not reappear.
-    assert "model_colorspace" not in out
-
-
-def test_cli_test_subcommand_exposes_ckpt_path():
-    """`cli test --help` documents --ckpt_path and --data.test_datasets."""
-    proc = _cli("test", "--help")
-    assert proc.returncode == 0
-    assert "--ckpt_path" in proc.stdout
-    assert "--data.test_datasets" in proc.stdout
-
-
-def test_cli_optimizer_lr_override():
-    """Top-level --optimizer.init_args.lr override surfaces in resolved config."""
-    proc = _cli(
-        "fit", "--config", str(TEMPLATE),
-        "--optimizer.init_args.lr=5e-3",
-        "--print_config",
+def test_srresnet_config_resolves_in_process():
+    """SRResNet template resolves to the paper-faithful model/processor/config
+    classes + the random-crop dataset specs — resolved in-process (no subprocess).
+    Ports the class-wiring assertions of the old subprocess --print_config test."""
+    from sisr.models.srresnet import (
+        SRResNet,
+        SRResNetEvalConfig,
+        SRResNetTrainingConfig,
     )
-    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
-    assert "lr: 0.005" in proc.stdout
+    from sisr.processors import RGBProcessor
+
+    cli = _resolve("--config", str(SRRESNET_TEMPLATE))
+    m = cli.model
+    assert isinstance(m.model, SRResNet)
+    assert isinstance(m.processor, RGBProcessor)
+    assert isinstance(m.training_config, SRResNetTrainingConfig)
+    assert isinstance(m.eval_config, SRResNetEvalConfig)
+    assert m.eval_config.crop_border == 4          # inherited-default check
+    # Dataset specs stay plain {class_path, init_args} dicts (materialized lazily
+    # in SRDataModule.setup), so assert on the resolved raw config.
+    assert cli.config.data.train_dataset["class_path"] == "sisr.datasets.srresnet.TrainDataset"
+    assert cli.config.data.val_dataset["class_path"] == "sisr.datasets.srresnet.ValidationDataset"
+    assert cli.config.data.train_dataset["init_args"]["hr_crop_size"] == 96
+    # The removed model_colorspace field must not reappear anywhere.
+    assert not hasattr(m, "model_colorspace")
+    assert not hasattr(m.eval_config, "model_colorspace")
+
+
+def test_test_subcommand_help_exposes_ckpt_path_in_process(capsys, monkeypatch):
+    """`test --help` documents --ckpt_path and --data.test_datasets.
+
+    run=True + args=['test','--help'] parses in-process and exits after printing
+    help (SystemExit) — no cold subprocess, no class instantiation. sys.argv is
+    blanked so LightningCLI doesn't warn (→ error under the strict filter) about
+    seeing both args= and pytest's own argv."""
+    from sisr.cli import SRLightningCLI
+    from sisr.training import SRDataModule, SRLightning
+
+    monkeypatch.setattr(sys, "argv", sys.argv[:1])
+    with pytest.raises(SystemExit):
+        SRLightningCLI(
+            model_class=SRLightning,
+            datamodule_class=SRDataModule,
+            auto_configure_optimizers=False,
+            save_config_kwargs={"overwrite": True},
+            args=["test", "--help"],
+            run=True,
+        )
+    out = capsys.readouterr().out
+    assert "--ckpt_path" in out
+    assert "--data.test_datasets" in out
+
+
+def test_optimizer_lr_override_in_process():
+    """Top-level --optimizer.init_args.lr override surfaces in the resolved config."""
+    cli = _resolve("--config", str(TEMPLATE), "--optimizer.init_args.lr=5e-3")
+    assert cli.config.optimizer.init_args.lr == pytest.approx(0.005)
 
 
 def test_cli_help_lists_subcommands():
@@ -97,32 +168,23 @@ def test_cli_help_lists_subcommands():
         assert sub in proc.stdout
 
 
-def test_cli_matmul_precision_accepted_and_surfaces():
-    """`--matmul_precision=high` is accepted and round-trips through --print_config."""
-    proc = _cli(
-        "fit", "--config", str(TEMPLATE),
-        "--matmul_precision=high",
-        "--print_config",
-    )
-    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
-    assert "matmul_precision: high" in proc.stdout
+def test_matmul_precision_accepted_in_process():
+    """--matmul_precision=high is accepted and round-trips into the resolved config."""
+    cli = _resolve("--config", str(TEMPLATE), "--matmul_precision=high")
+    assert cli.config.matmul_precision == "high"
 
 
-def test_cli_matmul_precision_defaults_to_null():
-    """When unset, matmul_precision surfaces as null in --print_config."""
-    proc = _cli("fit", "--config", str(TEMPLATE), "--print_config")
-    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
-    assert "matmul_precision: null" in proc.stdout
+def test_matmul_precision_defaults_to_none_in_process():
+    """When unset, matmul_precision resolves to None."""
+    cli = _resolve("--config", str(TEMPLATE))
+    assert cli.config.matmul_precision is None
 
 
-def test_cli_matmul_precision_rejects_invalid():
-    """Invalid matmul_precision values are rejected by the Literal validator."""
-    proc = _cli(
-        "fit", "--config", str(TEMPLATE),
-        "--matmul_precision=bogus",
-        "--print_config",
-    )
-    assert proc.returncode != 0
+def test_matmul_precision_rejects_invalid_in_process():
+    """Invalid matmul_precision is rejected by the Literal validator during parse
+    (SystemExit from jsonargparse), before any class is instantiated."""
+    with pytest.raises(SystemExit):
+        _resolve("--config", str(TEMPLATE), "--matmul_precision=bogus")
 
 
 # In-process unit tests for SRLightningCLI.before_instantiate_classes. Subprocess
@@ -189,12 +251,13 @@ def test_template_yaml_parses(template_path: Path):
 def test_template_disables_default_hp_metric(template_path: Path):
     """Each shipped template must disable TensorBoard's hp_metric: -1 placeholder.
 
-    The resolved --print_config output is the source of truth; checking the YAML
-    file directly would miss cases where a default is inherited or overridden.
-    """
-    proc = _cli("fit", "--config", str(template_path), "--print_config")
-    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
-    assert "default_hp_metric: false" in proc.stdout, (
+    Resolved in-process: cli.config is the same merged config --print_config would
+    dump, so an inherited/overridden default is honored (checking the raw YAML
+    would miss that)."""
+    cli = _resolve("--config", str(template_path))
+    loggers = cli.config.trainer.logger
+    tb = next(l for l in loggers if str(l.class_path).endswith("TensorBoardLogger"))
+    assert tb.init_args.default_hp_metric is False, (
         f"{template_path.name} does not disable the hp_metric placeholder. "
         f"Add `default_hp_metric: false` under the TensorBoardLogger init_args."
     )

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -18,6 +18,7 @@ def _make_dm(image_dir: Path, *, with_train: bool = True) -> SRDataModule:
             "blur_sigma": 1.0,
             "use_tqdm": False,
             "cache_dir": str(image_dir / ".lmdb_cache_train"),
+            "build_num_workers": 1,
         },
     }
     val_spec = {
@@ -110,6 +111,7 @@ def test_test_dataloader_kwargs_falls_back_to_val(tiny_rgb_image_dir: Path):
             "blur_sigma": 1.0,
             "use_tqdm": False,
             "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_train_fb"),
+            "build_num_workers": 1,
         },
     }
     val_spec = {
@@ -139,6 +141,7 @@ def test_no_test_datasets_val_dataloader_returns_only_primary(tiny_rgb_image_dir
             "blur_sigma": 1.0,
             "use_tqdm": False,
             "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_only_primary"),
+            "build_num_workers": 1,
         },
     }
     val_spec = {
@@ -195,6 +198,7 @@ def test_train_dataset_built_from_class_path_spec(tiny_rgb_image_dir: Path):
             "blur_sigma": 1.0,
             "use_tqdm": False,
             "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_train_cp"),
+            "build_num_workers": 1,
         },
     }
     val_spec = {


### PR DESCRIPTION
Parallelize the suite with pytest-xdist (-n 8, loadscope), convert cold CLI subprocess tests to in-process resolution, and share one inline-built SRCNN LMDB cache. About 284s down to about 44s (P4.10).

**Stacked PR** - base: `stack/07-pr7` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code