### PR TITLE
Adopt conda + uv for local development, move test CI to uv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # setup-uv stopped publishing moving major/minor tags at v8.0.0 as supply-chain
+      # hardening, so this pins an exact patch unlike the @v4/@v5 actions above.
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
       - name: Install ruff
-        run: pip install ruff
+        run: uv pip install --system ruff
       - name: Ruff lint
         run: ruff check --output-format=github .
       - name: Ruff format check
@@ -42,10 +47,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      # See the lint job for why this pins an exact patch version.
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
       - name: Install
-        run: pip install -e ".[dev]"
+        run: uv pip install --system -e ".[dev]"
       - name: Run tests with coverage
         run: pytest -n 8 --cov=sisr --cov-report=xml --cov-report=term --cov-fail-under=90
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
+          cache-suffix: lint
       - name: Install ruff
         run: uv pip install --system ruff
       - name: Ruff lint
@@ -51,6 +52,7 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
+          cache-suffix: py${{ matrix.python-version }}
           cache-dependency-glob: pyproject.toml
       - name: Install
         run: uv pip install --system -e ".[dev]"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestArgs": ["-n", "0"],
 
+    "python.terminal.activateEnvironment": true,
+
     "files.watcherExclude": {
         "data/**": true,
         ".lmdb_cache/**": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
+    "python.testing.pytestArgs": ["-n", "0"],
 
     "files.watcherExclude": {
         "data/**": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,31 @@ covers how to set up a development environment, run the tests, and land a change
 Requires **Python ≥ 3.12**.
 
 ```bash
-# Clone your fork, then install in editable mode with the dev extras:
+# Clone your fork:
 git clone https://github.com/YeapJieShen/single-image-super-resolution.git
 cd single-image-super-resolution
-pip install -e ".[dev]"
+
+# Create an isolated environment (conda shown; any virtualenv works):
+conda create -n sisr python=3.13
+conda activate sisr
+
+# Install uv into the environment, then install the project with dev extras:
+pip install uv
+python -m uv pip install -e ".[dev]"
 ```
 
-The `[dev]` extra adds the test toolchain (`pytest`, `pytest-cov`). `pyproject.toml`
-is the single source of truth for dependencies — there is no `requirements.txt`.
+Invoke it as `python -m uv`, not bare `uv`: uv resolves `VIRTUAL_ENV` ahead of the active
+conda env, so the bare binary installs into whatever virtualenv happens to be active,
+while `python -m uv` targets the interpreter you just activated.
+
+`uv` is a much faster drop-in replacement for `pip install`. Installing it *into* the
+environment keeps it self-contained — removing the environment removes uv with it. Plain
+`pip install -e ".[dev]"` remains fully supported; CI's **build** check verifies the
+end-user `pip install .` path on all four matrix legs.
+
+The `[dev]` extra adds the test and lint toolchain (`pytest`, `pytest-cov`,
+`pytest-xdist`, `pyyaml`, `ruff`). `pyproject.toml` is the single source of truth for
+dependencies — there is no `requirements.txt`.
 
 If you develop on a CUDA GPU, install the CUDA `torch` / `torchvision` wheels from
 PyTorch's own index **first** (the `+cu###` wheels are not on PyPI), then install the

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ rest from PyPI. Same convention as PyTorch's own
 ```bash
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
 pip install .
+
+# or, with uv (inside the activated environment):
+python -m uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
+python -m uv pip install .
 ```
 
 The bundled templates set `accelerator: cuda`; change it to `cpu` to run without a GPU.
@@ -112,7 +116,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
 ## Development
 
 ```bash
-pip install -e ".[dev]"
+pip install -e ".[dev]"     # or: python -m uv pip install -e ".[dev]"
 pytest
 ```
 


### PR DESCRIPTION
Retires the in-project `.venv` in favour of a named conda env (`sisr`, Python 3.13), installs packages with uv from inside that env, and moves the test workflow to uv.

## What changed

- **CI** — `test.yml` installs via `uv pip install --system`, with the uv cache scoped per matrix leg. `build.yml` deliberately stays on plain `pip install .`, so the end-user pip path remains verified on every PR across all four matrix legs. Gate job names are unchanged, so required-check contexts do not move.
- **VS Code** — adds `python.testing.pytestArgs: ["-n", "0"]` so Test Explorer breakpoints and per-test results work despite the `-n 8 --dist=loadscope` in pyproject's `addopts`. Terminal `pytest` keeps all 8 workers. No interpreter path is committed; it is selected via the palette and stored in VS Code's own workspace storage.
- **Docs** — conda + uv setup in CONTRIBUTING, uv variants in the README, with pip retained as the supported path throughout.

## Notes

uv is documented as `python -m uv`, not bare `uv`: uv resolves `VIRTUAL_ENV` ahead of the active conda env, so the bare binary installs into whatever virtualenv happens to be active. A bash-style `--python "$CONDA_PREFIX"` guard was rejected because it expands to the empty string in PowerShell.

`astral-sh/setup-uv` is pinned to the exact patch `v9.0.0` rather than a moving major tag — the action stopped publishing moving tags at v8.0.0 as supply-chain hardening.

Two doc corrections ride along: CONTRIBUTING's `[dev]` extra list omitted `pytest-xdist`, `pyyaml` and `ruff`, and it claimed the `build` check exercises `pip install -e ".[dev]"` when that job runs `pip install .`.

No dependency or version constraint changed. No `uv.lock`, no `requirements.txt`, no `[tool.uv]` block.

## Verification

Locally in the `sisr` env: `torch 2.13.0+cu132` with `cuda.is_available() == True`, 216 tests passed, `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
