### PR TITLE
Adopt ruff for lint + format with CI gate (INIT.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,21 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Ruff lint
+        run: ruff check --output-format=github .
+      - name: Ruff format check
+        run: ruff format --check .
+
   test-matrix:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     # tests/test_cli.py parses/emits config YAML directly; PyYAML otherwise
     # resolves only transitively (via jsonargparse/lightning), which is fragile.
     "pyyaml>=6",
+    "ruff>=0.9",
 ]
 
 [project.scripts]
@@ -106,3 +107,25 @@ filterwarnings = [
     # Upstream: https://github.com/Lightning-AI/pytorch-lightning (pytree LeafSpec deprecation)
     "ignore::FutureWarning:lightning.*",
 ]
+
+[tool.ruff]
+# Ruff owns lint + format for this project (INIT.1). line-length 100 matches the
+# code as written: 88 would reflow ~157 lines across every file, 100 only ~53
+# (mostly docstrings the formatter can't wrap). It governs both E501 and the
+# formatter's wrap width. target-version pins syntax so UP never rewrites below
+# our requires-python floor. Formatter runs with defaults (double quotes, which
+# already dominate the tree).
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+# E,F: pycodestyle errors + pyflakes (unused imports/vars, undefined names).
+# I: import sorting. UP: pyupgrade (modern syntax for the py312 floor).
+# B: flake8-bugbear (likely-bug patterns, e.g. zip() without strict=).
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.ruff.lint.per-file-ignores]
+# Re-export hubs import names purely to surface them under short class paths.
+# Names in __all__ are already treated as used; this documents the intent and
+# covers any future __init__.py that omits __all__.
+"__init__.py" = ["F401"]

--- a/sisr/__init__.py
+++ b/sisr/__init__.py
@@ -3,4 +3,5 @@
 See :class:`sisr.training.SRLightning` for the generic Lightning wrapper
 and :mod:`sisr.cli` for the LightningCLI entrypoint.
 """
+
 __version__ = "0.1.0"

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -18,6 +18,7 @@ Top-level ``matmul_precision:`` (``'highest' | 'high' | 'medium'``) calls
 :func:`torch.set_float32_matmul_precision` once at startup. Set to ``'high'``
 on Ampere+ GPUs to enable TF32 matmul kernels.
 """
+
 import sys
 from typing import Literal
 
@@ -55,7 +56,7 @@ class SRLightningCLI(LightningCLI):
         parser.add_lr_scheduler_args(link_to="model.lr_scheduler")
         parser.add_argument(
             "--matmul_precision",
-            type=Literal['highest', 'high', 'medium'] | None,
+            type=Literal["highest", "high", "medium"] | None,
             default=None,
             help=(
                 "If set, calls torch.set_float32_matmul_precision(<value>) "
@@ -82,16 +83,17 @@ def main() -> None:
     so it also runs under the console-script path, which bypasses
     ``__main__``.
     """
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         from multiprocessing import freeze_support
+
         freeze_support()
     SRLightningCLI(
         model_class=SRLightning,
         datamodule_class=SRDataModule,
-        save_config_kwargs={'overwrite': True},
+        save_config_kwargs={"overwrite": True},
         auto_configure_optimizers=False,
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -7,6 +7,7 @@ glob + empty-directory guard), the RGB image load, and the AlbumentationsX
 ``.img_paths`` filename contract that :class:`~sisr.training.SRDataModule`
 and :class:`~sisr.training.callbacks.BenchmarkImageLogger` rely on.
 """
+
 import abc
 from pathlib import Path
 
@@ -34,9 +35,19 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
             consumed by the datamodule and the benchmark logger.
     """
 
-    IMAGE_EXTENSIONS: frozenset[str] = frozenset({
-        '.png', '.jpg', '.jpeg', '.bmp', '.tif', '.tiff', '.webp', '.ppm', '.pgm',
-    })
+    IMAGE_EXTENSIONS: frozenset[str] = frozenset(
+        {
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".bmp",
+            ".tif",
+            ".tiff",
+            ".webp",
+            ".ppm",
+            ".pgm",
+        }
+    )
 
     img_dir: Path
     img_paths: list[Path]
@@ -57,7 +68,8 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
         """
         self.img_dir = Path(img_dir)
         self.img_paths = sorted(
-            p for p in self.img_dir.iterdir()
+            p
+            for p in self.img_dir.iterdir()
             if p.is_file() and p.suffix.lower() in self.IMAGE_EXTENSIONS
         )
         if not self.img_paths:
@@ -73,7 +85,7 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
         Returns:
             The decoded image as an HWC uint8 RGB ``numpy`` array.
         """
-        return np.array(Image.open(path).convert('RGB'))
+        return np.array(Image.open(path).convert("RGB"))
 
     @staticmethod
     def _to_tensor_transform() -> A.Compose:

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -6,15 +6,18 @@ formulation). :class:`TrainDataset` caches sliding-window sub-images
 through :class:`~sisr.utils.LMDBCache`; :class:`ValidationDataset`
 generates LR pairs on the fly for full images.
 """
-import math
+
 import hashlib
+import math
+from collections.abc import Iterator
+from pathlib import Path
+
+import albumentations as A
 import cv2
 import numpy as np
 import torch
-import albumentations as A
 from PIL import Image
-from pathlib import Path
-from collections.abc import Iterator
+
 from ..utils import LMDBCache, LMDBCacheBuildContext
 from .base import SRDataset
 
@@ -93,30 +96,32 @@ def _process_subimages(
         A flat list of ``(key_string, value_bytes)`` pairs where keys
         follow the pattern ``'lr_{idx:08d}'`` / ``'hr_{idx:08d}'``.
     """
-    arr = np.array(Image.open(path).convert('RGB'))
+    arr = np.array(Image.open(path).convert("RGB"))
     h, w = arr.shape[:2]
 
     lr_size = sub_img_size // scale
     kernel = 2 * math.ceil(3.0 * blur_sigma) + 1  # odd, covers ±3σ
-    lr_pipeline = A.Compose([
-        A.GaussianBlur(blur_limit=(kernel, kernel), sigma_limit=(blur_sigma, blur_sigma), p=1.0),
-        A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
-        A.Resize(sub_img_size, sub_img_size, interpolation=cv2.INTER_CUBIC),
-    ])
+    lr_pipeline = A.Compose(
+        [
+            A.GaussianBlur(
+                blur_limit=(kernel, kernel), sigma_limit=(blur_sigma, blur_sigma), p=1.0
+            ),
+            A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
+            A.Resize(sub_img_size, sub_img_size, interpolation=cv2.INTER_CUBIC),
+        ]
+    )
 
     keyed_pairs = []
-    for offset, (top, left) in enumerate(
-        _iter_patch_origins(h, w, scale, sub_img_size, stride)
-    ):
+    for offset, (top, left) in enumerate(_iter_patch_origins(h, w, scale, sub_img_size, stride)):
         idx = base_idx + offset
-        hr_subimg = arr[top:top + sub_img_size, left:left + sub_img_size, :]
-        lr_subimg = lr_pipeline(image=hr_subimg)['image']
+        hr_subimg = arr[top : top + sub_img_size, left : left + sub_img_size, :]
+        lr_subimg = lr_pipeline(image=hr_subimg)["image"]
 
         hr_chw = hr_subimg.transpose(2, 0, 1)
         lr_chw = lr_subimg.transpose(2, 0, 1)
 
-        keyed_pairs.append((f'lr_{idx:08d}', lr_chw.tobytes()))
-        keyed_pairs.append((f'hr_{idx:08d}', hr_chw.tobytes()))
+        keyed_pairs.append((f"lr_{idx:08d}", lr_chw.tobytes()))
+        keyed_pairs.append((f"hr_{idx:08d}", hr_chw.tobytes()))
 
     return keyed_pairs
 
@@ -179,7 +184,7 @@ class TrainDataset(SRDataset):
         self.blur_sigma = blur_sigma
         self.build_num_workers = build_num_workers
 
-        cache_dir = Path(cache_dir) if cache_dir else self.img_dir / '.lmdb_cache'
+        cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
         checksum = self._compute_checksum()
 
         self._img_offsets, total_patches = self._compute_offsets()
@@ -189,13 +194,13 @@ class TrainDataset(SRDataset):
 
         self._cache = LMDBCache(
             cache_dir=cache_dir,
-            name='srcnn_patches',
+            name="srcnn_patches",
             checksum=checksum,
             length=total_patches,
             map_size=map_size,
             metadata={
-                'channels': '3',
-                'subimg_size': str(self.sub_img_size),
+                "channels": "3",
+                "subimg_size": str(self.sub_img_size),
             },
             build_fn=self._build,
             use_tqdm=use_tqdm,
@@ -212,18 +217,18 @@ class TrainDataset(SRDataset):
         Returns:
             A hex-encoded SHA-256 digest string.
         """
-        file_manifest = ','.join(
-            f'{p.name}:{p.stat().st_size}' for p in self.img_paths
+        file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in self.img_paths)
+        canonical = "|".join(
+            [
+                file_manifest,
+                str(self.sub_img_size),
+                str(self.stride),
+                str(self.scale),
+                str(self.blur_sigma),
+                "transforms_impl=albumentations",
+            ]
         )
-        canonical = '|'.join([
-            file_manifest,
-            str(self.sub_img_size),
-            str(self.stride),
-            str(self.scale),
-            str(self.blur_sigma),
-            'transforms_impl=albumentations',
-        ])
-        return hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def _compute_offsets(self) -> tuple[list[int], int]:
         """Reads image dimensions (without decoding pixels) to compute
@@ -240,8 +245,9 @@ class TrainDataset(SRDataset):
             img = Image.open(path)
             w, h = img.size
             img.close()
-            n = sum(1 for _ in _iter_patch_origins(
-                h, w, self.scale, self.sub_img_size, self.stride))
+            n = sum(
+                1 for _ in _iter_patch_origins(h, w, self.scale, self.sub_img_size, self.stride)
+            )
             offsets.append(offset)
             offset += n
         return offsets, offset
@@ -258,8 +264,7 @@ class TrainDataset(SRDataset):
                 :class:`LMDBCache`.
         """
         process_args = [
-            (self.sub_img_size, self.stride, self.scale,
-             self.blur_sigma, self._img_offsets[i])
+            (self.sub_img_size, self.stride, self.scale, self.blur_sigma, self._img_offsets[i])
             for i in range(len(self.img_paths))
         ]
 
@@ -291,8 +296,8 @@ class TrainDataset(SRDataset):
         C = 3
         H = W = self.sub_img_size
 
-        lr_key = f'lr_{idx:08d}'
-        hr_key = f'hr_{idx:08d}'
+        lr_key = f"lr_{idx:08d}"
+        hr_key = f"hr_{idx:08d}"
         env = self._cache.get_env()
         with env.begin(write=False, buffers=True) as txn:
             lr_buf = txn.get(lr_key.encode())
@@ -303,10 +308,8 @@ class TrainDataset(SRDataset):
                 raise KeyError(lr_key)
             if hr_buf is None:
                 raise KeyError(hr_key)
-            lr_arr = np.frombuffer(
-                lr_buf, dtype=np.uint8).reshape(C, H, W).copy()
-            hr_arr = np.frombuffer(
-                hr_buf, dtype=np.uint8).reshape(C, H, W).copy()
+            lr_arr = np.frombuffer(lr_buf, dtype=np.uint8).reshape(C, H, W).copy()
+            hr_arr = np.frombuffer(hr_buf, dtype=np.uint8).reshape(C, H, W).copy()
 
         lr_tensor = torch.tensor(lr_arr, dtype=torch.float32).div_(255.0)
         hr_tensor = torch.tensor(hr_arr, dtype=torch.float32).div_(255.0)
@@ -368,18 +371,20 @@ class ValidationDataset(SRDataset):
         lr_h = h // self.scale
         lr_w = w // self.scale
 
-        lr_pipeline = A.Compose([
-            A.GaussianBlur(
-                blur_limit=(self._kernel, self._kernel),
-                sigma_limit=(self.blur_sigma, self.blur_sigma),
-                p=1.0,
-            ),
-            A.Resize(lr_h, lr_w, interpolation=cv2.INTER_CUBIC),
-            A.Resize(h, w, interpolation=cv2.INTER_CUBIC),
-        ])
-        lr_arr = lr_pipeline(image=arr)['image']
+        lr_pipeline = A.Compose(
+            [
+                A.GaussianBlur(
+                    blur_limit=(self._kernel, self._kernel),
+                    sigma_limit=(self.blur_sigma, self.blur_sigma),
+                    p=1.0,
+                ),
+                A.Resize(lr_h, lr_w, interpolation=cv2.INTER_CUBIC),
+                A.Resize(h, w, interpolation=cv2.INTER_CUBIC),
+            ]
+        )
+        lr_arr = lr_pipeline(image=arr)["image"]
 
-        lr_tensor = self._to_tensor(image=lr_arr)['image']
-        hr_tensor = self._to_tensor(image=arr)['image']
+        lr_tensor = self._to_tensor(image=lr_arr)["image"]
+        hr_tensor = self._to_tensor(image=arr)["image"]
 
         return lr_tensor, hr_tensor

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -6,11 +6,14 @@ serves random ``hr_crop_size`` crops without caching (random crops aren't
 cacheable); :class:`ValidationDataset` serves full images cropped to a
 multiple of ``scale``.
 """
+
+from pathlib import Path
+
+import albumentations as A
 import cv2
 import torch
-import albumentations as A
 from albumentations.pytorch import ToTensorV2
-from pathlib import Path
+
 from .base import SRDataset
 
 
@@ -57,9 +60,7 @@ class TrainDataset(SRDataset):
         super().__init__()
 
         if hr_crop_size % scale != 0:
-            raise ValueError(
-                f"hr_crop_size ({hr_crop_size}) must be divisible by scale ({scale})."
-            )
+            raise ValueError(f"hr_crop_size ({hr_crop_size}) must be divisible by scale ({scale}).")
 
         self._index_images(img_dir)
         self.scale = scale
@@ -68,11 +69,13 @@ class TrainDataset(SRDataset):
 
         lr_size = hr_crop_size // scale
         self._hr_crop = A.Compose([A.RandomCrop(hr_crop_size, hr_crop_size)])
-        self._lr_pipeline = A.Compose([
-            A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
-            A.ToFloat(max_value=255.0),
-            ToTensorV2(),
-        ])
+        self._lr_pipeline = A.Compose(
+            [
+                A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
+                A.ToFloat(max_value=255.0),
+                ToTensorV2(),
+            ]
+        )
         self._hr_to_tensor = self._to_tensor_transform()
 
     def __len__(self) -> int:
@@ -95,10 +98,10 @@ class TrainDataset(SRDataset):
                 f"Image {path.name} ({w}x{h}) is smaller than hr_crop_size {self.hr_crop_size}."
             )
 
-        hr_arr = self._hr_crop(image=arr)['image']  # HWC uint8
+        hr_arr = self._hr_crop(image=arr)["image"]  # HWC uint8
 
-        lr_tensor = self._lr_pipeline(image=hr_arr)['image']
-        hr_tensor = self._hr_to_tensor(image=hr_arr)['image']
+        lr_tensor = self._lr_pipeline(image=hr_arr)["image"]
+        hr_tensor = self._hr_to_tensor(image=hr_arr)["image"]
 
         return lr_tensor, hr_tensor
 
@@ -146,12 +149,14 @@ class ValidationDataset(SRDataset):
         w_crop = w - (w % self.scale)
         hr_arr = arr[:h_crop, :w_crop, :]  # deterministic exact-corner crop
 
-        lr_pipeline = A.Compose([
-            A.Resize(h_crop // self.scale, w_crop // self.scale, interpolation=cv2.INTER_CUBIC),
-        ])
-        lr_arr = lr_pipeline(image=hr_arr)['image']
+        lr_pipeline = A.Compose(
+            [
+                A.Resize(h_crop // self.scale, w_crop // self.scale, interpolation=cv2.INTER_CUBIC),
+            ]
+        )
+        lr_arr = lr_pipeline(image=hr_arr)["image"]
 
-        lr_tensor = self._to_tensor(image=lr_arr)['image']
-        hr_tensor = self._to_tensor(image=hr_arr)['image']
+        lr_tensor = self._to_tensor(image=lr_arr)["image"]
+        hr_tensor = self._to_tensor(image=hr_arr)["image"]
 
         return lr_tensor, hr_tensor

--- a/sisr/models/base.py
+++ b/sisr/models/base.py
@@ -1,4 +1,5 @@
 """Abstract base class for single-image super-resolution architectures."""
+
 import abc
 
 import torch

--- a/sisr/models/srcnn/__init__.py
+++ b/sisr/models/srcnn/__init__.py
@@ -1,4 +1,5 @@
 """SRCNN architecture and paper-faithful config defaults."""
+
 from .config import SRCNNEvalConfig, SRCNNTrainingConfig
 from .model import SRCNN
 

--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -8,6 +8,7 @@ classes via ``class_path`` to inherit defaults.
 Reference: Image Super-Resolution Using Deep Convolutional Networks
 (https://arxiv.org/pdf/1501.00092).
 """
+
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -41,10 +42,8 @@ class SRCNNTrainingConfig(SRTrainingConfig):
             to deviate.
     """
 
-    layer_lrs: list[float] | None = field(
-        default_factory=lambda: [1.0e-4, 1.0e-4, 1.0e-5]
-    )
-    init_strategy: Literal['default', 'paper'] = 'paper'
+    layer_lrs: list[float] | None = field(default_factory=lambda: [1.0e-4, 1.0e-4, 1.0e-5])
+    init_strategy: Literal["default", "paper"] = "paper"
 
 
 @dataclass
@@ -63,4 +62,4 @@ class SRCNNEvalConfig(SREvalConfig):
     """
 
     crop_border: int = 3
-    psnr_channels: list[str] = field(default_factory=lambda: ['RGB', 'YCbCr'])
+    psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "YCbCr"])

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -3,44 +3,55 @@
 Reference: Image Super-Resolution Using Deep Convolutional Networks
 (https://arxiv.org/pdf/1501.00092).
 """
+
 import torch
 
 from sisr.models.base import SRModel
 
 
 class SRCNN(SRModel):
-    """SRCNN (Super-Resolution Convolutional Neural Network) model for single image super-resolution.
-    The architecture consists of three main parts: feature extraction, non-linear mapping, and reconstruction.
+    """SRCNN (Super-Resolution Convolutional Neural Network) model for single image
+    super-resolution. The architecture consists of three main parts: feature extraction,
+    non-linear mapping, and reconstruction.
 
     Reference:
     - Image Super-Resolution Using Deep Convolutional Networks: https://arxiv.org/pdf/1501.00092
 
     Args:
-        num_channels (int): The number of channels in the input and output images (e.g., 3 for RGB, 1 for Y channel).
-        num_filters (tuple[int, ...]): A tuple containing the number of filters for each convolutional layer
-            (e.g., (64, 32, 1) for the original SRCNN architecture).
-        kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each convolutional layer
-            (e.g., (9, 1, 5) for the original SRCNN architecture).
+        num_channels (int): The number of channels in the input and output images (e.g., 3 for
+            RGB, 1 for Y channel).
+        num_filters (tuple[int, ...]): A tuple containing the number of filters for each
+            convolutional layer (e.g., (64, 32, 1) for the original SRCNN architecture).
+        kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each
+            convolutional layer (e.g., (9, 1, 5) for the original SRCNN architecture).
         padding (str | int): The padding type or size for the convolutional layers.
-            Can be 'valid', 'same', or an integer specifying the number of pixels to pad. Default is 'valid'.
+            Can be 'valid', 'same', or an integer specifying the number of pixels to pad.
+            Default is 'valid'.
     """
 
-    def __init__(self, num_channels: int, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...], padding: str | int = 'valid'):
+    def __init__(
+        self,
+        num_channels: int,
+        num_filters: tuple[int, ...],
+        kernel_sizes: tuple[int, ...],
+        padding: str | int = "valid",
+    ):
         super().__init__()
 
         self._check_architecture(num_filters, kernel_sizes)
 
         self._hparams = {
-            'num_channels': num_channels,
-            'num_filters': num_filters,
-            'kernel_sizes': kernel_sizes,
-            'padding': padding,
+            "num_channels": num_channels,
+            "num_filters": num_filters,
+            "kernel_sizes": kernel_sizes,
+            "padding": padding,
         }
 
         self.feat = torch.nn.Sequential(
             torch.nn.Conv2d(
-                num_channels, num_filters[0], kernel_size=kernel_sizes[0], padding=padding),
-            torch.nn.ReLU(inplace=True)
+                num_channels, num_filters[0], kernel_size=kernel_sizes[0], padding=padding
+            ),
+            torch.nn.ReLU(inplace=True),
         )
 
         self.mapping = torch.nn.Sequential(
@@ -49,26 +60,36 @@ class SRCNN(SRModel):
                 for i in range(len(num_filters) - 1)
                 for layer in (
                     torch.nn.Conv2d(
-                        num_filters[i], num_filters[i + 1], kernel_size=kernel_sizes[i + 1], padding=padding),
-                    torch.nn.ReLU(inplace=True)
+                        num_filters[i],
+                        num_filters[i + 1],
+                        kernel_size=kernel_sizes[i + 1],
+                        padding=padding,
+                    ),
+                    torch.nn.ReLU(inplace=True),
                 )
             ]
         )
 
         self.recon = torch.nn.Conv2d(
-            num_filters[-1], num_channels, kernel_size=kernel_sizes[-1], padding=padding)
+            num_filters[-1], num_channels, kernel_size=kernel_sizes[-1], padding=padding
+        )
 
     def _check_architecture(self, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...]):
         """Validates the architecture parameters for the SRCNN model.
 
         Args:
-            num_filters (tuple[int, ...]): A tuple containing the number of filters for each convolutional layer.
-            kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each convolutional layer.
+            num_filters (tuple[int, ...]): A tuple containing the number of filters for each
+                convolutional layer.
+            kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each
+                convolutional layer.
 
         Raises:
-            ValueError: If num_filters or kernel_sizes are not tuples, if they have different lengths, or if any of their elements are not positive integers.
+            ValueError: If num_filters or kernel_sizes are not tuples, if they have different
+                lengths, or if any of their elements are not positive integers.
         """
