### PR TITLE
Cosmetic sweep: docstrings, typing, deprecation, validation (P5.1-P5.7)

### DIFF
--- a/sisr/models/base.py
+++ b/sisr/models/base.py
@@ -10,7 +10,7 @@ class SRModel(nn.Module, abc.ABC):
     """Abstract base for SR architectures.
 
     Subclasses must populate ``self._hparams`` in ``__init__`` and
-    implement :meth:`forward`. ``reset_parameters`` is a no-op by default;
+    implement ``forward``. ``reset_parameters`` is a no-op by default;
     override it for paper-faithful weight init schemes.
     """
 
@@ -28,9 +28,9 @@ class SRModel(nn.Module, abc.ABC):
     def reset_parameters(self, **kwargs) -> None:
         """Optional paper-style weight init. Default: no-op (kwargs ignored).
 
-        Subclasses may declare specific kwargs (e.g. :class:`SRCNN`'s ``mean`` /
+        Subclasses may declare specific kwargs (e.g. ``SRCNN``'s ``mean`` /
         ``std``). The base accepts ``**kwargs`` so callers like
-        :class:`~sisr.training.SRLightning` can pass paper-init options
+        ``SRLightning`` can pass paper-init options
         polymorphically without knowing the subclass signature — models that
         don't override absorb the kwargs as no-ops.
         """

--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -1,7 +1,7 @@
 """SRCNN-paper-faithful training and eval defaults.
 
-Subclassing :class:`SRTrainingConfig` / :class:`SREvalConfig` from
-:mod:`sisr.training.config` lets the SRCNN-paper recipe live alongside the
+Subclassing ``SRTrainingConfig`` / ``SREvalConfig`` from
+``sisr.training.config`` lets the SRCNN-paper recipe live alongside the
 model architecture, so an SRCNN experiment YAML only has to point at these
 classes via ``class_path`` to inherit defaults.
 
@@ -20,7 +20,7 @@ class SRCNNTrainingConfig(SRTrainingConfig):
     """SRCNN-paper-faithful training defaults.
 
     The paper trains on the Y channel of YCbCr only (selected at the YAML
-    layer by pairing with :class:`~sisr.processors.YChannelProcessor`) and
+    layer by pairing with ``YChannelProcessor``) and
     uses a per-layer learning rate of ``1e-4`` for the feature-extraction
     and non-linear-mapping layers and ``1e-5`` for the reconstruction layer
     — i.e. the last layer learns 10× slower. Weight initialization follows
@@ -32,12 +32,12 @@ class SRCNNTrainingConfig(SRTrainingConfig):
         layer_lrs: Per-``Conv2d`` LRs ``[1e-4, 1e-4, 1e-5]`` matching the
             paper's recipe. Set to ``None`` to disable per-layer LRs.
         init_strategy: ``'paper'`` (default) triggers the Gaussian
-            init via :meth:`SRCNN.reset_parameters` in
-            :class:`~sisr.training.SRLightning`'s constructor;
+            init via ``SRCNN.reset_parameters`` in
+            ``SRLightning``'s constructor;
             ``'default'`` skips it and uses PyTorch's defaults.
         init_mean / init_std: Gaussian parameters used by
             ``init_strategy='paper'``; inherited from
-            :class:`~sisr.training.config.SRTrainingConfig` with defaults
+            ``SRTrainingConfig`` with defaults
             ``0.0`` / ``0.01`` matching the SRCNN paper. Override in YAML
             to deviate.
     """

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -138,10 +138,16 @@ class SRCNN(SRModel):
     ) -> torch.Tensor:
         """Forward pass of the SRCNN model.
 
+        clamp_output is a direct-call convenience for offline inference: the
+        SRLightning training and validation paths always call model(x) without
+        it, so clamping only takes effect on direct model(x, clamp_output=True)
+        calls used to clip the raw output into a displayable range.
+
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, num_channels, height, width)
-            clamp_output (bool): Whether to clamp the output values to a specified range.
-                Default is False.
+            clamp_output (bool): Whether to clamp the output to clamp_minmax. Only
+                honoured on direct model(x, clamp_output=True) calls; the SRLightning
+                pipeline never sets it. Default is False.
             clamp_minmax (tuple[float, float]): The minimum and maximum values for clamping
                 the output. Default is (0.0, 1.0).
 

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -116,6 +116,7 @@ class SRResNet(SRModel):
         super().__init__()
 
         self._check_scale(scale)
