### PR TITLE
Add LR-only prediction path: predict_dataloader, predict_step, SRPredictionWriter (P3.7)

### DIFF
--- a/sisr/datasets/predict.py
+++ b/sisr/datasets/predict.py
@@ -27,12 +27,24 @@ class PredictDataset(SRDataset):
             inference on.
 
     Raises:
-        ValueError: If no image files are found in ``img_dir``.
+        ValueError: If no image files are found in ``img_dir``, or if two
+            images share a filename stem.
     """
 
     def __init__(self, img_dir: str | Path):
         super().__init__()
         self._index_images(img_dir)
+        # SRPredictionWriter names outputs by stem, so `cat.png` and `cat.jpg`
+        # would silently overwrite each other. Fail at construction instead.
+        stems: dict[str, Path] = {}
+        for path in self.img_paths:
+            if path.stem in stems:
+                raise ValueError(
+                    f"Duplicate filename stem {path.stem!r} in {img_dir}: "
+                    f"{stems[path.stem].name} and {path.name}. Predictions are "
+                    f"named by stem, so these would overwrite each other."
+                )
+            stems[path.stem] = path
         self._to_tensor = self._to_tensor_transform()
 
     def __len__(self) -> int:

--- a/sisr/datasets/predict.py
+++ b/sisr/datasets/predict.py
@@ -1,0 +1,51 @@
+"""LR-only prediction dataset — real inference images, no HR pair.
+
+Unlike the architecture datasets (which synthesize LR from HR for training and
+evaluation), :class:`PredictDataset` loads images that already *are* LR — the
+only genuine no-ground-truth input the framework serves. Reuses
+:class:`~sisr.datasets.base.SRDataset` for file discovery and the uint8-HWC ->
+float32-CHW tensor adapter, since both are architecture/colorspace agnostic.
+"""
+
+from pathlib import Path
+
+import torch
+
+from .base import SRDataset
+
+
+class PredictDataset(SRDataset):
+    """Loads real LR images for inference — no synthetic downsampling, no HR pair.
+
+    Serves the raw image at each path as RGB ``float32`` in ``[0, 1]``,
+    unmodified. Colorspace extraction (RGB vs. Y vs. YCbCr) happens
+    downstream in :class:`~sisr.training.SRLightning` via the processor,
+    exactly as it does for the paired training/validation datasets.
+
+    Args:
+        img_dir (str | Path): Directory containing the LR images to run
+            inference on.
+
+    Raises:
+        ValueError: If no image files are found in ``img_dir``.
+    """
+
+    def __init__(self, img_dir: str | Path):
+        super().__init__()
+        self._index_images(img_dir)
+        self._to_tensor = self._to_tensor_transform()
+
+    def __len__(self) -> int:
+        return len(self.img_paths)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        """Returns the LR RGB tensor at ``idx``.
+
+        Args:
+            idx (int): Zero-based image index.
+
+        Returns:
+            ``float32`` tensor of shape ``(3, H, W)`` in ``[0, 1]``.
+        """
+        arr = self._load_rgb(self.img_paths[idx])
+        return self._to_tensor(image=arr)["image"]

--- a/sisr/training/__init__.py
+++ b/sisr/training/__init__.py
@@ -8,6 +8,7 @@ from .callbacks import (
     BenchmarkImageLogger,
     GradNormLogger,
     SRCheckpoint,
+    SRPredictionWriter,
     WeightHistogramLogger,
 )
 from .config import SREvalConfig, SRTrainingConfig
@@ -22,5 +23,6 @@ __all__ = [
     "BenchmarkImageLogger",
     "GradNormLogger",
     "SRCheckpoint",
+    "SRPredictionWriter",
     "WeightHistogramLogger",
 ]

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -5,10 +5,13 @@ for held-out test sets (Set5, Set14, ...) during both ``cli fit`` (every
 N val cycles) and ``cli test`` (one-shot final eval).
 :class:`GradNormLogger` and :class:`WeightHistogramLogger` log diagnostic
 training signals; :class:`SRCheckpoint` is a thin
-:class:`~lightning.pytorch.callbacks.ModelCheckpoint` preset for SR metrics.
+:class:`~lightning.pytorch.callbacks.ModelCheckpoint` preset for SR metrics;
+:class:`SRPredictionWriter` writes ``cli predict`` output to disk as PNGs.
 """
 
 import math
+from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 import lightning
@@ -16,7 +19,7 @@ import torch
 import torch.nn.functional
 import torchmetrics.functional
 import torchvision