-        for i, name in zip([num_filters, kernel_sizes], ["num_filters", "kernel_sizes"]):
+        for i, name in zip(
+            [num_filters, kernel_sizes], ["num_filters", "kernel_sizes"], strict=False
+        ):
             if not isinstance(i, tuple):
                 raise ValueError(f"{name} must be tuples. Got {type(i)}.")
             elif len(i) == 0:
@@ -76,38 +97,53 @@ class SRCNN(SRModel):
             elif len(i) < 3:
                 if len(i) < 2 and name == "num_filters":
                     raise ValueError(
-                        f"{name} must have at least 2 elements for the feature extraction and reconstruction layers. Got {i}.")
+                        f"{name} must have at least 2 elements for the feature extraction "
+                        f"and reconstruction layers. Got {i}."
+                    )
                 elif name == "kernel_sizes":
                     raise ValueError(
-                        f"{name} must have at least 3 elements for the feature extraction, mapping, and reconstruction layers. Got {i}.")
+                        f"{name} must have at least 3 elements for the feature extraction, "
+                        f"mapping, and reconstruction layers. Got {i}."
+                    )
             if any(f < 1 for f in i):
-                raise ValueError(
-                    f"All elements in {name} must be positive integers. Got {i}.")
+                raise ValueError(f"All elements in {name} must be positive integers. Got {i}.")
 
         if len(num_filters) + 1 != len(kernel_sizes):
             raise ValueError(
-                f"num_filters must have exactly one less element than kernel_sizes. Got num_filters={num_filters} and kernel_sizes={kernel_sizes}.")
+                f"num_filters must have exactly one less element than kernel_sizes. "
+                f"Got num_filters={num_filters} and kernel_sizes={kernel_sizes}."
+            )
 
     def reset_parameters(self, mean: float = 0.0, std: float = 0.01):
-        """Initializes the weights of the convolutional layers using a normal distribution and sets the biases to zero.
-        Following the initialization method described in the original SRCNN paper (https://arxiv.org/pdf/1501.00092).
+        """Initializes the weights of the convolutional layers using a normal distribution and
+        sets the biases to zero. Following the initialization method described in the original
+        SRCNN paper (https://arxiv.org/pdf/1501.00092).
 
         Args:
-            mean (float): The mean of the normal distribution for weight initialization. Default is 0
-            std (float): The standard deviation of the normal distribution for weight initialization. Default is 0.01
+            mean (float): The mean of the normal distribution for weight initialization.
+                Default is 0
+            std (float): The standard deviation of the normal distribution for weight
+                initialization. Default is 0.01
         """
         for module in self.modules():
             if isinstance(module, torch.nn.Conv2d):
                 torch.nn.init.normal_(module.weight, mean=mean, std=std)
                 torch.nn.init.constant_(module.bias, 0.0)
 
-    def forward(self, x: torch.Tensor, clamp_output: bool = False, clamp_minmax: tuple[float, float] = (0.0, 1.0)) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        clamp_output: bool = False,
+        clamp_minmax: tuple[float, float] = (0.0, 1.0),
+    ) -> torch.Tensor:
         """Forward pass of the SRCNN model.
 
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, num_channels, height, width)
-            clamp_output (bool): Whether to clamp the output values to a specified range. Default is False.
-            clamp_minmax (tuple[float, float]): The minimum and maximum values for clamping the output. Default is (0.0, 1.0).
+            clamp_output (bool): Whether to clamp the output values to a specified range.
+                Default is False.
+            clamp_minmax (tuple[float, float]): The minimum and maximum values for clamping
+                the output. Default is (0.0, 1.0).
 
         Returns:
             torch.Tensor: Output tensor of shape (batch_size, num_channels, height, width)

--- a/sisr/models/srresnet/__init__.py
+++ b/sisr/models/srresnet/__init__.py
@@ -1,4 +1,5 @@
 """SRResNet architecture (the residual generator from Ledig et al., 2017)."""