+        self._check_architecture(kernel_sizes, num_residual_blocks)
 
         self._hparams = {
             "scale": scale,
@@ -173,6 +174,34 @@ class SRResNet(SRModel):
             raise ValueError(f"scale must be a positive integer. Got {scale}.")
         if (scale & (scale - 1)) != 0:
             raise ValueError(f"scale must be a power of 2. Got {scale}.")
+
+    def _check_architecture(self, kernel_sizes: tuple[int, ...], num_residual_blocks: int):
+        """Validates the architecture parameters for the SRResNet model.
+
+        Args:
+            kernel_sizes (tuple[int, ...]): Kernel sizes for the head, residual,
+                and tail convolutional layers.
+            num_residual_blocks (int): Number of residual blocks in the network.
+
+        Raises:
+            ValueError: If kernel_sizes is not a length-3 tuple of positive
+                integers, or if num_residual_blocks is not a positive integer.
+        """
+        if not isinstance(kernel_sizes, tuple):
+            raise ValueError(f"kernel_sizes must be a tuple. Got {type(kernel_sizes)}.")
+        if len(kernel_sizes) != 3:
+            raise ValueError(
+                f"kernel_sizes must have exactly 3 elements for the head, residual, "
+                f"and tail layers. Got {kernel_sizes}."
+            )
+        if any(k < 1 for k in kernel_sizes):
+            raise ValueError(
+                f"All elements in kernel_sizes must be positive integers. Got {kernel_sizes}."
+            )
+        if num_residual_blocks < 1:
+            raise ValueError(
+                f"num_residual_blocks must be a positive integer. Got {num_residual_blocks}."
+            )
 
     def forward(
         self,

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -211,10 +211,16 @@ class SRResNet(SRModel):
     ) -> torch.Tensor:
         """Forward pass of the SRResNet model.
 
+        clamp_output is a direct-call convenience for offline inference: the
+        SRLightning training and validation paths always call model(x) without
+        it, so clamping only takes effect on direct model(x, clamp_output=True)
+        calls used to clip the raw output into a displayable range.
+
         Args:
             x (torch.Tensor): Input tensor of shape (batch_size, in_out_channels, height, width).
-            clamp_output (bool): Whether to clamp the output values to a specified range.
-                Default is False.
+            clamp_output (bool): Whether to clamp the output to clamp_minmax. Only
+                honoured on direct model(x, clamp_output=True) calls; the SRLightning
+                pipeline never sets it. Default is False.
             clamp_minmax (tuple[float, float]): The minimum and maximum values for clamping
                 the output. Default is (0.0, 1.0).
 

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -540,7 +540,7 @@ class SRCheckpoint(ModelCheckpoint):
             Defaults to ``3``.
         dirpath (str | None): Directory to save checkpoints.
         filename_prefix (str): Prefix for checkpoint filenames.
-            Defaults to ``"srcnn"``.
+            Defaults to ``"sr"``.
         **kwargs: Extra keyword arguments forwarded to
             :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
     """
@@ -550,7 +550,7 @@ class SRCheckpoint(ModelCheckpoint):
         monitor_metric: str = "val_psnr(RGB)",
         save_top_k: int = 3,
         dirpath: str | None = None,
-        filename_prefix: str = "srcnn",
+        filename_prefix: str = "sr",
         mode: str = "max",
         **kwargs: Any,
     ):

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -464,7 +464,7 @@ class GradNormLogger(Callback):
         total_norm_sq = 0.0
         for p in pl_module.parameters():
             if p.grad is not None:
-                total_norm_sq += p.grad.data.norm(2).item() ** 2
+                total_norm_sq += p.grad.detach().norm(2).item() ** 2
         total_norm = math.sqrt(total_norm_sq)
 
         pl_module.log("grad_norm", total_norm, on_step=True, on_epoch=False)

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -2,10 +2,10 @@
 
 Split into two classes by lifecycle:
 
-* :class:`SRTrainingConfig` controls behaviour during ``cli fit`` — per-Conv2d
+* ``SRTrainingConfig`` controls behaviour during ``cli fit`` — per-Conv2d
   learning rates, paper-init knobs, and the example input shape used to log
   the model graph to TensorBoard.
-* :class:`SREvalConfig` controls validation/test metric computation —
+* ``SREvalConfig`` controls validation/test metric computation —
   boundary-pixel exclusion (``crop_border``) and which colorspaces PSNR is
   reported in.
 
@@ -15,7 +15,7 @@ Per-architecture defaults live in subclasses next to the model code (e.g.
 overrides individual fields with ``init_args``.
 
 The colorspace the model trains in is no longer a string field here; it is
-expressed by the choice of processor (see :mod:`sisr.processors`).
+expressed by the choice of processor (see ``sisr.processors``).
 """
 
 from dataclasses import dataclass, field
@@ -32,7 +32,7 @@ class SRTrainingConfig:
             ``None`` (default), training uses the optimizer's base ``lr``
             uniformly across all parameters.  Only valid for architectures
             where every trainable parameter lives in a ``Conv2d`` (no
-            BatchNorm / PReLU); :meth:`SRLightning.configure_optimizers`
+            BatchNorm / PReLU); ``SRLightning.configure_optimizers``
             raises ``ValueError`` otherwise.
 
         example_input_shape: Shape of a single input sample *excluding* the
@@ -41,7 +41,7 @@ class SRTrainingConfig:
             TensorBoard logger can capture the model graph.
 
         init_strategy: ``'paper'`` triggers a paper-faithful weight init via
-            :meth:`SRModel.reset_parameters` in :class:`SRLightning`'s constructor;
+            ``SRModel.reset_parameters`` in ``SRLightning``'s constructor;
             ``'default'`` (the default) skips it and uses PyTorch's defaults.
             Subclasses pin a paper-faithful default (e.g. ``SRCNNTrainingConfig``
             uses ``'paper'``).

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -73,7 +73,7 @@ class SRDataModule(lightning.LightningDataModule):
         self._test_ds: dict[str, Dataset] = {}
 
     @property
-    def test_names(self) -> list:
+    def test_names(self) -> list[str]:
         """Ordered list of test dataset names — drives BenchmarkImageLogger auto-discovery.
 
         Returns:
@@ -116,7 +116,7 @@ class SRDataModule(lightning.LightningDataModule):
         """
         return DataLoader(self._train_ds, shuffle=True, **self._train_dl_kwargs)
 
-    def val_dataloader(self) -> list:
+    def val_dataloader(self) -> list[DataLoader]:
         """Primary validation loader followed by every test loader.
 
         Index 0 is the held-out primary val set; indices 1+ are the test
@@ -132,7 +132,7 @@ class SRDataModule(lightning.LightningDataModule):
             loaders.append(DataLoader(ds, shuffle=False, **self._test_dl_kwargs))
         return loaders
 
-    def test_dataloader(self) -> list:
+    def test_dataloader(self) -> list[DataLoader]:
         """Test loaders only — for ``cli test --ckpt_path <path>`` final eval.
 
         Returns:

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -16,6 +16,7 @@ import torch
 import torchmetrics.functional
 import torchvision
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+from lightning.pytorch.utilities.types import OptimizerLRScheduler
 
 from ..models.base import SRModel
 from ..processors import SRProcessor
@@ -425,7 +426,7 @@ class SRLightning(lightning.LightningModule):
         """
         return None
 
-    def configure_optimizers(self):
+    def configure_optimizers(self) -> OptimizerLRScheduler:
         """Build optimizer (and optional scheduler) from top-level YAML.
 
         Uniform LR by default — ``self.optimizer(self.parameters())``

--- a/sisr/utils.py
+++ b/sisr/utils.py
@@ -105,7 +105,7 @@ class LMDBCacheBuildContext:
         process_args: Sequence[Sequence[Any]] | None = None,
         num_workers: int | None = None,
         desc: str = "Building LMDB cache",
-    ):
+    ) -> None:
         """Processes *items* and writes the results to LMDB.
 
         The worker function *process_fn* must be a top-level (picklable)
@@ -339,7 +339,7 @@ class LMDBCache:
         map_size: int,
         build_fn: Callable[[LMDBCacheBuildContext], None],
         use_tqdm: bool,
-    ):
+    ) -> None:
         """Creates a fresh LMDB and delegates population to *build_fn*.
 
         Args:

--- a/tests/models/srresnet/test_model.py
+++ b/tests/models/srresnet/test_model.py
@@ -74,6 +74,20 @@ def test_check_scale_non_int_raises():
         SRResNet(scale=2.0)
 
 
+def test_check_architecture_wrong_kernel_sizes_length_raises():
+    """P5.6: a kernel_sizes tuple that isn't length-3 must raise a clear
+    ValueError at construction, not an IndexError deep in layer wiring."""
+    with pytest.raises(ValueError, match="kernel_sizes"):
+        SRResNet(scale=2, kernel_sizes=(9, 3))
+
+
+def test_check_architecture_nonpositive_num_residual_blocks_raises():
+    """P5.6: num_residual_blocks <= 0 must raise a clear ValueError instead of
+    silently building an empty residual Sequential."""
+    with pytest.raises(ValueError, match="num_residual_blocks"):
+        SRResNet(scale=2, num_residual_blocks=0)
+
+
 def test_residual_block_preserves_shape():
     block = SRResidualBlock(channels=16, kernel_size=3)
     x = torch.zeros(2, 16, 8, 8)

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -255,6 +255,13 @@ def test_srcheckpoint_custom_filename_prefix():
     assert ckpt.filename.startswith("myrun-")
 
 
+def test_srcheckpoint_default_filename_prefix_is_neutral_sr():
+    """P5.5: the generic checkpoint's default prefix must be arch-neutral 'sr',
+    not the SRCNN-specific 'srcnn'."""
+    ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath="/tmp/x")
+    assert ckpt.filename.startswith("sr-")
+
+
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger validation/test hook bodies (mock-driven, no Trainer)
 # ---------------------------------------------------------------------------

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -184,6 +184,28 @@ def test_grad_norm_logger_handles_none_grads():
     assert args[1] == 0.0
 
 
+def test_grad_norm_logger_uses_grad_detach_not_grad_data():
+    """P5.3: gradient-norm accumulation must read gradients via
+    ``p.grad.detach()``, not the legacy ``p.grad.data`` attribute — and must
+    still compute the correct L2 norm. The source check gives the red->green
+    signal (``.grad.data`` does not raise a Python warning on the pinned torch,
+    so a warnings-based assert cannot go red); the numeric check confirms
+    behaviour is unchanged."""
+    import inspect
+
+    src = inspect.getsource(GradNormLogger.on_after_backward)
+    assert ".grad.data" not in src
+    assert "p.grad.detach()" in src
+
+    cb = GradNormLogger(log_every_n_steps=1)
+    trainer = SimpleNamespace(global_step=1)
+    pl_module = _make_gradnorm_pl_module()
+    cb.on_after_backward(trainer, pl_module)
+    args, _ = pl_module.log.call_args
+    assert args[0] == "grad_norm"
+    assert args[1] == pytest.approx(10.0)
+
+
 # ---------------------------------------------------------------------------
 # WeightHistogramLogger
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
reST to Google docstrings, filled typing gaps, p.grad.detach() over the deprecated .grad.data, neutral SRCheckpoint prefix sr, SRResNet construction-time validation, and documented clamp_output (P5.1, P5.2, P5.3, P5.5, P5.6, P5.7).

**Stacked PR** - base: `stack/10-pr8` (merge after its base). Part of the triage-delivery stack of 11 PRs; the full stack is 216 tests passing and ruff-clean.

See triage items in the title.

> Generated with Claude Code