### PR TITLE
Split sisr/utils.py; cut the test suite's redundant cold imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,11 +91,17 @@ testpaths = ["tests"]
 # --import-mode=importlib avoids duplicate-basename collisions across test
 # subdirs (e.g. tests/models/srcnn/test_model.py vs
 # tests/models/srresnet/test_model.py) without requiring __init__.py files.
-# -n 8 is the measured-clean xdist worker count; -n auto (=16 here) oversubscribed.
-# Capped so it merely time-slices on smaller CI runners. --dist=loadscope keeps
-# same-module tests on one worker so module-scoped fixtures (e.g. the shared
-# SRCNN LMDB cache) build once instead of once per worker.
-addopts = "-ra --strict-markers --import-mode=importlib -n 8 --dist=loadscope"
+# -n 2, deliberately low: every xdist worker is a fresh interpreter that
+# cold-imports the whole torch + lightning stack (~10s; torch 3.7s, plus scipy
+# and sympy via torchmetrics/torchvision), while the suite's own compute is only
+# ~20s. Past a couple of workers the added startup costs more than the
+# parallelism wins back. Measured 2026-07-30, 8-core/16-thread Windows:
+# -n 0 44.0s, -n 2 38.3s, -n 4 38.3s, -n 8 47.1s (-n auto = 16 is far worse).
+# Re-measure before raising this — "more workers" is not free here, and the
+# break-even moves whenever the import cost or the suite's compute changes.
+# --dist=loadscope keeps same-module tests on one worker so module-scoped
+# fixtures (e.g. the shared SRCNN LMDB cache) build once instead of once per worker.
+addopts = "-ra --strict-markers --import-mode=importlib -n 2 --dist=loadscope"
 filterwarnings = [
     "error",
     # Lightning 2.6.5 constructs torch 2.12's deprecated pytree `LeafSpec` at

--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -1,13 +1,15 @@
-"""Colorspace conversions and the LMDB cache infrastructure.
+"""Checksum-validated LMDB key-value store with parallel build support.
 
-BT.601 full-range YCbCr is the project's working chroma space. Pure
-conversion functions live here so the :class:`~sisr.processors.SRProcessor`
-subclasses and any external callers can use them without depending on
-Lightning or model code.
+:class:`LMDBCache` is used by :class:`~sisr.datasets.srcnn.TrainDataset` to
+persist precomputed LR/HR sub-image pairs.
 
-:class:`LMDBCache` is a checksum-validated key-value store used by
-:class:`~sisr.datasets.srcnn.TrainDataset` to persist precomputed
-LR/HR sub-image pairs.
+This module deliberately imports no torch, and must stay that way.
+:meth:`LMDBCacheBuildContext.parallel_build` fans work out over a
+``ProcessPoolExecutor``, and on spawn platforms (Windows, macOS) every worker
+re-imports the module tree holding its ``process_fn`` — so a torch import
+reachable from here costs each worker several seconds for a dependency the
+build path never calls. ``tests/test_cache.py`` asserts the module stays
+torch-free; colorspace math lives in :mod:`sisr.colorspace` for this reason.
 """
 
 import os
@@ -18,59 +20,7 @@ from pathlib import Path
 from typing import Any
 
 import lmdb
-import torch
 from tqdm.auto import tqdm
-
-# BT.601 full-range RGB <-> YCbCr conversion (ITU-R Rec. BT.601-7).
-# Both colorspaces are normalised to [0, 1]. Cb and Cr have a +0.5 offset on
-# their stored representation so that signed chroma values in [-0.5, +0.5]
-# map onto unsigned [0, 1]. This is the *full-range* (a.k.a. "JPEG") variant
-# of BT.601 — distinct from the studio-range variant which scales Y to
-# [16/255, 235/255] and Cb/Cr to [16/255, 240/255].
-
-_RGB_TO_Y = (0.299, 0.587, 0.114)
-_RGB_TO_CB = (-0.169, -0.331, 0.500)  # output offset +0.5
-_RGB_TO_CR = (0.500, -0.419, -0.081)  # output offset +0.5
-_YCBCR_TO_R = 1.402  # cr coefficient
-_YCBCR_TO_G_CB = -0.344  # cb coefficient
-_YCBCR_TO_G_CR = -0.714  # cr coefficient
-_YCBCR_TO_B = 1.772  # cb coefficient
-
-
-def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
-    """Convert a normalised RGB tensor to YCbCr (BT.601 full-range).
-
-    Args:
-        img (torch.Tensor): RGB tensor of shape ``(B, 3, H, W)`` with
-            values in ``[0, 1]``.
-
-    Returns:
-        torch.Tensor: YCbCr tensor of shape ``(B, 3, H, W)`` in
-        ``[0, 1]`` with Cb/Cr offset by +0.5.
-    """
-    r, g, b = img[:, 0:1], img[:, 1:2], img[:, 2:3]
-    y = _RGB_TO_Y[0] * r + _RGB_TO_Y[1] * g + _RGB_TO_Y[2] * b
-    cb = _RGB_TO_CB[0] * r + _RGB_TO_CB[1] * g + _RGB_TO_CB[2] * b + 0.5
-    cr = _RGB_TO_CR[0] * r + _RGB_TO_CR[1] * g + _RGB_TO_CR[2] * b + 0.5
-    return torch.cat([y, cb, cr], dim=1)
-
-
-def ycbcr_to_rgb(img: torch.Tensor) -> torch.Tensor:
-    """Convert a YCbCr tensor to RGB (BT.601 full-range, clamped to [0, 1]).
-
-    Args:
-        img (torch.Tensor): YCbCr tensor of shape ``(B, 3, H, W)`` with
-            Cb/Cr offset by +0.5.
-
-    Returns:
-        torch.Tensor: RGB tensor of shape ``(B, 3, H, W)`` clamped to
-        ``[0, 1]``.
-    """
-    y, cb, cr = img[:, 0:1], img[:, 1:2] - 0.5, img[:, 2:3] - 0.5
-    r = y + _YCBCR_TO_R * cr
-    g = y + _YCBCR_TO_G_CB * cb + _YCBCR_TO_G_CR * cr
-    b = y + _YCBCR_TO_B * cb
-    return torch.cat([r, g, b], dim=1).clamp(0.0, 1.0)
 
 
 class LMDBCacheBuildContext:

--- a/sisr/colorspace.py
+++ b/sisr/colorspace.py
@@ -1,0 +1,60 @@
+"""BT.601 full-range RGB <-> YCbCr conversion.
+
+BT.601 full-range YCbCr is the project's working chroma space. These pure
+tensor functions live on their own so the
+:class:`~sisr.processors.SRProcessor` subclasses and any external callers can
+convert colorspaces without depending on Lightning or model code.
+"""
+
+import torch
+
+# BT.601 full-range RGB <-> YCbCr conversion (ITU-R Rec. BT.601-7).
+# Both colorspaces are normalised to [0, 1]. Cb and Cr have a +0.5 offset on
+# their stored representation so that signed chroma values in [-0.5, +0.5]
+# map onto unsigned [0, 1]. This is the *full-range* (a.k.a. "JPEG") variant
+# of BT.601 — distinct from the studio-range variant which scales Y to
+# [16/255, 235/255] and Cb/Cr to [16/255, 240/255].
+
+_RGB_TO_Y = (0.299, 0.587, 0.114)
+_RGB_TO_CB = (-0.169, -0.331, 0.500)  # output offset +0.5
+_RGB_TO_CR = (0.500, -0.419, -0.081)  # output offset +0.5
+_YCBCR_TO_R = 1.402  # cr coefficient
+_YCBCR_TO_G_CB = -0.344  # cb coefficient
+_YCBCR_TO_G_CR = -0.714  # cr coefficient
+_YCBCR_TO_B = 1.772  # cb coefficient
+
+
+def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
+    """Convert a normalised RGB tensor to YCbCr (BT.601 full-range).
+
+    Args:
+        img (torch.Tensor): RGB tensor of shape ``(B, 3, H, W)`` with
+            values in ``[0, 1]``.
+
+    Returns:
+        torch.Tensor: YCbCr tensor of shape ``(B, 3, H, W)`` in
+        ``[0, 1]`` with Cb/Cr offset by +0.5.
+    """
+    r, g, b = img[:, 0:1], img[:, 1:2], img[:, 2:3]
+    y = _RGB_TO_Y[0] * r + _RGB_TO_Y[1] * g + _RGB_TO_Y[2] * b
+    cb = _RGB_TO_CB[0] * r + _RGB_TO_CB[1] * g + _RGB_TO_CB[2] * b + 0.5
+    cr = _RGB_TO_CR[0] * r + _RGB_TO_CR[1] * g + _RGB_TO_CR[2] * b + 0.5
+    return torch.cat([y, cb, cr], dim=1)
+
+
+def ycbcr_to_rgb(img: torch.Tensor) -> torch.Tensor:
+    """Convert a YCbCr tensor to RGB (BT.601 full-range, clamped to [0, 1]).
+
+    Args:
+        img (torch.Tensor): YCbCr tensor of shape ``(B, 3, H, W)`` with
+            Cb/Cr offset by +0.5.
+
+    Returns:
+        torch.Tensor: RGB tensor of shape ``(B, 3, H, W)`` clamped to
+        ``[0, 1]``.
+    """
+    y, cb, cr = img[:, 0:1], img[:, 1:2] - 0.5, img[:, 2:3] - 0.5
+    r = y + _YCBCR_TO_R * cr
+    g = y + _YCBCR_TO_G_CB * cb + _YCBCR_TO_G_CR * cr
+    b = y + _YCBCR_TO_B * cb
+    return torch.cat([r, g, b], dim=1).clamp(0.0, 1.0)

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -3,7 +3,7 @@
 LR is generated from HR via blur → bicubic-down → bicubic-up so the LR
 patches share the spatial size of the HR patches (pre-upsampled SRCNN
 formulation). :class:`TrainDataset` caches sliding-window sub-images
-through :class:`~sisr.utils.LMDBCache`; :class:`ValidationDataset`
+through :class:`~sisr.cache.LMDBCache`; :class:`ValidationDataset`
 generates LR pairs on the fly for full images.
 """
 
@@ -18,7 +18,7 @@ import numpy as np
 import torch
 from PIL import Image
 
-from ..utils import LMDBCache, LMDBCacheBuildContext
+from ..cache import LMDBCache, LMDBCacheBuildContext
 from .base import SRDataset
 
 

--- a/sisr/processors/base.py
+++ b/sisr/processors/base.py
@@ -11,7 +11,7 @@ class SRProcessor(abc.ABC):
     Partitioned by colorspace, not by model — the same processor instance
     is shared across all models that train in that colorspace. Replaces
     the per-batch colorspace logic that previously lived as standalone
-    functions in :mod:`sisr.utils`.
+    functions in :mod:`sisr.colorspace`.
     """
 
     @abc.abstractmethod

--- a/sisr/processors/y_channel.py
+++ b/sisr/processors/y_channel.py
@@ -3,7 +3,7 @@
 import torch
 import torch.nn.functional as F
 
-from sisr.utils import rgb_to_ycbcr, ycbcr_to_rgb
+from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb
 
 from .base import SRProcessor
 

--- a/sisr/processors/ycbcr.py
+++ b/sisr/processors/ycbcr.py
@@ -2,7 +2,7 @@
 
 import torch
 
-from sisr.utils import rgb_to_ycbcr, ycbcr_to_rgb
+from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb
 
 from .base import SRProcessor
 

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -18,9 +18,9 @@ import torchvision
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 
+from ..colorspace import rgb_to_ycbcr
 from ..models.base import SRModel
 from ..processors import SRProcessor
-from ..utils import rgb_to_ycbcr
 from .config import SREvalConfig, SRTrainingConfig
 
 

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -144,7 +144,7 @@ def test_train_dataset_build_num_workers_1_builds_inline(tiny_rgb_image_dir: Pat
     """build_num_workers=1 must thread through to an inline LMDB build (no
     ProcessPoolExecutor), so the one-time build is safe inside a test/xdist
     worker instead of nesting an 8-process pool."""
-    with patch("sisr.utils.ProcessPoolExecutor") as mock_pool:
+    with patch("sisr.cache.ProcessPoolExecutor") as mock_pool:
         ds = _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8, build_num_workers=1)
     mock_pool.assert_not_called()
     assert len(ds) > 0

--- a/tests/processors/test_y_channel.py
+++ b/tests/processors/test_y_channel.py
@@ -2,8 +2,8 @@
 
 import torch
 
+from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb
 from sisr.processors import SRProcessor, YChannelProcessor
-from sisr.utils import rgb_to_ycbcr, ycbcr_to_rgb
 
 
 def test_y_channel_processor_is_srprocessor():
@@ -38,7 +38,7 @@ def test_y_channel_reconstruct_same_size_roundtrips_to_lr():
         rgb_to_ycbcr(lr)[:, 1:], size=(16, 16), mode="bicubic", align_corners=False
     )
     assert torch.equal(same, rgb_to_ycbcr(lr)[:, 1:])  # bicubic@same-size == identity
-    # Tolerance 1e-3: the BT.601 coeffs in sisr.utils are truncated to 3 dp, so
+    # Tolerance 1e-3: the BT.601 coeffs in sisr.colorspace are truncated to 3 dp, so
     # the forward/inverse matrices aren't perfect inverses (worst-case ~5e-4).
     assert torch.allclose(out, lr, atol=1e-3)
 

--- a/tests/processors/test_ycbcr.py
+++ b/tests/processors/test_ycbcr.py
@@ -2,8 +2,8 @@
 
 import torch
 
+from sisr.colorspace import rgb_to_ycbcr
 from sisr.processors import SRProcessor, YCbCrProcessor
-from sisr.utils import rgb_to_ycbcr
 
 
 def test_ycbcr_processor_is_srprocessor():
@@ -32,7 +32,7 @@ def test_ycbcr_reconstruct_matches_bt601_inverse_not_just_clamp():
     lr = torch.rand(1, 3, 2, 2)  # only its shape matters to reconstruct
     out = p.reconstruct(ycbcr, lr)
 
-    # Hand-computed BT.601 full-range inverse (coefficients from sisr.utils).
+    # Hand-computed BT.601 full-range inverse (coefficients from sisr.colorspace).
     cb, cr = 0.1, -0.1
     r = 0.5 + 1.402 * cr
     g = 0.5 - 0.344 * cb - 0.714 * cr
@@ -46,7 +46,7 @@ def test_ycbcr_reconstruct_matches_bt601_inverse_not_just_clamp():
 def test_ycbcr_roundtrip_recovers_input():
     """extract -> reconstruct approximately recovers the input RGB.
 
-    Tolerance is 1e-3 because the BT.601 coefficients in :mod:`sisr.utils`
+    Tolerance is 1e-3 because the BT.601 coefficients in :mod:`sisr.colorspace`
     are truncated to 3 decimal places (e.g. ``-0.169`` vs the exact
     ``-0.168736``), so the forward and inverse matrices aren't perfect
     inverses. Observed worst-case error is ~5e-4 across the chroma channels.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,72 +1,12 @@
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import lmdb
 import pytest
-import torch
 
-from sisr.utils import (
-    LMDBCache,
-    LMDBCacheBuildContext,
-    rgb_to_ycbcr,
-    ycbcr_to_rgb,
-)
-
-# ---------------------------------------------------------------------------
-# Colorspace utilities
-# ---------------------------------------------------------------------------
-
-
-def test_rgb_to_ycbcr_shape_and_dtype():
-    x = torch.rand(2, 3, 8, 8, dtype=torch.float32)
-    y = rgb_to_ycbcr(x)
-    assert y.shape == (2, 3, 8, 8)
-    assert y.dtype == torch.float32
-
-
-def test_ycbcr_to_rgb_shape_and_dtype():
-    x = torch.rand(2, 3, 8, 8, dtype=torch.float32)
-    y = ycbcr_to_rgb(x)
-    assert y.shape == (2, 3, 8, 8)
-    assert y.dtype == torch.float32
-
-
-def test_rgb_to_ycbcr_known_values_white():
-    # White: (1, 1, 1) -> Y=1, Cb=0.5, Cr=0.5
-    x = torch.ones(1, 3, 1, 1)
-    y = rgb_to_ycbcr(x)
-    expected = torch.tensor([[[[1.0]], [[0.5]], [[0.5]]]])
-    assert torch.allclose(y, expected, atol=1e-5)
-
-
-def test_rgb_to_ycbcr_known_values_black():
-    # Black: (0, 0, 0) -> Y=0, Cb=0.5, Cr=0.5
-    x = torch.zeros(1, 3, 1, 1)
-    y = rgb_to_ycbcr(x)
-    expected = torch.tensor([[[[0.0]], [[0.5]], [[0.5]]]])
-    assert torch.allclose(y, expected, atol=1e-5)
-
-
-def test_rgb_to_ycbcr_known_values_red():
-    # Pure red: (1, 0, 0) -> Y=0.299, Cb=0.5−0.169, Cr=0.5+0.500
-    x = torch.tensor([[[[1.0]], [[0.0]], [[0.0]]]])
-    y = rgb_to_ycbcr(x)
-    expected = torch.tensor([[[[0.299]], [[0.331]], [[1.000]]]])
-    assert torch.allclose(y, expected, atol=1e-5)
-
-
-def test_round_trip_within_coefficient_precision():
-    # BT.601 coefficients are 3-decimal-place; round-trip error floor ~5e-4.
-    torch.manual_seed(0)
-    x = torch.rand(1, 3, 16, 16)
-    y = ycbcr_to_rgb(rgb_to_ycbcr(x))
-    err = (y - x).abs().max().item()
-    assert err < 5e-4
-
-
-# ---------------------------------------------------------------------------
-# LMDBCache
-# ---------------------------------------------------------------------------
+from sisr.cache import LMDBCache, LMDBCacheBuildContext
 
 _MAP_SIZE = 16 * 1024 * 1024  # 16 MiB — plenty for tiny test caches
 
@@ -78,6 +18,34 @@ def _make_build_fn(n: int, value_prefix: bytes = b"v"):
         ctx.write_batch([(f"key_{i}", value_prefix + str(i).encode()) for i in range(n)])
 
     return build
+
+
+# ---------------------------------------------------------------------------
+# Import weight
+# ---------------------------------------------------------------------------
+
+
+def test_cache_module_imports_no_torch():
+    """sisr.cache must not pull torch in, directly or transitively.
+
+    parallel_build fans out over a ProcessPoolExecutor, and on spawn platforms
+    each worker re-imports the module tree holding its process_fn. A torch
+    import reachable from here costs every worker several seconds for a
+    dependency the build path never calls, so guard it: a fresh interpreter is
+    required because the test session itself has torch loaded already.
+    """
+    probe = "import sys, sisr.cache; print('torch' in sys.modules)"
+    proc = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+    assert proc.stdout.strip() == "False", (
+        "sisr.cache now imports torch (directly or transitively). Every spawned "
+        "LMDB build worker pays that import for nothing — move the torch-dependent "
+        "code to sisr.colorspace or another module."
+    )
+
+
+# ---------------------------------------------------------------------------
+# LMDBCache
+# ---------------------------------------------------------------------------
 
 
 def test_lmdb_build_and_read(tmp_path: Path):
@@ -219,7 +187,7 @@ def test_lmdb_try_load_swallows_lmdb_error_and_drops_cache(tmp_path: Path):
         build_fn=_make_build_fn(1),
     )
     assert cache.path.exists()
