### PR TITLE
Cache SRResNet HR images raw in LMDB, eliminating per-crop PNG re-decode (INIT.13)

### DIFF
--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -14,8 +14,9 @@ torch-free; colorspace math lives in :mod:`sisr.colorspace` for this reason.
 
 import os
 import shutil
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -233,6 +234,31 @@ class LMDBCache:
             if buf is None:
                 return None
             return bytes(buf)
+
+    @contextmanager
+    def get_buffer(self, key: str) -> Iterator[memoryview | None]:
+        """Yields a zero-copy view onto the raw value stored at *key*.
+
+        The read transaction is opened on entry and committed on exit, so the
+        yielded ``memoryview`` aliases memory that is **only valid inside this
+        ``with`` block** — LMDB is free to reclaim it the moment the
+        transaction closes. Do all interpretation (``np.frombuffer``, slicing)
+        and copying (``.copy()``, ``torch.from_numpy(...).clone()``) *before*
+        the block exits. This is a context manager rather than a plain return
+        specifically so a caller cannot accidentally retain the view past its
+        transaction — there is no variable holding the buffer until you
+        actually enter the ``with``.
+
+        Args:
+            key (str): The string key to look up.
+
+        Yields:
+            A ``memoryview`` onto the raw value bytes, or ``None`` if *key* is
+            absent.
+        """
+        env = self.get_env()
+        with env.begin(write=False, buffers=True) as txn:
+            yield txn.get(key.encode())
 
     def get_batch(self, keys: Sequence[str]) -> list[bytes | None]:
         """Reads multiple values from the cache in a single transaction.

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -2,36 +2,80 @@
 
 LR is the bicubic downscale of HR by ``scale`` (no upsample round-trip);
 the model is responsible for the ×``scale`` upsampling. :class:`TrainDataset`
-serves random ``hr_crop_size`` crops without caching (random crops aren't
-cacheable); :class:`ValidationDataset` serves full images cropped to a
-multiple of ``scale``.
+caches full decoded HR images (raw, uint8) through :class:`~sisr.cache.LMDBCache`
+— decoding a DIV2K PNG costs ~109ms, while the 96x96 crop kept from it costs
+~1ms, so re-decoding per crop is ~99% wasted work. The random crop itself is
+**not** cached (that would defeat crop randomness); it is drawn fresh, from
+the cached raw array, on every ``__getitem__`` call.
+:class:`ValidationDataset` serves full images cropped to a multiple of
+``scale``, uncached (each is decoded once per epoch, no repetition).
 """
 
+import hashlib
+import random
+import struct
 from pathlib import Path
 
 import albumentations as A
 import cv2
+import numpy as np
 import torch
 from albumentations.pytorch import ToTensorV2
+from PIL import Image
 
+from ..cache import LMDBCache, LMDBCacheBuildContext
 from .base import SRDataset
+
+# (height, width) as little-endian uint32 each, prefixed to every cached HR
+# value so a per-image shape (DIV2K images vary in size) travels with its
+# pixel data in one LMDB read instead of a second lookup.
+_SHAPE_HEADER = struct.Struct("<II")
+
+
+def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
+    """Decodes one HR image and returns its single LMDB entry.
+
+    Top-level (not a method) so it can be pickled by ``ProcessPoolExecutor``
+    across all platforms, mirroring :func:`sisr.datasets.srcnn._process_subimages`.
+
+    Args:
+        path (Path): File path of the high-resolution image.
+        idx (int): This image's position in the manifest — determines its LMDB key.
+
+    Returns:
+        A single-element list ``[(f'hr_{idx:08d}', header + raw_bytes)]`` where
+        *header* is :data:`_SHAPE_HEADER`-packed ``(h, w)`` and *raw_bytes* is
+        the ``(H, W, 3)`` uint8 RGB array's bytes.
+    """
+    arr = np.array(Image.open(path).convert("RGB"))
+    h, w = arr.shape[:2]
+    value = _SHAPE_HEADER.pack(h, w) + arr.tobytes()
+    return [(f"hr_{idx:08d}", value)]
 
 
 class TrainDataset(SRDataset):
-    """Random-crop HR/LR pairs for SRResNet-style training (AlbumentationsX backend).
+    """Random-crop HR/LR pairs for SRResNet-style training, HR served from an
+    LMDB cache of full raw images.
 