-from lightning.pytorch.callbacks import Callback, ModelCheckpoint
+from lightning.pytorch.callbacks import BasePredictionWriter, Callback, ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 
@@ -625,3 +628,70 @@ class SRCheckpoint(ModelCheckpoint):
                 f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or monitor "
                 f"`val_ssim`."
             )
+
+
+class SRPredictionWriter(BasePredictionWriter):
+    """Writes ``predict_step`` output as 8-bit PNGs named after their input files.
+
+    ``cli predict`` has no HR reference to score against, so a saved image
+    *is* the entire result — this callback is what makes the subcommand
+    produce a visible artifact instead of a discarded in-memory tensor.
+
+    Only ``write_interval='batch'`` is supported — ``'epoch'`` /
+    ``'batch_and_epoch'`` would accumulate every prediction in memory for
+    the whole run before writing, which defeats writing PNGs one-by-one in
+    the first place, and this class doesn't implement
+    ``write_on_epoch_end``.
+
+    Args:
+        output_dir: Directory PNGs are written to; created (including
+            parents) if missing.
+    """
+
+    def __init__(self, output_dir: str | Path):
+        super().__init__("batch")
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_on_batch_end(
+        self,
+        trainer: lightning.Trainer,
+        pl_module: lightning.LightningModule,
+        prediction: torch.Tensor,
+        batch_indices: Sequence[int] | None,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int,
+    ) -> None:
+        """Save each SR image in ``prediction`` as ``<input_stem>.png``.
+
+        Filenames are resolved from the predict dataloader's underlying
+        dataset via ``batch_indices`` and its ``.img_paths`` contract — the
+        same one :class:`BenchmarkImageLogger` relies on — rather than from
+        ``batch`` itself, which is a bare LR tensor with no filename.
+
+        Args:
+            trainer (lightning.Trainer): The active trainer.
+            pl_module (lightning.LightningModule): The model being run
+                (unused).
+            prediction (torch.Tensor): ``SRLightning.predict_step`` output —
+                SR RGB batch, ``float32`` in ``[0, 1]``, shape
+                ``(B, 3, H, W)``.
+            batch_indices (Sequence[int] | None): Dataset indices of the
+                samples in this batch, supplied by Lightning's predict loop.
+            batch (Any): The input LR batch (unused — filenames come from
+                ``batch_indices``, not the tensor itself).
+            batch_idx (int): Index of the batch within the current
+                dataloader (unused).
+            dataloader_idx (int): Index of the predict loader — used only
+                when ``trainer.predict_dataloaders`` is a list.
+        """
+        loader = trainer.predict_dataloaders
+        if isinstance(loader, list | tuple):
+            loader = loader[dataloader_idx]
+        img_paths = loader.dataset.img_paths
+
+        for i, sample_idx in enumerate(batch_indices):
+            filename = img_paths[sample_idx].stem
+            out_path = self.output_dir / f"{filename}.png"
+            torchvision.utils.save_image(prediction[i].clamp(0.0, 1.0), out_path)

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -33,6 +33,10 @@ class SRDataModule(lightning.LightningDataModule):
     * :meth:`test_dataloader` returns the test loaders only, for
       ``cli test --ckpt_path <path>`` final evaluation.
 