-    with patch("sisr.utils.lmdb.open", side_effect=lmdb.Error("corrupt")):
+    with patch("sisr.cache.lmdb.open", side_effect=lmdb.Error("corrupt")):
         assert cache._try_load("abc") is False
     assert not cache.path.exists()
 
@@ -235,7 +203,7 @@ def test_lmdb_try_load_propagates_unexpected_error(tmp_path: Path):
         map_size=_MAP_SIZE,
         build_fn=_make_build_fn(1),
     )
-    with patch("sisr.utils.lmdb.open", side_effect=ValueError("unexpected")):
+    with patch("sisr.cache.lmdb.open", side_effect=ValueError("unexpected")):
         with pytest.raises(ValueError, match="unexpected"):
             cache._try_load("abc")
 
@@ -281,7 +249,7 @@ def test_parallel_build_single_worker_skips_process_pool(tmp_path: Path):
     def build(ctx: LMDBCacheBuildContext) -> None:
         ctx.parallel_build(items=[2, 3, 4], process_fn=_sq_process_fn, num_workers=1)
 
-    with patch("sisr.utils.ProcessPoolExecutor") as mock_pool:
+    with patch("sisr.cache.ProcessPoolExecutor") as mock_pool:
         cache = LMDBCache(
             cache_dir=tmp_path,
             name="pb1",
@@ -302,7 +270,7 @@ def test_parallel_build_none_workers_builds_single_item_inline(tmp_path: Path):
     def build(ctx: LMDBCacheBuildContext) -> None:
         ctx.parallel_build(items=[7], process_fn=_sq_process_fn, num_workers=None)
 
-    with patch("sisr.utils.ProcessPoolExecutor") as mock_pool:
+    with patch("sisr.cache.ProcessPoolExecutor") as mock_pool:
         cache = LMDBCache(
             cache_dir=tmp_path,
             name="pbn",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,10 @@
-"""CLI tests: mostly in-process config resolution, plus two subprocess smokes.
+"""CLI tests: in-process config resolution, plus one subprocess entry-point smoke.
 
 Config-resolution / matmul / override / subcommand-help assertions run in-process
 via ``SRLightningCLI(args=..., run=False)`` (see ``_resolve``); only
-``test_cli_print_config_resolves`` and ``test_cli_help_lists_subcommands`` still
-spawn the installed ``sisr`` console script to exercise the real entry point.
+``test_cli_help_lists_subcommands`` spawns the installed ``sisr`` console script.
+Each spawn re-imports the whole torch + lightning stack (~10s wall), so a single
+smoke covers "the entry point works" and every other assertion runs in-process.
 """
 
 import subprocess
@@ -83,22 +84,31 @@ def _resolve(*args: str):
         sys.argv = saved_argv
 
 
-def test_cli_print_config_resolves():
-    """`cli fit --print_config` exits 0 and resolves the SRCNN template."""
-    proc = _cli("fit", "--config", str(TEMPLATE), "--print_config")
-    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
-    out = proc.stdout
-    # Sanity markers — confirm config-class wiring resolved correctly.
-    assert "class_path: sisr.models.srcnn.SRCNN" in out
-    assert "class_path: sisr.processors.YChannelProcessor" in out
-    assert "class_path: sisr.models.srcnn.SRCNNTrainingConfig" in out
-    assert "class_path: sisr.models.srcnn.SRCNNEvalConfig" in out
-    assert "layer_lrs:" in out
-    assert "crop_border: 3" in out
-    # The removed model_colorspace field must not reappear.
-    assert "model_colorspace" not in out
+def test_srcnn_config_resolves_in_process():
+    """SRCNN template resolves to the paper-faithful model/processor/config
+    classes — resolved in-process (no subprocess).
+
+    Ports the class-wiring assertions of the old subprocess ``--print_config``
+    test. ``cli.config`` is the same merged config ``--print_config`` dumps, so
+    these assert on resolved objects rather than on dumped YAML text.
+    """
+    from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig
+    from sisr.processors import YChannelProcessor
+
+    cli = _resolve("--config", str(TEMPLATE))
+    m = cli.model
+    assert isinstance(m.model, SRCNN)
+    assert isinstance(m.processor, YChannelProcessor)
+    assert isinstance(m.training_config, SRCNNTrainingConfig)
+    assert isinstance(m.eval_config, SRCNNEvalConfig)
+    assert m.eval_config.crop_border == 3  # inherited-default check
+    # Paper recipe: reconstruction layer learns 10x slower than the other two.
+    assert m.training_config.layer_lrs == [1.0e-4, 1.0e-4, 1.0e-5]
     # Top-level optimizer block linked from YAML.
-    assert "optimizer:" in out
+    assert cli.config.optimizer.class_path == "torch.optim.SGD"
+    # The removed model_colorspace field must not reappear.
+    assert not hasattr(m, "model_colorspace")
+    assert not hasattr(m.eval_config, "model_colorspace")
 
 
 def test_srresnet_config_resolves_in_process():

--- a/tests/test_colorspace.py
+++ b/tests/test_colorspace.py
@@ -1,0 +1,50 @@
+import torch
+
+from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb
+
+
+def test_rgb_to_ycbcr_shape_and_dtype():
+    x = torch.rand(2, 3, 8, 8, dtype=torch.float32)
+    y = rgb_to_ycbcr(x)
+    assert y.shape == (2, 3, 8, 8)
+    assert y.dtype == torch.float32
+
+
+def test_ycbcr_to_rgb_shape_and_dtype():
+    x = torch.rand(2, 3, 8, 8, dtype=torch.float32)
+    y = ycbcr_to_rgb(x)
+    assert y.shape == (2, 3, 8, 8)
+    assert y.dtype == torch.float32
+
+
+def test_rgb_to_ycbcr_known_values_white():
+    # White: (1, 1, 1) -> Y=1, Cb=0.5, Cr=0.5
+    x = torch.ones(1, 3, 1, 1)
+    y = rgb_to_ycbcr(x)
+    expected = torch.tensor([[[[1.0]], [[0.5]], [[0.5]]]])
+    assert torch.allclose(y, expected, atol=1e-5)
+
+
+def test_rgb_to_ycbcr_known_values_black():
+    # Black: (0, 0, 0) -> Y=0, Cb=0.5, Cr=0.5
+    x = torch.zeros(1, 3, 1, 1)
+    y = rgb_to_ycbcr(x)
+    expected = torch.tensor([[[[0.0]], [[0.5]], [[0.5]]]])
+    assert torch.allclose(y, expected, atol=1e-5)
+
+
+def test_rgb_to_ycbcr_known_values_red():
+    # Pure red: (1, 0, 0) -> Y=0.299, Cb=0.5−0.169, Cr=0.5+0.500
+    x = torch.tensor([[[[1.0]], [[0.0]], [[0.0]]]])
+    y = rgb_to_ycbcr(x)
+    expected = torch.tensor([[[[0.299]], [[0.331]], [[1.000]]]])
+    assert torch.allclose(y, expected, atol=1e-5)
+
+
+def test_round_trip_within_coefficient_precision():
+    # BT.601 coefficients are 3-decimal-place; round-trip error floor ~5e-4.
+    torch.manual_seed(0)
+    x = torch.rand(1, 3, 16, 16)
+    y = ycbcr_to_rgb(rgb_to_ycbcr(x))
+    err = (y - x).abs().max().item()
+    assert err < 5e-4

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -2,7 +2,9 @@
 
 
 def test_public_exports():
+    from sisr.cache import LMDBCache, LMDBCacheBuildContext  # noqa: F401
     from sisr.cli import main  # noqa: F401
+    from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb  # noqa: F401
     from sisr.datasets.srcnn import TrainDataset, ValidationDataset  # noqa: F401
     from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig  # noqa: F401
     from sisr.models.srresnet.model import (  # noqa: F401
@@ -19,10 +21,4 @@ def test_public_exports():
         SRLightning,
         SRTrainingConfig,
         WeightHistogramLogger,
-    )
-    from sisr.utils import (  # noqa: F401
-        LMDBCache,
-        LMDBCacheBuildContext,
-        rgb_to_ycbcr,
-        ycbcr_to_rgb,
     )


### PR DESCRIPTION
Started from "why does the suite take so long with only 216 tests?". Profiling said the test count is irrelevant: wall time is set by **how many fresh interpreters start**, each cold-importing torch + lightning (~10s) before running anything, against only ~20s of real test compute.

`import lightning.pytorch.cli` = 3,395 modules / 9.9s — torch 4.8s, **scipy 1.9s** and **sympy 0.8s** (pulled by torchmetrics/torchvision; torch itself imports neither), torchvision 0.4s, lightning 0.4s, torchmetrics 0.4s. The default `-n 8` run started **13 processes** — 1 main + 8 xdist workers + 2 subprocess CLI tests + 2 `ProcessPoolExecutor` workers — roughly 130 CPU-seconds of import.

## Results

| | Before | After |
|---|---|---|
| Default `pytest` | 50.1s | **35.2s** |
| `test_parallel_build_persists_every_submitted_item` | 4.63s | **1.11s** |
| Tests | 216 | **217** |
| Coverage | — | 97.31% |

## `bed749a` — split `sisr/utils.py`

`utils.py` held two unrelated responsibilities: BT.601 colorspace math (needs torch) and the LMDB cache (needs only `lmdb` + `tqdm`). Sharing a module made `import sisr.utils` cost **3.78s instead of 0.31s**.

**That cost is per process, and this is a production bug before it is a test problem.** `parallel_build` fans out over a `ProcessPoolExecutor`, and Windows/macOS re-import each worker's module tree on spawn — so every LMDB build worker imported a torch it never calls. Real builds resolve `num_workers` to `min(os.cpu_count(), n_items)`, so a DIV2K cache build burned ~60 CPU-seconds of pointless import. Training runs get that back, not just CI.

Split into `sisr/colorspace.py` (torch) and `sisr/cache.py` (torch-free). Clean break, no compatibility shim — `sisr.utils` is gone and all seven importers moved. `tests/test_utils.py` splits along the same seam into `test_colorspace.py` + `test_cache.py`.

New guard `test_cache_module_imports_no_torch` probes a **fresh interpreter** (required — the test session already has torch loaded) and fails with a message naming the fix, so the coupling cannot silently come back.

## `dfe083b` — stop starting processes we don't need

- `test_cli_print_config_resolves` spawned the `sisr` binary only to grep dumped `--print_config` text. Every assertion is available from the resolved config object, so it becomes `test_srcnn_config_resolves_in_process`, mirroring what `test_srresnet_config_resolves_in_process` already did for the other template. Not a coverage cut — the in-process version actually runs *under* coverage, which the subprocess never did. `test_cli_help_lists_subcommands` stays as the single subprocess smoke, since a real process is precisely what it tests. `--dist=loadscope` had pinned both to one worker, making them a ~24s serial critical path no worker count could shorten.

- `addopts`: `-n 8` → `-n 2`. Each worker pays a full cold import, so parallelism stops paying almost immediately at this suite size. Measured on 8-core/16-thread Windows after the CLI fix: `-n 0` 44.0s, **`-n 2` 38.3s**, `-n 4` 38.3s, `-n 8` **47.1s** — eight workers was *slower than serial*. The previous "measured-clean" figure had simply rotted as the dependency stack grew. The comment now records the measurements and the reason the number is low, so the next reader re-measures rather than assuming more workers help.

## Scope notes

- No behaviour change; `sisr` public API moves module, nothing else.
- The **~13s floor** (collection alone imports the stack) is not removable while the tests import torch.
- Filed triage **P5.11**: the surviving subprocess smoke is still ~10s of the 35s for one assertion. Marking it `slow`, or moving the entry-point check into `build.yml` (which already smoke-imports the wheel), would recover it — both trade away default-run coverage, so left as a deliberate decision rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)