-    Each ``__getitem__`` takes a random ``hr_crop_size`` square crop from an
-    HR image via :class:`albumentations.RandomCrop` and bicubic-downsamples
-    it by ``scale`` (via :class:`albumentations.Resize` with
-    ``cv2.INTER_CUBIC``) to form the LR input. Unlike
+    On first instantiation with a given set of parameters, every HR image is
+    decoded once and stored whole (uint8, RGB, with its own ``(H, W)`` header)
+    in an LMDB database — see module docstring for why. Each ``__getitem__``
+    then reads that image's cached bytes via a zero-copy
+    :meth:`~sisr.cache.LMDBCache.get_buffer` view, takes a fresh random
+    ``hr_crop_size`` square crop (plain numpy slicing — crop randomness must
+    survive the cache, so only the *decode* is memoized, never the crop), and
+    bicubic-downsamples it by ``scale`` (via :class:`albumentations.Resize`
+    with ``cv2.INTER_CUBIC``) to form the LR input. Unlike
     :class:`sisr.datasets.srcnn.TrainDataset` there is **no
     blur+downsample+upsample round-trip** and the LR is *not* upsampled back —
     the model is responsible for the ×``scale`` upsampling, so the LR tensor is
     ``hr_crop_size // scale`` on a side.
 
-    Crops are generated on the fly (so they differ every epoch); there is no
-    LMDB cache because random crops are not cacheable. HR is always served as
-    RGB; Y/YCbCr selection happens downstream in :class:`SRLightning`.
+    Because the cache holds whole decoded images rather than crops, it is independent of
+    ``hr_crop_size``/``crops_per_image``/``scale`` — the checksum keys only on
+    the file manifest, so changing the crop recipe never invalidates the
+    cache. HR is always served as RGB; Y/YCbCr selection happens downstream in
+    :class:`SRLightning`.
 
     Reference:
         Photo-Realistic Single Image Super-Resolution Using a Generative
@@ -43,7 +87,17 @@ class TrainDataset(SRDataset):
         hr_crop_size (int): Side length of the square HR crop.
         crops_per_image (int): Number of random crops drawn per image per
             epoch (the dataset length is ``len(images) * crops_per_image``).
-            Defaults to ``1``.
+            Each draw re-reads the same cached array (a cheap mmap access, not
+            a decode) and takes an independently random crop. Defaults to ``1``.
+        use_tqdm (bool): Whether to display a progress bar during the LMDB
+            build. Defaults to ``False``.
+        cache_dir (str | Path | None): Directory in which to store the LMDB
+            cache. Defaults to ``img_dir / '.lmdb_cache'``.
+        build_num_workers (int | None): Number of worker processes for the
+            one-time LMDB build. ``None`` (default) uses
+            ``min(os.cpu_count() or 1, num_images)``; a value that resolves to
+            ``<= 1`` effective workers runs an inline, no-subprocess build.
+            Only affects cache construction, not data loading.
 
     Raises:
         ValueError: If no images are found, or ``hr_crop_size`` is not
@@ -56,6 +110,9 @@ class TrainDataset(SRDataset):
         scale: int,
         hr_crop_size: int,
         crops_per_image: int = 1,
+        use_tqdm: bool = False,
+        cache_dir: str | Path | None = None,
+        build_num_workers: int | None = None,
     ):
         super().__init__()
 
@@ -66,9 +123,9 @@ class TrainDataset(SRDataset):
         self.scale = scale
         self.hr_crop_size = hr_crop_size
         self.crops_per_image = crops_per_image
+        self.build_num_workers = build_num_workers
 
         lr_size = hr_crop_size // scale
-        self._hr_crop = A.Compose([A.RandomCrop(hr_crop_size, hr_crop_size)])
         self._lr_pipeline = A.Compose(
             [
                 A.Resize(lr_size, lr_size, interpolation=cv2.INTER_CUBIC),
@@ -77,6 +134,64 @@ class TrainDataset(SRDataset):
             ]
         )
         self._hr_to_tensor = self._to_tensor_transform()
