### PR TITLE
Add construction-time config validation seam (INIT.16)

### DIFF
--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -12,6 +12,8 @@ Reference: Image Super-Resolution Using Deep Convolutional Networks
 from dataclasses import dataclass, field
 from typing import Literal
 
+from sisr.models.base import SRModel
+from sisr.processors.base import SRProcessor
 from sisr.training.config import SREvalConfig, SRTrainingConfig
 
 
@@ -44,6 +46,33 @@ class SRCNNTrainingConfig(SRTrainingConfig):
 
     layer_lrs: list[float] | None = field(default_factory=lambda: [1.0e-4, 1.0e-4, 1.0e-5])
     init_strategy: Literal["default", "paper"] = "paper"
+
+    def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
+        """Extend the base checks with SRCNN's ``num_channels``/processor correlation.
+
+        Raises a readable error before the base's forward probe would
+        otherwise surface the same defect as a cryptic Conv2d shape mismatch.
+
+        Args:
+            model: The constructed :class:`~sisr.models.srcnn.SRCNN` instance.
+            processor: The :class:`~sisr.processors.base.SRProcessor` paired
+                with ``model``.
+
+        Raises:
+            ValueError: If ``model``'s ``num_channels`` doesn't match
+                ``processor.model_channels``.
+        """
+        num_channels = model.hparams["num_channels"]
+        if num_channels != processor.model_channels:
+            raise ValueError(
+                f"SRCNN num_channels={num_channels} does not match "
+                f"{type(processor).__name__}.model_channels={processor.model_channels}. "
+                f"num_channels sets both the feature-extraction input and the "
+                f"reconstruction output channel count; pick a processor whose "
+                f"model_channels matches (e.g. YChannelProcessor for num_channels=1, "
+                f"RGBProcessor or YCbCrProcessor for num_channels=3)."
+            )
+        super().validate_against(model, processor)
 
 
 @dataclass

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -13,6 +13,8 @@ Section 3.2 (SRResNet baseline).
 from dataclasses import dataclass, field
 from typing import Literal
 
+from sisr.models.base import SRModel
+from sisr.processors.base import SRProcessor
 from sisr.training.config import SREvalConfig, SRTrainingConfig
 
 
@@ -35,6 +37,33 @@ class SRResNetTrainingConfig(SRTrainingConfig):
     """
 
     init_strategy: Literal["default", "paper"] = "default"
+
+    def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
+        """Extend the base checks with SRResNet's ``in_out_channels``/processor correlation.
+
+        Raises a readable error before the base's forward probe would
+        otherwise surface the same defect as a cryptic Conv2d shape mismatch.
+
+        Args:
+            model: The constructed :class:`~sisr.models.srresnet.SRResNet` instance.
+            processor: The :class:`~sisr.processors.base.SRProcessor` paired
+                with ``model``.
+
+        Raises:
+            ValueError: If ``model``'s ``in_out_channels`` doesn't match
+                ``processor.model_channels``.
+        """
+        in_out_channels = model.hparams["in_out_channels"]
+        if in_out_channels != processor.model_channels:
+            raise ValueError(
+                f"SRResNet in_out_channels={in_out_channels} does not match "
+                f"{type(processor).__name__}.model_channels={processor.model_channels}. "
+                f"in_out_channels sets both the head Conv2d's input and the tail "
+                f"Conv2d's output (after the scale={model.hparams['scale']}x "
+                f"PixelShuffle upsampling); pick a processor whose model_channels "
+                f"matches (e.g. RGBProcessor or YCbCrProcessor for in_out_channels=3)."
+            )
+        super().validate_against(model, processor)
 
 
 @dataclass

--- a/sisr/processors/base.py
+++ b/sisr/processors/base.py
@@ -21,3 +21,13 @@ class SRProcessor(abc.ABC):
     @abc.abstractmethod
     def reconstruct(self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
         """Convert the model's output tensor back to SR RGB (``[B, 3, H', W']``)."""
+
+    @property
+    @abc.abstractmethod
+    def model_channels(self) -> int:
+        """Number of channels ``extract`` produces — the model's IO channel count.
+
+        A fact only the processor knows (not a mirror of the model's own
+        config), used to validate a model/processor pairing at construction
+        time (see ``SRTrainingConfig.validate_against``).
+        """

