### PR TITLE
Add CONTRIBUTING.md and refresh README (INIT.2, INIT.3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing
+
+Thanks for your interest in `single-image-super-resolution` — a PyTorch Lightning
+framework for reproducing single-image super-resolution (SISR) papers. This guide
+covers how to set up a development environment, run the tests, and land a change.
+
+## Development setup
+
+Requires **Python ≥ 3.12**.
+
+```bash
+# Clone your fork, then install in editable mode with the dev extras:
+git clone https://github.com/YeapJieShen/single-image-super-resolution.git
+cd single-image-super-resolution
+pip install -e ".[dev]"
+```
+
+The `[dev]` extra adds the test toolchain (`pytest`, `pytest-cov`). `pyproject.toml`
+is the single source of truth for dependencies — there is no `requirements.txt`.
+
+If you develop on a CUDA GPU, install the CUDA `torch` / `torchvision` wheels from
+PyTorch's own index **first** (the `+cu###` wheels are not on PyPI), then install the
+project — see the README's *GPU / CUDA notes*.
+
+## Running the tests
+
+```bash
+# Full suite:
+pytest
+
+# With coverage (matches CI):
+pytest --cov=sisr --cov-report=term
+```
+
+Tests live under `tests/`, mirroring the `sisr/` package layout
+(e.g. `sisr/training/lightning_module.py` → `tests/training/test_lightning_module.py`).
+
+### Strict-warnings policy
+
+The suite runs under `filterwarnings = ["error", ...]`: **any unexpected warning fails
+the test run.** A short, explicit ignore-list in `pyproject.toml` covers known upstream
+deprecations only. If your change surfaces a new warning, fix the cause rather than
+broadening the ignore-list; add a narrowly-scoped ignore only for a genuine third-party
+deprecation you cannot control, and note why.
+
+### Regression tests
+
+When you fix a bug, add one test that **fails on the old behavior and passes on the new**.
+Name it after what the failure catches, not after the fix.
+
+## The change workflow
+
+1. Branch off `main`.
+2. Make your change; add or update tests alongside it.
+3. Run `pytest` locally and make sure it is green.
+4. Open a pull request against `main`.
+
+All PRs must pass two GitHub Actions checks before they can merge:
+
+- **test** — installs `.[dev]` and runs `pytest` with coverage (uploaded to Codecov).
+- **build** — verifies `pip install .` and that `sisr` / `sisr.cli.main` import cleanly.
+
+`main` uses linear history (rebase/squash, no merge commits) and requires PRs.
+
+## Commit conventions
+
+- **Imperative subject line** ("Add …", "Fix …", "Refactor …", "Document …").
+- Where a commit closes a tracked item, reference it in the subject
+  (e.g. a PR number like `(#12)`).
+- **Keep documentation-only changes in commits separate from code changes.** A commit
+  either touches code or touches docs, not both.
+
+## Code style
+
+- **Terse code, minimal comments.** Comment only non-obvious *why*, never narrate *what*.
+- **Google-style docstrings** on every public class / function / method in `sisr/`
+  (one-line summary opener, then `Args:` / `Returns:` / `Raises:` when the signature
+  warrants). Class-level `Args:` documents `__init__`; `__init__` itself stays bare.
+- **Modern type hints** — PEP 585 (`list`, `dict`, `tuple`) and PEP 604 (`X | None`);
+  import `Callable` / `Sequence` from `collections.abc`.
+- **No backward-compatibility shims when refactoring.** Prefer clean breaks — drop the
+  old API, remove the unused parameter, delete the dead branch.
+
+## Adding a new architecture
+
+The training stack is generic: one `SRLightning` module composes an `SRModel`
+(pure tensor network) with an `SRProcessor` (colorspace adapter), fed by a generic
+`SRDataModule`. To add an architecture you do **not** write a new Lightning subclass —
+instead:
+
+1. Subclass `sisr.models.base.SRModel` with your network (`forward`, `self._hparams`,
+   and an optional `reset_parameters(**kwargs)` init hook).
+2. Define `<Arch>TrainingConfig` / `<Arch>EvalConfig` dataclasses with the paper's
+   defaults (mirroring `sisr/models/srcnn/config.py`).
+3. Pick an existing `SRProcessor` (`RGBProcessor`, `YChannelProcessor`, `YCbCrProcessor`)
+   or add a new one.
+4. Copy a template in `templates/`, point `model.model` / `model.processor` /
+   `model.training_config` / `model.eval_config` and each dataset `class_path` at your
+   new classes, and run `sisr fit --config <your.yaml>`.
+
+## License
+
+This project is MIT-licensed. Note it depends on
+[AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX) (AGPL-3.0, or a
+separate commercial license from upstream); if you redistribute or host this code as a
+network service, review the AGPL-3.0 obligations.

--- a/README.md
+++ b/README.md
@@ -2,39 +2,57 @@
 
 [![coverage](https://codecov.io/gh/YeapJieShen/single-image-super-resolution/branch/main/graph/badge.svg)](https://app.codecov.io/gh/YeapJieShen/single-image-super-resolution)
 
-A PyTorch Lightning framework for reproducing single image super-resolution (SISR) papers. Training, validation, and test evaluation are all driven through a single `LightningCLI` entrypoint — switching architectures is just a matter of pointing the config at a different model and dataset.
+**Reproduce single-image super-resolution (SISR) papers with one command.** Train any
+architecture through a single `LightningCLI` entrypoint — switching models is just
+pointing the config at a different network and dataset. Built on PyTorch Lightning; every
+experiment is one self-contained YAML.
+
+## Why this exists
+
+SISR papers each ship their own training script, colorspace quirks, and evaluation
+protocol. This framework factors all of that into reusable parts — a generic
+`SRLightning` module (an `SRModel` network × an `SRProcessor` colorspace adapter), a
+generic `SRDataModule`, and per-paper behavior expressed in config dataclasses — so
+reproducing a paper means writing a config, not a new training loop.
 
 ## Models
 
-- **SRCNN** — the 3-layer CNN from [Image Super-Resolution Using Deep Convolutional Networks](https://arxiv.org/pdf/1501.00092). The LR input is pre-upsampled to the HR size (blur → downsample → bicubic upsample), so the model learns a same-resolution refinement. Trained on the Y channel by default.
-- **SRResNet** — the residual generator from [Photo-Realistic Single Image Super-Resolution Using a GAN](https://arxiv.org/pdf/1609.04802). The LR input is genuinely small and the model upsamples it ×`scale` via sub-pixel convolution. Trained on RGB.
+| Model | Paper | LR input | Upsampling | Colorspace |
+|---|---|---|---|---|
+| **SRCNN** | [Image Super-Resolution Using Deep Convolutional Networks](https://arxiv.org/pdf/1501.00092) | Pre-upsampled to HR size (blur → downsample → bicubic up) | None — same-resolution refinement | Y channel |
+| **SRResNet** | [Photo-Realistic Single Image Super-Resolution Using a GAN](https://arxiv.org/pdf/1609.04802) | Genuine low-resolution | ×`scale` sub-pixel convolution | RGB |
 
-The generic [`SRLightning`](sisr/training/lightning_module.py) module wraps any SR model, and [`SRDataModule`](sisr/training/datamodule.py) feeds it; per-architecture knobs live in config dataclasses ([`sisr/training/config.py`](sisr/training/config.py) and the SRCNN subclasses in [`sisr/models/srcnn/config.py`](sisr/models/srcnn/config.py)).
+During training and test evaluation, PSNR/SSIM are logged and **bicubic│SR│HR** image
+strips are written to TensorBoard for each benchmark set (Set5, Set14, …), so you can
+watch reconstruction quality improve run-over-run.
 
-## Install
+## Quickstart
 
-Requires Python ≥ 3.12.
+Requires **Python ≥ 3.12**.
 
 ```bash
-# CPU / default install:
+# 1. Install (CPU / default):
 pip install .
 
-# GPU install — install the CUDA torch/torchvision wheels from PyTorch's
-# own index first (pick the cu### matching your CUDA toolkit), then the
-# project. The second command sees torch already satisfied and resolves
-# the remaining deps from PyPI.
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
-pip install .
+# 2. Confirm the CLI is wired up:
+sisr --help
 
-# Editable + tests:
-pip install -e ".[dev]"
+# 3. Put HR images under data/ (e.g. data/DIV2K_train_HR, data/Set5_HR, …),
+#    then validate a config resolves without training:
+sisr fit --config templates/config.srcnn.template.yaml --print_config
+
+# 4. Train:
+sisr fit --config templates/config.srcnn.template.yaml
 ```
 
-`pyproject.toml` is the single source of truth for dependencies. The CUDA-built torch / torchvision wheels aren't on PyPI, so GPU users install them from PyTorch's index first — same convention as PyTorch's own [Get Started](https://pytorch.org/get-started/locally/) selector.
+`--print_config` dumps the fully resolved config and exits — a fast way to check a config
+before committing to a run (no dataset build happens at parse time).
 
 ## Usage
 
-Training is configured entirely through YAML. Copy a template from [`templates/`](templates/), edit the dataset directories and experiment output paths, then:
+Training is configured entirely through YAML. Copy a template from
+[`templates/`](templates/), edit the dataset directories and experiment output paths,
+then:
 
 ```bash
 # Train SRCNN (x3):
@@ -44,28 +62,76 @@ sisr fit --config templates/config.srcnn.template.yaml
 sisr fit --config templates/config.srresnet.template.yaml
 ```
 
-Per-run overrides can be passed on the CLI without editing the YAML:
+Per-run overrides can be passed on the CLI without editing the YAML (dot-notation;
+optimizer/scheduler args are top-level keys):
 
 ```bash
 sisr fit --config templates/config.srcnn.template.yaml \
     --trainer.max_steps=500000 --optimizer.init_args.lr=1e-3
 ```
 
-After training, evaluate a checkpoint against the test sets (Set5, Set14, …):
+After training, evaluate a checkpoint against the test sets:
 
 ```bash
 sisr test --config templates/config.srcnn.template.yaml \
     --ckpt_path path/to/best.ckpt
 ```
 
-Test sets are also surfaced during `fit` (monitored each validation cycle), and PSNR/SSIM plus bicubic│SR│HR image strips are logged to TensorBoard.
+Test sets are also surfaced during `fit` (monitored each validation cycle). The `sisr`
+console script is registered by `pyproject.toml`; `python -m sisr.cli ...` works too.
 
-## Tests
+## GPU / CUDA notes
+
+The CUDA-built `torch` / `torchvision` wheels aren't on PyPI, so GPU users install them
+from PyTorch's own index **first** (pick the `cu###` matching your CUDA toolkit), then
+install the project — the second command sees `torch` already satisfied and resolves the
+rest from PyPI. Same convention as PyTorch's own
+[Get Started](https://pytorch.org/get-started/locally/) selector.
 
 ```bash
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
+pip install .
+```
+
+The bundled templates set `accelerator: cuda`; change it to `cpu` to run without a GPU.
+
+## Extending it
+
+The training stack is architecture-agnostic — adding a model does **not** require a new
+Lightning subclass:
+
+1. Subclass `sisr.models.base.SRModel` with your network.
+2. Define `<Arch>TrainingConfig` / `<Arch>EvalConfig` dataclasses with the paper's
+   defaults (see `sisr/models/srcnn/config.py`).
+3. Pick an `SRProcessor` (`RGBProcessor`, `YChannelProcessor`, `YCbCrProcessor`) or add
+   one.
+4. Copy a template, point the `class_path`s at your new classes, and `sisr fit`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
+
+## Development
+
+```bash
+pip install -e ".[dev]"
 pytest
 ```
 
-## Note on dependencies
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev loop, testing conventions, commit
+style, and code-style expectations.
 
-This project depends on [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX), which is licensed under AGPL-3.0 (or a separate commercial license from the upstream). The `single-image-super-resolution` project itself remains MIT-licensed. Users who redistribute or host this code as a network service should review AGPL-3.0 obligations.
+## Dependency notes
+
+`pyproject.toml` is the single source of truth for dependencies (no `requirements.txt`).
+
+This project depends on
+[AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX), licensed under
+AGPL-3.0 (or a separate commercial license from upstream). The
+`single-image-super-resolution` project itself remains MIT-licensed. Users who
+redistribute or host this code as a network service should review AGPL-3.0 obligations.
+AlbumentationsX is capped at `<=2.1.0` so it stays on the `simsimd`-backed `albucore`;
+`albucore` 0.1.0 switched its native backend to one whose runtime dependency
+(`libomp140`) is not bundled on stock Windows / Python 3.13, breaking import there.
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Add a human-facing CONTRIBUTING.md (dev loop, strict-warnings policy, commit/style conventions) and refactor README into a layered what/why, quickstart, usage, GPU-and-extend guide with the Codecov badge preserved (INIT.2, INIT.3).

**Stacked PR** - base: `stack/08-pr3` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code