### PR TITLE
Restructure TensorBoard tags into a metric-first hierarchy (INIT.8)

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -45,9 +45,9 @@ class BenchmarkImageLogger(Callback):
     SR output is center-padded when smaller than HR (``padding='valid'``) so
     all three panels share the same spatial size.
 
-    Per-image PSNR/SSIM scalars go under ``"{name}_psnr/{filename}"`` and
-    ``"{name}_ssim/{filename}"``; per-set means under
-    ``"{name}_psnr({key})"`` and ``"{name}_ssim"``.
+    Per-image PSNR/SSIM scalars go under ``"per_image/{name}/psnr/{key}/{filename}"``
+    and ``"per_image/{name}/ssim/{filename}"``; per-set means under
+    ``"psnr/{name}/{key}"`` and ``"ssim/{name}"``.
 
     Border cropping is sourced from ``pl_module.eval_config.crop_border`` at
     the use site; this avoids dual-knob configuration drift.
@@ -353,8 +353,8 @@ class BenchmarkImageLogger(Callback):
 
             for key in psnr_keys:
                 mean_psnr = sum(s[4][key] for s in samples) / len(samples)
-                pl_module.log(f"{dataset_name}_psnr({key})", mean_psnr, add_dataloader_idx=False)
-            pl_module.log(f"{dataset_name}_ssim", mean_ssim, add_dataloader_idx=False)
+                pl_module.log(f"psnr/{dataset_name}/{key}", mean_psnr, add_dataloader_idx=False)
+            pl_module.log(f"ssim/{dataset_name}", mean_ssim, add_dataloader_idx=False)
 
             if should_log_images:
                 tb_logger = next(
@@ -372,9 +372,13 @@ class BenchmarkImageLogger(Callback):
                 for filename, lr, sr, hr, psnr_dict, ssim in samples:
                     for key, psnr_val in psnr_dict.items():
                         experiment.add_scalar(
-                            f"{dataset_name}_psnr({key})/{filename}", psnr_val, global_step=step
+                            f"per_image/{dataset_name}/psnr/{key}/{filename}",
+                            psnr_val,
+                            global_step=step,
                         )
-                    experiment.add_scalar(f"{dataset_name}_ssim/{filename}", ssim, global_step=step)
+                    experiment.add_scalar(
+                        f"per_image/{dataset_name}/ssim/{filename}", ssim, global_step=step
+                    )
 
                     # Triptych: bicubic | SR | HR, all at HR size.
                     # The bicubic panel is the LR upsampled to HR via bicubic
@@ -448,7 +452,7 @@ class GradNormLogger(Callback):
     """Log the total gradient L2 norm to TensorBoard periodically.
 
     Computes ``sqrt(sum(p.grad.norm() ** 2))`` across all model parameters
-    after the backward pass and logs it as the ``"grad_norm"`` scalar.
+    after the backward pass and logs it as the ``"diag/grad_norm"`` scalar.
 
     Args:
         log_every_n_steps (int): Compute and log every *n* training steps.
@@ -462,6 +466,11 @@ class GradNormLogger(Callback):
     def on_after_backward(self, trainer: lightning.Trainer, pl_module: lightning.LightningModule):
         """Compute and log gradient norm if on the right step cadence.
 
+        Per-parameter norms are stacked and reduced with a single
+        ``torch.linalg.vector_norm`` call so only one ``.item()`` forces a
+        GPU sync, instead of one per parameter (the previous per-parameter
+        ``.item()`` accumulation loop).
+
         Args:
             trainer (lightning.Trainer): The trainer instance.
             pl_module (lightning.LightningModule): The model being trained.
@@ -469,13 +478,12 @@ class GradNormLogger(Callback):
         if trainer.global_step % self.log_every_n_steps != 0:
             return
 
-        total_norm_sq = 0.0
-        for p in pl_module.parameters():
-            if p.grad is not None:
-                total_norm_sq += p.grad.detach().norm(2).item() ** 2
-        total_norm = math.sqrt(total_norm_sq)
+        grad_norms = [p.grad.detach().norm(2) for p in pl_module.parameters() if p.grad is not None]
+        total_norm = (
+            torch.linalg.vector_norm(torch.stack(grad_norms), ord=2).item() if grad_norms else 0.0
+        )
 
-        pl_module.log("grad_norm", total_norm, on_step=True, on_epoch=False)
+        pl_module.log("diag/grad_norm", total_norm, on_step=True, on_epoch=False)
 
 
 class WeightHistogramLogger(Callback):
@@ -484,10 +492,17 @@ class WeightHistogramLogger(Callback):
 
     Args:
         log_every_n_steps (int): Log histograms every *n* training steps.
-            Defaults to ``100``.
+            Defaults to ``10000``. Histograms dominate event-file size, and
+            one is written per tracked parameter on every cadence hit — at
+            the templates' 1M-step schedule the old default of ``100`` was
+            ~10k writes per parameter (multi-GB event files) despite never
+            having been exercised at that scale (this callback is absent
+            from the SRResNet template). ``10000`` drops that to ~100
+            writes per parameter, still enough to see the weight-drift
+            trend across a full run.
     """
 
-    def __init__(self, log_every_n_steps: int = 100):
+    def __init__(self, log_every_n_steps: int = 10000):
         super().__init__()
         self.log_every_n_steps = log_every_n_steps
 
@@ -541,8 +556,8 @@ class SRCheckpoint(ModelCheckpoint):
 
     The filename's metric *label* is sanitised (``/`` -> ``_``) and
     ``auto_insert_metric_name`` is disabled, so a ``/``-bearing
-    ``monitor_metric`` (e.g. a future ``psnr/val/RGB`` TensorBoard-style tag)
-    cannot leak a raw ``/`` into the filename template. Lightning's
+    ``monitor_metric`` (e.g. the default ``psnr/val/RGB`` TensorBoard-hierarchy
+    tag) cannot leak a raw ``/`` into the filename template. Lightning's
     ``_format_checkpoint_name`` does no sanitisation itself, and with
     ``auto_insert_metric_name=True`` (the default) a raw ``/`` there causes
     ``TorchCheckpointIO`` to silently create a nested directory tree per
@@ -552,9 +567,9 @@ class SRCheckpoint(ModelCheckpoint):
 
     Args:
         monitor_metric (str): The validation metric to monitor.
-            Defaults to ``"val_psnr(RGB)"``.  Use any ``val_psnr({key})``
-            logged by the lightning module (e.g. ``"val_psnr(Y)"``,
-            ``"val_psnr(YCbCr)"``) or ``"val_ssim"``.
+            Defaults to ``"psnr/val/RGB"``.  Use any ``psnr/val/{key}``
+            logged by the lightning module (e.g. ``"psnr/val/Y"``,
+            ``"psnr/val/YCbCr"``) or ``"ssim/val"``.
         save_top_k (int): Number of best checkpoints to keep.
             Defaults to ``3``.
         dirpath (str | None): Directory to save checkpoints.
@@ -566,7 +581,7 @@ class SRCheckpoint(ModelCheckpoint):
 
     def __init__(
         self,
-        monitor_metric: str = "val_psnr(RGB)",
+        monitor_metric: str = "psnr/val/RGB",
         save_top_k: int = 3,
         dirpath: str | None = None,
         filename_prefix: str = "sr",
@@ -619,14 +634,14 @@ class SRCheckpoint(ModelCheckpoint):
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
             return
-        valid_metrics = {f"val_psnr({key})" for key in pl_module.eval_config.psnr_keys}
-        valid_metrics.add("val_ssim")
+        valid_metrics = {f"psnr/val/{key}" for key in pl_module.eval_config.psnr_keys}
+        valid_metrics.add("ssim/val")
         if self.monitor is not None and self.monitor not in valid_metrics:
             raise MisconfigurationException(
                 f"`SRCheckpoint(monitor_metric={self.monitor!r})` does not match any "
                 f"metric `SRLightning` will log: {sorted(valid_metrics)}. HINT: check "
                 f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or monitor "
-                f"`val_ssim`."
+                f"`ssim/val`."
             )
 
 

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -9,7 +9,6 @@ training signals; :class:`SRCheckpoint` is a thin
 :class:`SRPredictionWriter` writes ``cli predict`` output to disk as PNGs.
 """
 
-import math
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -496,8 +495,8 @@ class WeightHistogramLogger(Callback):
             one is written per tracked parameter on every cadence hit — at
             the templates' 1M-step schedule the old default of ``100`` was
             ~10k writes per parameter (multi-GB event files) despite never
-            having been exercised at that scale (this callback is absent
-            from the SRResNet template). ``10000`` drops that to ~100
+            having been exercised at that scale (neither tracked template
+            wires this callback). ``10000`` drops that to ~100
             writes per parameter, still enough to see the weight-drift
             trend across a full run.
     """

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -139,12 +139,12 @@ class SREvalConfig:
         psnr_channels: Colorspaces in which PSNR is reported.  Supported
             values are ``'RGB'`` and ``'YCbCr'``.  Multiple entries are
             allowed (e.g. ``['RGB', 'YCbCr']`` produces both
-            ``val_psnr(RGB)`` and ``val_psnr(YCbCr)``).
+            ``psnr/val/RGB`` and ``psnr/val/YCbCr``).
 
         separate_psnr: When ``True``, also reports PSNR for each individual
             channel within each requested colorspace (e.g. ``'RGB'`` adds
-            ``val_psnr(R)`` / ``val_psnr(G)`` / ``val_psnr(B)`` alongside
-            the aggregate ``val_psnr(RGB)``).
+            ``psnr/val/R`` / ``psnr/val/G`` / ``psnr/val/B`` alongside
+            the aggregate ``psnr/val/RGB``).
     """
 
     crop_border: int = 0

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -29,7 +29,7 @@ class SRDataModule(lightning.LightningDataModule):
       so they fire during every val cycle of ``cli fit`` for monitoring
       (driven by :class:`~sisr.training.callbacks.BenchmarkImageLogger`).
       ``dataloader_idx == 0`` is the primary held-out validation loader and
-      drives ``val_loss`` / ``val_psnr`` / ``val_ssim``.
+      drives ``loss/val`` / ``psnr/val`` / ``ssim/val``.
     * :meth:`test_dataloader` returns the test loaders only, for
       ``cli test --ckpt_path <path>`` final evaluation.
 

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -331,7 +331,7 @@ class SRLightning(lightning.LightningModule):
         """Compute training loss for one batch and log it.
 
         Delegates the forward + colorspace + loss pipeline to :meth:`_step`
-        and logs ``train_loss`` on every step for the progress bar.
+        and logs ``loss/train`` on every step for the progress bar.
 
         Args:
             batch: ``(lr_img, hr_img)`` tuple as produced by the
@@ -343,7 +343,7 @@ class SRLightning(lightning.LightningModule):
             Scalar loss tensor for the optimizer.
         """
         loss, *_ = self._step(batch)
-        self.log("train_loss", loss, prog_bar=True, on_step=True)
+        self.log("loss/train", loss, prog_bar=True, on_step=True)
         return loss
 
     def validation_step(
@@ -375,19 +375,19 @@ class SRLightning(lightning.LightningModule):
 
         # add_dataloader_idx=False keeps metric names clean — needed because the
         # primary val loader is at idx 0 of a list that also contains test loaders.
-        self.log("val_loss", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
+        self.log("loss/val", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
         primary = self.eval_config.psnr_channels[0]
         for key in self.eval_config.psnr_keys:
             sr_t, hr_t = psnr_tensors[key]
             self.log(
-                f"val_psnr({key})",
+                f"psnr/val/{key}",
                 self._mean_psnr(sr_t, hr_t),
                 prog_bar=(key == primary),
                 on_step=False,
                 add_dataloader_idx=False,
             )
         self.log(
-            "val_ssim",
+            "ssim/val",
             torchmetrics.functional.image.structural_similarity_index_measure(
                 sr, hr_cropped, data_range=1.0
             ),
@@ -413,8 +413,8 @@ class SRLightning(lightning.LightningModule):
         if not tb_loggers:
             return
         metrics = {
-            **{f"val_psnr({k})": 0.0 for k in self.eval_config.psnr_keys},
-            "val_ssim": 0.0,
+            **{f"psnr/val/{k}": 0.0 for k in self.eval_config.psnr_keys},
+            "ssim/val": 0.0,
         }
         for tb in tb_loggers:
             tb.log_hyperparams(self.hparams, metrics)

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -83,11 +83,11 @@ trainer:
         log_every_n_val_runs: 1
     - class_path: sisr.training.SRCheckpoint
       init_args:
-        monitor_metric: val_psnr(RGB)
+        monitor_metric: psnr/val/RGB
         save_top_k: 3
     - class_path: sisr.training.SRCheckpoint
       init_args:
-        monitor_metric: val_ssim
+        monitor_metric: ssim/val
         save_top_k: 3
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -82,11 +82,11 @@ trainer:
         log_every_n_val_runs: 1
     - class_path: sisr.training.SRCheckpoint
       init_args:
-        monitor_metric: val_psnr(RGB)
+        monitor_metric: psnr/val/RGB
         save_top_k: 3
     - class_path: sisr.training.SRCheckpoint
       init_args:
-        monitor_metric: val_ssim
+        monitor_metric: ssim/val
         save_top_k: 3
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -163,7 +163,7 @@ def test_grad_norm_logger_logs_on_cadence():
     cb.on_after_backward(trainer, pl_module)
     pl_module.log.assert_called_once()
     args, _ = pl_module.log.call_args
-    assert args[0] == "grad_norm"
+    assert args[0] == "diag/grad_norm"
     assert args[1] == pytest.approx(10.0)
 
 
@@ -205,7 +205,7 @@ def test_grad_norm_logger_uses_grad_detach_not_grad_data():
     pl_module = _make_gradnorm_pl_module()
     cb.on_after_backward(trainer, pl_module)
     args, _ = pl_module.log.call_args
-    assert args[0] == "grad_norm"
+    assert args[0] == "diag/grad_norm"
     assert args[1] == pytest.approx(10.0)
 
 
@@ -326,15 +326,15 @@ def test_srcheckpoint_setup_accepts_monitor_matching_psnr_keys(tmp_path: Path):
     """monitor_metric derived from eval_config.psnr_keys must pass setup()
     without raising."""
     pl_module = _make_real_pl_module()  # SREvalConfig(crop_border=0) -> psnr_keys=['RGB']
-    ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath=str(tmp_path))
+    ckpt = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
     ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")  # must not raise
 
 
 @_ignore_gpu_warning
 def test_srcheckpoint_setup_accepts_val_ssim_monitor(tmp_path: Path):
-    """val_ssim is always logged regardless of psnr_keys and must be accepted."""
+    """ssim/val is always logged regardless of psnr_keys and must be accepted."""
     pl_module = _make_real_pl_module()
-    ckpt = SRCheckpoint(monitor_metric="val_ssim", dirpath=str(tmp_path))
+    ckpt = SRCheckpoint(monitor_metric="ssim/val", dirpath=str(tmp_path))
     ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")  # must not raise
 
 
@@ -345,8 +345,8 @@ def test_srcheckpoint_setup_rejects_monitor_not_in_psnr_keys(tmp_path: Path):
     MisconfigurationException at setup() time — startup, not 20k steps into
     training once Lightning's own val_loop._has_run-gated check would fire."""
     pl_module = _make_real_pl_module()
-    ckpt = SRCheckpoint(monitor_metric="val_psnr(Y)", dirpath=str(tmp_path))
-    with pytest.raises(MisconfigurationException, match=r"val_psnr\(Y\)"):
+    ckpt = SRCheckpoint(monitor_metric="psnr/val/Y", dirpath=str(tmp_path))
+    with pytest.raises(MisconfigurationException, match=r"psnr/val/Y"):
         ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")
 
 
@@ -358,8 +358,8 @@ def test_srcheckpoint_setup_error_lists_valid_metrics(tmp_path: Path):
     ckpt = SRCheckpoint(monitor_metric="bogus_metric", dirpath=str(tmp_path))
     with pytest.raises(MisconfigurationException) as exc_info:
         ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")
-    assert "val_psnr(RGB)" in str(exc_info.value)
-    assert "val_ssim" in str(exc_info.value)
+    assert "psnr/val/RGB" in str(exc_info.value)
+    assert "ssim/val" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------
@@ -458,10 +458,10 @@ def test_benchmark_validation_epoch_end_logs_means():
     cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
     # Two log calls per dataset: psnr + ssim.
     log_keys = [call.args[0] for call in pl_module.log.call_args_list]
-    assert "Set5_psnr(RGB)" in log_keys
-    assert "Set5_ssim" in log_keys
+    assert "psnr/Set5/RGB" in log_keys
+    assert "ssim/Set5" in log_keys
     # Mean PSNR = (30.0 + 32.0) / 2 = 31.0
-    psnr_call = next(c for c in pl_module.log.call_args_list if c.args[0] == "Set5_psnr(RGB)")
+    psnr_call = next(c for c in pl_module.log.call_args_list if c.args[0] == "psnr/Set5/RGB")
     assert psnr_call.args[1] == pytest.approx(31.0)
 
 
@@ -504,7 +504,7 @@ def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path:
     assert strip.ndim == 3 and strip.shape[0] == 3  # (C, H, W) triptych
     # One psnr scalar (RGB) + one ssim scalar for the single buffered image.
     scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
-    assert scalar_tags == ["Set5_psnr(RGB)/img_0", "Set5_ssim/img_0"]
+    assert scalar_tags == ["per_image/Set5/psnr/RGB/img_0", "per_image/Set5/ssim/img_0"]
 
 
 def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path, monkeypatch):
@@ -618,7 +618,7 @@ def test_benchmark_test_epoch_end_logs_means():
     trainer = SimpleNamespace(global_step=0, loggers=[])
     cb.on_test_epoch_end(trainer=trainer, pl_module=pl_module)
     log_keys = [call.args[0] for call in pl_module.log.call_args_list]
-    assert "Set5_psnr(RGB)" in log_keys
+    assert "psnr/Set5/RGB" in log_keys
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -100,15 +100,15 @@ def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
     trainer.fit(module, datamodule=datamodule)
     fit_metrics = set(trainer.callback_metrics)
     # Module-logged: training_step + validation_step on the primary val loader (idx 0).
-    assert {"train_loss", "val_loss", "val_psnr(RGB)", "val_ssim"} <= fit_metrics
+    assert {"loss/train", "loss/val", "psnr/val/RGB", "ssim/val"} <= fit_metrics
     # Callback-logged for the Set5 test loader (val_dataloader idx 1) — proves
     # BenchmarkImageLogger auto-discovered the datamodule's test set and ran.
-    assert {"Set5_psnr(RGB)", "Set5_ssim"} <= fit_metrics
+    assert {"psnr/Set5/RGB", "ssim/Set5"} <= fit_metrics
 
     trainer.test(module, datamodule=datamodule)
     test_metrics = set(trainer.callback_metrics)
     # test_step is a no-op; these come solely from BenchmarkImageLogger.on_test_*.
-    assert {"Set5_psnr(RGB)", "Set5_ssim"} <= test_metrics
+    assert {"psnr/Set5/RGB", "ssim/Set5"} <= test_metrics
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -345,8 +345,8 @@ def test_on_train_start_logs_hparams_with_val_metrics(srcnn_rgb_lit: SRLightning
     params_arg = args[0] if args else kwargs.get("params")
     metrics_arg = args[1] if len(args) > 1 else kwargs.get("metrics")
 
-    expected_metrics = {f"val_psnr({k})": 0.0 for k in srcnn_rgb_lit.eval_config.psnr_keys}
-    expected_metrics["val_ssim"] = 0.0
+    expected_metrics = {f"psnr/val/{k}": 0.0 for k in srcnn_rgb_lit.eval_config.psnr_keys}
+    expected_metrics["ssim/val"] = 0.0
 
     assert params_arg == srcnn_rgb_lit.hparams
     assert metrics_arg == expected_metrics


### PR DESCRIPTION
> **Stacked on #33** (which is stacked on #32). Merge #32 → #33 → this. Also contains a merge of `chore/template-dry` (#31), since the rename must touch templates that PR deduplicated.

### The problem

TensorBoard groups on `/`, and almost nothing had one. `train_loss`, `val_loss`, `val_ssim`, `val_psnr(RGB)`, `grad_norm`, `Set5_psnr(RGB)`, `Set5_ssim` were all top-level. Worse, per-image tags `Set5_psnr(RGB)/{filename}` created a **group** named `Set5_psnr(RGB)` sitting beside a same-named **scalar**.

### The scheme — metric-type first

```
loss/train              loss/val
psnr/val/RGB            psnr/val/YCbCr
psnr/Set5/RGB           psnr/Set14/RGB
ssim/val                ssim/Set5
per_image/Set5/psnr/RGB/{filename}
diag/grad_norm
```

Chosen over split-first grouping (`train/loss`, `val/psnr/RGB`) because metric-kind-first puts train and val loss in one panel for direct comparison and keeps all PSNR together regardless of split.

Per-image tags carry a `{key}` segment the illustrative design omitted — both architectures default to `psnr_channels: ["RGB", "YCbCr"]`, so without it the RGB and YCbCr per-image means collide on one tag.

### Why this needed #33 first

The monitor string is interpolated into the checkpoint filename, and `/` is a path separator. Lightning's `_format_checkpoint_name` does **no** sanitisation, and `TorchCheckpointIO.save_checkpoint` calls `fs.makedirs(os.path.dirname(path), exist_ok=True)` — so a renamed monitor would have **silently created a `psnr/val/` directory tree per save**.

#33 defused that (`auto_insert_metric_name=False` + a self-supplied flattened label). Verified by a real `fit` run here: filenames come out flat as `sr-1-psnr_val_RGB=7.1435.ckpt`, with no nested directories under `checkpoints/`.

### Landed in lockstep — all five, or the monitor silently stops firing

Emitted tags · HParams registration in `on_train_start` · `BenchmarkImageLogger` per-set and per-image tags · `monitor_metric` in both tracked templates · `SRCheckpoint.setup`'s validation set. Reviewer independently grepped for stragglers: none.

### Two independent perf fixes

- **`GradNormLogger`** called `.item()` **per parameter** — one GPU sync each. Now stacks per-parameter norms on-device and takes a single `vector_norm`: one sync instead of N. Same value, since the L2 norm of per-partition norms equals the global L2 norm.
- **`WeightHistogramLogger`** default `100` → `10000`. At the templates' 1M-step schedule the old default meant ~10k histogram writes **per parameter**, and histograms dominate event-file size — multi-GB runs. Never exercised at that scale, since neither tracked template wires this callback.

### Known limitation

`LearningRateMonitor` is a stock Lightning callback naming its own tags (`lr-SGD/pgN`); it stays outside the scheme rather than wrapping Lightning internals to force it.

**Tests:** 251 passing. Reviewed independently: spec PASS (all five lockstep points traced), quality APPROVED, one Minor docstring fix in `0b4dcca`.

Part of the 2026-07-31 triage delivery arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)