--- a/sisr/processors/rgb.py
+++ b/sisr/processors/rgb.py
@@ -13,3 +13,7 @@ class RGBProcessor(SRProcessor):
 
     def reconstruct(self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
         return sr_model_out
+
+    @property
+    def model_channels(self) -> int:
+        return 3

--- a/sisr/processors/y_channel.py
+++ b/sisr/processors/y_channel.py
@@ -29,3 +29,7 @@ class YChannelProcessor(SRProcessor):
             align_corners=False,
         )
         return ycbcr_to_rgb(torch.cat([sr_y, cbcr], dim=1))
+
+    @property
+    def model_channels(self) -> int:
+        return 1

--- a/sisr/processors/ycbcr.py
+++ b/sisr/processors/ycbcr.py
@@ -15,3 +15,7 @@ class YCbCrProcessor(SRProcessor):
 
     def reconstruct(self, sr_ycbcr: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
         return ycbcr_to_rgb(sr_ycbcr)
+
+    @property
+    def model_channels(self) -> int:
+        return 3

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -16,10 +16,29 @@ overrides individual fields with ``init_args``.
 
 The colorspace the model trains in is no longer a string field here; it is
 expressed by the choice of processor (see ``sisr.processors``).
+
+``SRTrainingConfig.validate_against`` / ``SREvalConfig.psnr_keys`` are the
+config-side half of the correlated-field validation seam: fields like
+``num_channels`` (model) and ``class_path`` (processor) live in sibling
+objects a single dataclass ``__post_init__`` cannot see across, so the
+cross-object check happens once both are constructed, orchestrated by
+``SRLightning.__init__``.
 """
 
 from dataclasses import dataclass, field
 from typing import Literal
+
+import torch
+
+from ..models.base import SRModel
+from ..processors.base import SRProcessor
+
+# Per-colorspace channel names, in report order. Doubles as the set of
+# supported ``psnr_channels`` entries (validated in `SREvalConfig.__post_init__`).
+_PSNR_CHANNEL_NAMES: dict[str, tuple[str, ...]] = {
+    "RGB": ("R", "G", "B"),
+    "YCbCr": ("Y", "Cb", "Cr"),
+}
 
 
 @dataclass
@@ -38,7 +57,8 @@ class SRTrainingConfig:
         example_input_shape: Shape of a single input sample *excluding* the
             batch dimension (e.g. ``(1, 33, 33)`` for a 33×33 Y-channel patch).
             When provided, ``self.example_input_array`` is set so the
-            TensorBoard logger can capture the model graph.
+            TensorBoard logger can capture the model graph, and
+            :meth:`validate_against` probes the model with it.
 
         init_strategy: ``'paper'`` triggers a paper-faithful weight init via
             ``SRModel.reset_parameters`` in ``SRLightning``'s constructor;
@@ -60,6 +80,51 @@ class SRTrainingConfig:
     init_strategy: Literal["default", "paper"] = "default"
     init_mean: float = 0.0
     init_std: float = 0.01
+
+    def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
+        """Validate this config against the model/processor it will pair with.
+
+        Universal, architecture-agnostic checks: when ``example_input_shape``
+        is set, its channel dimension must equal ``processor.model_channels``,
+        and a ``torch.no_grad()`` forward pass of the real ``model`` on a
+        zero tensor of that shape must succeed. The probe exercises the
+        actual ``nn.Module`` rather than a separate description of it, so it
+        cannot go stale as the architecture evolves. A no-op when
+        ``example_input_shape`` is unset — it is optional (TensorBoard graph
+        / FLOPs reporting only).
+
+        Subclasses (e.g. ``SRCNNTrainingConfig``) override this to add
+        architecture-specific correlation checks — e.g. ``num_channels`` vs
+        ``processor.model_channels`` — that exist purely to raise an
+        actionable message *before* a mismatched pairing would otherwise
+        surface as a raw shape-mismatch error from this probe. They call
+        ``super().validate_against(model, processor)`` to keep the universal
+        checks.
+
+        Args:
+            model: The constructed :class:`~sisr.models.base.SRModel` this
+                config will train/evaluate.
+            processor: The :class:`~sisr.processors.base.SRProcessor` paired
+                with ``model`` for this run.
+
+        Raises:
+            ValueError: If ``example_input_shape`` is set and its channel
+                dimension doesn't match ``processor.model_channels``.
+        """
+        if self.example_input_shape is None:
+            return
+        channels = self.example_input_shape[0]
+        if channels != processor.model_channels:
+            raise ValueError(
+                f"training_config.example_input_shape has {channels} channel(s) "
+                f"(position 0), but {type(processor).__name__}.model_channels="
+                f"{processor.model_channels}. Fix example_input_shape[0] or pick "
+                f"a processor whose model_channels matches the model's actual "
+                f"input/output channel count."
+            )
+        dummy = torch.zeros(1, *self.example_input_shape)
+        with torch.no_grad():
+            model(dummy)
 
 
 @dataclass
@@ -93,7 +158,7 @@ class SREvalConfig:
             ValueError: If any entry is not a supported colorspace
                 (``'RGB'`` or ``'YCbCr'``).
         """
-        valid = ("RGB", "YCbCr")
+        valid = tuple(_PSNR_CHANNEL_NAMES)
         invalid = [c for c in self.psnr_channels if c not in valid]
         if invalid:
             raise ValueError(
@@ -101,3 +166,28 @@ class SREvalConfig:
                 f"{list(valid)}; got unsupported {invalid}. Fix "
                 f"model.eval_config.init_args.psnr_channels in your YAML."
             )
+
+    @property
+    def psnr_keys(self) -> list[str]:
+        """Ordered PSNR metric keys this config requests.
+
+        For each colorspace in ``psnr_channels`` (in order), per-channel keys
+        are emitted first when ``separate_psnr`` is ``True``, followed by the
+        aggregate colorspace key itself — e.g. ``psnr_channels=['RGB']`` with
+        ``separate_psnr=True`` yields ``['R', 'G', 'B', 'RGB']``.
+
+        This is the seam consumed by ``SRLightning`` (val metric logging /
+        HParams registration) and ``BenchmarkImageLogger`` (benchmark PSNR
+        key selection) — the single place the key set and its order are
+        derived, so the two consumers cannot disagree.
+
+        Returns:
+            Ordered list of PSNR keys, e.g. ``['RGB', 'YCbCr']`` or
+            ``['R', 'G', 'B', 'RGB', 'Y', 'Cb', 'Cr', 'YCbCr']``.
+        """
+        keys: list[str] = []
+        for cs in self.psnr_channels:
+            if self.separate_psnr:
+                keys.extend(_PSNR_CHANNEL_NAMES[cs])
+            keys.append(cs)
+        return keys

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -55,11 +55,6 @@ class SRLightning(lightning.LightningModule):
             if ``processor`` is not an :class:`SRProcessor` subclass.
     """
 
-    _CS_CHANNEL_NAMES: dict[str, tuple[str, ...]] = {
-        "RGB": ("R", "G", "B"),
-        "YCbCr": ("Y", "Cb", "Cr"),
-    }
-
     def __init__(
         self,
         model: SRModel,
@@ -97,6 +92,8 @@ class SRLightning(lightning.LightningModule):
         self.optimizer = optimizer
         self.lr_scheduler = lr_scheduler
 
+        self.training_config.validate_against(self.model, self.processor)
+
         if self.training_config.init_strategy == "paper":
             model.reset_parameters(
                 mean=self.training_config.init_mean,
@@ -118,13 +115,6 @@ class SRLightning(lightning.LightningModule):
 
         if self.training_config.example_input_shape is not None:
             self.example_input_array = torch.zeros(1, *self.training_config.example_input_shape)
-
-        metric_keys: list[str] = []
-        for cs in self.eval_config.psnr_channels:
-            if self.eval_config.separate_psnr:
-                metric_keys.extend(self._CS_CHANNEL_NAMES[cs])
-            metric_keys.append(cs)
-        self._psnr_keys = metric_keys
 
     @staticmethod
     def _flatten_hparams(hparams: dict[str, Any], sep: str = "/") -> dict:
@@ -180,7 +170,7 @@ class SRLightning(lightning.LightningModule):
             ``(sr_subset, hr_subset)`` tensor pair ready for PSNR
             computation.
         """
-        keys = set(self._psnr_keys)
+        keys = set(self.eval_config.psnr_keys)
         tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
         if keys & {"RGB", "R", "G", "B"}:
@@ -366,7 +356,7 @@ class SRLightning(lightning.LightningModule):
         # primary val loader is at idx 0 of a list that also contains test loaders.
         self.log("val_loss", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
         primary = self.eval_config.psnr_channels[0]
-        for key in self._psnr_keys:
+        for key in self.eval_config.psnr_keys:
             sr_t, hr_t = psnr_tensors[key]
             self.log(
                 f"val_psnr({key})",
@@ -402,7 +392,7 @@ class SRLightning(lightning.LightningModule):
         if not tb_loggers:
             return
         metrics = {
-            **{f"val_psnr({k})": 0.0 for k in self._psnr_keys},
+            **{f"val_psnr({k})": 0.0 for k in self.eval_config.psnr_keys},
             "val_ssim": 0.0,
         }
         for tb in tb_loggers:

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -1,4 +1,7 @@
-from sisr.models.srcnn import SRCNNEvalConfig, SRCNNTrainingConfig
+import pytest
+
+from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig
+from sisr.processors import RGBProcessor, YChannelProcessor
 from sisr.training import SREvalConfig, SRTrainingConfig
 
 
@@ -46,3 +49,28 @@ def test_srcnn_training_config_init_defaults():
     assert cfg.init_strategy == "paper"
     assert cfg.init_mean == 0.0
     assert cfg.init_std == 0.01
+
+
+# ---------------------------------------------------------------------------
+# validate_against (INIT.16) — SRCNN-specific num_channels/processor check
+# ---------------------------------------------------------------------------
+
+
+def test_srcnn_validate_against_rejects_num_channels_mismatch():
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    with pytest.raises(ValueError, match="num_channels"):
+        SRCNNTrainingConfig().validate_against(model, YChannelProcessor())
+
+
+def test_srcnn_validate_against_accepts_matching_num_channels():
+    model = SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    SRCNNTrainingConfig().validate_against(model, YChannelProcessor())  # must not raise
+
+
+def test_srcnn_validate_against_still_runs_base_forward_probe():
+    """SRCNNTrainingConfig.validate_against must chain to the base check
+    (example_input_shape/forward probe) via super(), not just its own."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    cfg = SRCNNTrainingConfig(example_input_shape=(1, 33, 33))  # 1 != processor.model_channels=3
+    with pytest.raises(ValueError, match="example_input_shape"):
+        cfg.validate_against(model, RGBProcessor())

--- a/tests/models/srresnet/test_config.py
+++ b/tests/models/srresnet/test_config.py
@@ -1,6 +1,10 @@
 """Defaults, subclass, and isolation tests for SRResNet's paper-faithful configs."""
 
+import pytest
+
 from sisr.models.srresnet import SRResNetEvalConfig, SRResNetTrainingConfig
+from sisr.models.srresnet.model import SRResNet
+from sisr.processors import RGBProcessor, YChannelProcessor
 from sisr.training import SREvalConfig, SRTrainingConfig
 
 
@@ -36,3 +40,28 @@ def test_srresnet_eval_config_psnr_channels_independent_per_instance():
     b = SRResNetEvalConfig()
     a.psnr_channels.append("X")
     assert b.psnr_channels == ["RGB", "YCbCr"]
+
+
+# ---------------------------------------------------------------------------
+# validate_against (INIT.16) — SRResNet-specific in_out_channels/processor check
+# ---------------------------------------------------------------------------
+
+
+def test_srresnet_validate_against_rejects_in_out_channels_mismatch():
+    model = SRResNet(scale=2, num_residual_blocks=1, in_out_channels=3)
+    with pytest.raises(ValueError, match="in_out_channels"):
+        SRResNetTrainingConfig().validate_against(model, YChannelProcessor())
+
+
+def test_srresnet_validate_against_accepts_matching_in_out_channels():
+    model = SRResNet(scale=2, num_residual_blocks=1, in_out_channels=3)
+    SRResNetTrainingConfig().validate_against(model, RGBProcessor())  # must not raise
+
+
+def test_srresnet_validate_against_still_runs_base_forward_probe():
+    """SRResNetTrainingConfig.validate_against must chain to the base check
+    (example_input_shape/forward probe) via super(), not just its own."""
+    model = SRResNet(scale=2, num_residual_blocks=1, in_out_channels=3)
+    cfg = SRResNetTrainingConfig(example_input_shape=(1, 16, 16))  # 1 != model_channels=3
+    with pytest.raises(ValueError, match="example_input_shape"):
+        cfg.validate_against(model, RGBProcessor())

--- a/tests/processors/test_base.py
+++ b/tests/processors/test_base.py
@@ -12,8 +12,8 @@ def test_srprocessor_is_abstract():
         SRProcessor()
 
 
-def test_srprocessor_subclass_must_implement_both_methods():
-    """A subclass missing either abstract method also raises on instantiation."""
+def test_srprocessor_subclass_must_implement_all_abstract_members():
+    """A subclass missing any abstract member also raises on instantiation."""
 
     class _ExtractOnly(SRProcessor):
         def extract(self, lr_rgb):
@@ -30,8 +30,22 @@ def test_srprocessor_subclass_must_implement_both_methods():
         _ReconstructOnly()
 
 
+def test_srprocessor_subclass_missing_model_channels_raises():
+    """model_channels is abstract too — extract/reconstruct alone isn't enough."""
+
+    class _MissingModelChannels(SRProcessor):
+        def extract(self, lr_rgb):
+            return lr_rgb
+
+        def reconstruct(self, sr_model_out, lr_rgb):
+            return sr_model_out
+
+    with pytest.raises(TypeError, match="abstract"):
+        _MissingModelChannels()
+
+
 def test_srprocessor_complete_subclass_instantiates():
-    """Subclass implementing both abstract methods can be instantiated."""
+    """Subclass implementing all abstract members can be instantiated."""
 
     class _Complete(SRProcessor):
         def extract(self, lr_rgb):
@@ -40,8 +54,13 @@ def test_srprocessor_complete_subclass_instantiates():
         def reconstruct(self, sr_model_out, lr_rgb):
             return sr_model_out
 
+        @property
+        def model_channels(self):
+            return 3
+
     p = _Complete()
     assert isinstance(p, SRProcessor)
     x = torch.zeros(1, 3, 4, 4)
     assert torch.equal(p.extract(x), x)
     assert torch.equal(p.reconstruct(x, x), x)
+    assert p.model_channels == 3

--- a/tests/processors/test_rgb.py
+++ b/tests/processors/test_rgb.py
@@ -25,3 +25,7 @@ def test_rgb_reconstruct_is_identity():
     lr_rgb = torch.rand(2, 3, 8, 8)
     out = p.reconstruct(sr_rgb, lr_rgb)
     assert out is sr_rgb
+
+
+def test_rgb_model_channels_is_3():
+    assert RGBProcessor().model_channels == 3

--- a/tests/processors/test_y_channel.py
+++ b/tests/processors/test_y_channel.py
@@ -10,6 +10,10 @@ def test_y_channel_processor_is_srprocessor():
     assert isinstance(YChannelProcessor(), SRProcessor)
 
 
+def test_y_channel_model_channels_is_1():
+    assert YChannelProcessor().model_channels == 1
+
+
 def test_y_channel_extract_returns_single_y_channel():
     """extract returns Y of the LR in YCbCr (shape [B,1,H,W])."""
     p = YChannelProcessor()

--- a/tests/processors/test_ycbcr.py
+++ b/tests/processors/test_ycbcr.py
@@ -10,6 +10,10 @@ def test_ycbcr_processor_is_srprocessor():
     assert isinstance(YCbCrProcessor(), SRProcessor)
 
 
+def test_ycbcr_model_channels_is_3():
+    assert YCbCrProcessor().model_channels == 3
+
+
 def test_ycbcr_extract_returns_full_ycbcr():
     """extract returns full YCbCr (shape [B,3,H,W]) matching rgb_to_ycbcr."""
     p = YCbCrProcessor()

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -2,6 +2,8 @@ from dataclasses import fields
 
 import pytest
 
+from sisr.models.srcnn import SRCNN
+from sisr.processors import RGBProcessor
 from sisr.training import SREvalConfig, SRTrainingConfig
 
 
@@ -47,3 +49,79 @@ def test_eval_config_rejects_unknown_psnr_channel():
     SREvalConfig(psnr_channels=["RGB", "YCbCr"])  # valid — must not raise
     with pytest.raises(ValueError, match="psnr_channels"):
         SREvalConfig(psnr_channels=["RGB", "HSV"])
+
+
+# ---------------------------------------------------------------------------
+# psnr_keys (INIT.16) — the public seam B1/C1 depend on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "psnr_channels,separate_psnr",
+    [
+        (["RGB"], False),
+        (["RGB"], True),
+        (["YCbCr"], False),
+        (["YCbCr"], True),
+        (["RGB", "YCbCr"], False),
+        (["RGB", "YCbCr"], True),
+    ],
+)
+def test_psnr_keys_matches_legacy_loop_derivation(psnr_channels, separate_psnr):
+    """psnr_keys must reproduce exactly the loop SRLightning.__init__ used to
+    inline (self._psnr_keys) before this property existed. Downstream PRs
+    (benchmark PSNR-key selection, TensorBoard tag rename) depend on this
+    exact ordering."""
+    channel_names = {"RGB": ("R", "G", "B"), "YCbCr": ("Y", "Cb", "Cr")}
+    legacy_keys: list[str] = []
+    for cs in psnr_channels:
+        if separate_psnr:
+            legacy_keys.extend(channel_names[cs])
+        legacy_keys.append(cs)
+
+    cfg = SREvalConfig(psnr_channels=psnr_channels, separate_psnr=separate_psnr)
+    assert cfg.psnr_keys == legacy_keys
+
+
+def test_psnr_keys_is_not_a_dataclass_field():
+    """psnr_keys is a derived property, not a stored field — guards against
+    it silently becoming a constructor argument / dataclasses.asdict() entry."""
+    names = {f.name for f in fields(SREvalConfig)}
+    assert "psnr_keys" not in names
+
+
+# ---------------------------------------------------------------------------
+# SRTrainingConfig.validate_against (INIT.16) — the construction-time seam
+# ---------------------------------------------------------------------------
+
+
+def test_validate_against_noop_when_example_input_shape_unset():
+    """example_input_shape is optional; validate_against must not probe the
+    model (or raise) when it's left at the default None."""
+    cfg = SRTrainingConfig()
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    cfg.validate_against(model, RGBProcessor())  # must not raise
+
+
+def test_validate_against_rejects_channel_mismatch():
+    cfg = SRTrainingConfig(example_input_shape=(1, 33, 33))
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    with pytest.raises(ValueError, match="example_input_shape"):
+        cfg.validate_against(model, RGBProcessor())  # RGBProcessor.model_channels == 3
+
+
+def test_validate_against_accepts_matching_shape_and_runs_forward_probe():
+    cfg = SRTrainingConfig(example_input_shape=(3, 33, 33))
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    cfg.validate_against(model, RGBProcessor())  # must not raise
+
+
+def test_validate_against_forward_probe_catches_architecture_mismatch_not_just_channels():
+    """The forward probe validates the real nn.Module, so it also catches
+    defects a bare channel-count check would miss — here, a 'valid'-padding
+    9x9 kernel run over a 5x5 spatial input (channels match; PyTorch itself
+    rejects the spatial size)."""
+    cfg = SRTrainingConfig(example_input_shape=(3, 5, 5))
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    with pytest.raises(RuntimeError):
+        cfg.validate_against(model, RGBProcessor())

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -8,6 +8,7 @@ import torch
 import torchmetrics
 
 from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
+from sisr.models.srresnet import SRResNetTrainingConfig
 from sisr.models.srresnet.model import SRResNet
 from sisr.processors import (
     RGBProcessor,
@@ -344,7 +345,7 @@ def test_on_train_start_logs_hparams_with_val_metrics(srcnn_rgb_lit: SRLightning
     params_arg = args[0] if args else kwargs.get("params")
     metrics_arg = args[1] if len(args) > 1 else kwargs.get("metrics")
 
-    expected_metrics = {f"val_psnr({k})": 0.0 for k in srcnn_rgb_lit._psnr_keys}
+    expected_metrics = {f"val_psnr({k})": 0.0 for k in srcnn_rgb_lit.eval_config.psnr_keys}
     expected_metrics["val_ssim"] = 0.0
 
     assert params_arg == srcnn_rgb_lit.hparams
@@ -405,6 +406,72 @@ def test_srlightning_rejects_non_srprocessor():
             processor=object(),  # not an SRProcessor
             optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
         )
+
+
+def test_srlightning_construction_rejects_mismatched_num_channels():
+    """Regression (INIT.16): SRCNNTrainingConfig.validate_against catches a
+    num_channels/processor mismatch at construction, not silently at train time."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    with pytest.raises(ValueError, match="num_channels"):
+        SRLightning(
+            model=model,
+            processor=YChannelProcessor(),  # model_channels=1, mismatches num_channels=3
+            training_config=SRCNNTrainingConfig(),
+            eval_config=SREvalConfig(),
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+        )
+
+
+def test_srlightning_construction_rejects_mismatched_in_out_channels():
+    """Same regression for SRResNet's in_out_channels/processor correlation."""
+    model = SRResNet(scale=2, num_residual_blocks=1, in_out_channels=3)
+    with pytest.raises(ValueError, match="in_out_channels"):
+        SRLightning(
+            model=model,
+            processor=YChannelProcessor(),  # model_channels=1, mismatches in_out_channels=3
+            training_config=SRResNetTrainingConfig(),
+            eval_config=SREvalConfig(),
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+        )
+
+
+def test_srlightning_construction_accepts_matching_channels():
+    """The happy path (matching num_channels/processor) must not raise."""
+    model = SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    SRLightning(
+        model=model,
+        processor=YChannelProcessor(),
+        training_config=SRCNNTrainingConfig(),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )  # must not raise
+
+
+def test_srlightning_construction_rejects_mismatched_example_input_shape_channels():
+    """The base (architecture-agnostic) channel check fires even with a plain
+    SRTrainingConfig, via example_input_shape[0] vs processor.model_channels."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    with pytest.raises(ValueError, match="example_input_shape"):
+        SRLightning(
+            model=model,
+            processor=RGBProcessor(),  # model_channels=3
+            training_config=SRTrainingConfig(example_input_shape=(1, 33, 33)),  # 1 != 3
+            eval_config=SREvalConfig(),
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+        )
+
+
+def test_srlightning_construction_forward_probe_succeeds_with_matching_shape():
+    """A correctly-paired example_input_shape runs the real forward probe with
+    no error — the base validate_against no-ops past the channel check."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(example_input_shape=(3, 33, 33)),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )  # must not raise
 
 
 def test_step_calls_processor_extract_and_reconstruct():


### PR DESCRIPTION
Fail-fast validation for template fields that must agree but are written in **different forms**, so YAML anchors cannot express the relationship.

Anchors (#31) solve *"the same value repeated"*. They cannot solve *"different values that must agree"* — e.g. `num_channels: 1` ↔ `YChannelProcessor` ↔ `example_input_shape: [1, ...]`, three encodings of "we work in Y". Setting `num_channels: 3` with `YChannelProcessor` silently trains the wrong thing.

### Design

**Template method, not `@abstractmethod`.** Both config bases are concrete and **directly instantiated as fallbacks** (`training_config or SRTrainingConfig()`), so making either an ABC would break that path.

| Layer | Responsibility |
|---|---|
| `SRTrainingConfig.validate_against(model, processor)` | Universal: `example_input_shape[0] == processor.model_channels`, plus a `torch.no_grad()` forward probe |
| `SRCNNTrainingConfig` / `SRResNetTrainingConfig` | Own channel field first (readable error), then `super()` |
| `SRLightning.__init__` | Orchestration only — **zero architecture knowledge** |

The forward probe validates the *actual* `nn.Module`, so it **cannot drift** — it is not a description of the model, it is the model. Subclass checks exist only to give better errors than a raw shape mismatch. Guarded on `example_input_shape` being set, since it is optional.

New abstract `SRProcessor.model_channels` — RGB 3, Y 1, YCbCr 3. A fact only the processor knows, not a mirror of the model.

### Also: `SREvalConfig.psnr_keys`

Moves PSNR key derivation off `SRLightning.__init__` onto the config that owns `psnr_channels` / `separate_psnr`. Verified byte-for-byte equal to the old inlined loop for both `separate_psnr` settings. This public seam is what lets the benchmark logger and validation stop disagreeing (follow-up PR).

### Rejected alternative

A parallel pydantic schema — it would be a *third* validation system (jsonargparse already type-validates real `__init__` signatures), it cannot see across the seam anyway since the correlations span *sibling* objects, and a schema *describes* rather than *tests*, so it goes stale when `__init__` changes.

Follows the existing precedent: `SREvalConfig.__post_init__` already validates `psnr_channels`.

**Tests:** 217 → **243** (26 new). `ruff check` / `ruff format --check` clean.

Part of the 2026-07-31 triage delivery arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)