### PR TITLE
Fix benchmark PSNR key over-emission; harden checkpoint filenames (P2.7, P5.9)

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -293,6 +293,10 @@ class BenchmarkImageLogger(Callback):
             if n > 0:
                 sr_4d = sr_4d[..., n:-n, n:-n]
                 hr_4d = hr_4d[..., n:-n, n:-n]
+            # Still a private reach (P5.9): the colorspace split has no public
+            # seam, and duplicating it here would recreate the divergence P2.1
+            # removed. Keys now come from eval_config, so this is a value
+            # lookup only — the callback no longer decides *which* keys exist.
             psnr_tensors = pl_module._build_psnr_tensors(sr_4d, hr_4d)
             psnr_dict = {
                 key: torchmetrics.functional.image.peak_signal_noise_ratio(
@@ -599,13 +603,19 @@ class SRCheckpoint(ModelCheckpoint):
             trainer (lightning.Trainer): The active trainer.
             pl_module (lightning.LightningModule): The model being trained;
                 must expose ``eval_config`` (an :class:`SREvalConfig`).
-            stage (str): Lightning trainer stage.
+            stage (str): Lightning trainer stage. Only ``"fit"`` is checked —
+                the monitored tags are val-loop metrics, so they are never
+                logged under ``validate``/``test``/``predict`` and demanding
+                them there would reject configs that are perfectly valid for
+                the stage actually being run.
 
         Raises:
             MisconfigurationException: If ``monitor`` does not name a
-                metric ``SRLightning`` will log for ``stage``.
+                metric ``SRLightning`` will log during ``fit``.
         """
         super().setup(trainer, pl_module, stage)
+        if stage != "fit":
+            return
         valid_metrics = {f"val_psnr({key})" for key in pl_module.eval_config.psnr_keys}
         valid_metrics.add("val_ssim")
         if self.monitor is not None and self.monitor not in valid_metrics:

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -17,6 +17,7 @@ import torch.nn.functional
 import torchmetrics.functional
 import torchvision
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint
+from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 
 class BenchmarkImageLogger(Callback):
@@ -295,9 +296,9 @@ class BenchmarkImageLogger(Callback):
             psnr_tensors = pl_module._build_psnr_tensors(sr_4d, hr_4d)
             psnr_dict = {
                 key: torchmetrics.functional.image.peak_signal_noise_ratio(
-                    sr_t, hr_t, data_range=1.0
+                    *psnr_tensors[key], data_range=1.0
                 ).item()
-                for key, (sr_t, hr_t) in psnr_tensors.items()
+                for key in pl_module.eval_config.psnr_keys
             }
             ssim = torchmetrics.functional.image.structural_similarity_index_measure(
                 sr_4d, hr_4d, data_range=1.0
@@ -531,6 +532,17 @@ class SRCheckpoint(ModelCheckpoint):
     automatically sets ``mode='max'`` (both PSNR and SSIM are
     higher-is-better) and builds a descriptive filename pattern.
 
+    The filename's metric *label* is sanitised (``/`` -> ``_``) and
+    ``auto_insert_metric_name`` is disabled, so a ``/``-bearing
+    ``monitor_metric`` (e.g. a future ``psnr/val/RGB`` TensorBoard-style tag)
+    cannot leak a raw ``/`` into the filename template. Lightning's
+    ``_format_checkpoint_name`` does no sanitisation itself, and with
+    ``auto_insert_metric_name=True`` (the default) a raw ``/`` there causes
+    ``TorchCheckpointIO`` to silently create a nested directory tree per
+    save instead of a flat file. The ``metrics`` dict lookup that supplies
+    the interpolated *value* is unaffected — it is a plain dict key and
+    handles ``/`` fine.
+
     Args:
         monitor_metric (str): The validation metric to monitor.
             Defaults to ``"val_psnr(RGB)"``.  Use any ``val_psnr({key})``
@@ -554,12 +566,52 @@ class SRCheckpoint(ModelCheckpoint):
         mode: str = "max",
         **kwargs: Any,
     ):
-        filename = f"{filename_prefix}-{{step}}-{{{monitor_metric}:.4f}}"
+        label = monitor_metric.replace("/", "_")
+        filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
         super().__init__(
             monitor=monitor_metric,
             mode=mode,
             save_top_k=save_top_k,
             dirpath=dirpath,
             filename=filename,
+            auto_insert_metric_name=False,
             **kwargs,
         )
+
+    def setup(
+        self,
+        trainer: lightning.Trainer,
+        pl_module: lightning.LightningModule,
+        stage: str,
+    ) -> None:
+        """Validate ``monitor`` against the metrics ``SRLightning`` will log.
+
+        Lightning itself only raises ``MisconfigurationException`` for a
+        missing monitor once the val loop has already run at least once
+        (``ModelCheckpoint._save_topk_checkpoint``, gated on
+        ``val_loop._has_run``) — with a long ``val_check_interval`` that is a
+        late, expensive-to-reach crash. This moves the same failure to
+        startup by checking ``monitor`` against ``pl_module.eval_config.psnr_keys``
+        (the same seam ``SRLightning`` logs val PSNR from) up front, before
+        any training happens.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being trained;
+                must expose ``eval_config`` (an :class:`SREvalConfig`).
+            stage (str): Lightning trainer stage.
+
+        Raises:
+            MisconfigurationException: If ``monitor`` does not name a
+                metric ``SRLightning`` will log for ``stage``.
+        """
+        super().setup(trainer, pl_module, stage)
+        valid_metrics = {f"val_psnr({key})" for key in pl_module.eval_config.psnr_keys}
+        valid_metrics.add("val_ssim")
+        if self.monitor is not None and self.monitor not in valid_metrics:
+            raise MisconfigurationException(
+                f"`SRCheckpoint(monitor_metric={self.monitor!r})` does not match any "
+                f"metric `SRLightning` will log: {sorted(valid_metrics)}. HINT: check "
+                f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or monitor "
+                f"`val_ssim`."
+            )

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import lightning
 import pytest
 import torch
+from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 from sisr.models.srcnn import SRCNN
 from sisr.processors import RGBProcessor, YChannelProcessor
@@ -260,6 +262,103 @@ def test_srcheckpoint_default_filename_prefix_is_neutral_sr():
     not the SRCNN-specific 'srcnn'."""
     ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath="/tmp/x")
     assert ckpt.filename.startswith("sr-")
+
+
+def test_srcheckpoint_disables_auto_insert_metric_name():
+    """INIT.8 prerequisite: auto_insert_metric_name must be off, since it is the
+    mechanism that would otherwise splice the raw (possibly `/`-bearing) metric
+    name into the filename as literal text."""
+    ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath="/tmp/x")
+    assert ckpt.auto_insert_metric_name is False
+
+
+def test_srcheckpoint_slash_monitor_renders_flat_filename(tmp_path: Path):
+    """INIT.8 prerequisite: a `/`-bearing monitor_metric (e.g. a future
+    `psnr/val/RGB` TensorBoard-hierarchy tag) must render to a flat basename
+    with no path separator. Lightning's `_format_checkpoint_name` does no
+    sanitisation of its own — with the default `auto_insert_metric_name=True`
+    it splices the raw metric name in as literal text before the value
+    placeholder, which would make `TorchCheckpointIO.save_checkpoint`
+    silently create a nested directory tree (one per save) instead of a flat
+    checkpoint file. The `metrics` dict lookup that supplies the *value* is
+    unaffected by the `/` — it's just a dict key."""
+    ckpt = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    rendered = ckpt.format_checkpoint_name(
+        {"step": torch.tensor(1000), "psnr/val/RGB": torch.tensor(30.1234)}
+    )
+    basename = Path(rendered).name
+    assert "/" not in basename
+    assert basename == "sr-1000-psnr_val_RGB=30.1234.ckpt"
+
+
+# ---------------------------------------------------------------------------
+# SRCheckpoint.setup monitor validation
+# ---------------------------------------------------------------------------
+
+
+def _make_bare_trainer() -> lightning.Trainer:
+    """Minimal, unfitted Trainer — enough for ModelCheckpoint.setup's
+    `__resolve_ckpt_dir` / `trainer.strategy.broadcast` / `is_global_zero`
+    calls without running an actual loop."""
+    return lightning.Trainer(
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+
+# _make_bare_trainer logs a "GPU available but not used" PossibleUserWarning on
+# this CUDA-equipped dev box (accelerator="cpu" is deliberate — matches how the
+# templates run in CI, which has no GPU); harmless environment noise, not a
+# library-health signal, but the strict global `filterwarnings=error` config
+# would otherwise fail these tests on it. Same pattern as test_integration.py.
+_ignore_gpu_warning = pytest.mark.filterwarnings(
+    "ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning"
+)
+
+
+@_ignore_gpu_warning
+def test_srcheckpoint_setup_accepts_monitor_matching_psnr_keys(tmp_path: Path):
+    """monitor_metric derived from eval_config.psnr_keys must pass setup()
+    without raising."""
+    pl_module = _make_real_pl_module()  # SREvalConfig(crop_border=0) -> psnr_keys=['RGB']
+    ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath=str(tmp_path))
+    ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")  # must not raise
+
+
+@_ignore_gpu_warning
+def test_srcheckpoint_setup_accepts_val_ssim_monitor(tmp_path: Path):
+    """val_ssim is always logged regardless of psnr_keys and must be accepted."""
+    pl_module = _make_real_pl_module()
+    ckpt = SRCheckpoint(monitor_metric="val_ssim", dirpath=str(tmp_path))
+    ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")  # must not raise
+
+
+@_ignore_gpu_warning
+def test_srcheckpoint_setup_rejects_monitor_not_in_psnr_keys(tmp_path: Path):
+    """P5.9/INIT.8: monitoring a PSNR key eval_config never requests (here 'Y',
+    since psnr_channels=['RGB'] and separate_psnr=False) must raise
+    MisconfigurationException at setup() time — startup, not 20k steps into
+    training once Lightning's own val_loop._has_run-gated check would fire."""
+    pl_module = _make_real_pl_module()
+    ckpt = SRCheckpoint(monitor_metric="val_psnr(Y)", dirpath=str(tmp_path))
+    with pytest.raises(MisconfigurationException, match=r"val_psnr\(Y\)"):
+        ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")
+
+
+@_ignore_gpu_warning
+def test_srcheckpoint_setup_error_lists_valid_metrics(tmp_path: Path):
+    """The error message must enumerate the actually-loggable metric set, so a
+    misconfigured monitor is actionable without reading source."""
+    pl_module = _make_real_pl_module()
+    ckpt = SRCheckpoint(monitor_metric="bogus_metric", dirpath=str(tmp_path))
+    with pytest.raises(MisconfigurationException) as exc_info:
+        ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")
+    assert "val_psnr(RGB)" in str(exc_info.value)
+    assert "val_ssim" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------
@@ -642,6 +741,71 @@ def test_benchmark_collect_batch_routes_through_processor():
     assert "RGB" in psnr_dict
     assert "YCbCr" in psnr_dict
     assert isinstance(ssim, float)