+
 from .config import SRResNetEvalConfig, SRResNetTrainingConfig
 from .model import SRResidualBlock, SRResNet, SRUpsampleBlock
 

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -9,6 +9,7 @@ Reference: Photo-Realistic Single Image Super-Resolution Using a
 Generative Adversarial Network (https://arxiv.org/pdf/1609.04802),
 Section 3.2 (SRResNet baseline).
 """
+
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -33,7 +34,7 @@ class SRResNetTrainingConfig(SRTrainingConfig):
     a YAML schema change.
     """
 
-    init_strategy: Literal['default', 'paper'] = 'default'
+    init_strategy: Literal["default", "paper"] = "default"
 
 
 @dataclass
@@ -52,4 +53,4 @@ class SRResNetEvalConfig(SREvalConfig):
     """
 
     crop_border: int = 4
-    psnr_channels: list[str] = field(default_factory=lambda: ['RGB', 'YCbCr'])
+    psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "YCbCr"])

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -3,8 +3,10 @@
 Reference: Photo-Realistic Single Image Super-Resolution Using a Generative
 Adversarial Network (https://arxiv.org/pdf/1609.04802).
 """
-import torch
+
 import math
+
+import torch
 
 from sisr.models.base import SRModel
 
@@ -20,18 +22,18 @@ class SRResidualBlock(torch.nn.Module):
         padding (str | int): Padding for the convolutional layers. Default is 'same'.
     """
 
-    def __init__(self, channels: int, kernel_size: int, padding: str | int = 'same'):
+    def __init__(self, channels: int, kernel_size: int, padding: str | int = "same"):
         super().__init__()
 
         self.block1 = torch.nn.Sequential(
             torch.nn.Conv2d(channels, channels, kernel_size=kernel_size, padding=padding),
             torch.nn.BatchNorm2d(channels),
-            torch.nn.PReLU()
+            torch.nn.PReLU(),
         )
 
         self.block2 = torch.nn.Sequential(
             torch.nn.Conv2d(channels, channels, kernel_size=kernel_size, padding=padding),
-            torch.nn.BatchNorm2d(channels)
+            torch.nn.BatchNorm2d(channels),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -50,7 +52,8 @@ class SRResidualBlock(torch.nn.Module):
 
 
 class SRUpsampleBlock(torch.nn.Module):
-    """An upsampling block used in SRResNet that increases spatial resolution using sub-pixel convolution.
+    """An upsampling block used in SRResNet that increases spatial resolution using sub-pixel
+    convolution.
 
     Args:
         channels (int): Number of input channels.
@@ -62,9 +65,11 @@ class SRUpsampleBlock(torch.nn.Module):
         super().__init__()
 
         self.upsample = torch.nn.Sequential(
-            torch.nn.Conv2d(channels, channels * (scale ** 2), kernel_size=kernel_size, padding='same'),
+            torch.nn.Conv2d(
+                channels, channels * (scale**2), kernel_size=kernel_size, padding="same"
+            ),
             torch.nn.PixelShuffle(scale),
-            torch.nn.PReLU()
+            torch.nn.PReLU(),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -89,46 +94,71 @@ class SRResNet(SRModel):
 
     Args:
         scale (int): The upscaling factor. Must be a power of 2.
-        in_out_channels (int): Number of channels in the input and output images (e.g., 3 for RGB). Default is 3.
-        hidden_channel (int): Number of feature channels used in the residual and upsample blocks. Default is 64.
-        kernel_sizes (tuple[int, ...]): Kernel sizes for the head, residual, and tail convolutional layers. Default is (9, 3, 9).
+        in_out_channels (int): Number of channels in the input and output images (e.g., 3 for
+            RGB). Default is 3.
+        hidden_channel (int): Number of feature channels used in the residual and upsample
+            blocks. Default is 64.
+        kernel_sizes (tuple[int, ...]): Kernel sizes for the head, residual, and tail
+            convolutional layers. Default is (9, 3, 9).
         num_residual_blocks (int): Number of residual blocks in the network. Default is 16.
         padding (str | int): Padding for the convolutional layers. Default is 'same'.
     """
 
-    def __init__(self, scale: int, in_out_channels: int = 3, hidden_channel: int = 64, kernel_sizes: tuple[int, ...] = (9, 3, 9), num_residual_blocks: int = 16, padding: str | int = 'same'):
+    def __init__(
+        self,
+        scale: int,
+        in_out_channels: int = 3,
+        hidden_channel: int = 64,
+        kernel_sizes: tuple[int, ...] = (9, 3, 9),
+        num_residual_blocks: int = 16,
+        padding: str | int = "same",
+    ):
         super().__init__()
 
         self._check_scale(scale)
 
         self._hparams = {
-            'scale': scale,
-            'in_out_channels': in_out_channels,
-            'hidden_channel': hidden_channel,
-            'kernel_sizes': kernel_sizes,
-            'num_residual_blocks': num_residual_blocks,
-            'padding': padding,
+            "scale": scale,
+            "in_out_channels": in_out_channels,
+            "hidden_channel": hidden_channel,
+            "kernel_sizes": kernel_sizes,
+            "num_residual_blocks": num_residual_blocks,
+            "padding": padding,
         }
 
         self.head = torch.nn.Sequential(
-            torch.nn.Conv2d(in_out_channels, hidden_channel, kernel_size=kernel_sizes[0], padding=padding),
-            torch.nn.PReLU()
+            torch.nn.Conv2d(
+                in_out_channels, hidden_channel, kernel_size=kernel_sizes[0], padding=padding
+            ),
+            torch.nn.PReLU(),
         )
 
         self.residual_blocks = torch.nn.Sequential(
-            *[SRResidualBlock(channels=hidden_channel, kernel_size=kernel_sizes[1], padding=padding) for _ in range(num_residual_blocks)]
+            *[
+                SRResidualBlock(
+                    channels=hidden_channel, kernel_size=kernel_sizes[1], padding=padding
+                )
+                for _ in range(num_residual_blocks)
+            ]
         )
 
         self.post_residual = torch.nn.Sequential(
-            torch.nn.Conv2d(hidden_channel, hidden_channel, kernel_size=kernel_sizes[1], padding=padding),
-            torch.nn.BatchNorm2d(hidden_channel)
+            torch.nn.Conv2d(
+                hidden_channel, hidden_channel, kernel_size=kernel_sizes[1], padding=padding
+            ),
+            torch.nn.BatchNorm2d(hidden_channel),
         )
 
         self.upsample = torch.nn.Sequential(
-            *[SRUpsampleBlock(channels=hidden_channel, scale=2) for _ in range(int(math.log2(scale)))]
+            *[
+                SRUpsampleBlock(channels=hidden_channel, scale=2)
+                for _ in range(int(math.log2(scale)))
+            ]
         )
 
-        self.tail = torch.nn.Conv2d(hidden_channel, in_out_channels, kernel_size=kernel_sizes[2], padding=padding)
+        self.tail = torch.nn.Conv2d(
+            hidden_channel, in_out_channels, kernel_size=kernel_sizes[2], padding=padding
+        )
 
     def _check_scale(self, scale: int):
         """Validates that the scale factor is a power of 2.
@@ -144,16 +174,24 @@ class SRResNet(SRModel):
         if (scale & (scale - 1)) != 0:
             raise ValueError(f"scale must be a power of 2. Got {scale}.")
 
-    def forward(self, x: torch.Tensor, clamp_output: bool = False, clamp_minmax: tuple[float, float] = (0.0, 1.0)) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        clamp_output: bool = False,
+        clamp_minmax: tuple[float, float] = (0.0, 1.0),
+    ) -> torch.Tensor:
         """Forward pass of the SRResNet model.
 
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, in_out_channels, height, width).
-            clamp_output (bool): Whether to clamp the output values to a specified range. Default is False.
-            clamp_minmax (tuple[float, float]): The minimum and maximum values for clamping the output. Default is (0.0, 1.0).
+            clamp_output (bool): Whether to clamp the output values to a specified range.
+                Default is False.
+            clamp_minmax (tuple[float, float]): The minimum and maximum values for clamping
+                the output. Default is (0.0, 1.0).
 
         Returns:
-            torch.Tensor: Output tensor of shape (batch_size, in_out_channels, height * scale, width * scale).
+            torch.Tensor: Output tensor of shape (batch_size, in_out_channels, height * scale,
+            width * scale).
         """
         x = self.head(x)
         identity = x

--- a/sisr/processors/__init__.py
+++ b/sisr/processors/__init__.py
@@ -1,4 +1,5 @@
 """Per-batch colorspace adapters partitioned by model IO colorspace."""
+
 from .base import SRProcessor
 from .rgb import RGBProcessor
 from .y_channel import YChannelProcessor

--- a/sisr/processors/base.py
+++ b/sisr/processors/base.py
@@ -1,4 +1,5 @@
 """Abstract base class for per-batch colorspace adapters."""
+
 import abc
 
 import torch
@@ -18,7 +19,5 @@ class SRProcessor(abc.ABC):
         """Convert dataset LR (RGB, ``[B, 3, H, W]``) into the model's input tensor."""
 
     @abc.abstractmethod