+    :meth:`predict_dataloader` serves a separate, optional LR-only dataset
+    (e.g. :class:`~sisr.datasets.predict.PredictDataset`) for ``cli predict``
+    — the only stage with no HR reference at all.
+
     Architecture-agnostic: each dataset spec carries its own ``class_path``,
     so swapping in an alternative pipeline (e.g. SRResNet's random-crop dataset)
     only requires pointing the YAML at a different class.
@@ -43,12 +47,20 @@ class SRDataModule(lightning.LightningDataModule):
             held-out validation dataset.
         test_datasets: ``{name: {class_path, init_args}}`` mapping for held-out
             test sets (Set5, Set14, …). ``None`` disables test evaluation.
+        predict_dataset: ``{class_path, init_args}`` spec for the LR-only
+            prediction dataset. ``None`` (default) leaves ``cli predict``
+            unconfigured — :meth:`predict_dataloader` raises if called.
         train_dataloader_kwargs: DataLoader kwargs for the training loader
             (excluding ``shuffle``, which is forced to ``True``).
         val_dataloader_kwargs: DataLoader kwargs for the primary validation
             loader. Defaults to ``{'batch_size': 1, 'num_workers': 1}``.
         test_dataloader_kwargs: DataLoader kwargs reused for every test
             loader. Defaults to the same as the validation loader.
+        predict_dataloader_kwargs: DataLoader kwargs for the prediction
+            loader. Defaults to ``{'batch_size': 1, 'num_workers': 0}`` —
+            predict images vary in size so batch_size 1 is the safe default,
+            and num_workers 0 keeps a one-off inference call free of
+            multiprocessing startup cost.
     """
 
     def __init__(
@@ -56,21 +68,26 @@ class SRDataModule(lightning.LightningDataModule):
         train_dataset: dict[str, Any],
         val_dataset: dict[str, Any],
         test_datasets: dict[str, dict[str, Any]] | None = None,
+        predict_dataset: dict[str, Any] | None = None,
         train_dataloader_kwargs: dict[str, Any] | None = None,
         val_dataloader_kwargs: dict[str, Any] | None = None,
         test_dataloader_kwargs: dict[str, Any] | None = None,
+        predict_dataloader_kwargs: dict[str, Any] | None = None,
     ):
         super().__init__()
         self._train_spec = train_dataset
         self._val_spec = val_dataset
         self._test_specs = test_datasets or {}
+        self._predict_spec = predict_dataset
         self._train_dl_kwargs = train_dataloader_kwargs or {}
         self._val_dl_kwargs = val_dataloader_kwargs or {"batch_size": 1, "num_workers": 1}
         self._test_dl_kwargs = test_dataloader_kwargs or self._val_dl_kwargs
+        self._predict_dl_kwargs = predict_dataloader_kwargs or {"batch_size": 1, "num_workers": 0}
 
         self._train_ds: Dataset | None = None
         self._val_ds: Dataset | None = None
         self._test_ds: dict[str, Dataset] = {}
+        self._predict_ds: Dataset | None = None
 
     @property
     def test_names(self) -> list[str]:
@@ -92,8 +109,8 @@ class SRDataModule(lightning.LightningDataModule):
 
         Args:
             stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
-                ``'test'``, or ``None`` (for all). Determines which
-                datasets get instantiated.
+                ``'test'``, ``'predict'``, or ``None`` (for all). Determines
+                which datasets get instantiated.
         """
         if stage in ("fit", None) and self._train_ds is None:
             self._train_ds = instantiate_class((), self._train_spec)
@@ -103,6 +120,8 @@ class SRDataModule(lightning.LightningDataModule):
             }
         if stage in ("fit", "validate", None) and self._val_ds is None:
             self._val_ds = instantiate_class((), self._val_spec)
+        if stage in ("predict", None) and self._predict_ds is None and self._predict_spec:
+            self._predict_ds = instantiate_class((), self._predict_spec)
 
     def train_dataloader(self) -> DataLoader:
         """Build the training DataLoader.
@@ -142,3 +161,22 @@ class SRDataModule(lightning.LightningDataModule):
         return [
             DataLoader(ds, shuffle=False, **self._test_dl_kwargs) for ds in self._test_ds.values()
         ]
+
+    def predict_dataloader(self) -> DataLoader:
+        """Build the DataLoader over the LR-only prediction dataset.
+
+        Returns:
+            DataLoader over the ``predict_dataset`` spec.
+
+        Raises:
+            RuntimeError: If ``predict_dataset`` was not configured — there
+                is nothing to run ``cli predict`` against.
+        """
+        if self._predict_ds is None:
+            raise RuntimeError(
+                "SRDataModule.predict_dataloader() called but no predict_dataset was "
+                "configured. Set data.predict_dataset (a {class_path, init_args} spec, "
+                "e.g. sisr.datasets.predict.PredictDataset) pointing at a directory of "
+                "LR images."
+            )
+        return DataLoader(self._predict_ds, shuffle=False, **self._predict_dl_kwargs)

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -227,15 +227,38 @@ class SRLightning(lightning.LightningModule):
         """
         return self.model(x)
 