+
+
+def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_false():
+    """P2.7 regression: a real run's metrics.csv contained 8 PSNR keys
+    (RGB/R/G/B/YCbCr/Y/Cb/Cr) for a config requesting only ['RGB', 'YCbCr']
+    with separate_psnr=False — because _collect_batch iterated every tensor
+    `_build_psnr_tensors` populates for the colorspace *family*, not the
+    configured key set. The emitted key set must equal `eval_config.psnr_keys`
+    exactly."""
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    pl_module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(
+            crop_border=0, psnr_channels=["RGB", "YCbCr"], separate_psnr=False
+        ),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer = SimpleNamespace(val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)])
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
+    )
+    _, _, _, _, psnr_dict, _ = cb._buffer["Set5"][0]
+    assert set(psnr_dict.keys()) == set(pl_module.eval_config.psnr_keys) == {"RGB", "YCbCr"}
+
+
+def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_true():
+    """separate_psnr=True must surface per-channel keys alongside the
+    aggregate key for the requested colorspace only — no keys from an
+    unrequested colorspace family leak in."""
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    pl_module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(crop_border=0, psnr_channels=["RGB"], separate_psnr=True),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer = SimpleNamespace(val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)])
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
+    )
+    _, _, _, _, psnr_dict, _ = cb._buffer["Set5"][0]
+    assert set(psnr_dict.keys()) == set(pl_module.eval_config.psnr_keys) == {"R", "G", "B", "RGB"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Stacked on #32** (`feat/config-validation-seam`) — merge that first. This PR targets that branch, so the diff shows only its own changes.

### P2.7 — `separate_psnr` was silently inert on the benchmark path

`BenchmarkImageLogger._collect_batch` built `psnr_dict` by iterating **every** tensor `_build_psnr_tensors()` returns — and that method populates all four of `RGB/R/G/B` if *any* RGB-family key is requested (likewise `YCbCr/Y/Cb/Cr`). So a config asking for 2 keys emitted **8**.

Observed in a real run's `metrics.csv`:

```
Set5_psnr(B),Set5_psnr(Cb),Set5_psnr(Cr),Set5_psnr(G),Set5_psnr(R),Set5_psnr(RGB),Set5_psnr(Y),Set5_psnr(YCbCr),Set5_ssim
```

alongside only `val_psnr(RGB),val_psnr(YCbCr),val_ssim` from validation.

Now iterates the public `eval_config.psnr_keys` (#32's seam). This also shrinks `_flush_buffer`'s output, which derives its key set downstream — so per-set means and **per-image TensorBoard tags** shrink too. Set5 previously emitted 40 per-image tags per val run where 10 were configured.

### P5.9 — reduced private coupling

Key *selection* no longer reaches into `SRLightning` privates. `_build_psnr_tensors` is still called as a **value lookup**, with an inline note explaining why: the colorspace split has no public seam, and duplicating it in the callback would recreate the exact divergence P2.1 removed.

### Checkpoint filename hardening

`_format_checkpoint_name` does **no** sanitisation — with `auto_insert_metric_name=True` it interpolates the raw metric name, so a `/`-bearing monitor yields `sr-step=1000-psnr/val/RGB=30.1234.ckpt`. It doesn't crash: `TorchCheckpointIO.save_checkpoint` calls `fs.makedirs(os.path.dirname(path), exist_ok=True)`, so Lightning **silently creates a `psnr/val/` directory tree per save**.

Fixed with `auto_insert_metric_name=False` plus a self-supplied `label = monitor_metric.replace("/", "_")`. The monitor still resolves against the real tag — a `/` in a dict key is fine; only the *printed* label is flattened. Landing now because the queued TensorBoard tag-hierarchy PR depends on it.

### Monitor validation moved earlier

Lightning already raises `MisconfigurationException` for a missing monitor — but only after the val loop has run, which under the templates' `val_check_interval: 20000` is a **20k-step-late** crash. `SRCheckpoint.setup` now checks at startup. This moves an existing failure earlier rather than adding a new guard, and is scoped to the `fit` stage so it can't reject configs valid for `validate`/`test`/`predict`.

**Tests:** 243 → **251**. Reviewed independently: spec PASS, quality APPROVED, two Minor findings both fixed in `e5ec1ea`.

Part of the 2026-07-31 triage delivery arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)