### PR TITLE
Deduplicate experiment templates via YAML anchors (INIT.15)

### DIFF
--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -30,29 +30,29 @@ data:
       img_dir: data/DIV2K_train_HR
       subimg_size: 33
       stride: 14
-      scale: 3
-      blur_sigma: 1.0
+      scale: &scale 3
+      blur_sigma: &blur_sigma 1.0
       use_tqdm: true
       cache_dir: .lmdb_cache/DIV2K_train_HR
   val_dataset:
     class_path: sisr.datasets.srcnn.ValidationDataset
     init_args:
       img_dir: data/DIV2K_valid_HR
-      scale: 3
-      blur_sigma: 1.0
+      scale: *scale
+      blur_sigma: *blur_sigma
   test_datasets:
     Set5:
       class_path: sisr.datasets.srcnn.ValidationDataset
       init_args:
         img_dir: data/Set5_HR
-        scale: 3
-        blur_sigma: 1.0
+        scale: *scale
+        blur_sigma: *blur_sigma
     Set14:
       class_path: sisr.datasets.srcnn.ValidationDataset
       init_args:
         img_dir: data/Set14_HR
-        scale: 3
-        blur_sigma: 1.0
+        scale: *scale
+        blur_sigma: *blur_sigma
   train_dataloader_kwargs:
     batch_size: 64
     num_workers: 16
@@ -83,12 +83,10 @@ trainer:
       init_args:
         monitor_metric: val_psnr(RGB)
         save_top_k: 3
-        dirpath: experiments/SRCNN/baseline
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_ssim
         save_top_k: 3
-        dirpath: experiments/SRCNN/baseline
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
@@ -98,13 +96,12 @@ trainer:
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:
-        save_dir: experiments
-        name: SRCNN
-        version: baseline
+        <<: &log_dest
+          save_dir: experiments
+          name: SRCNN
+          version: baseline
         log_graph: true
         default_hp_metric: false
     - class_path: lightning.pytorch.loggers.CSVLogger
       init_args:
-        save_dir: experiments
-        name: SRCNN
-        version: baseline
+        <<: *log_dest

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -9,7 +9,7 @@ model:
   model:
     class_path: sisr.models.srresnet.SRResNet
     init_args:
-      scale: 4
+      scale: &scale 4
       in_out_channels: 3
       hidden_channel: 64
       kernel_sizes: [9, 3, 9]
@@ -29,25 +29,25 @@ data:
     class_path: sisr.datasets.srresnet.TrainDataset
     init_args:
       img_dir: data/DIV2K_train_HR
-      scale: 4
+      scale: *scale
       hr_crop_size: 96
       crops_per_image: 1
   val_dataset:
     class_path: sisr.datasets.srresnet.ValidationDataset
     init_args:
       img_dir: data/DIV2K_valid_HR
-      scale: 4
+      scale: *scale
   test_datasets:
     Set5:
       class_path: sisr.datasets.srresnet.ValidationDataset
       init_args:
         img_dir: data/Set5_HR
-        scale: 4
+        scale: *scale
     Set14:
       class_path: sisr.datasets.srresnet.ValidationDataset
       init_args:
         img_dir: data/Set14_HR
-        scale: 4
+        scale: *scale
   train_dataloader_kwargs:
     batch_size: 16
     num_workers: 16
@@ -78,12 +78,10 @@ trainer:
       init_args:
         monitor_metric: val_psnr(RGB)
         save_top_k: 3
-        dirpath: experiments/SRResNet/baseline
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: val_ssim
         save_top_k: 3
-        dirpath: experiments/SRResNet/baseline
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
@@ -93,13 +91,12 @@ trainer:
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:
-        save_dir: experiments
-        name: SRResNet
-        version: baseline
+        <<: &log_dest
+          save_dir: experiments
+          name: SRResNet
+          version: baseline
         log_graph: true
         default_hp_metric: false
     - class_path: lightning.pytorch.loggers.CSVLogger
       init_args:
-        save_dir: experiments
-        name: SRResNet
-        version: baseline
+        <<: *log_dest


### PR DESCRIPTION
**Zero code — YAML only.** Each duplicated value drops from 4 occurrences to 1.

### Fix 1 — delete `dirpath` from every `SRCheckpoint` (the visible one)

`ModelCheckpoint.__resolve_ckpt_dir` **short-circuits on an explicit `dirpath` and returns it verbatim** — the `checkpoints` subdirectory is appended only on the *derived* branches (logger `log_dir`, `default_root_dir`). The docstring line "The path gets extended with subdirectory 'checkpoints'" applies to those cases only, which is easy to misread.

Because the templates set `dirpath: experiments/<Arch>/<version>`, checkpoint files currently land **flat in the version directory, intermixed with `config.yaml`, `hparams.yaml`, `metrics.csv`, and the TensorBoard event file**. With `dirpath` omitted they resolve to `experiments/<Arch>/<version>/checkpoints/` and track the logger version automatically instead of silently diverging when someone edits one and not the other.

> **Behavioural note:** this is a path change. Existing checkpoints stay where they are; new ones move down a level.

### Fix 2 — YAML merge key for the logger triple

`save_dir` / `name` / `version` were repeated across both loggers. Now anchored once and aliased with `<<: *log_dest`.

### Fix 3 — anchor repeated scalars

`scale` (4x in the SRCNN template, 5x in SRResNet) and `blur_sigma` (4x in SRCNN) are anchored at first occurrence and aliased thereafter. The model's own `scale` is the anchor site since `model:` precedes `data:` in document order.

---

All three verified end-to-end through a real `python -m sisr.cli fit` run, not just in-process config resolution — anchors survive jsonargparse for both maps and scalars.

**Scope note:** only `config.srcnn.template.yaml` and `config.srresnet.template.yaml` are git-tracked; `.gitignore` excludes the dated per-run configs.

Full suite green (217 passed).

Part of the 2026-07-31 triage delivery arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)