+
+        cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
+        checksum = self._compute_checksum()
+        map_size = max(int(self._estimate_raw_bytes() * 1.1), 64 * 1024 * 1024)
+
+        self._cache = LMDBCache(
+            cache_dir=cache_dir,
+            name="srresnet_hr",
+            checksum=checksum,
+            length=len(self.img_paths),
+            map_size=map_size,
+            metadata={"format": "raw_rgb_v1"},
+            build_fn=self._build,
+            use_tqdm=use_tqdm,
+        )
+
+    def _compute_checksum(self) -> str:
+        """Computes a SHA-256 checksum over the file manifest only.
+
+        Unlike :meth:`sisr.datasets.srcnn.TrainDataset._compute_checksum`, no
+        crop/scale parameter enters this hash: the cache stores whole raw
+        images, so it is valid for any ``hr_crop_size``/``crops_per_image``/
+        ``scale`` combination over the same file set.
+
+        Returns:
+            A hex-encoded SHA-256 digest string.
+        """
+        file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in self.img_paths)
+        canonical = "|".join([file_manifest, "format=raw_rgb_v1"])
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def _estimate_raw_bytes(self) -> int:
+        """Sums each image's decoded byte size from its header, without decoding pixels.
+
+        Returns:
+            Total bytes the LMDB build will write (header + raw RGB per image).
+        """
+        total = 0
+        for path in self.img_paths:
+            img = Image.open(path)
+            w, h = img.size
+            img.close()
+            total += _SHAPE_HEADER.size + h * w * 3
+        return total
+
+    def _build(self, ctx: LMDBCacheBuildContext) -> None:
+        """Populates the LMDB cache by decoding each HR image once in parallel.
+
+        Args:
+            ctx (LMDBCacheBuildContext): Build context provided by :class:`~sisr.cache.LMDBCache`.
+        """
+        ctx.parallel_build(
+            items=self.img_paths,
+            process_fn=_process_hr_image,
+            process_args=[(i,) for i in range(len(self.img_paths))],
+            num_workers=self.build_num_workers,
+            desc="Building SRResNet HR cache",
+        )
 
     def __len__(self) -> int:
         return len(self.img_paths) * self.crops_per_image