-    def reconstruct(
-        self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor
-    ) -> torch.Tensor:
+    def reconstruct(self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
         """Convert the model's output tensor back to SR RGB (``[B, 3, H', W']``)."""

--- a/sisr/processors/rgb.py
+++ b/sisr/processors/rgb.py
@@ -1,4 +1,5 @@
 """No-op pass-through processor — model trains and emits RGB directly."""
+
 import torch
 
 from .base import SRProcessor
@@ -10,7 +11,5 @@ class RGBProcessor(SRProcessor):
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:
         return lr_rgb
 
-    def reconstruct(
-        self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor
-    ) -> torch.Tensor:
+    def reconstruct(self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
         return sr_model_out

--- a/sisr/processors/y_channel.py
+++ b/sisr/processors/y_channel.py
@@ -1,4 +1,5 @@
 """Y-channel processor: extract Y from LR, stitch SR-Y with bicubic LR Cb/Cr."""
+
 import torch
 import torch.nn.functional as F
 
@@ -19,9 +20,7 @@ class YChannelProcessor(SRProcessor):
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:
         return rgb_to_ycbcr(lr_rgb)[:, 0:1]
 
-    def reconstruct(
-        self, sr_y: torch.Tensor, lr_rgb: torch.Tensor
-    ) -> torch.Tensor:
+    def reconstruct(self, sr_y: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
         lr_ycbcr = rgb_to_ycbcr(lr_rgb)
         cbcr = F.interpolate(
             lr_ycbcr[:, 1:],

--- a/sisr/processors/ycbcr.py
+++ b/sisr/processors/ycbcr.py
@@ -1,4 +1,5 @@
 """Full YCbCr processor: convert LR to YCbCr in, convert SR back to RGB out."""
+
 import torch
 
 from sisr.utils import rgb_to_ycbcr, ycbcr_to_rgb
@@ -12,7 +13,5 @@ class YCbCrProcessor(SRProcessor):
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:
         return rgb_to_ycbcr(lr_rgb)
 
-    def reconstruct(
-        self, sr_ycbcr: torch.Tensor, lr_rgb: torch.Tensor
-    ) -> torch.Tensor:
+    def reconstruct(self, sr_ycbcr: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
         return ycbcr_to_rgb(sr_ycbcr)

--- a/sisr/training/__init__.py
+++ b/sisr/training/__init__.py
@@ -3,6 +3,7 @@
 Re-exports are flat so experiment YAMLs can use short class paths like
 ``sisr.training.SRLightning`` instead of ``sisr.training.lightning_module.SRLightning``.
 """
+
 from .callbacks import (
     BenchmarkImageLogger,
     GradNormLogger,

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -7,14 +7,16 @@ N val cycles) and ``cli test`` (one-shot final eval).
 training signals; :class:`SRCheckpoint` is a thin
 :class:`~lightning.pytorch.callbacks.ModelCheckpoint` preset for SR metrics.
 """
+
 import math
+from typing import Any
+
+import lightning
 import torch
 import torch.nn.functional
 import torchmetrics.functional
 import torchvision
-import lightning
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint
-from typing import Any
 
 
 class BenchmarkImageLogger(Callback):
@@ -171,9 +173,7 @@ class BenchmarkImageLogger(Callback):
             should_log_images=self._on_image_log_interval(),
         )
 
-    def on_test_epoch_start(
-        self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
-    ):
+    def on_test_epoch_start(self, trainer: lightning.Trainer, pl_module: lightning.LightningModule):
         """Clear buffers ahead of a test run.
 
         Args:
@@ -223,9 +223,7 @@ class BenchmarkImageLogger(Callback):
             should_log_images=True,
         )
 
-    def on_test_epoch_end(
-        self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
-    ):
+    def on_test_epoch_end(self, trainer: lightning.Trainer, pl_module: lightning.LightningModule):
         """Log per-set means and image strips at the end of ``cli test``.
 
         Args:
@@ -304,14 +302,16 @@ class BenchmarkImageLogger(Callback):
             ssim = torchmetrics.functional.image.structural_similarity_index_measure(
                 sr_4d, hr_4d, data_range=1.0
             )
-            self._buffer[dataset_name].append((
-                filename,
-                lr_img[i].cpu() if should_log_images else None,
-                sr[i].cpu() if should_log_images else None,
-                hr_img[i].cpu() if should_log_images else None,
-                psnr_dict,
-                ssim.item(),
-            ))
+            self._buffer[dataset_name].append(
+                (
+                    filename,
+                    lr_img[i].cpu() if should_log_images else None,
+                    sr[i].cpu() if should_log_images else None,
+                    hr_img[i].cpu() if should_log_images else None,
+                    psnr_dict,
+                    ssim.item(),
+                )
+            )
 
     def _flush_buffer(
         self,
@@ -350,8 +350,11 @@ class BenchmarkImageLogger(Callback):
 
             if should_log_images:
                 tb_logger = next(
-                    (l for l in trainer.loggers
-                     if isinstance(l, lightning.pytorch.loggers.TensorBoardLogger)),
+                    (
+                        logger
+                        for logger in trainer.loggers
+                        if isinstance(logger, lightning.pytorch.loggers.TensorBoardLogger)
+                    ),
                     None,
                 )
                 if tb_logger is None:
@@ -360,7 +363,9 @@ class BenchmarkImageLogger(Callback):
                 experiment = tb_logger.experiment
                 for filename, lr, sr, hr, psnr_dict, ssim in samples:
                     for key, psnr_val in psnr_dict.items():
-                        experiment.add_scalar(f"{dataset_name}_psnr({key})/{filename}", psnr_val, global_step=step)
+                        experiment.add_scalar(
+                            f"{dataset_name}_psnr({key})/{filename}", psnr_val, global_step=step
+                        )
                     experiment.add_scalar(f"{dataset_name}_ssim/{filename}", ssim, global_step=step)
 
                     # Triptych: bicubic | SR | HR, all at HR size.
@@ -422,7 +427,8 @@ class BenchmarkImageLogger(Callback):
         img = torch.nn.functional.pad(img, (pad_lr, pad_lr, pad_ud, pad_ud), value=0.0)
 
         if img.shape[1] != target_h or img.shape[2] != target_w:
-            # If target size is odd and img is even (or vice versa), add one more pixel of padding to the right/bottom
+            # If target size is odd and img is even (or vice versa), add one more pixel of
+            # padding to the right/bottom
             pad_right = target_w - img.shape[2]
             pad_bottom = target_h - img.shape[1]
             img = torch.nn.functional.pad(img, (0, pad_right, 0, pad_bottom), value=0.0)
@@ -445,9 +451,7 @@ class GradNormLogger(Callback):
         super().__init__()
         self.log_every_n_steps = log_every_n_steps
 
-    def on_after_backward(
-        self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
-    ):
+    def on_after_backward(self, trainer: lightning.Trainer, pl_module: lightning.LightningModule):
         """Compute and log gradient norm if on the right step cadence.
 
         Args:
@@ -463,7 +467,7 @@ class GradNormLogger(Callback):
                 total_norm_sq += p.grad.data.norm(2).item() ** 2
         total_norm = math.sqrt(total_norm_sq)
 
-        pl_module.log('grad_norm', total_norm, on_step=True, on_epoch=False)
+        pl_module.log("grad_norm", total_norm, on_step=True, on_epoch=False)
 
 
 class WeightHistogramLogger(Callback):
@@ -480,7 +484,12 @@ class WeightHistogramLogger(Callback):
         self.log_every_n_steps = log_every_n_steps
 
     def on_train_batch_end(
-        self, trainer: lightning.Trainer, pl_module: lightning.LightningModule, outputs: Any, batch: Any, batch_idx: int
+        self,
+        trainer: lightning.Trainer,
+        pl_module: lightning.LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
     ):
         """Log grouped weights as histograms if on the right step cadence.
 
@@ -495,7 +504,11 @@ class WeightHistogramLogger(Callback):
             return
 
         tb_logger = next(
-            (l for l in trainer.loggers if isinstance(l, lightning.pytorch.loggers.TensorBoardLogger)),
+            (
+                logger
+                for logger in trainer.loggers
+                if isinstance(logger, lightning.pytorch.loggers.TensorBoardLogger)
+            ),
             None,
         )
         if tb_logger is None:
@@ -505,7 +518,7 @@ class WeightHistogramLogger(Callback):
 
         for name, param in pl_module.named_parameters():
             if param.requires_grad and name.startswith("model."):
-                parts = name.split('.', 2)
+                parts = name.split(".", 2)
                 tb_name = parts[0] + "." + "/".join(parts[1:])
                 experiment.add_histogram(tb_name, param, global_step=trainer.global_step)
 
@@ -534,11 +547,11 @@ class SRCheckpoint(ModelCheckpoint):
 
     def __init__(
         self,
-        monitor_metric: str = 'val_psnr(RGB)',
+        monitor_metric: str = "val_psnr(RGB)",
         save_top_k: int = 3,
         dirpath: str | None = None,
-        filename_prefix: str = 'srcnn',
-        mode: str = 'max',
+        filename_prefix: str = "srcnn",
+        mode: str = "max",
         **kwargs: Any,
     ):
         filename = f"{filename_prefix}-{{step}}-{{{monitor_metric}:.4f}}"

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -17,6 +17,7 @@ overrides individual fields with ``init_args``.
 The colorspace the model trains in is no longer a string field here; it is
 expressed by the choice of processor (see :mod:`sisr.processors`).
 """
+
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -56,7 +57,7 @@ class SRTrainingConfig:
 
     layer_lrs: list[float] | None = None
     example_input_shape: tuple[int, ...] | None = None
-    init_strategy: Literal['default', 'paper'] = 'default'
+    init_strategy: Literal["default", "paper"] = "default"
     init_mean: float = 0.0
     init_std: float = 0.01
 
@@ -82,7 +83,7 @@ class SREvalConfig:
     """
 
     crop_border: int = 0
-    psnr_channels: list[str] = field(default_factory=lambda: ['RGB'])
+    psnr_channels: list[str] = field(default_factory=lambda: ["RGB"])
     separate_psnr: bool = False
 
     def __post_init__(self) -> None:
@@ -92,7 +93,7 @@ class SREvalConfig:
             ValueError: If any entry is not a supported colorspace
                 (``'RGB'`` or ``'YCbCr'``).
         """
-        valid = ('RGB', 'YCbCr')
+        valid = ("RGB", "YCbCr")
         invalid = [c for c in self.psnr_channels if c not in valid]
         if invalid:
             raise ValueError(

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -6,6 +6,7 @@ only run for the stages that need them. Test sets are surfaced through
 *both* :meth:`val_dataloader` (for ``cli fit`` monitoring) and
 :meth:`test_dataloader` (for ``cli test --ckpt_path`` final eval).
 """
+
 from typing import Any
 
 import lightning
@@ -64,7 +65,7 @@ class SRDataModule(lightning.LightningDataModule):
         self._val_spec = val_dataset
         self._test_specs = test_datasets or {}
         self._train_dl_kwargs = train_dataloader_kwargs or {}
-        self._val_dl_kwargs = val_dataloader_kwargs or {'batch_size': 1, 'num_workers': 1}
+        self._val_dl_kwargs = val_dataloader_kwargs or {"batch_size": 1, "num_workers": 1}
         self._test_dl_kwargs = test_dataloader_kwargs or self._val_dl_kwargs
 
         self._train_ds: Dataset | None = None
@@ -94,14 +95,13 @@ class SRDataModule(lightning.LightningDataModule):
                 ``'test'``, or ``None`` (for all). Determines which
                 datasets get instantiated.
         """
-        if stage in ('fit', None) and self._train_ds is None:
+        if stage in ("fit", None) and self._train_ds is None:
             self._train_ds = instantiate_class((), self._train_spec)
-        if stage in ('fit', 'validate', 'test', None) and not self._test_ds and self._test_specs:
+        if stage in ("fit", "validate", "test", None) and not self._test_ds and self._test_specs:
             self._test_ds = {
-                name: instantiate_class((), spec)
-                for name, spec in self._test_specs.items()
+                name: instantiate_class((), spec) for name, spec in self._test_specs.items()
             }
-        if stage in ('fit', 'validate', None) and self._val_ds is None:
+        if stage in ("fit", "validate", None) and self._val_ds is None:
             self._val_ds = instantiate_class((), self._val_spec)
 
     def train_dataloader(self) -> DataLoader:
@@ -140,6 +140,5 @@ class SRDataModule(lightning.LightningDataModule):
             insertion order. Empty when no test sets are configured.
         """
         return [
-            DataLoader(ds, shuffle=False, **self._test_dl_kwargs)
-            for ds in self._test_ds.values()
+            DataLoader(ds, shuffle=False, **self._test_dl_kwargs) for ds in self._test_ds.values()
         ]

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -7,13 +7,15 @@ in :class:`~sisr.training.config.SRTrainingConfig` /
 itself. Optimizer / LR scheduler are wired in from top-level YAML keys by
 :class:`~sisr.cli.SRLightningCLI`.
 """
+
 import dataclasses
-import torch
-import torchvision
-import torchmetrics.functional
-import lightning
-from lightning.pytorch.cli import OptimizerCallable, LRSchedulerCallable
 from typing import Any
+
+import lightning
+import torch
+import torchmetrics.functional
+import torchvision
+from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 
 from ..models.base import SRModel
 from ..processors import SRProcessor
@@ -53,8 +55,8 @@ class SRLightning(lightning.LightningModule):
     """
 
     _CS_CHANNEL_NAMES: dict[str, tuple[str, ...]] = {
-        'RGB':   ('R', 'G', 'B'),
-        'YCbCr': ('Y', 'Cb', 'Cr'),
+        "RGB": ("R", "G", "B"),
+        "YCbCr": ("Y", "Cb", "Cr"),
     }
 
     def __init__(
@@ -82,7 +84,9 @@ class SRLightning(lightning.LightningModule):
                 f"SRProcessor."
             )
 
-        self.save_hyperparameters(ignore=['model', 'processor', 'criterion', 'optimizer', 'lr_scheduler'])
+        self.save_hyperparameters(
+            ignore=["model", "processor", "criterion", "optimizer", "lr_scheduler"]
+        )
 
         self.model = model
         self.processor = processor
@@ -92,7 +96,7 @@ class SRLightning(lightning.LightningModule):
         self.optimizer = optimizer
         self.lr_scheduler = lr_scheduler
 
-        if self.training_config.init_strategy == 'paper':
+        if self.training_config.init_strategy == "paper":
             model.reset_parameters(
                 mean=self.training_config.init_mean,
                 std=self.training_config.init_std,
@@ -100,14 +104,16 @@ class SRLightning(lightning.LightningModule):
 
         # Merge model.hparams + processor identity into Lightning hparams for TensorBoard HParams.
         # Configs are expanded via dataclasses.asdict so each field becomes its own HParams column.
-        self._hparams = self._flatten_hparams({
-            **self._hparams,
-            'training_config': dataclasses.asdict(self.training_config),
-            'eval_config': dataclasses.asdict(self.eval_config),
-            'model': model.hparams,
-            'processor': type(processor).__name__,
-            'criterion': type(self.criterion).__name__,
-        })
+        self._hparams = self._flatten_hparams(
+            {
+                **self._hparams,
+                "training_config": dataclasses.asdict(self.training_config),
+                "eval_config": dataclasses.asdict(self.eval_config),
+                "model": model.hparams,
+                "processor": type(processor).__name__,
+                "criterion": type(self.criterion).__name__,
+            }
+        )
 
         if self.training_config.example_input_shape is not None:
             self.example_input_array = torch.zeros(1, *self.training_config.example_input_shape)
@@ -120,7 +126,7 @@ class SRLightning(lightning.LightningModule):
         self._psnr_keys = metric_keys
 
     @staticmethod
-    def _flatten_hparams(hparams: dict[str, Any], sep: str = '/') -> dict:
+    def _flatten_hparams(hparams: dict[str, Any], sep: str = "/") -> dict:
         """Recursively flatten nested hparams dicts/lists for clean TensorBoard HParams columns.
 
         None values are dropped (they add noise without aiding comparison).
@@ -144,10 +150,10 @@ class SRLightning(lightning.LightningModule):
             elif isinstance(obj, dict):
                 for k, v in obj.items():
                     _recurse(v, f"{prefix}{sep}{k}")
-            elif isinstance(obj, (list, tuple)):
+            elif isinstance(obj, list | tuple):
                 for i, v in enumerate(obj):
                     _recurse(v, f"{prefix}{sep}{i}")
-            elif isinstance(obj, (bool, int, float, str)):
+            elif isinstance(obj, bool | int | float | str):
                 result[prefix] = obj
             else:
                 result[prefix] = str(obj)
@@ -176,19 +182,19 @@ class SRLightning(lightning.LightningModule):
         keys = set(self._psnr_keys)
         tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
-        if keys & {'RGB', 'R', 'G', 'B'}:
-            tensors['RGB'] = (sr, hr)
-            tensors['R']   = (sr[:, 0:1], hr[:, 0:1])
-            tensors['G']   = (sr[:, 1:2], hr[:, 1:2])
-            tensors['B']   = (sr[:, 2:3], hr[:, 2:3])
+        if keys & {"RGB", "R", "G", "B"}:
+            tensors["RGB"] = (sr, hr)
+            tensors["R"] = (sr[:, 0:1], hr[:, 0:1])
+            tensors["G"] = (sr[:, 1:2], hr[:, 1:2])
+            tensors["B"] = (sr[:, 2:3], hr[:, 2:3])
 
-        if keys & {'YCbCr', 'Y', 'Cb', 'Cr'}:
+        if keys & {"YCbCr", "Y", "Cb", "Cr"}:
             sr_ycc = rgb_to_ycbcr(sr)
             hr_ycc = rgb_to_ycbcr(hr)
-            tensors['YCbCr'] = (sr_ycc, hr_ycc)
-            tensors['Y']     = (sr_ycc[:, 0:1], hr_ycc[:, 0:1])
-            tensors['Cb']    = (sr_ycc[:, 1:2], hr_ycc[:, 1:2])
-            tensors['Cr']    = (sr_ycc[:, 2:3], hr_ycc[:, 2:3])
+            tensors["YCbCr"] = (sr_ycc, hr_ycc)
+            tensors["Y"] = (sr_ycc[:, 0:1], hr_ycc[:, 0:1])
+            tensors["Cb"] = (sr_ycc[:, 1:2], hr_ycc[:, 1:2])
+            tensors["Cr"] = (sr_ycc[:, 2:3], hr_ycc[:, 2:3])
 
         return tensors
 
@@ -209,7 +215,7 @@ class SRLightning(lightning.LightningModule):
             Scalar tensor — the batch mean of the per-image PSNRs.
         """
         return torchmetrics.functional.image.peak_signal_noise_ratio(
-            sr, hr, data_range=1.0, dim=(1, 2, 3), reduction='elementwise_mean'
+            sr, hr, data_range=1.0, dim=(1, 2, 3), reduction="elementwise_mean"
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -280,9 +286,9 @@ class SRLightning(lightning.LightningModule):
         _, sr_rgb, hr_cropped = self._forward_sr(lr_img, hr_img)
         return sr_rgb, hr_cropped
 
-    def _step(self, batch: tuple[torch.Tensor, torch.Tensor]) -> tuple[
-        torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
-    ]:
+    def _step(
+        self, batch: tuple[torch.Tensor, torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Shared forward + loss for training and validation steps.
 
         The processor handles all colorspace conversion; loss is computed in
@@ -307,7 +313,9 @@ class SRLightning(lightning.LightningModule):
 
         return loss, lr_img, hr_img, sr_rgb, hr_cropped
 
-    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
+    def training_step(
+        self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int
+    ) -> torch.Tensor:
         """Compute training loss for one batch and log it.
 
         Delegates the forward + colorspace + loss pipeline to :meth:`_step`
@@ -323,7 +331,7 @@ class SRLightning(lightning.LightningModule):
             Scalar loss tensor for the optimizer.
         """
         loss, *_ = self._step(batch)
-        self.log('train_loss', loss, prog_bar=True, on_step=True)
+        self.log("train_loss", loss, prog_bar=True, on_step=True)
         return loss
 
     def validation_step(
@@ -355,20 +363,25 @@ class SRLightning(lightning.LightningModule):
 
         # add_dataloader_idx=False keeps metric names clean — needed because the
         # primary val loader is at idx 0 of a list that also contains test loaders.
-        self.log('val_loss', loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
+        self.log("val_loss", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
         primary = self.eval_config.psnr_channels[0]
         for key in self._psnr_keys:
             sr_t, hr_t = psnr_tensors[key]
             self.log(
-                f'val_psnr({key})',
+                f"val_psnr({key})",
                 self._mean_psnr(sr_t, hr_t),
                 prog_bar=(key == primary),
-                on_step=False, add_dataloader_idx=False,
+                on_step=False,
+                add_dataloader_idx=False,
             )
         self.log(
-            'val_ssim',
-            torchmetrics.functional.image.structural_similarity_index_measure(sr, hr_cropped, data_range=1.0),
-            prog_bar=True, on_step=False, add_dataloader_idx=False,
+            "val_ssim",
+            torchmetrics.functional.image.structural_similarity_index_measure(
+                sr, hr_cropped, data_range=1.0
+            ),
+            prog_bar=True,
+            on_step=False,
+            add_dataloader_idx=False,
         )
 
     def on_train_start(self) -> None:
@@ -381,14 +394,15 @@ class SRLightning(lightning.LightningModule):
         logged by :meth:`validation_step`.
         """
         tb_loggers = [
-            l for l in self.loggers
-            if isinstance(l, lightning.pytorch.loggers.TensorBoardLogger)
+            logger
+            for logger in self.loggers
+            if isinstance(logger, lightning.pytorch.loggers.TensorBoardLogger)
         ]
         if not tb_loggers:
             return
         metrics = {
-            **{f'val_psnr({k})': 0.0 for k in self._psnr_keys},
-            'val_ssim': 0.0,
+            **{f"val_psnr({k})": 0.0 for k in self._psnr_keys},
+            "val_ssim": 0.0,
         }
         for tb in tb_loggers:
             tb.log_hyperparams(self.hparams, metrics)
@@ -445,7 +459,8 @@ class SRLightning(lightning.LightningModule):
                 )
             conv_params = {id(p) for layer in conv_layers for p in layer.parameters()}
             other = [
-                n for n, p in self.model.named_parameters()
+                n
+                for n, p in self.model.named_parameters()
                 if p.requires_grad and id(p) not in conv_params
             ]
             if other:
@@ -455,8 +470,8 @@ class SRLightning(lightning.LightningModule):
                     f"non-Conv layers (BatchNorm, PReLU, etc.)."
                 )
             param_groups = [
-                {'params': list(layer.parameters()), 'lr': lr}
-                for layer, lr in zip(conv_layers, lrs)
+                {"params": list(layer.parameters()), "lr": lr}
+                for layer, lr in zip(conv_layers, lrs, strict=False)
             ]
             optimizer = self.optimizer(param_groups)
 

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -9,16 +9,17 @@ Lightning or model code.
 :class:`~sisr.datasets.srcnn.TrainDataset` to persist precomputed
 LR/HR sub-image pairs.
 """
+
 import os
 import shutil
-import lmdb
-import torch
+from collections.abc import Callable, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from pathlib import Path
-from tqdm.auto import tqdm
-from collections.abc import Callable, Sequence
 from typing import Any
 
+import lmdb
+import torch
+from tqdm.auto import tqdm
 
 # BT.601 full-range RGB <-> YCbCr conversion (ITU-R Rec. BT.601-7).
 # Both colorspaces are normalised to [0, 1]. Cb and Cr have a +0.5 offset on
@@ -27,13 +28,13 @@ from typing import Any
 # of BT.601 — distinct from the studio-range variant which scales Y to
 # [16/255, 235/255] and Cb/Cr to [16/255, 240/255].
 
-_RGB_TO_Y  = (0.299, 0.587, 0.114)
-_RGB_TO_CB = (-0.169, -0.331, 0.500)   # output offset +0.5
-_RGB_TO_CR = (0.500, -0.419, -0.081)   # output offset +0.5
-_YCBCR_TO_R = 1.402                     # cr coefficient
-_YCBCR_TO_G_CB = -0.344                 # cb coefficient
-_YCBCR_TO_G_CR = -0.714                 # cr coefficient
-_YCBCR_TO_B = 1.772                     # cb coefficient
+_RGB_TO_Y = (0.299, 0.587, 0.114)
+_RGB_TO_CB = (-0.169, -0.331, 0.500)  # output offset +0.5
+_RGB_TO_CR = (0.500, -0.419, -0.081)  # output offset +0.5
+_YCBCR_TO_R = 1.402  # cr coefficient
+_YCBCR_TO_G_CB = -0.344  # cb coefficient
+_YCBCR_TO_G_CR = -0.714  # cr coefficient
+_YCBCR_TO_B = 1.772  # cb coefficient
 
 
 def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
@@ -48,7 +49,7 @@ def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
         ``[0, 1]`` with Cb/Cr offset by +0.5.
     """
     r, g, b = img[:, 0:1], img[:, 1:2], img[:, 2:3]
-    y  = _RGB_TO_Y[0]  * r + _RGB_TO_Y[1]  * g + _RGB_TO_Y[2]  * b
+    y = _RGB_TO_Y[0] * r + _RGB_TO_Y[1] * g + _RGB_TO_Y[2] * b
     cb = _RGB_TO_CB[0] * r + _RGB_TO_CB[1] * g + _RGB_TO_CB[2] * b + 0.5
     cr = _RGB_TO_CR[0] * r + _RGB_TO_CR[1] * g + _RGB_TO_CR[2] * b + 0.5
     return torch.cat([y, cb, cr], dim=1)
@@ -116,10 +117,10 @@ class LMDBCacheBuildContext:
 
         Args:
             items (Sequence[Any]): One item per job (e.g. a list of image paths).
-            process_fn (Callable[..., list[tuple[str, bytes]]]): Top-level callable invoked per item.  Receives
-                ``(item, *extra_args)`` and returns keyed pairs.
-            process_args (Sequence[Sequence[Any]], optional): Per-item extra arguments for *process_fn*.
-                If ``None``, each job calls ``process_fn(item)``.
+            process_fn (Callable[..., list[tuple[str, bytes]]]): Top-level callable invoked per
+                item.  Receives ``(item, *extra_args)`` and returns keyed pairs.
+            process_args (Sequence[Sequence[Any]], optional): Per-item extra arguments for
+                *process_fn*. If ``None``, each job calls ``process_fn(item)``.
                 If provided, must have the same length as *items* and
                 each element is unpacked as positional args.
             num_workers (int | None): Maximum number of parallel worker
@@ -202,8 +203,8 @@ class LMDBCache:
         map_size (int): Maximum size of the LMDB database in bytes.
         metadata (dict[str, str] | None): Extra key-value pairs to persist alongside the data
             (e.g. ``{'channels': '3', 'subimg_size': '33'}``).
-        build_fn (Callable[[LMDBCacheBuildContext], None] | None): A callable that populates the database.  It receives
-            a single :class:`LMDBCacheBuildContext` argument exposing
+        build_fn (Callable[[LMDBCacheBuildContext], None] | None): A callable that populates the
+            database.  It receives a single :class:`LMDBCacheBuildContext` argument exposing
             a ``write_batch`` helper and an ``env`` handle.  If
             ``None`` and no valid cache is found, a ``RuntimeError``
             is raised.
@@ -223,7 +224,7 @@ class LMDBCache:
     ):
         self._cache_dir = Path(cache_dir)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
-        self._lmdb_path = self._cache_dir / f'{name}_{checksum[:16]}'
+        self._lmdb_path = self._cache_dir / f"{name}_{checksum[:16]}"
         self._length = length
         self._metadata = metadata or {}
         self._env: lmdb.Environment | None = None
@@ -231,8 +232,7 @@ class LMDBCache:
         if not self._try_load(checksum):
             if build_fn is None:
                 raise RuntimeError(
-                    f"No valid LMDB cache found at {self._lmdb_path} "
-                    "and no build_fn was provided."
+                    f"No valid LMDB cache found at {self._lmdb_path} and no build_fn was provided."
                 )
             self._build(checksum, length, map_size, build_fn, use_tqdm)
 
@@ -265,8 +265,7 @@ class LMDBCache:
             A read-only LMDB environment.
         """
         if self._env is None:
-            self._env = lmdb.open(
-                str(self._lmdb_path), readonly=True, lock=False)
+            self._env = lmdb.open(str(self._lmdb_path), readonly=True, lock=False)
         return self._env
 
     def get(self, key: str) -> bytes | None:
@@ -317,11 +316,11 @@ class LMDBCache:
         try:
             env = lmdb.open(str(self._lmdb_path), readonly=True, lock=False)
             with env.begin(write=False) as txn:
-                stored = txn.get(b'__checksum__')
+                stored = txn.get(b"__checksum__")
                 if stored is None or stored.decode() != checksum:
                     env.close()
                     return False
-                self._length = int(txn.get(b'__length__').decode())
+                self._length = int(txn.get(b"__length__").decode())
             env.close()
             return True
         except (lmdb.Error, OSError):
@@ -347,9 +346,10 @@ class LMDBCache:
             checksum (str): The checksum to store for future validation.
             length (int): The number of entries that will be stored.
             map_size (int): The maximum size of the LMDB database in bytes.
-            build_fn (Callable[[LMDBCacheBuildContext], None]): A callable that populates the database.  It receives
-                a single :class:`LMDBCacheBuildContext` argument exposing
-                a ``write_batch`` helper and an ``env`` handle. Must populate the database with exactly *length* entries.
+            build_fn (Callable[[LMDBCacheBuildContext], None]): A callable that populates the
+                database.  It receives a single :class:`LMDBCacheBuildContext` argument exposing
+                a ``write_batch`` helper and an ``env`` handle. Must populate the database with
+                exactly *length* entries.
             use_tqdm (bool): Whether to display a progress bar during the build.
         """
         if self._lmdb_path.exists():
@@ -362,10 +362,10 @@ class LMDBCache:
 
         # Write metadata — __checksum__ last for incomplete-build detection
         txn = env.begin(write=True)
-        txn.put(b'__length__', str(length).encode())
+        txn.put(b"__length__", str(length).encode())
         for k, v in self._metadata.items():
-            txn.put(f'__{k}__'.encode(), str(v).encode())
-        txn.put(b'__checksum__', checksum.encode())
+            txn.put(f"__{k}__".encode(), str(v).encode())
+        txn.put(b"__checksum__", checksum.encode())
         txn.commit()
         env.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared pytest fixtures for the sisr test suite."""
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/datasets/test_base.py
+++ b/tests/datasets/test_base.py
@@ -31,6 +31,7 @@ class _Mini(SRDataset):
 def test_srdataset_subclass_missing_abstract_methods_fails_at_construction():
     """A mis-shaped dataset (no __len__/__getitem__) must fail clearly at
     construction time via the ABC, not silently at first runtime access."""
+
     class Bad(SRDataset):
         pass
 

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -8,10 +8,10 @@ from PIL import Image
 
 from sisr.datasets.srcnn import TrainDataset, ValidationDataset
 
-
 # ---------------------------------------------------------------------------
 # TrainDataset
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="module")
 def shared_srcnn_train_ds(tmp_path_factory) -> TrainDataset:
@@ -100,19 +100,20 @@ def test_train_dataset_checksum_includes_transforms_impl_tag(shared_srcnn_train_
     """The checksum input must include 'transforms_impl=albumentations' so caches
     built under the old PIL implementation invalidate automatically on upgrade."""
     import hashlib
+
     ds = shared_srcnn_train_ds
-    file_manifest = ','.join(
-        f'{p.name}:{p.stat().st_size}' for p in ds.img_paths
+    file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in ds.img_paths)
+    expected_canonical = "|".join(
+        [
+            file_manifest,
+            "20",  # subimg_size
+            "8",  # stride
+            "2",  # scale
+            "1.0",  # blur_sigma
+            "transforms_impl=albumentations",
+        ]
     )
-    expected_canonical = '|'.join([
-        file_manifest,
-        '20',     # subimg_size
-        '8',      # stride
-        '2',      # scale
-        '1.0',    # blur_sigma
-        'transforms_impl=albumentations',
-    ])
-    expected = hashlib.sha256(expected_canonical.encode('utf-8')).hexdigest()
+    expected = hashlib.sha256(expected_canonical.encode("utf-8")).hexdigest()
     assert ds._compute_checksum() == expected, (
         "checksum must include the 'transforms_impl=albumentations' tag — "
         "without it, caches built under the PIL implementation would be reused."
@@ -144,8 +145,7 @@ def test_train_dataset_build_num_workers_1_builds_inline(tiny_rgb_image_dir: Pat
     ProcessPoolExecutor), so the one-time build is safe inside a test/xdist
     worker instead of nesting an 8-process pool."""
     with patch("sisr.utils.ProcessPoolExecutor") as mock_pool:
-        ds = _make_train(
-            tiny_rgb_image_dir, subimg_size=20, stride=8, build_num_workers=1)
+        ds = _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8, build_num_workers=1)
     mock_pool.assert_not_called()
     assert len(ds) > 0
     lr, hr = ds[0]
@@ -159,8 +159,7 @@ def test_patch_grid_derived_from_shared_helper(tiny_rgb_image_dir: Path):
     misalign the LMDB lr_/hr_ keys."""
     from sisr.datasets.srcnn import _iter_patch_origins, _process_subimages
 
-    ds = _make_train(
-        tiny_rgb_image_dir, subimg_size=20, stride=8, build_num_workers=1)
+    ds = _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8, build_num_workers=1)
     _, total = ds._compute_offsets()
 
     # The worker's actual emitted pairs (one lr + one hr per patch) across every
@@ -182,6 +181,7 @@ def test_patch_grid_derived_from_shared_helper(tiny_rgb_image_dir: Path):
 # ---------------------------------------------------------------------------
 # ValidationDataset
 # ---------------------------------------------------------------------------
+
 
 def test_validation_dataset_serves_full_image_pairs(tiny_rgb_image_dir: Path):
     ds = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2)
@@ -222,8 +222,10 @@ def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):
 # SRDataset contract (P3.6 / P5.4)
 # ---------------------------------------------------------------------------
 
+
 def test_srcnn_datasets_are_srdataset_subclasses():
     from sisr.datasets.base import SRDataset
+
     assert issubclass(TrainDataset, SRDataset)
     assert issubclass(ValidationDataset, SRDataset)
 

--- a/tests/datasets/test_srresnet.py
+++ b/tests/datasets/test_srresnet.py
@@ -5,10 +5,10 @@ import torch
 
 from sisr.datasets.srresnet import TrainDataset, ValidationDataset
 
-
 # ---------------------------------------------------------------------------
 # TrainDataset (random-crop)
 # ---------------------------------------------------------------------------
+
 
 def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
     """LR must be the cv2 INTER_CUBIC downscale of the SAME HR crop the item
@@ -16,9 +16,9 @@ def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
     returned HR crop as uint8 and re-runs the dataset's own LR pipeline as the
     reference; the crop is random, but LR and HR come from one call, so the
     reference is exact. A regression to bilinear/nearest downscaling fails here."""
+    import albumentations as A
     import cv2
     import numpy as np
-    import albumentations as A
     from albumentations.pytorch import ToTensorV2
 
     ds = TrainDataset(img_dir=tiny_rgb_image_dir, scale=4, hr_crop_size=16)
@@ -35,19 +35,19 @@ def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
     # LR pipeline (A.Resize INTER_CUBIC -> ToFloat -> ToTensorV2).
     hr_uint8 = (hr.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
     lr_size = 16 // 4
-    ref_pipeline = A.Compose([
-        A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
-        A.ToFloat(max_value=255.0),
-        ToTensorV2(),
-    ])
+    ref_pipeline = A.Compose(
+        [
+            A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
+            A.ToFloat(max_value=255.0),
+            ToTensorV2(),
+        ]
+    )
     lr_expected = ref_pipeline(image=hr_uint8)["image"]
     torch.testing.assert_close(lr, lr_expected, atol=1e-6, rtol=0)
 
 
 def test_train_dataset_len_scales_with_crops_per_image(tiny_rgb_image_dir: Path):
-    ds = TrainDataset(
-        img_dir=tiny_rgb_image_dir, scale=2, hr_crop_size=16, crops_per_image=4
-    )
+    ds = TrainDataset(img_dir=tiny_rgb_image_dir, scale=2, hr_crop_size=16, crops_per_image=4)
     assert len(ds) == 3 * 4  # tiny_rgb_image_dir has 3 images
 
 
@@ -77,8 +77,7 @@ def test_train_dataset_random_crop_varies_across_calls(tiny_rgb_image_dir: Path)
     samples = [ds[0] for _ in range(8)]
     hrs = [hr for _, hr in samples]
     differ = any(
-        not torch.equal(hrs[i], hrs[j])
-        for i in range(len(hrs)) for j in range(i + 1, len(hrs))
+        not torch.equal(hrs[i], hrs[j]) for i in range(len(hrs)) for j in range(i + 1, len(hrs))
     )
     assert differ, "A.RandomCrop must yield varying HR crops across calls"
 
@@ -86,6 +85,7 @@ def test_train_dataset_random_crop_varies_across_calls(tiny_rgb_image_dir: Path)
 # ---------------------------------------------------------------------------
 # ValidationDataset (full image)
 # ---------------------------------------------------------------------------
+
 
 def test_validation_dataset_hr_cropped_to_multiple_of_scale(tiny_rgb_image_dir: Path):
     """36x36 image, scale=4 -> hr stays 36 (divisible), lr is 9x9, and the
@@ -117,8 +117,10 @@ def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):
 # SRDataset contract (P3.6 / P5.4)
 # ---------------------------------------------------------------------------
 
+
 def test_srresnet_datasets_are_srdataset_subclasses():
     from sisr.datasets.base import SRDataset
+
     assert issubclass(TrainDataset, SRDataset)
     assert issubclass(ValidationDataset, SRDataset)
 

--- a/tests/models/srcnn/test_model.py
+++ b/tests/models/srcnn/test_model.py
@@ -143,7 +143,7 @@ def test_forward_multilayer_mapping_builds_extra_conv_and_preserves_shape():
     model = SRCNN(
         num_channels=3,
         num_filters=(64, 32, 16),
-        kernel_sizes=(9, 1, 3, 5),   # len == len(num_filters) + 1
+        kernel_sizes=(9, 1, 3, 5),  # len == len(num_filters) + 1
         padding="same",
     )
     n_convs = sum(1 for m in model.modules() if isinstance(m, torch.nn.Conv2d))

--- a/tests/models/srresnet/test_config.py
+++ b/tests/models/srresnet/test_config.py
@@ -1,4 +1,5 @@
 """Defaults, subclass, and isolation tests for SRResNet's paper-faithful configs."""
+
 from sisr.models.srresnet import SRResNetEvalConfig, SRResNetTrainingConfig
 from sisr.training import SREvalConfig, SRTrainingConfig
 
@@ -10,7 +11,7 @@ def test_srresnet_training_config_paper_defaults():
     assert cfg.init_strategy == "default"
     assert cfg.init_mean == 0.0
     assert cfg.init_std == 0.01
-    assert cfg.layer_lrs is None              # SRResNet has BatchNorm/PReLU; layer_lrs would error
+    assert cfg.layer_lrs is None  # SRResNet has BatchNorm/PReLU; layer_lrs would error
 
 
 def test_srresnet_eval_config_paper_defaults():

--- a/tests/models/srresnet/test_model.py
+++ b/tests/models/srresnet/test_model.py
@@ -6,9 +6,10 @@ from sisr.models.srresnet.model import SRResidualBlock, SRResNet, SRUpsampleBloc
 
 def test_package_reexports_public_symbols():
     """SRResNet et al. are importable from the package, not just .model."""
-    from sisr.models.srresnet import SRResNet as PkgSRResNet
     from sisr.models.srresnet import SRResidualBlock as PkgBlock
+    from sisr.models.srresnet import SRResNet as PkgSRResNet
     from sisr.models.srresnet import SRUpsampleBlock as PkgUpsample
+
     assert PkgSRResNet is SRResNet
     assert PkgBlock is SRResidualBlock
     assert PkgUpsample is SRUpsampleBlock
@@ -90,9 +91,9 @@ def test_residual_block_is_identity_when_branch_zeroed():
     torch.manual_seed(0)
     block = SRResidualBlock(channels=16, kernel_size=3).eval()
     with torch.no_grad():
-        block.block2[0].weight.zero_()   # block2 = Sequential(Conv2d, BatchNorm2d)
+        block.block2[0].weight.zero_()  # block2 = Sequential(Conv2d, BatchNorm2d)
         block.block2[0].bias.zero_()
-    x = torch.rand(1, 16, 4, 4)           # random, non-zero: identity must survive
+    x = torch.rand(1, 16, 4, 4)  # random, non-zero: identity must survive
     with torch.no_grad():
         out = block(x)
     torch.testing.assert_close(out, x, atol=1e-6, rtol=0)

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,4 +1,5 @@
 """Contract tests for SRModel — the abstract base for SR architectures."""
+
 import pytest
 import torch
 import torch.nn as nn
@@ -14,12 +15,15 @@ def test_srmodel_is_abstract():
 
 def test_srmodel_subclass_inherits_nn_module():
     """A concrete SRModel subclass is also an nn.Module (for Lightning interop)."""
+
     class _Trivial(SRModel):
         def __init__(self):
             super().__init__()
             self._hparams = {"trivial": True}
             self.conv = nn.Conv2d(3, 3, 1)
-        def forward(self, x): return self.conv(x)
+
+        def forward(self, x):
+            return self.conv(x)
 
     m = _Trivial()
     assert isinstance(m, nn.Module)
@@ -28,32 +32,39 @@ def test_srmodel_subclass_inherits_nn_module():
 
 def test_srmodel_hparams_returns_underlying_dict():
     """hparams property exposes self._hparams (same pattern as SRCNN / SRResNet)."""
+
     class _Trivial(SRModel):
         def __init__(self):
             super().__init__()
             self._hparams = {"foo": 1, "bar": "two"}
-        def forward(self, x): return x
+
+        def forward(self, x):
+            return x
 
     m = _Trivial()
     assert m.hparams == {"foo": 1, "bar": "two"}
 
 
 def test_srmodel_reset_parameters_default_is_noop():
-    """Default reset_parameters returns None, accepts arbitrary kwargs, and does not mutate parameters.
+    """Default reset_parameters returns None, accepts arbitrary kwargs, and does not mutate
+    parameters.
 
     The ``**kwargs`` signature lets SRLightning pass paper-init kwargs (e.g. ``mean``,
     ``std`` from SRCNN) polymorphically without knowing the subclass signature —
     base subclasses without paper init absorb the kwargs as no-ops.
     """
+
     class _Trivial(SRModel):
         def __init__(self):
             super().__init__()
             self._hparams = {}
             self.conv = nn.Conv2d(3, 3, 1)
-        def forward(self, x): return self.conv(x)
+
+        def forward(self, x):
+            return self.conv(x)
 
     m = _Trivial()
     before = m.conv.weight.detach().clone()
-    assert m.reset_parameters() is None                       # no kwargs
-    assert m.reset_parameters(mean=0.5, std=0.1) is None      # kwargs absorbed
+    assert m.reset_parameters() is None  # no kwargs
+    assert m.reset_parameters(mean=0.5, std=0.1) is None  # kwargs absorbed
     assert torch.equal(m.conv.weight, before)

--- a/tests/processors/test_base.py
+++ b/tests/processors/test_base.py
@@ -1,4 +1,5 @@
 """Contract tests for SRProcessor — the abstract base for colorspace adapters."""
+
 import pytest
 import torch
 
@@ -13,14 +14,17 @@ def test_srprocessor_is_abstract():
 
 def test_srprocessor_subclass_must_implement_both_methods():
     """A subclass missing either abstract method also raises on instantiation."""
+
     class _ExtractOnly(SRProcessor):
-        def extract(self, lr_rgb): return lr_rgb
+        def extract(self, lr_rgb):
+            return lr_rgb
 
     with pytest.raises(TypeError, match="abstract"):
         _ExtractOnly()
 
     class _ReconstructOnly(SRProcessor):
-        def reconstruct(self, sr_model_out, lr_rgb): return sr_model_out
+        def reconstruct(self, sr_model_out, lr_rgb):
+            return sr_model_out
 
     with pytest.raises(TypeError, match="abstract"):
         _ReconstructOnly()
@@ -28,9 +32,13 @@ def test_srprocessor_subclass_must_implement_both_methods():
 
 def test_srprocessor_complete_subclass_instantiates():
     """Subclass implementing both abstract methods can be instantiated."""
+
     class _Complete(SRProcessor):
-        def extract(self, lr_rgb): return lr_rgb
-        def reconstruct(self, sr_model_out, lr_rgb): return sr_model_out
+        def extract(self, lr_rgb):
+            return lr_rgb
+
+        def reconstruct(self, sr_model_out, lr_rgb):
+            return sr_model_out
 
     p = _Complete()
     assert isinstance(p, SRProcessor)

--- a/tests/processors/test_rgb.py
+++ b/tests/processors/test_rgb.py
@@ -1,4 +1,5 @@
 """Behavior tests for RGBProcessor — no-op pass-through."""
+
 import torch
 
 from sisr.processors import RGBProcessor, SRProcessor

--- a/tests/processors/test_y_channel.py
+++ b/tests/processors/test_y_channel.py
@@ -1,7 +1,8 @@
 """Behavior tests for YChannelProcessor — Y extract + bicubic Cb/Cr stitch."""
+
 import torch
 
-from sisr.processors import YChannelProcessor, SRProcessor
+from sisr.processors import SRProcessor, YChannelProcessor
 from sisr.utils import rgb_to_ycbcr, ycbcr_to_rgb
 
 
@@ -26,14 +27,16 @@ def test_y_channel_reconstruct_same_size_roundtrips_to_lr():
     The old assertion only checked out was in [0, 1] (always true after the
     clamp); this pins that the stitch + inverse actually recover the input."""
     import torch.nn.functional as F
+
     p = YChannelProcessor()
     lr = torch.rand(2, 3, 16, 16)
-    sr_y = rgb_to_ycbcr(lr)[:, 0:1]        # SR-Y is exactly the LR-Y
+    sr_y = rgb_to_ycbcr(lr)[:, 0:1]  # SR-Y is exactly the LR-Y
     out = p.reconstruct(sr_y, lr)
     assert out.shape == (2, 3, 16, 16)
     # Same-size interpolate is an exact no-op, so the whole path is a roundtrip.
-    same = F.interpolate(rgb_to_ycbcr(lr)[:, 1:], size=(16, 16),
-                         mode="bicubic", align_corners=False)
+    same = F.interpolate(
+        rgb_to_ycbcr(lr)[:, 1:], size=(16, 16), mode="bicubic", align_corners=False
+    )
     assert torch.equal(same, rgb_to_ycbcr(lr)[:, 1:])  # bicubic@same-size == identity
     # Tolerance 1e-3: the BT.601 coeffs in sisr.utils are truncated to 3 dp, so
     # the forward/inverse matrices aren't perfect inverses (worst-case ~5e-4).
@@ -47,15 +50,14 @@ def test_y_channel_reconstruct_upscaled_stitches_bicubic_chroma():
     from the same primitives, so switching the interpolation mode/target size or
     dropping the Y pass-through fails."""
     import torch.nn.functional as F
+
     p = YChannelProcessor()
     lr = torch.rand(2, 3, 8, 8)
-    sr_y = torch.rand(2, 1, 32, 32)        # 4x upscale
+    sr_y = torch.rand(2, 1, 32, 32)  # 4x upscale
     out = p.reconstruct(sr_y, lr)
     assert out.shape == (2, 3, 32, 32)
 
     lr_ycbcr = rgb_to_ycbcr(lr)
-    cbcr = F.interpolate(lr_ycbcr[:, 1:], size=(32, 32),
-                        mode="bicubic", align_corners=False)
+    cbcr = F.interpolate(lr_ycbcr[:, 1:], size=(32, 32), mode="bicubic", align_corners=False)
     expected = ycbcr_to_rgb(torch.cat([sr_y, cbcr], dim=1))
     torch.testing.assert_close(out, expected, atol=1e-6, rtol=0)
-

--- a/tests/processors/test_ycbcr.py
+++ b/tests/processors/test_ycbcr.py
@@ -1,7 +1,8 @@
 """Behavior tests for YCbCrProcessor — full YCbCr convert."""
+
 import torch
 
-from sisr.processors import YCbCrProcessor, SRProcessor
+from sisr.processors import SRProcessor, YCbCrProcessor
 from sisr.utils import rgb_to_ycbcr
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ via ``SRLightningCLI(args=..., run=False)`` (see ``_resolve``); only
 ``test_cli_print_config_resolves`` and ``test_cli_help_lists_subcommands`` still
 spawn the installed ``sisr`` console script to exercise the real entry point.
 """
+
 import subprocess
 import sys
 import sysconfig
@@ -23,9 +24,7 @@ SRRESNET_TEMPLATE = REPO_ROOT / "templates" / "config.srresnet.template.yaml"
 # exercise the same entry point an end user gets after `pip install`. The
 # scripts dir is the venv's Scripts/ (Windows) or bin/ (POSIX), resolved
 # without depending on PATH activation.
-SISR_BIN = Path(sysconfig.get_path("scripts")) / (
-    "sisr.exe" if sys.platform == "win32" else "sisr"
-)
+SISR_BIN = Path(sysconfig.get_path("scripts")) / ("sisr.exe" if sys.platform == "win32" else "sisr")
 assert SISR_BIN.exists(), (
     f"sisr console script not found at {SISR_BIN} — run `pip install -e .` first"
 )
@@ -119,7 +118,7 @@ def test_srresnet_config_resolves_in_process():
     assert isinstance(m.processor, RGBProcessor)
     assert isinstance(m.training_config, SRResNetTrainingConfig)
     assert isinstance(m.eval_config, SRResNetEvalConfig)
-    assert m.eval_config.crop_border == 4          # inherited-default check
+    assert m.eval_config.crop_border == 4  # inherited-default check
     # Dataset specs stay plain {class_path, init_args} dicts (materialized lazily
     # in SRDataModule.setup), so assert on the resolved raw config.
     assert cli.config.data.train_dataset["class_path"] == "sisr.datasets.srresnet.TrainDataset"
@@ -193,17 +192,21 @@ def test_matmul_precision_rejects_invalid_in_process():
 def _make_cli_stub(subcommand: str | None, matmul_precision: str | None):
     """Build an SRLightningCLI instance bypassing __init__ for direct hook testing."""
     from types import SimpleNamespace
+
     from sisr.cli import SRLightningCLI
 
     cli = SRLightningCLI.__new__(SRLightningCLI)
     cli.subcommand = subcommand
-    cli.config = {subcommand: SimpleNamespace(matmul_precision=matmul_precision)} if subcommand else {}
+    cli.config = (
+        {subcommand: SimpleNamespace(matmul_precision=matmul_precision)} if subcommand else {}
+    )
     return cli
 
 
 def test_before_instantiate_classes_calls_torch_setter(monkeypatch):
     """When matmul_precision is set, torch.set_float32_matmul_precision is called with it."""
     import torch
+
     calls: list[str] = []
     monkeypatch.setattr(torch, "set_float32_matmul_precision", lambda p: calls.append(p))
 
@@ -215,6 +218,7 @@ def test_before_instantiate_classes_calls_torch_setter(monkeypatch):
 def test_before_instantiate_classes_skips_when_unset(monkeypatch):
     """When matmul_precision is None, torch.set_float32_matmul_precision is NOT called."""
     import torch
+
     calls: list[str] = []
     monkeypatch.setattr(torch, "set_float32_matmul_precision", lambda p: calls.append(p))
 
@@ -226,6 +230,7 @@ def test_before_instantiate_classes_skips_when_unset(monkeypatch):
 def test_before_instantiate_classes_skips_when_no_subcommand(monkeypatch):
     """The hook returns early when self.subcommand is None (e.g., --help)."""
     import torch
+
     calls: list[str] = []
     monkeypatch.setattr(torch, "set_float32_matmul_precision", lambda p: calls.append(p))
 
@@ -256,7 +261,7 @@ def test_template_disables_default_hp_metric(template_path: Path):
     would miss that)."""
     cli = _resolve("--config", str(template_path))
     loggers = cli.config.trainer.logger
-    tb = next(l for l in loggers if str(l.class_path).endswith("TensorBoardLogger"))
+    tb = next(logger for logger in loggers if str(logger.class_path).endswith("TensorBoardLogger"))
     assert tb.init_args.default_hp_metric is False, (
         f"{template_path.name} does not disable the hp_metric placeholder. "
         f"Add `default_hp_metric: false` under the TensorBoardLogger init_args."

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -3,6 +3,13 @@
 
 def test_public_exports():
     from sisr.cli import main  # noqa: F401
+    from sisr.datasets.srcnn import TrainDataset, ValidationDataset  # noqa: F401
+    from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig  # noqa: F401
+    from sisr.models.srresnet.model import (  # noqa: F401
+        SRResidualBlock,
+        SRResNet,
+        SRUpsampleBlock,
+    )
     from sisr.training import (  # noqa: F401
         BenchmarkImageLogger,
         GradNormLogger,
@@ -12,13 +19,6 @@ def test_public_exports():
         SRLightning,
         SRTrainingConfig,
         WeightHistogramLogger,
-    )
-    from sisr.datasets.srcnn import TrainDataset, ValidationDataset  # noqa: F401
-    from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig  # noqa: F401
-    from sisr.models.srresnet.model import (  # noqa: F401
-        SRResNet,
-        SRResidualBlock,
-        SRUpsampleBlock,
     )
     from sisr.utils import (  # noqa: F401
         LMDBCache,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,5 @@
 """Packaging-contract checks that don't need the app imported."""
+
 import re
 import tomllib
 from pathlib import Path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,10 +12,10 @@ from sisr.utils import (
     ycbcr_to_rgb,
 )
 
-
 # ---------------------------------------------------------------------------
 # Colorspace utilities
 # ---------------------------------------------------------------------------
+
 
 def test_rgb_to_ycbcr_shape_and_dtype():
     x = torch.rand(2, 3, 8, 8, dtype=torch.float32)
@@ -73,8 +73,10 @@ _MAP_SIZE = 16 * 1024 * 1024  # 16 MiB — plenty for tiny test caches
 
 def _make_build_fn(n: int, value_prefix: bytes = b"v"):
     """Returns a build_fn that writes n keys named key_0..key_{n-1}."""
+
     def build(ctx: LMDBCacheBuildContext) -> None:
         ctx.write_batch([(f"key_{i}", value_prefix + str(i).encode()) for i in range(n)])
+
     return build
 
 
@@ -242,6 +244,7 @@ def test_lmdb_try_load_propagates_unexpected_error(tmp_path: Path):
 # LMDBCacheBuildContext.parallel_build
 # ---------------------------------------------------------------------------
 
+
 def _sq_process_fn(item: int) -> list[tuple[str, bytes]]:
     """Top-level (picklable) worker: squares *item* into one keyed pair.
 
@@ -254,6 +257,7 @@ def test_parallel_build_persists_every_submitted_item(tmp_path: Path):
     """parallel_build must submit every item to the pool and persist each
     worker's returned pairs — previously only write_batch was covered, so the
     submit/collect loop was untested."""
+
     def build(ctx: LMDBCacheBuildContext) -> None:
         ctx.parallel_build(items=[2, 3, 4, 5], process_fn=_sq_process_fn, num_workers=2)
 
@@ -273,6 +277,7 @@ def test_parallel_build_persists_every_submitted_item(tmp_path: Path):
 def test_parallel_build_single_worker_skips_process_pool(tmp_path: Path):
     """num_workers=1 must run the build inline (no ProcessPoolExecutor), so it
     is safe to nest inside a test/xdist worker without oversubscribing cores."""
+
     def build(ctx: LMDBCacheBuildContext) -> None:
         ctx.parallel_build(items=[2, 3, 4], process_fn=_sq_process_fn, num_workers=1)
 
@@ -293,6 +298,7 @@ def test_parallel_build_single_worker_skips_process_pool(tmp_path: Path):
 def test_parallel_build_none_workers_builds_single_item_inline(tmp_path: Path):
     """num_workers=None must resolve to min(os.cpu_count() or 1, n_items); a lone
     item yields <= 1 effective worker and therefore an inline build."""
+
     def build(ctx: LMDBCacheBuildContext) -> None:
         ctx.parallel_build(items=[7], process_fn=_sq_process_fn, num_workers=None)
 

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -18,10 +18,10 @@ from sisr.training import (
     WeightHistogramLogger,
 )
 
-
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
 # ---------------------------------------------------------------------------
+
 
 def test_benchmark_setup_auto_discovers_dataset_names():
     cb = BenchmarkImageLogger()
@@ -60,6 +60,7 @@ def test_benchmark_setup_datamodule_without_test_names_is_safe():
 # BenchmarkImageLogger._bicubic_to
 # ---------------------------------------------------------------------------
 
+
 def test_bicubic_to_returns_target_shape():
     """LR (3, 4, 4) -> (3, 16, 16) for a 4x upscaling model."""
     lr = torch.rand(3, 4, 4)
@@ -81,9 +82,13 @@ def test_bicubic_to_matches_torch_interpolate_bicubic():
     """Lock the helper to bicubic mode (not bilinear/nearest)."""
     torch.manual_seed(0)
     lr = torch.rand(3, 4, 4)
-    expected = torch.nn.functional.interpolate(
-        lr.unsqueeze(0), size=(16, 16), mode="bicubic", align_corners=False
-    ).squeeze(0).clamp(0.0, 1.0)
+    expected = (
+        torch.nn.functional.interpolate(
+            lr.unsqueeze(0), size=(16, 16), mode="bicubic", align_corners=False
+        )
+        .squeeze(0)
+        .clamp(0.0, 1.0)
+    )
     out = BenchmarkImageLogger._bicubic_to(lr, (16, 16))
     torch.testing.assert_close(out, expected)
 
@@ -91,6 +96,7 @@ def test_bicubic_to_matches_torch_interpolate_bicubic():
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger._pad_to_match
 # ---------------------------------------------------------------------------
+
 
 def test_pad_to_match_no_op_when_shapes_match():
     img = torch.zeros(3, 8, 8)
@@ -133,6 +139,7 @@ def test_pad_to_match_off_by_one_both_dims():
 # ---------------------------------------------------------------------------
 # GradNormLogger
 # ---------------------------------------------------------------------------
+
 
 def _make_gradnorm_pl_module():
     """Stub LightningModule with parameters that have non-zero grads."""
@@ -181,6 +188,7 @@ def test_grad_norm_logger_handles_none_grads():
 # WeightHistogramLogger
 # ---------------------------------------------------------------------------
 
+
 def test_weight_histogram_logger_skips_off_cadence():
     cb = WeightHistogramLogger(log_every_n_steps=10)
     trainer = SimpleNamespace(global_step=7, loggers=[])
@@ -200,6 +208,7 @@ def test_weight_histogram_logger_skips_when_no_tb_logger():
 # ---------------------------------------------------------------------------
 # SRCheckpoint
 # ---------------------------------------------------------------------------
+
 
 def test_srcheckpoint_filename_pattern():
     """monitor_metric='val_psnr(RGB)' -> filename pattern uses that metric."""
@@ -227,6 +236,7 @@ def test_srcheckpoint_custom_filename_prefix():
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger validation/test hook bodies (mock-driven, no Trainer)
 # ---------------------------------------------------------------------------
+
 
 def _make_real_pl_module() -> SRLightning:
     """Real SRLightning with a small SRCNN — needed because the callback
@@ -279,7 +289,10 @@ def test_benchmark_validation_batch_end_collects_for_test_loader():
 
     ds = _stub_dataset_with_img_paths(n=2, name="Set5")
     trainer = SimpleNamespace(
-        val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)],  # idx 0 = primary, idx 1 = Set5
+        val_dataloaders=[
+            _stub_dataloader(None),
+            _stub_dataloader(ds),
+        ],  # idx 0 = primary, idx 1 = Set5
     )
     batch = (torch.rand(2, 3, 16, 16), torch.rand(2, 3, 16, 16))
     cb.on_validation_batch_end(
@@ -329,14 +342,21 @@ def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path:
     for the per-image psnr + ssim. The old test only checked it didn't raise, so
     a silently-skipped emit would have passed."""
     import lightning.pytorch.loggers as pl_loggers
+
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
     # SRCNN-style: LR already at HR size (4x4). One image, one psnr key.
     cb._buffer["Set5"] = [
-        ("img_0", torch.rand(3, 4, 4), torch.rand(3, 4, 4), torch.rand(3, 4, 4),
-         {"RGB": 30.0}, 0.9),
+        (
+            "img_0",
+            torch.rand(3, 4, 4),
+            torch.rand(3, 4, 4),
+            torch.rand(3, 4, 4),
+            {"RGB": 30.0},
+            0.9,
+        ),
     ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     experiment = tb_logger.experiment  # materialize the SummaryWriter before wrapping
@@ -352,7 +372,7 @@ def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path:
     add_image.assert_called_once()
     tag, strip = add_image.call_args.args[0], add_image.call_args.args[1]
     assert tag == "Set5/img_0"
-    assert strip.ndim == 3 and strip.shape[0] == 3   # (C, H, W) triptych
+    assert strip.ndim == 3 and strip.shape[0] == 3  # (C, H, W) triptych
     # One psnr scalar (RGB) + one ssim scalar for the single buffered image.
     scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
     assert scalar_tags == ["Set5_psnr(RGB)/img_0", "Set5_ssim/img_0"]
@@ -402,14 +422,21 @@ def test_benchmark_image_strips_upsample_lr_to_hr_size(tmp_path: Path, monkeypat
     with a panel taller than the LR (not crash make_grid on a size mismatch, and
     not log at LR size). The old test only asserted it didn't raise."""
     import lightning.pytorch.loggers as pl_loggers
+
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
     # LR 4x4, SR and HR 16x16 (x4 model).
     cb._buffer["Set5"] = [
-        ("img_0", torch.rand(3, 4, 4), torch.rand(3, 16, 16), torch.rand(3, 16, 16),
-         {"RGB": 30.0}, 0.9),
+        (
+            "img_0",
+            torch.rand(3, 4, 4),
+            torch.rand(3, 16, 16),
+            torch.rand(3, 16, 16),
+            {"RGB": 30.0},
+            0.9,
+        ),
     ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     experiment = tb_logger.experiment
@@ -440,8 +467,12 @@ def test_benchmark_test_batch_end_collects_with_zero_indexed_mapping():
     )
     batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
     cb.on_test_batch_end(
-        trainer=trainer, pl_module=pl_module, outputs=None,
-        batch=batch, batch_idx=0, dataloader_idx=1,
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
     )
     assert len(cb._buffer["Set14"]) == 1
     assert len(cb._buffer["Set5"]) == 0
@@ -465,18 +496,24 @@ def test_benchmark_test_epoch_end_logs_means():
 # WeightHistogramLogger on-cadence path
 # ---------------------------------------------------------------------------
 
-def test_weight_histogram_logger_calls_add_histogram_for_model_params_only(tmp_path: Path, monkeypatch):
+
+def test_weight_histogram_logger_calls_add_histogram_for_model_params_only(
+    tmp_path: Path, monkeypatch
+):
     """On-cadence, the logger must call experiment.add_histogram exactly once for
     the single `model.`-prefixed parameter (the non-model param is filtered out),
     with the prefix-grouped tag. The old test only checked it didn't raise, so a
     broken `model.` filter or a missing emit would have passed."""
     import lightning.pytorch.loggers as pl_loggers
+
     cb = WeightHistogramLogger(log_every_n_steps=1)
     pl_module = MagicMock()
-    pl_module.named_parameters = MagicMock(return_value=[
-        ("model.feat.0.weight", torch.nn.Parameter(torch.rand(4, 3, 3, 3))),
-        ("non_model_param", torch.nn.Parameter(torch.rand(4))),  # filtered out
-    ])
+    pl_module.named_parameters = MagicMock(
+        return_value=[
+            ("model.feat.0.weight", torch.nn.Parameter(torch.rand(4, 3, 3, 3))),
+            ("non_model_param", torch.nn.Parameter(torch.rand(4))),  # filtered out
+        ]
+    )
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     experiment = tb_logger.experiment
     add_histogram = MagicMock(wraps=experiment.add_histogram)
@@ -494,6 +531,7 @@ def test_weight_histogram_logger_calls_add_histogram_for_model_params_only(tmp_p
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger crop_border migration to eval_config
 # ---------------------------------------------------------------------------
+
 
 def test_crop_border_init_arg_rejected():
     """crop_border was dropped from BenchmarkImageLogger; now lives on eval_config."""
@@ -523,8 +561,12 @@ def test_benchmark_collect_batch_crops_per_eval_config():
     # 16x16 input; after crop_border=3 sides, the inner 10x10 region drives PSNR/SSIM.
     batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
     cb.on_validation_batch_end(
-        trainer=trainer, pl_module=pl_module, outputs=None,
-        batch=batch, batch_idx=0, dataloader_idx=1,
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 1
     _, _, _, _, psnr_dict, ssim = cb._buffer["Set5"][0]
@@ -555,8 +597,12 @@ def test_benchmark_collect_batch_routes_through_processor():
     # Batch is 3-channel RGB (dataset-format); the processor must extract Y before the model.
     batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
     cb.on_validation_batch_end(
-        trainer=trainer, pl_module=pl_module, outputs=None,
-        batch=batch, batch_idx=0, dataloader_idx=1,
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 1
     _, lr_cached, sr_cached, hr_cached, psnr_dict, ssim = cb._buffer["Set5"][0]
@@ -572,6 +618,7 @@ def test_benchmark_collect_batch_routes_through_processor():
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger consumes the public predict_rgb seam + SRDataset (P2.1)
 # ---------------------------------------------------------------------------
+
 
 def test_benchmark_collect_batch_routes_through_predict_rgb():
     """_collect_batch must call the public pl_module.predict_rgb, and the
@@ -595,8 +642,12 @@ def test_benchmark_collect_batch_routes_through_predict_rgb():
         val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)],
     )
     cb.on_validation_batch_end(
-        trainer=trainer, pl_module=pl_module, outputs=None,
-        batch=batch, batch_idx=0, dataloader_idx=1,
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
     )
 
     spy.assert_called_once()
@@ -627,8 +678,12 @@ def test_benchmark_collect_batch_consumes_srdataset_img_paths(tiny_rgb_image_dir
     )
     batch = (torch.rand(2, 3, 16, 16), torch.rand(2, 3, 16, 16))
     cb.on_validation_batch_end(
-        trainer=trainer, pl_module=pl_module, outputs=None,
-        batch=batch, batch_idx=0, dataloader_idx=1,
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
     )
     fnames = [entry[0] for entry in cb._buffer["Set5"]]
     assert fnames == [p.stem for p in ds.img_paths[:2]]  # e.g. ["img_00", "img_01"]

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -9,7 +9,7 @@ def test_sr_training_config_defaults():
     cfg = SRTrainingConfig()
     assert cfg.layer_lrs is None
     assert cfg.example_input_shape is None
-    assert cfg.init_strategy == 'default'
+    assert cfg.init_strategy == "default"
     assert cfg.init_mean == 0.0
     assert cfg.init_std == 0.01
 

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -75,6 +75,7 @@ def test_train_dataloader_shuffles(tiny_rgb_image_dir: Path):
     assert isinstance(loader, DataLoader)
     # DataLoader.sampler is RandomSampler when shuffle=True.
     from torch.utils.data import RandomSampler
+
     assert isinstance(loader.sampler, RandomSampler)
 
 
@@ -219,6 +220,7 @@ def test_train_dataset_built_from_class_path_spec(tiny_rgb_image_dir: Path):
     )
     dm.setup(stage="fit")
     from sisr.datasets.srcnn import TrainDataset, ValidationDataset
+
     assert isinstance(dm._train_ds, TrainDataset)
     assert isinstance(dm._val_ds, ValidationDataset)
     assert isinstance(dm._test_ds["Set5"], ValidationDataset)

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -11,6 +11,7 @@ the metric names actually logged, and the module -> datamodule ->
 and the strict ``filterwarnings=error`` config turns it into a failure unless
 the scoped ignore in ``pyproject.toml`` is in place.
 """
+
 import functools
 from pathlib import Path
 
@@ -71,9 +72,7 @@ def _make_datamodule(image_dir: Path) -> SRDataModule:
 # lightning PossibleUserWarnings — config/environment noise, not a library-health
 # signal. Silence them for THIS test only so the strict global filter stays honest
 # and the test fails specifically on the real FutureWarning when the filter is stale.
-@pytest.mark.filterwarnings(
-    "ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning"
-)
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
 def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
     tiny_rgb_image_dir: Path,
 ):

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -7,21 +7,20 @@ import pytest
 import torch
 import torchmetrics
 
-from sisr.models.base import SRModel
 from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
 from sisr.models.srresnet.model import SRResNet
 from sisr.processors import (
     RGBProcessor,
     SRProcessor,
-    YChannelProcessor,
     YCbCrProcessor,
+    YChannelProcessor,
 )
 from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
-
 
 # ---------------------------------------------------------------------------
 # fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def srcnn_rgb_lit() -> SRLightning:
@@ -61,6 +60,7 @@ def rgb_lr_hr_batch() -> tuple[torch.Tensor, torch.Tensor]:
 # ---------------------------------------------------------------------------
 # forward + step
 # ---------------------------------------------------------------------------
+
 
 def test_forward_delegates_to_model(srcnn_rgb_lit: SRLightning):
     x = torch.zeros(1, 3, 33, 33)
@@ -128,6 +128,7 @@ def test_step_ycbcr_path():
 # ---------------------------------------------------------------------------
 # configure_optimizers
 # ---------------------------------------------------------------------------
+
 
 def test_configure_optimizers_uniform(srcnn_rgb_lit: SRLightning):
     out = srcnn_rgb_lit.configure_optimizers()
@@ -202,13 +203,14 @@ def test_configure_optimizers_with_lr_scheduler(srcnn_rgb_lit: SRLightning):
 
 def test_configure_optimizers_no_scheduler_returns_bare(srcnn_rgb_lit: SRLightning):
     out = srcnn_rgb_lit.configure_optimizers()
-    assert not isinstance(out, (tuple, list)), "single optimizer when no scheduler"
+    assert not isinstance(out, tuple | list), "single optimizer when no scheduler"
     assert isinstance(out, torch.optim.Optimizer)
 
 
 # ---------------------------------------------------------------------------
 # test_step / build_psnr_tensors / flatten_hparams
 # ---------------------------------------------------------------------------
+
 
 def test_test_step_is_no_op(srcnn_rgb_lit: SRLightning):
     """test_step exists so Lightning iterates test_dataloaders; the body is a no-op."""
@@ -261,12 +263,14 @@ def test_build_psnr_tensors_ycbcr_does_conversion():
 
 
 def test_flatten_hparams_handles_nested():
-    flat = SRLightning._flatten_hparams({
-        "a": 1,
-        "b": {"x": 2, "y": [3, 4]},
-        "c": None,             # None values dropped
-        "d": SRCNN,            # class -> __name__
-    })
+    flat = SRLightning._flatten_hparams(
+        {
+            "a": 1,
+            "b": {"x": 2, "y": [3, 4]},
+            "c": None,  # None values dropped
+            "d": SRCNN,  # class -> __name__
+        }
+    )
     assert flat == {
         "a": 1,
         "b/x": 2,
@@ -316,7 +320,7 @@ def test_base_training_config_skips_reset_parameters():
     SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),    # init_strategy='default' by default
+        training_config=SRTrainingConfig(),  # init_strategy='default' by default
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -327,6 +331,7 @@ def test_base_training_config_skips_reset_parameters():
 # on_train_start hook
 # ---------------------------------------------------------------------------
 
+
 def test_on_train_start_logs_hparams_with_val_metrics(srcnn_rgb_lit: SRLightning):
     """The hook calls TensorBoardLogger.log_hyperparams once with val metrics dict."""
     tb = MagicMock(spec=lightning.pytorch.loggers.TensorBoardLogger)
@@ -336,11 +341,11 @@ def test_on_train_start_logs_hparams_with_val_metrics(srcnn_rgb_lit: SRLightning
 
     tb.log_hyperparams.assert_called_once()
     args, kwargs = tb.log_hyperparams.call_args
-    params_arg = args[0] if args else kwargs.get('params')
-    metrics_arg = args[1] if len(args) > 1 else kwargs.get('metrics')
+    params_arg = args[0] if args else kwargs.get("params")
+    metrics_arg = args[1] if len(args) > 1 else kwargs.get("metrics")
 
-    expected_metrics = {f'val_psnr({k})': 0.0 for k in srcnn_rgb_lit._psnr_keys}
-    expected_metrics['val_ssim'] = 0.0
+    expected_metrics = {f"val_psnr({k})": 0.0 for k in srcnn_rgb_lit._psnr_keys}
+    expected_metrics["val_ssim"] = 0.0
 
     assert params_arg == srcnn_rgb_lit.hparams
     assert metrics_arg == expected_metrics
@@ -379,9 +384,10 @@ def test_on_train_start_multiple_tb_loggers_each_receive_call(srcnn_rgb_lit: SRL
 # new: isinstance guards and processor flow
 # ---------------------------------------------------------------------------
 
+
 def test_srlightning_rejects_non_srmodel():
     """SRLightning(model=<plain nn.Module>) raises TypeError with a readable message."""
-    model = torch.nn.Conv2d(3, 3, 1)              # plain nn.Module, not SRModel
+    model = torch.nn.Conv2d(3, 3, 1)  # plain nn.Module, not SRModel
     with pytest.raises(TypeError, match="SRModel subclass"):
         SRLightning(
             model=model,
@@ -396,7 +402,7 @@ def test_srlightning_rejects_non_srprocessor():
     with pytest.raises(TypeError, match="SRProcessor subclass"):
         SRLightning(
             model=model,
-            processor=object(),                    # not an SRProcessor
+            processor=object(),  # not an SRProcessor
             optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
         )
 
@@ -459,6 +465,7 @@ def test_saved_hparams_contain_processor_name():
 # predict_rgb public inference seam (P2.1)
 # ---------------------------------------------------------------------------
 
+
 def test_predict_rgb_returns_sr_and_hr_pair(srcnn_rgb_lit: SRLightning, rgb_lr_hr_batch):
     lr, hr = rgb_lr_hr_batch
     sr_rgb, hr_cropped = srcnn_rgb_lit.predict_rgb(lr, hr)
@@ -492,6 +499,7 @@ def test_predict_rgb_matches_step_forward_path_y_channel(srcnn_y_lit: SRLightnin
 # P2.2 — no dead stateful metric accumulator
 # ---------------------------------------------------------------------------
 
+
 def test_val_metrics_hold_no_stateful_accumulators(srcnn_y_lit: SRLightning):
     """Regression (P2.2): PSNR/SSIM are computed via torchmetrics.functional,
     so SRLightning registers no stateful torchmetrics.Metric accumulators that
@@ -505,6 +513,7 @@ def test_val_metrics_hold_no_stateful_accumulators(srcnn_y_lit: SRLightning):
 # ---------------------------------------------------------------------------
 # P2.4 — nested config dataclasses expand into HParams columns
 # ---------------------------------------------------------------------------
+
 
 def test_hparams_expand_nested_config_fields():
     """Regression (P2.4): training_config/eval_config dataclasses expand into
@@ -530,6 +539,7 @@ def test_hparams_expand_nested_config_fields():
 # P2.6 — val PSNR is the per-image mean, invariant to batch size
 # ---------------------------------------------------------------------------
 
+
 def test_val_psnr_is_per_image_mean_not_batch_pooled():
     """Regression (P2.6): PSNR for a batch equals the mean of the per-image
     PSNRs (SR-standard reduction, invariant to val batch_size), not the
@@ -537,15 +547,15 @@ def test_val_psnr_is_per_image_mean_not_batch_pooled():
     from torchmetrics.functional.image import peak_signal_noise_ratio as psnr_fn
 
     g = torch.Generator().manual_seed(1)
-    hr = torch.rand(2, 3, 8, 8, generator=g) * 0.8   # keep values in [0, 0.8]
+    hr = torch.rand(2, 3, 8, 8, generator=g) * 0.8  # keep values in [0, 0.8]
     sr = hr.clone()
-    sr[0] = sr[0] + 0.01                             # image 0: small error
-    sr[1] = sr[1] + 0.15                             # image 1: larger error
+    sr[0] = sr[0] + 0.01  # image 0: small error
+    sr[1] = sr[1] + 0.15  # image 1: larger error
 
-    per_image = torch.stack([
-        psnr_fn(sr[i:i + 1], hr[i:i + 1], data_range=1.0) for i in range(2)
-    ]).mean()
-    pooled = psnr_fn(sr, hr, data_range=1.0)          # dim=None -> pools the batch
+    per_image = torch.stack(
+        [psnr_fn(sr[i : i + 1], hr[i : i + 1], data_range=1.0) for i in range(2)]
+    ).mean()
+    pooled = psnr_fn(sr, hr, data_range=1.0)  # dim=None -> pools the batch
 
     batch_val = SRLightning._mean_psnr(sr, hr)
     assert torch.allclose(batch_val, per_image, atol=1e-5)


### PR DESCRIPTION
Adopt ruff: add [tool.ruff] (rules E,F,I,UP,B; line-length 100), run the format + autofix pass, and add a CI lint gate. Config, format-churn, and CI are three separate commits (INIT.1).

**Stacked PR** - base: `stack/09-pr10` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code