+    def _forward_lr(self, lr_img: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """LR-only core of the forward pipeline: extract → model → reconstruct.
+
+        Factored out of :meth:`_forward_sr` so :meth:`predict_step` can share
+        the exact colorspace pipeline instead of forking it — HR is only ever
+        needed for the center-crop :meth:`_forward_sr` adds on top, which has
+        no meaning without an HR reference at inference time.
+
+        Args:
+            lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
+                ``(B, 3, H, W)``.
+
+        Returns:
+            ``(sr_model_out, sr_rgb)`` — the raw model output in the model IO
+            colorspace, and the reconstructed SR RGB.
+        """
+        model_input = self.processor.extract(lr_img)
+        sr_model_out = self.model(model_input)
+        sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
+        return sr_model_out, sr_rgb
+
     def _forward_sr(
         self, lr_img: torch.Tensor, hr_img: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Canonical SR forward: extract → model → reconstruct → crop HR.
 
         The single source of truth for the forward pipeline. Shared by
-        :meth:`_step` (which also needs the model-space output for the loss)
-        and :meth:`predict_rgb` (the public scoring seam), so the training and
-        benchmark-logging paths cannot silently diverge.
+        :meth:`_step` (which also needs the model-space output for the loss),
+        :meth:`predict_rgb` (the public scoring seam), and — via
+        :meth:`_forward_lr` — :meth:`predict_step` (the HR-free inference
+        seam), so the training, benchmark-logging, and prediction paths
+        cannot silently diverge.
 
         Args:
             lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
@@ -247,9 +270,7 @@ class SRLightning(lightning.LightningModule):
             the model IO colorspace, the reconstructed SR RGB, and HR
             center-cropped to the SR spatial size.
         """
-        model_input = self.processor.extract(lr_img)
-        sr_model_out = self.model(model_input)
-        sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
+        sr_model_out, sr_rgb = self._forward_lr(lr_img)
         hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_rgb.shape[-2:])
         return sr_model_out, sr_rgb, hr_cropped
 
@@ -415,6 +436,34 @@ class SRLightning(lightning.LightningModule):
             dataloader_idx: Index of the test loader (unused).
         """
         return None
+
+    def predict_step(
+        self, batch: torch.Tensor, batch_idx: int, dataloader_idx: int = 0
+    ) -> torch.Tensor:
+        """Run the HR-free inference pipeline: extract → model → reconstruct.
+
+        Shares :meth:`_forward_lr` with :meth:`_forward_sr` (the pipeline
+        backing :meth:`_step` / :meth:`predict_rgb`) — the same colorspace
+        pipeline minus the HR-dependent center-crop and scoring, neither of
+        which has meaning without an HR reference. Paired with
+        :meth:`~sisr.training.SRDataModule.predict_dataloader` and typically
+        consumed by :class:`~sisr.training.callbacks.SRPredictionWriter`.
+
+        Args:
+            batch: LR batch, RGB ``float32`` in ``[0, 1]``, shape
+                ``(B, 3, H, W)``, as produced by
+                :class:`~sisr.datasets.predict.PredictDataset`.
+            batch_idx: Index of the batch within the predict run (unused).
+            dataloader_idx: Index of the predict loader (unused — a single
+                predict loader is expected).
+
+        Returns:
+            SR RGB tensor, ``float32`` in ``[0, 1]``, shape
+            ``(B, 3, H', W')`` — same size as the input for SRCNN,
+            ``H'=H*scale``/``W'=W*scale`` for SRResNet.
+        """
+        _, sr_rgb = self._forward_lr(batch)
+        return sr_rgb
 
     def configure_optimizers(self) -> OptimizerLRScheduler:
         """Build optimizer (and optional scheduler) from top-level YAML.

--- a/tests/datasets/test_predict.py
+++ b/tests/datasets/test_predict.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pytest
+import torch
+
+from sisr.datasets.base import SRDataset
+from sisr.datasets.predict import PredictDataset
+
+
+def test_predict_dataset_returns_lr_tensor_only(tiny_rgb_image_dir: Path):
+    """__getitem__ returns a bare tensor (no HR pair) — the LR-only contract."""
+    ds = PredictDataset(img_dir=tiny_rgb_image_dir)
+    assert len(ds) == 3
+    item = ds[0]
+    assert isinstance(item, torch.Tensor)
+    assert item.shape == (3, 36, 36)
+    assert item.dtype == torch.float32
+    assert 0.0 <= item.min() <= item.max() <= 1.0
+
+
+def test_predict_dataset_no_images_raises(tmp_path: Path):
+    with pytest.raises(ValueError, match="No images"):
+        PredictDataset(img_dir=tmp_path)
+
+
+def test_predict_dataset_is_srdataset_subclass():
+    assert issubclass(PredictDataset, SRDataset)
+
+
+def test_predict_dataset_skips_non_image_files(tiny_rgb_image_dir: Path):
+    (tiny_rgb_image_dir / "notes.txt").write_text("not an image")
+    (tiny_rgb_image_dir / "MANIFEST").write_text("extensionless")
+    ds = PredictDataset(img_dir=tiny_rgb_image_dir)
+    assert len(ds) == 3
+    assert all(p.suffix == ".png" for p in ds.img_paths)
+
+
+def test_predict_dataset_is_deterministic(tiny_rgb_image_dir: Path):
+    """No random augmentation — real inference input must round-trip identically."""
+    ds = PredictDataset(img_dir=tiny_rgb_image_dir)
+    a = ds[0]
+    b = ds[0]
+    assert torch.equal(a, b)
+
+
+def test_predict_dataset_does_not_resize_or_downsample(tiny_rgb_image_dir: Path):
+    """Unlike ValidationDataset, PredictDataset must not synthesize LR from HR —
+    it serves genuine LR images exactly as found on disk."""
+    from PIL import Image
+
+    path = sorted(tiny_rgb_image_dir.glob("*.png"))[0]
+    expected = torch.from_numpy(SRDataset._load_rgb(path)).permute(2, 0, 1).float().div(255.0)
+    ds = PredictDataset(img_dir=tiny_rgb_image_dir)
+    idx = ds.img_paths.index(path)
+    torch.testing.assert_close(ds[idx], expected)
+    Image.open(path).close()  # sanity: file still readable, unmodified

--- a/tests/datasets/test_predict.py
+++ b/tests/datasets/test_predict.py
@@ -23,6 +23,19 @@ def test_predict_dataset_no_images_raises(tmp_path: Path):
         PredictDataset(img_dir=tmp_path)
 
 
+def test_predict_dataset_duplicate_stems_raise(tmp_path: Path):
+    """Outputs are named by stem, so `cat.png` + `cat.jpg` would collide."""
+    import numpy as np
+    from PIL import Image
+
+    arr = np.zeros((8, 8, 3), dtype=np.uint8)
+    Image.fromarray(arr).save(tmp_path / "cat.png")
+    Image.fromarray(arr).save(tmp_path / "cat.jpg")
+
+    with pytest.raises(ValueError, match="Duplicate filename stem"):
+        PredictDataset(img_dir=tmp_path)
+
+
 def test_predict_dataset_is_srdataset_subclass():
     assert issubclass(PredictDataset, SRDataset)
 

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -16,6 +16,7 @@ from sisr.training import (
     SRCheckpoint,
     SREvalConfig,
     SRLightning,
+    SRPredictionWriter,
     SRTrainingConfig,
     WeightHistogramLogger,
 )
@@ -851,6 +852,87 @@ def test_benchmark_collect_batch_routes_through_predict_rgb():
     _, _, sr0, hr0, _, _ = cb._buffer["Set5"][0]
     torch.testing.assert_close(sr0, ref_sr[0].cpu())
     torch.testing.assert_close(hr0, ref_hr[0].cpu())
+
+
+def test_prediction_writer_creates_output_dir(tmp_path: Path):
+    out_dir = tmp_path / "preds" / "nested"
+    SRPredictionWriter(output_dir=out_dir)
+    assert out_dir.is_dir()
+
+
+def test_prediction_writer_writes_png_named_after_input(tmp_path: Path):
+    from PIL import Image
+
+    out_dir = tmp_path / "preds"
+    writer = SRPredictionWriter(output_dir=out_dir)
+
+    ds = _stub_dataset_with_img_paths(n=2, name="lr")
+    trainer = SimpleNamespace(predict_dataloaders=_stub_dataloader(ds))
+    prediction = torch.rand(2, 3, 8, 8)
+    writer.write_on_batch_end(
+        trainer=trainer,
+        pl_module=None,
+        prediction=prediction,
+        batch_indices=[0, 1],
+        batch=None,
+        batch_idx=0,
+        dataloader_idx=0,
+    )
+    written = sorted(p.name for p in out_dir.glob("*.png"))
+    assert written == ["lr_000.png", "lr_001.png"]
+    with Image.open(out_dir / "lr_000.png") as img:
+        assert img.size == (8, 8)
+
+
+def test_prediction_writer_handles_dataloader_list():
+    """trainer.predict_dataloaders may be a list (Lightning's CombinedLoader
+    behaviour for multi-loader predict); the writer must index it by
+    dataloader_idx rather than assuming a single bare DataLoader."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp) / "preds"
+        writer = SRPredictionWriter(output_dir=out_dir)
+
+        ds = _stub_dataset_with_img_paths(n=1, name="lr")
+        trainer = SimpleNamespace(predict_dataloaders=[_stub_dataloader(ds)])
+        prediction = torch.rand(1, 3, 4, 4)
+        writer.write_on_batch_end(
+            trainer=trainer,
+            pl_module=None,
+            prediction=prediction,
+            batch_indices=[0],
+            batch=None,
+            batch_idx=0,
+            dataloader_idx=0,
+        )
+        assert (out_dir / "lr_000.png").exists()
+
+
+def test_prediction_writer_clamps_out_of_range_values(tmp_path: Path):
+    """Model output isn't guaranteed to land in [0, 1]; the writer must clamp
+    before saving rather than let save_image wrap/overflow."""
+    out_dir = tmp_path / "preds"
+    writer = SRPredictionWriter(output_dir=out_dir)
+
+    ds = _stub_dataset_with_img_paths(n=1, name="lr")
+    trainer = SimpleNamespace(predict_dataloaders=_stub_dataloader(ds))
+    prediction = torch.full((1, 3, 4, 4), 1.5)  # out of [0, 1]
+    writer.write_on_batch_end(
+        trainer=trainer,
+        pl_module=None,
+        prediction=prediction,
+        batch_indices=[0],
+        batch=None,
+        batch_idx=0,
+        dataloader_idx=0,
+    )
+    import numpy as np
+    from PIL import Image
+
+    with Image.open(out_dir / "lr_000.png") as img:
+        arr = np.array(img)
+    assert (arr == 255).all()
 
 
 def test_benchmark_collect_batch_consumes_srdataset_img_paths(tiny_rgb_image_dir: Path):

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -187,6 +187,108 @@ def test_old_class_params_rejected(tiny_rgb_image_dir: Path):
         )
 
 
+def _predict_spec(image_dir: Path) -> dict:
+    return {
+        "class_path": "sisr.datasets.predict.PredictDataset",
+        "init_args": {"img_dir": str(image_dir)},
+    }
+
+
+def test_setup_predict_only_builds_predict_dataset(tiny_rgb_image_dir: Path):
+    """stage='predict' must build only the predict dataset, not train/val/test —
+    mirroring the other stages' selective-instantiation contract."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_predict_stage"),
+            "build_num_workers": 1,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    dm = SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        test_datasets={"Set5": val_spec},
+        predict_dataset=_predict_spec(tiny_rgb_image_dir),
+    )
+    dm.setup(stage="predict")
+    assert dm._train_ds is None
+    assert dm._val_ds is None
+    assert dm._test_ds == {}
+    assert dm._predict_ds is not None
+
+
+def test_predict_dataloader_returns_loader_over_predict_dataset(tiny_rgb_image_dir: Path):
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_predict_loader"),
+            "build_num_workers": 1,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    dm = SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        predict_dataset=_predict_spec(tiny_rgb_image_dir),
+        predict_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+    )
+    dm.setup(stage="predict")
+    loader = dm.predict_dataloader()
+    assert isinstance(loader, DataLoader)
+    assert loader.dataset is dm._predict_ds
+    from torch.utils.data import SequentialSampler
+
+    assert isinstance(loader.sampler, SequentialSampler)  # shuffle=False
+
+
+def test_predict_dataloader_default_kwargs(tiny_rgb_image_dir: Path):
+    """batch_size=1/num_workers=0 default when predict_dataloader_kwargs is omitted."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "cache_dir": str(tiny_rgb_image_dir / ".lmdb_cache_predict_default"),
+            "build_num_workers": 1,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    dm = SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        predict_dataset=_predict_spec(tiny_rgb_image_dir),
+    )
+    assert dm._predict_dl_kwargs == {"batch_size": 1, "num_workers": 0}
+
+
+def test_predict_dataloader_without_predict_dataset_raises(tiny_rgb_image_dir: Path):
+    """No predict_dataset configured -> a clear RuntimeError, not a silent None loader."""
+    dm = _make_dm(tiny_rgb_image_dir)
+    dm.setup(stage="predict")
+    with pytest.raises(RuntimeError, match="predict_dataset"):
+        dm.predict_dataloader()
+
+
 def test_train_dataset_built_from_class_path_spec(tiny_rgb_image_dir: Path):
     """train_dataset accepts {class_path, init_args} and setup() instantiates it."""
     train_spec = {

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -20,12 +20,14 @@ import pytest
 import torch
 
 from sisr.models.srcnn import SRCNN
-from sisr.processors import RGBProcessor
+from sisr.models.srresnet.model import SRResNet
+from sisr.processors import RGBProcessor, YChannelProcessor
 from sisr.training import (
     BenchmarkImageLogger,
     SRDataModule,
     SREvalConfig,
     SRLightning,
+    SRPredictionWriter,
 )
 
 
@@ -108,3 +110,103 @@ def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
     test_metrics = set(trainer.callback_metrics)
     # test_step is a no-op; these come solely from BenchmarkImageLogger.on_test_*.
     assert {"Set5_psnr(RGB)", "Set5_ssim"} <= test_metrics
+
+
+# ---------------------------------------------------------------------------
+# cli predict end-to-end (P3.7) — LR-only inference path, both architectures
+# ---------------------------------------------------------------------------
+
+
+def _make_predict_datamodule(image_dir: Path, arch: str) -> SRDataModule:
+    """Predict-only SRDataModule: train_dataset/val_dataset are required by
+    the constructor but never instantiated — setup(stage='predict') only
+    builds predict_dataset, matching every other stage's selective build."""
+    unused_spec = {
+        "class_path": f"sisr.datasets.{arch}.ValidationDataset",
+        "init_args": {"img_dir": str(image_dir), "scale": 2},
+    }
+    return SRDataModule(
+        train_dataset=unused_spec,
+        val_dataset=unused_spec,
+        predict_dataset={
+            "class_path": "sisr.datasets.predict.PredictDataset",
+            "init_args": {"img_dir": str(image_dir)},
+        },
+        predict_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+    )
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_predict_end_to_end_srcnn_y_channel_same_size_output(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """SRCNN's pre-upsampled, Y-channel path: predict output must be the same
+    H/W as the input (scale=1x) and land as one PNG per input file."""
+    from PIL import Image
+
+    model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    module = SRLightning(
+        model=model,
+        processor=YChannelProcessor(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    datamodule = _make_predict_datamodule(tiny_rgb_image_dir, arch="srcnn")
+    out_dir = tmp_path / "predictions"
+    trainer = lightning.Trainer(
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        callbacks=[SRPredictionWriter(output_dir=out_dir)],
+    )
+
+    predictions = trainer.predict(module, datamodule=datamodule)
+
+    assert len(predictions) == 3  # tiny_rgb_image_dir has 3 images, batch_size=1
+    for pred in predictions:
+        assert pred.shape == (1, 3, 36, 36)  # 36x36 input, scale=1x
+
+    written = sorted(p.stem for p in out_dir.glob("*.png"))
+    assert written == ["img_00", "img_01", "img_02"]
+    for name in written:
+        with Image.open(out_dir / f"{name}.png") as img:
+            assert img.size == (36, 36)
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_predict_end_to_end_srresnet_rgb_upsamples_by_scale(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """SRResNet's genuine-LR, RGB path: predict output must be exactly
+    scale x the input H/W."""
+    from PIL import Image
+
+    model = SRResNet(scale=2, num_residual_blocks=1)
+    module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    datamodule = _make_predict_datamodule(tiny_rgb_image_dir, arch="srresnet")
+    out_dir = tmp_path / "predictions"
+    trainer = lightning.Trainer(
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        callbacks=[SRPredictionWriter(output_dir=out_dir)],
+    )
+
+    predictions = trainer.predict(module, datamodule=datamodule)
+
+    assert len(predictions) == 3
+    for pred in predictions:
+        assert pred.shape == (1, 3, 72, 72)  # 36x36 input, scale=2x -> 72x72
+
+    written = sorted(p.stem for p in out_dir.glob("*.png"))
+    assert written == ["img_00", "img_01", "img_02"]
+    for name in written:
+        with Image.open(out_dir / f"{name}.png") as img:
+            assert img.size == (72, 72)

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -607,6 +607,61 @@ def test_hparams_expand_nested_config_fields():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# predict_step — LR-only inference seam (P3.7)
+# ---------------------------------------------------------------------------
+
+
+def test_forward_lr_matches_forward_sr_sr_component(srcnn_rgb_lit: SRLightning, rgb_lr_hr_batch):
+    """_forward_sr's (sr_model_out, sr_rgb) must equal _forward_lr's output on
+    the same LR — the refactor shares the pipeline instead of forking it."""
+    lr, hr = rgb_lr_hr_batch
+    sr_model_out_a, sr_rgb_a, _ = srcnn_rgb_lit._forward_sr(lr, hr)
+    sr_model_out_b, sr_rgb_b = srcnn_rgb_lit._forward_lr(lr)
+    torch.testing.assert_close(sr_model_out_a, sr_model_out_b)
+    torch.testing.assert_close(sr_rgb_a, sr_rgb_b)
+
+
+def test_predict_step_matches_forward_lr_rgb_path(srcnn_rgb_lit: SRLightning):
+    lr = torch.rand(2, 3, 33, 33, generator=torch.Generator().manual_seed(0))
+    _, expected_sr = srcnn_rgb_lit._forward_lr(lr)
+    out = srcnn_rgb_lit.predict_step(lr, batch_idx=0)
+    torch.testing.assert_close(out, expected_sr)
+
+
+def test_predict_step_y_channel_reconstructs_rgb(srcnn_y_lit: SRLightning):
+    """Y-channel model output is 1-channel; predict_step must still return
+    RGB — the processor.reconstruct step stitches back bicubic LR Cb/Cr.
+    srcnn_y_lit uses 'valid' padding (33 -> 21), so the size check locks that
+    same shrinkage; the channel check is the actual regression guard."""
+    lr = torch.rand(2, 3, 33, 33, generator=torch.Generator().manual_seed(1))
+    out = srcnn_y_lit.predict_step(lr, batch_idx=0)
+    assert out.shape == (2, 3, 21, 21)
+
+
+def test_predict_step_srresnet_upsamples_by_scale():
+    """Genuine-LR RGB path: output must be exactly scale x the LR input."""
+    model = SRResNet(scale=2, num_residual_blocks=1)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    lr = torch.rand(1, 3, 12, 12)
+    out = lit.predict_step(lr, batch_idx=0)
+    assert out.shape == (1, 3, 24, 24)
+
+
+def test_predict_step_dataloader_idx_default_is_ignored(srcnn_rgb_lit: SRLightning):
+    """A single predict loader is expected; dataloader_idx must not change output."""
+    lr = torch.rand(1, 3, 33, 33, generator=torch.Generator().manual_seed(2))
+    out_default = srcnn_rgb_lit.predict_step(lr, batch_idx=0)
+    out_explicit = srcnn_rgb_lit.predict_step(lr, batch_idx=0, dataloader_idx=0)
+    torch.testing.assert_close(out_default, out_explicit)
+
+
 def test_val_psnr_is_per_image_mean_not_batch_pooled():
     """Regression (P2.6): PSNR for a batch equals the mean of the per-image
     PSNRs (SR-standard reduction, invariant to val batch_size), not the


### PR DESCRIPTION
> **Stacked on #32** (`feat/config-validation-seam`) — merge that first. This PR targets that branch, so the diff shows only its own changes.

### The gap

`sisr predict` was entirely non-functional. `SRDataModule` had **no `predict_dataloader`**, and `SRLightning` did not override `predict_step` — so Lightning's default would call `self(batch)` on the datasets' `(lr, hr)` tuple and crash.

The deeper problem: **no public path took an LR image to an SR image.**
- `forward()` runs the model *without* the processor — for SRCNN it expects a Y-channel tensor, not an image.
- `predict_rgb(lr, hr)` requires an HR reference that doesn't exist at inference.

Both existing entry points assumed a paired evaluation context. This is the first genuine inference path.

### What makes it work

`YChannelProcessor.reconstruct(sr, lr_rgb)` needs the LR RGB back for chroma — and at inference the LR RGB **is** available. So the full `extract → model → reconstruct` pipeline runs end-to-end without HR; only HR-dependent cropping and scoring drop away.

### `_forward_sr` was extracted, not forked

`_forward_sr` is documented as *"the single source of truth for the forward pipeline … so the training and benchmark-logging paths cannot silently diverge."* Rather than duplicating it, the extract→model→reconstruct core moved into a new `_forward_lr`, which `_forward_sr` now delegates to before applying its unchanged centre crop. `predict_step` calls `_forward_lr` directly.

Independently reviewed and traced line-by-line: `_step`'s behaviour is **unchanged** — same call sites, same arguments, same order, zero logic duplicated.

### Also

- `PredictDataset` reuses `SRDataset` for discovery and the uint8→float32 adapter — no reimplemented globbing.
- `SRPredictionWriter` (a `BasePredictionWriter`) saves 8-bit PNGs to a configurable dir, clamping out-of-range output.
- **Duplicate filename stems now raise at construction** — outputs are named by stem, so `cat.png` + `cat.jpg` would have silently overwritten each other (review finding, `5f7e7db`).

### Tests

243 → **265**. End-to-end `Trainer.predict(...)` for **both** architectures, which exercise genuinely different processor paths: SRCNN through `YChannelProcessor` (non-trivial chroma stitching, same-resolution 36×36) and SRResNet through `RGBProcessor` (identity reconstruct, ×2 upsampling to 72×72).

### Known scope boundaries

- `train_dataset` / `val_dataset` remain required on `SRDataModule` even for predict-only runs.
- `predict_dataset` is typed `dict[str, Any] | None`, matching the existing `train_dataset`/`val_dataset` convention where each spec carries its own `class_path`. The CLI therefore takes it as a JSON spec — consistent with the existing design, not a new wart.
- Templates deliberately untouched.

Reviewed independently: spec PASS, quality APPROVED, one Minor finding fixed.

Part of the 2026-07-31 triage delivery arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)