@@ -89,16 +204,24 @@ class TrainDataset(SRDataset):
         ``hr_crop_size // scale``). Both are ``float32`` in ``[0, 1]``
         with shape ``(3, H, W)``.
         """
-        path = self.img_paths[idx % len(self.img_paths)]
-        arr = self._load_rgb(path)  # HWC uint8 RGB
+        img_idx = idx % len(self.img_paths)
+        key = f"hr_{img_idx:08d}"
 
-        h, w = arr.shape[:2]
-        if w < self.hr_crop_size or h < self.hr_crop_size:
-            raise ValueError(
-                f"Image {path.name} ({w}x{h}) is smaller than hr_crop_size {self.hr_crop_size}."
-            )
-
-        hr_arr = self._hr_crop(image=arr)["image"]  # HWC uint8
+        with self._cache.get_buffer(key) as buf:
+            if buf is None:
+                raise KeyError(key)
+            h, w = _SHAPE_HEADER.unpack_from(buf, 0)
+            if w < self.hr_crop_size or h < self.hr_crop_size:
+                raise ValueError(
+                    f"Image {self.img_paths[img_idx].name} ({w}x{h}) is smaller than "
+                    f"hr_crop_size {self.hr_crop_size}."
+                )
+            # Read-only view into the LMDB transaction's mmap page — sliced and
+            # copied out below, before the `with` block ends and the view dies.
+            arr = np.frombuffer(buf, dtype=np.uint8, offset=_SHAPE_HEADER.size).reshape(h, w, 3)
+            top = random.randint(0, h - self.hr_crop_size)
+            left = random.randint(0, w - self.hr_crop_size)
+            hr_arr = arr[top : top + self.hr_crop_size, left : left + self.hr_crop_size, :].copy()
 
         lr_tensor = self._lr_pipeline(image=hr_arr)["image"]
         hr_tensor = self._hr_to_tensor(image=hr_arr)["image"]

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -137,6 +137,10 @@ class TrainDataset(SRDataset):
 
         cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
         checksum = self._compute_checksum()
+        # Exact sizes from image headers + 10% slack. If it is ever exceeded,
+        # lmdb raises MapFullError mid-build and the checksum is never written,
+        # so the partial DB reads as stale and is rebuilt rather than silently
+        # serving truncated data. Same unhandled-overflow behaviour as SRCNN's cache.
         map_size = max(int(self._estimate_raw_bytes() * 1.1), 64 * 1024 * 1024)
 
         self._cache = LMDBCache(

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -32,6 +32,8 @@ data:
       scale: *scale
       hr_crop_size: 96
       crops_per_image: 1
+      use_tqdm: true
+      cache_dir: .lmdb_cache/DIV2K_train_HR
   val_dataset:
     class_path: sisr.datasets.srresnet.ValidationDataset
     init_args:

--- a/tests/datasets/test_srresnet.py
+++ b/tests/datasets/test_srresnet.py
@@ -1,9 +1,28 @@
+from contextlib import contextmanager
 from pathlib import Path
+from unittest.mock import patch
 
+import numpy as np
 import pytest
 import torch
+from PIL import Image
 
 from sisr.datasets.srresnet import TrainDataset, ValidationDataset
+
+
+@pytest.fixture
+def varied_size_rgb_image_dir(tmp_path: Path) -> Path:
+    """Tmp dir with 3 RGB PNGs of different, non-square sizes.
+
+    Exercises the per-image ``(H, W)`` shape header the LMDB cache stores —
+    DIV2K images vary in size, unlike SRCNN's fixed sub-image constants.
+    """
+    rng = np.random.default_rng(seed=1)
+    for i, (h, w) in enumerate([(36, 36), (48, 32), (30, 50)]):
+        arr = rng.integers(0, 256, size=(h, w, 3), dtype=np.uint8)
+        Image.fromarray(arr).save(tmp_path / f"img_{i:02d}.png")
+    return tmp_path
+
 
 # ---------------------------------------------------------------------------
 # TrainDataset (random-crop)
@@ -80,6 +99,186 @@ def test_train_dataset_random_crop_varies_across_calls(tiny_rgb_image_dir: Path)
         not torch.equal(hrs[i], hrs[j]) for i in range(len(hrs)) for j in range(i + 1, len(hrs))
     )
     assert differ, "A.RandomCrop must yield varying HR crops across calls"
+
+
+# ---------------------------------------------------------------------------
+# TrainDataset LMDB HR cache (INIT.13)
+# ---------------------------------------------------------------------------
+
+
+def test_train_dataset_getitem_matches_source_pixels(varied_size_rgb_image_dir: Path):
+    """The cached-and-cropped HR tensor must reproduce the source image's own
+    pixels for the cropped region -- not merely the right shape. Guards
+    against an off-by-header-offset or transposed (H, W) bug in the zero-copy
+    read path, which shape/range assertions alone would miss."""
+    ds = TrainDataset(
+        img_dir=varied_size_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=varied_size_rgb_image_dir / ".lmdb_cache",
+        build_num_workers=1,
+    )
+    lr, hr = ds[1]  # 48x32 image
+    assert hr.shape == (3, 16, 16)
+    assert lr.shape == (3, 8, 8)
+
+    hr_uint8 = (hr.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
+    source = np.array(Image.open(ds.img_paths[1]).convert("RGB"))
+    # The crop must appear verbatim somewhere in the source image (a random
+    # offset, but an exact contiguous 16x16 block of it).
+    found = any(
+        np.array_equal(source[top : top + 16, left : left + 16, :], hr_uint8)
+        for top in range(0, 48 - 16 + 1)
+        for left in range(0, 32 - 16 + 1)
+    )
+    assert found, "cropped HR tensor does not match any 16x16 block of its source image"
+
+
+def test_train_dataset_varied_image_sizes_round_trip(varied_size_rgb_image_dir: Path):
+    """Each image's own (H, W) header must be used to reshape its bytes --
+    a fixed-constant reshape (as SRCNN uses, safely, for same-size sub-images)
+    would corrupt every non-square image here."""
+    ds = TrainDataset(
+        img_dir=varied_size_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=varied_size_rgb_image_dir / ".lmdb_cache",
+        build_num_workers=1,
+    )
+    for i in range(3):
+        lr, hr = ds[i]
+        assert hr.shape == (3, 16, 16)
+        assert lr.shape == (3, 8, 8)
+
+
+def test_train_dataset_cache_reuse_skips_rebuild(tiny_rgb_image_dir: Path):
+    """Second instantiation with the same file set must not re-decode images."""
+    cache_dir = tiny_rgb_image_dir / ".lmdb_cache"
+    TrainDataset(
+        img_dir=tiny_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=cache_dir,
+        build_num_workers=1,
+    )
+    with patch("sisr.datasets.srresnet._process_hr_image") as mock_proc:
+        TrainDataset(
+            img_dir=tiny_rgb_image_dir,
+            scale=2,
+            hr_crop_size=16,
+            cache_dir=cache_dir,
+            build_num_workers=1,
+        )
+        mock_proc.assert_not_called()
+
+
+def test_train_dataset_cache_independent_of_crop_params(tiny_rgb_image_dir: Path):
+    """The cache stores whole images, so changing hr_crop_size/crops_per_image/
+    scale over the same file set must NOT trigger a rebuild (contrast SRCNN,
+    whose checksum bakes in sub_img_size/stride/scale/blur_sigma)."""
+    cache_dir = tiny_rgb_image_dir / ".lmdb_cache"
+    TrainDataset(
+        img_dir=tiny_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        crops_per_image=1,
+        cache_dir=cache_dir,
+        build_num_workers=1,
+    )
+    with patch("sisr.datasets.srresnet._process_hr_image") as mock_proc:
+        TrainDataset(
+            img_dir=tiny_rgb_image_dir,
+            scale=4,
+            hr_crop_size=32,
+            crops_per_image=5,
+            cache_dir=cache_dir,
+            build_num_workers=1,
+        )
+        mock_proc.assert_not_called()
+
+
+def test_train_dataset_crops_per_image_reuses_one_cached_read(tiny_rgb_image_dir: Path):
+    """crops_per_image=N must decode each image exactly once at build time --
+    not once per crop -- regardless of how many items are drawn."""
+    import sisr.datasets.srresnet as srresnet_mod
+
+    with patch(
+        "sisr.datasets.srresnet._process_hr_image", wraps=srresnet_mod._process_hr_image
+    ) as mock_proc:
+        ds = TrainDataset(
+            img_dir=tiny_rgb_image_dir,
+            scale=2,
+            hr_crop_size=16,
+            crops_per_image=5,
+            cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
+            build_num_workers=1,
+        )
+        assert mock_proc.call_count == 3  # one decode per image, not per crop
+    assert len(ds) == 3 * 5
+    for i in range(len(ds)):
+        lr, hr = ds[i]
+        assert hr.shape == (3, 16, 16)
+
+
+def test_train_dataset_missing_key_raises_keyerror(tiny_rgb_image_dir: Path):
+    """A missing LMDB key (corrupt/incomplete cache) must surface as a
+    KeyError naming the key, not a cryptic struct.error from unpacking None.
+
+    __getitem__ maps idx via modulo into always-valid image indices, so an
+    out-of-range idx (SRCNN's approach) can't reach this path here -- instead
+    force get_buffer to report a miss, as a genuinely stale cache would."""
+    ds = TrainDataset(
+        img_dir=tiny_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
+        build_num_workers=1,
+    )
+
+    @contextmanager
+    def _always_missing(key):
+        yield None
+
+    with patch.object(ds._cache, "get_buffer", side_effect=_always_missing):
+        with pytest.raises(KeyError, match=r"hr_\d{8}"):
+            ds[0]
+
+
+def test_train_dataset_build_num_workers_1_builds_inline(tiny_rgb_image_dir: Path):
+    """build_num_workers=1 must thread through to an inline LMDB build (no
+    ProcessPoolExecutor), safe inside a test/xdist worker."""
+    with patch("sisr.cache.ProcessPoolExecutor") as mock_pool:
+        ds = TrainDataset(
+            img_dir=tiny_rgb_image_dir,
+            scale=2,
+            hr_crop_size=16,
+            cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
+            build_num_workers=1,
+        )
+    mock_pool.assert_not_called()
+    lr, hr = ds[0]
+    assert hr.shape == (3, 16, 16)
+
+
+def test_train_dataset_checksum_ignores_crop_params(tiny_rgb_image_dir: Path):
+    """_compute_checksum must depend only on the file manifest, not on
+    hr_crop_size/crops_per_image/scale."""
+    ds_a = TrainDataset(
+        img_dir=tiny_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
+        build_num_workers=1,
+    )
+    ds_b = TrainDataset(
+        img_dir=tiny_rgb_image_dir,
+        scale=4,
+        hr_crop_size=32,
+        crops_per_image=3,
+        cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
+        build_num_workers=1,
+    )
+    assert ds_a._compute_checksum() == ds_b._compute_checksum()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -77,6 +77,88 @@ def test_lmdb_get_method(tmp_path: Path):
     assert cache.get("missing") is None
 
 
+def test_lmdb_get_buffer_yields_memoryview_matching_get(tmp_path: Path):
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=3,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(3),
+    )
+    with cache.get_buffer("key_1") as buf:
+        assert isinstance(buf, memoryview)
+        assert bytes(buf) == b"v1"
+
+
+def test_lmdb_get_buffer_yields_none_for_missing_key(tmp_path: Path):
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    with cache.get_buffer("missing") as buf:
+        assert buf is None
+
+
+def test_lmdb_get_buffer_is_a_context_manager_not_a_plain_value(tmp_path: Path):
+    """get_buffer() itself must return a context manager, not the buffer --
+    misuse (retaining the view past its transaction) requires deliberately
+    working around the API shape rather than just calling it normally."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    ctx = cache.get_buffer("key_0")
+    assert hasattr(ctx, "__enter__") and hasattr(ctx, "__exit__")
+    assert not isinstance(ctx, (bytes, memoryview))
+
+
+def test_lmdb_get_buffer_does_not_leak_read_transactions(tmp_path: Path):
+    """Each with-block must commit its transaction on exit rather than leaking
+    it -- LMDB's default max_readers is 126, so many sequential get_buffer
+    calls would raise lmdb.ReadersFullError if the context manager failed to
+    close the transaction it opened."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    for _ in range(300):
+        with cache.get_buffer("key_0") as buf:
+            assert bytes(buf) == b"v0"
+
+
+def test_lmdb_get_buffer_propagates_exception_and_stays_usable(tmp_path: Path):
+    """An exception raised inside the with-block must propagate (the
+    transaction aborts, it isn't swallowed), and the cache must remain
+    readable afterward -- the aborted transaction must not corrupt or lock
+    the read-only environment for subsequent reads."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    with pytest.raises(ValueError, match="boom"):
+        with cache.get_buffer("key_0"):
+            raise ValueError("boom")
+    with cache.get_buffer("key_0") as buf:
+        assert bytes(buf) == b"v0"
+
+
 def test_lmdb_get_batch(tmp_path: Path):
     cache = LMDBCache(
         cache_dir=tmp_path,


### PR DESCRIPTION
> **Stacked on #31** (`chore/template-dry`) — merge that first.

### The problem, measured

`TrainDataset.__getitem__` decoded a full DIV2K HR PNG to keep one 96×96 crop. Profiled over 20 real images (mean 2.92 MP):

| Stage | Mean | Share |
|---|---|---|
| **decode (full PNG)** | **108.8 ms** | **98.94%** |
| random crop (slice) | 1.04 ms | 0.95% |
| resize 96→24 | 0.12 ms | 0.11% |

**0.316% pixel utilisation, 316× amplification.** And because `__len__` is `len(img_paths) * crops_per_image` while `__getitem__` indexes `img_paths[idx % len(img_paths)]`, `crops_per_image: N` **re-decoded the same image N times**.

This was invisible to every GPU-side optimisation — AMP, `channels_last`, `torch.compile` all leave it untouched. It's also why GPU augmentation couldn't have helped: the op being moved was ~1% of the cost.

### The fix

Cache each HR image **raw** in LMDB; random-crop and derive LR in-process at load. Crop randomness is fully preserved — an oversized-tile compromise (cache 128×128, crop 96×96 within) was rejected, because the point is eliminating decode, not reducing bytes read.

**Measured on the full 800-image DIV2K set:** build 35.3 s one-off; warm steady-state read **~0.05 ms**. Cold first touch is ~11–15 ms (real disk I/O on a fresh ~6.6 GB mmap), paid once per image rather than once per crop.

### Three things SRCNN's cache didn't need

1. **Zero-copy reads.** `LMDBCache.get()` copies the whole value, which would discard most of the win. New `get_buffer()` is a **context manager** yielding the memoryview, so the buffer's lifetime is structurally tied to its transaction rather than to caller discipline.
2. **Per-image shape metadata.** DIV2K images vary, so an 8-byte `struct("<II")` (H, W) header prefixes each value — one lookup, no second key.
3. **`map_size`** computed from real per-image header sizes × 1.1 (not hardcoded), floor 64 MiB.

`crops_per_image: N` now takes N cached reads instead of N decodes.

### Memory safety

LMDB buffers with `buffers=True` are valid **only inside the transaction**, and neither `np.frombuffer` nor slicing copies — so a returned crop could alias freed mmap pages. The dataset `.copy()`s the crop **before** the `with` block exits; nothing stores the buffer or a derived view.

The reviewer verified this empirically rather than by inspection: reproduced the hazard with an uncopied view (bytes turned to garbage after ~1000 write commits), then confirmed the `.copy()` pattern used here survives identical stress.

### Scope

SRCNN's cache is deliberately untouched — it stores both `lr_` and `hr_` keys and converting it is a separate PR. `sisr/cache.py` remains torch-free (guard still passing); build workers run under spawn and would otherwise pay a ~10s torch import each.

**Tests:** 217 → **230**. Reviewed independently: spec PASS, quality APPROVED, one Minor documented in `0cd2fa6`.

Part of the 2026-07-31 triage delivery arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)