### PR TITLE
Add opt-in bare-model ONNX export with CI parity check (INIT.7)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,12 +86,36 @@ jobs:
           path: coverage.xml
           retention-days: 14
 
+  # Numeric-parity check for the opt-in ONNX export (INIT.7): torch eager vs.
+  # onnxruntime CPU (GitHub runners have no GPU), both architectures. Single
+  # OS/Python leg — a correctness check on one code path, not a compatibility
+  # matrix. Installs the `export` extra explicitly since test-matrix's `.[dev]`
+  # deliberately excludes it (onnx/onnxruntime stay opt-in for contributors).
+  onnx-export:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-suffix: onnx-export
+      - name: Install
+        run: uv pip install --system -e ".[dev,export]"
+      - name: ONNX export parity tests
+        run: pytest tests/test_export.py tests/test_cli.py -k export -v
+
   # Stable required-check context: green only if every matrix leg passed
   # (legs report as "test-matrix (os, ver)", which are not fixed contexts).
   test:
-    needs: test-matrix
+    needs: [test-matrix, onnx-export]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Require all matrix legs to pass
-        run: '[ "${{ needs.test-matrix.result }}" = "success" ]'
+        run: |
+          [ "${{ needs.test-matrix.result }}" = "success" ]
+          [ "${{ needs.onnx-export.result }}" = "success" ]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,59 @@ sisr test --config templates/config.srcnn.template.yaml \
 Test sets are also surfaced during `fit` (monitored each validation cycle). The `sisr`
 console script is registered by `pyproject.toml`; `python -m sisr.cli ...` works too.
 
+## ONNX export
+
+Trained models can be exported to ONNX for inference outside this framework — install
+the optional extra first:
+
+```bash
+pip install ".[export]"     # or: python -m uv pip install ".[export]"
+
+sisr export --config templates/config.srresnet.template.yaml \
+    --ckpt_path path/to/best.ckpt --output_path model.onnx
+```
+
+`sisr.export.to_onnx(...)` is the underlying function, for exporting from Python
+directly (e.g. right after `trainer.fit(...)`, without a checkpoint round-trip):
+
+```python
+from sisr.export import to_onnx
+
+to_onnx(sr_lightning_module, "model.onnx")
+```
+
+**What gets exported — the bare model, not the processor.** The graph is exactly
+`SRLightning.forward`: the wrapped `SRModel`, with no `SRProcessor` colorspace step.
+Consumers are expected to have `sisr` importable and call `processor.extract` /
+`processor.reconstruct` themselves — that keeps the graph honest about what it actually
+computes, rather than silently baking in Python-side pre/post-processing an ONNX runtime
+can't see.
+
+- **SRResNet is unaffected by this**: `RGBProcessor.extract` / `reconstruct` are identity
+  functions, so the exported graph already is the complete LR-RGB → SR-RGB pipeline.
+- **SRCNN is not**: it trains on the Y channel, so the exported graph only maps Y → Y. A
+  non-Python consumer of an SRCNN ONNX graph must reimplement the surrounding steps
+  itself — extract Y from the LR RGB image (`sisr.colorspace.rgb_to_ycbcr`), run the
+  graph, then bicubic-upsample the LR Cb/Cr channels back to the SR size and recombine
+  (`sisr.colorspace.ycbcr_to_rgb`). See `sisr/processors/y_channel.py` for the exact
+  reference implementation.
+
+The exported graph accepts **arbitrary spatial dimensions** (`dynamic_axes` on height and
+width) — it is not limited to the size in `training_config.example_input_shape`, which is
+only a TensorBoard-graph-logging dummy input.
+
+**Deploying to TensorRT.** This project does not depend on TensorRT (NVIDIA-only,
+version-brittle, and untestable in CI without a GPU runner). Convert the exported `.onnx`
+yourself with NVIDIA's `trtexec`, which ships with the TensorRT SDK:
+
+```bash
+trtexec --onnx=model.onnx --saveEngine=model.trt \
+    --minShapes=input:1x3x64x64 --optShapes=input:1x3x256x256 --maxShapes=input:1x3x1080x1920
+```
+
+(drop the batch/channel dims to match SRCNN's single-channel Y input). `--minShapes` /
+`--maxShapes` are required because of the dynamic H/W axes above.
+
 ## GPU / CUDA notes
 
 The CUDA-built `torch` / `torchvision` wheels aren't on PyPI, so GPU users install them

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,10 @@ line-length = 100
 # removed and ignoring them has no effect" on every run, which is noise in a required
 # check. The isinstance(x, A | B) style it enforced is now convention, not lint.
 select = ["E", "F", "I", "UP", "B"]
+ignore = [
+    # UP038 deprecated upstream in ruff 0.12.0; will silently stop firing on the next bump.
+    "UP038",
+]
 
 [tool.ruff.lint.per-file-ignores]
 # Re-export hubs import names purely to surface them under short class paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,10 +127,6 @@ line-length = 100
 # removed and ignoring them has no effect" on every run, which is noise in a required
 # check. The isinstance(x, A | B) style it enforced is now convention, not lint.
 select = ["E", "F", "I", "UP", "B"]
-ignore = [
-    # UP038 deprecated upstream in ruff 0.12.0; will silently stop firing on the next bump.
-    "UP038",
-]
 
 [tool.ruff.lint.per-file-ignores]
 # Re-export hubs import names purely to surface them under short class paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,17 @@ dev = [
     "pyyaml>=6",
     "ruff>=0.9",
 ]
+# Opt-in (INIT.7): sisr/export.py gates the actual `import onnx` inside to_onnx(),
+# so plain `pip install .` stays onnx-free. onnxruntime is the CI numeric-parity
+# check's target (CPU build — GitHub runners have no GPU); it also lets users
+# verify an export locally without a separate inference framework. Deliberately
+# NOT paired with onnxscript: that would pull in torch's newer torch.export-based
+# exporter, so to_onnx() pins dynamo=False (the legacy TorchScript exporter) and
+# stays on this pair.
+export = [
+    "onnx>=1.16",
+    "onnxruntime>=1.19",
+]
 
 [project.scripts]
 sisr = "sisr.cli:main"

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -4,6 +4,8 @@ Usage:
     sisr fit --config templates/config.srcnn.template.yaml
     sisr test --config templates/config.srcnn.template.yaml \\
               --ckpt_path <best.ckpt>
+    sisr export --config templates/config.srcnn.template.yaml \\
+                --output_path model.onnx --ckpt_path <best.ckpt>
 
 The ``sisr`` console script is registered by ``pyproject.toml``; ``python -m
 sisr.cli ...`` also works.
@@ -17,15 +19,56 @@ architectures.
 Top-level ``matmul_precision:`` (``'highest' | 'high' | 'medium'``) calls
 :func:`torch.set_float32_matmul_precision` once at startup. Set to ``'high'``
 on Ampere+ GPUs to enable TF32 matmul kernels.
+
+``sisr export`` (INIT.7) is a thin CLI wrapper around
+:func:`sisr.export.to_onnx` — see that module for what gets exported and its
+SRCNN limitation. It requires the optional ``export`` extra
+(``pip install '.[export]'``).
 """
 
 import sys
 from typing import Literal
 
 import torch
+from lightning.pytorch import Trainer
 from lightning.pytorch.cli import LightningCLI
 
+from .export import to_onnx
 from .training import SRDataModule, SRLightning
+
+
+class _ExportTrainer(Trainer):
+    """``Trainer`` subclass adding an ``export`` method for the CLI subcommand.
+
+    ``LightningCLI`` derives each subcommand's argument parser and help text
+    from a method of this name on ``trainer_class`` (see
+    ``_add_subcommands`` / ``_prepare_subcommand_parser`` in
+    ``lightning.pytorch.cli``) — there is no supported way to register a
+    subcommand that isn't a ``Trainer`` method. This subclass exists solely to
+    give ``export`` that home; it changes no behavior for ``fit`` / ``validate``
+    / ``test`` / ``predict``.
+    """
+
+    def export(
+        self,
+        model: SRLightning,
+        datamodule: SRDataModule | None = None,
+        output_path: str = "model.onnx",
+        ckpt_path: str | None = None,
+        opset_version: int = 17,
+    ) -> None:
+        """Export ``model`` to ONNX — thin wrapper around ``sisr.export.to_onnx``.
+
+        Args:
+            output_path: Destination ``.onnx`` file path.
+            ckpt_path: Optional checkpoint whose weights are loaded into
+                ``model`` before export.
+            opset_version: ONNX opset to target.
+        """
+        # datamodule is unused: export needs no data, only the model's
+        # architecture + weights, but LightningCLI always injects it (matching
+        # every other subcommand's signature contract).
+        to_onnx(model, output_path, ckpt_path=ckpt_path, opset_version=opset_version)
 
 
 class SRLightningCLI(LightningCLI):
@@ -42,7 +85,18 @@ class SRLightningCLI(LightningCLI):
     Also exposes a top-level ``matmul_precision`` YAML key that calls
     :func:`torch.set_float32_matmul_precision` in
     :meth:`before_instantiate_classes`.
+
+    Defaults ``trainer_class`` to :class:`_ExportTrainer`: :meth:`subcommands`
+    unconditionally registers ``export``, and ``LightningCLI`` resolves every
+    subcommand's parser via ``getattr(trainer_class, subcommand)`` regardless
+    of which subcommand is actually invoked — so any caller constructing this
+    class needs a ``trainer_class`` that has an ``export`` method, not just
+    ``main()``. Callers may still override it explicitly (e.g. a project-specific
+    ``Trainer`` subclass), as long as it also provides ``export``.
     """
+
+    def __init__(self, *args, trainer_class: type[Trainer] = _ExportTrainer, **kwargs):
+        super().__init__(*args, trainer_class=trainer_class, **kwargs)
 
     def add_arguments_to_parser(self, parser):
         """Wire top-level ``optimizer:`` / ``lr_scheduler:`` / ``matmul_precision:`` keys.
@@ -72,6 +126,19 @@ class SRLightningCLI(LightningCLI):
         precision = self.config[self.subcommand].matmul_precision
         if precision is not None:
             torch.set_float32_matmul_precision(precision)
+
+    @staticmethod
+    def subcommands() -> dict[str, set[str]]:
+        """Register ``export`` alongside the stock ``fit``/``validate``/``test``/``predict``.
+
+        ``{"model", "datamodule"}`` is skipped from ``export``'s CLI-parsed
+        arguments the same way ``fit`` skips them — both are already wired
+        from the top-level ``model:`` / ``data:`` YAML keys, not re-specified
+        per-subcommand.
+        """
+        subcommands = LightningCLI.subcommands()
+        subcommands["export"] = {"model", "datamodule"}
+        return subcommands
 
 
 def main() -> None:

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -96,6 +96,16 @@ class SRLightningCLI(LightningCLI):
     """
 
     def __init__(self, *args, trainer_class: type[Trainer] = _ExportTrainer, **kwargs):
+        # LightningCLI resolves a parser for *every* registered subcommand during
+        # __init__, so a trainer_class without `export` fails as a bare AttributeError
+        # from inside Lightning. Say what is actually wrong instead.
+        if not hasattr(trainer_class, "export"):
+            raise TypeError(
+                f"{trainer_class.__name__} has no `export` method. SRLightningCLI "
+                f"registers an `export` subcommand, and LightningCLI resolves a parser "
+                f"for every subcommand at construction. Subclass _ExportTrainer, or add "
+                f"an `export` method with the same signature."
+            )
         super().__init__(*args, trainer_class=trainer_class, **kwargs)
 
     def add_arguments_to_parser(self, parser):

--- a/sisr/export.py
+++ b/sisr/export.py
@@ -1,0 +1,137 @@
+"""Bare-model ONNX export (INIT.7).
+
+Exports ``module.model`` — the wrapped :class:`~sisr.models.base.SRModel`,
+*without* the :class:`~sisr.processors.SRProcessor` — so the graph matches
+:meth:`SRLightning.forward` exactly (which is itself model-only; see
+``sisr/training/lightning_module.py``). This is a deliberate choice, not an
+oversight: a consumer of the exported graph is expected to have ``sisr``
+importable and call ``processor.extract`` / ``processor.reconstruct``
+themselves.
+
+For :class:`~sisr.processors.RGBProcessor` architectures (SRResNet), those
+methods are identity functions, so the bare graph is already an end-to-end
+LR-RGB -> SR-RGB pipeline. For :class:`~sisr.processors.YChannelProcessor`
+architectures (SRCNN), the graph only covers Y -> Y: reconstructing an RGB
+image needs the LR image's Cb/Cr channels back (bicubic-upsampled to the SR
+size), which this export omits. A non-Python ONNX consumer of an SRCNN graph
+must reimplement that chroma path itself — see the README's ONNX section.
+
+Requires the optional ``export`` extra (``onnx``, ``onnxruntime``). The
+import is gated inside :func:`to_onnx` so plain ``import sisr`` — and
+``import sisr.export`` itself — stays free of the dependency until export is
+actually invoked.
+"""
+
+from __future__ import annotations
+
+import warnings
+from os import PathLike
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from .training import SRLightning
+
+_EXTRA_HINT = (
+    "ONNX export requires the optional 'export' extra: "
+    "pip install '.[export]' (or: python -m uv pip install '.[export]')."
+)
+
+
+def _require_onnx() -> None:
+    """Raise a clear ``ImportError`` if ``onnx`` is not installed."""
+    try:
+        import onnx  # noqa: F401
+    except ImportError as e:
+        raise ImportError(f"onnx is not installed. {_EXTRA_HINT}") from e
+
+
+def to_onnx(
+    module: SRLightning,
+    file_path: str | PathLike,
+    *,
+    ckpt_path: str | PathLike | None = None,
+    input_sample: torch.Tensor | None = None,
+    opset_version: int = 17,
+) -> None:
+    """Export ``module.model`` (the bare SR model) to ONNX with dynamic H/W.
+
+    Traces the wrapped model alone — see the module docstring for why the
+    processor is excluded and what that means for SRCNN consumers. The
+    exported graph accepts arbitrary spatial dimensions (``dynamic_axes`` on
+    height/width): a fixed-shape export would be useless on real images,
+    since ``training_config.example_input_shape`` is only a TensorBoard-graph
+    dummy size, not a training or inference constraint.
+
+    Args:
+        module: An :class:`~sisr.training.SRLightning` instance (e.g. built
+            from YAML by :class:`~sisr.cli.SRLightningCLI`). Only
+            ``module.model`` is traced.
+        file_path: Destination ``.onnx`` file path.
+        ckpt_path: Optional path to a Lightning checkpoint. When given, its
+            ``state_dict`` is loaded into ``module`` before export — use this
+            to export trained weights rather than ``module``'s current
+            (e.g. freshly initialized) ones. Loaded with ``weights_only=True``.
+        input_sample: Dummy input tensor for tracing, shape ``(1, C, H, W)``.
+            Defaults to ``torch.zeros(1, *module.training_config.example_input_shape)``.
+        opset_version: ONNX opset to target. Defaults to ``17`` — a floor
+            broadly supported by onnxruntime and TensorRT's ``trtexec``, not
+            the newest opset torch happens to default to.
+
+    Raises:
+        ImportError: If ``onnx`` is not installed (see the ``export`` extra).
+        ValueError: If ``input_sample`` is omitted and
+            ``module.training_config.example_input_shape`` is unset.
+    """
+    _require_onnx()
+
+    if ckpt_path is not None:
+        checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=True)
+        module.load_state_dict(checkpoint["state_dict"])
+
+    if input_sample is None:
+        shape = module.training_config.example_input_shape
+        if shape is None:
+            raise ValueError(
+                "to_onnx needs a dummy input to trace the graph: pass "
+                "input_sample explicitly, or set "
+                "module.training_config.example_input_shape."
+            )
+        input_sample = torch.zeros(1, *shape)
+
+    model = module.model
+    was_training = model.training
+    model.eval()
+    try:
+        with warnings.catch_warnings():
+            # dynamo=False (the legacy TorchScript exporter) is deliberate: torch's
+            # newer torch.export-based path needs `onnxscript`, outside the
+            # `export` extra's onnx+onnxruntime scope (see pyproject.toml). Both
+            # warnings below are expected consequences of that choice, not export
+            # defects — the DeprecationWarning is the legacy exporter announcing
+            # itself, and the TracerWarning is `clamp_output`'s constant-False
+            # default branch (SRModel.forward's direct-call convenience, never
+            # taken from this call site) being recorded as a Python bool, not a
+            # tensor, so it can never diverge across export vs. real inference.
+            # Not filtered by `module=`: torch.onnx.export's own DeprecationWarning
+            # uses stacklevel=2, so warnings attributes it to *this* call site, not
+            # torch.onnx — scoping to this narrow `with` block is what keeps the
+            # ignore from hiding anything else.
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)
+            torch.onnx.export(
+                model,
+                (input_sample,),
+                str(file_path),
+                input_names=["input"],
+                output_names=["output"],
+                dynamic_axes={
+                    "input": {2: "height", 3: "width"},
+                    "output": {2: "height", 3: "width"},
+                },
+                opset_version=opset_version,
+                dynamo=False,
+            )
+    finally:
+        model.train(was_training)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,6 +141,72 @@ def test_test_subcommand_help_exposes_ckpt_path_in_process(capsys, monkeypatch):
     assert "--data.test_datasets" in out
 
 
+def test_export_subcommand_help_exposes_its_args_in_process(capsys, monkeypatch):
+    """`export --help` documents --output_path, --ckpt_path, --opset_version (INIT.7).
+
+    trainer_class is left at SRLightningCLI's default (_ExportTrainer) —
+    building this parser never calls sisr.export.to_onnx's body (only inspects
+    _ExportTrainer.export's signature), so it needs no onnx/onnxruntime install.
+    """
+    from sisr.cli import SRLightningCLI
+    from sisr.training import SRDataModule, SRLightning
+
+    monkeypatch.setattr(sys, "argv", sys.argv[:1])
+    with pytest.raises(SystemExit):
+        SRLightningCLI(
+            model_class=SRLightning,
+            datamodule_class=SRDataModule,
+            auto_configure_optimizers=False,
+            save_config_kwargs={"overwrite": True},
+            args=["export", "--help"],
+            run=True,
+        )
+    out = capsys.readouterr().out
+    assert "--output_path" in out
+    assert "--ckpt_path" in out
+    assert "--opset_version" in out
+
+
+def test_export_subcommand_runs_end_to_end_in_process(tmp_path):
+    """`sisr export --config ... --output_path ...` produces a real ONNX file.
+
+    Exercises the full subcommand wiring (_ExportTrainer.export -> to_onnx)
+    against the shipped SRCNN template, whose dataset dirs need not exist —
+    export never calls SRDataModule.setup(). Skips cleanly without the
+    optional onnx/onnxruntime extra.
+    """
+    pytest.importorskip("onnx")
+    from sisr.cli import SRLightningCLI
+    from sisr.training import SRDataModule, SRLightning
+
+    output_path = tmp_path / "srcnn.onnx"
+    saved_argv = sys.argv
+    sys.argv = saved_argv[:1]
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", message="GPU available but not used.*")
+            SRLightningCLI(
+                model_class=SRLightning,
+                datamodule_class=SRDataModule,
+                auto_configure_optimizers=False,
+                save_config_kwargs={"overwrite": True},
+                args=[
+                    "export",
+                    "--config",
+                    str(TEMPLATE),
+                    "--output_path",
+                    str(output_path),
+                    "--trainer.accelerator=cpu",
+                    "--trainer.devices=1",
+                ],
+            )
+    finally:
+        sys.argv = saved_argv
+
+    assert output_path.is_file()
+
+
 def test_optimizer_lr_override_in_process():
     """Top-level --optimizer.init_args.lr override surfaces in the resolved config."""
     cli = _resolve("--config", str(TEMPLATE), "--optimizer.init_args.lr=5e-3")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -132,14 +132,15 @@ def test_to_onnx_ckpt_path_loads_weights_before_export(tmp_path):
     np.testing.assert_allclose(actual, expected, atol=1e-4, rtol=1e-3)
 
 
-def test_to_onnx_restores_training_mode(tmp_path):
+@pytest.mark.parametrize("was_training", [True, False])
+def test_to_onnx_restores_training_mode(tmp_path, was_training):
     """model.training is restored after export, whatever it was before."""
     module = _make_srcnn_module(example_input_shape=(1, 16, 16))
-    module.model.train()
+    module.model.train(was_training)
 
     to_onnx(module, tmp_path / "model.onnx")
 
-    assert module.model.training is True
+    assert module.model.training is was_training
 
 
 def test_to_onnx_missing_onnx_raises_import_error_with_extra_hint(monkeypatch):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,151 @@
+"""Tests for sisr.export.to_onnx (INIT.7).
+
+Skips cleanly when the optional `onnx` / `onnxruntime` extra is absent, so the
+suite stays green for contributors who don't install `.[export]`. The CI
+`onnx-export` job in `.github/workflows/test.yml` installs the extra so these
+tests actually run somewhere.
+"""
+
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+onnx = pytest.importorskip("onnx")
+onnxruntime = pytest.importorskip("onnxruntime")
+
+from sisr.export import to_onnx  # noqa: E402
+from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig  # noqa: E402
+from sisr.models.srresnet import SRResNet, SRResNetTrainingConfig  # noqa: E402
+from sisr.processors import RGBProcessor, YChannelProcessor  # noqa: E402
+from sisr.training import SRLightning  # noqa: E402
+
+
+def _make_srcnn_module(example_input_shape: tuple[int, ...] | None) -> SRLightning:
+    """Tiny Y-channel SRCNN — small enough to trace/export quickly."""
+    model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(5, 1, 3), padding=0)
+    training_config = SRCNNTrainingConfig(example_input_shape=example_input_shape)
+    return SRLightning(model=model, processor=YChannelProcessor(), training_config=training_config)
+
+
+def _make_srresnet_module(example_input_shape: tuple[int, ...] | None) -> SRLightning:
+    """Tiny RGB SRResNet (x4) — small enough to trace/export quickly."""
+    model = SRResNet(
+        scale=4,
+        in_out_channels=3,
+        hidden_channel=8,
+        kernel_sizes=(9, 3, 9),
+        num_residual_blocks=2,
+        padding="same",
+    )
+    training_config = SRResNetTrainingConfig(example_input_shape=example_input_shape)
+    return SRLightning(model=model, processor=RGBProcessor(), training_config=training_config)
+
+
+def _run_ort(onnx_path, x: torch.Tensor) -> np.ndarray:
+    session = onnxruntime.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    (out,) = session.run(None, {"input": x.numpy()})
+    return out
+
+
+@pytest.mark.parametrize(
+    ("make_module", "export_shape", "sizes"),
+    [
+        (_make_srcnn_module, (1, 48, 48), [(48, 48), (30, 70)]),
+        (_make_srresnet_module, (3, 16, 16), [(16, 16), (20, 28)]),
+    ],
+    ids=["srcnn", "srresnet"],
+)
+def test_to_onnx_parity_and_dynamic_axes(tmp_path, make_module, export_shape, sizes):
+    """Exported graph matches torch eager at the export size AND a different one.
+
+    The second (different) size in `sizes` is the load-bearing assertion for
+    `dynamic_axes`: a fixed-shape export would only pass the first.
+    """
+    module = make_module(export_shape)
+    onnx_path = tmp_path / "model.onnx"
+
+    to_onnx(module, onnx_path)
+
+    model = module.model
+    model.eval()
+    channels = export_shape[0]
+    for h, w in sizes:
+        x = torch.rand(1, channels, h, w)
+        with torch.no_grad():
+            expected = model(x).numpy()
+        actual = _run_ort(onnx_path, x)
+        assert actual.shape == expected.shape
+        np.testing.assert_allclose(actual, expected, atol=1e-4, rtol=1e-3)
+
+
+def test_to_onnx_requires_example_input_shape_or_input_sample():
+    """No input_sample and no training_config.example_input_shape -> ValueError."""
+    model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(5, 1, 3), padding=0)
+    module = SRLightning(model=model, processor=YChannelProcessor())
+
+    with pytest.raises(ValueError, match="example_input_shape"):
+        to_onnx(module, "unused.onnx")
+
+
+def test_to_onnx_accepts_explicit_input_sample(tmp_path):
+    """An explicit input_sample bypasses the training_config.example_input_shape seam."""
+    model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(5, 1, 3), padding=0)
+    module = SRLightning(model=model, processor=YChannelProcessor())
+    onnx_path = tmp_path / "model.onnx"
+
+    to_onnx(module, onnx_path, input_sample=torch.zeros(1, 1, 24, 24))
+
+    model.eval()
+    x = torch.rand(1, 1, 40, 40)
+    with torch.no_grad():
+        expected = model(x).numpy()
+    actual = _run_ort(onnx_path, x)
+    np.testing.assert_allclose(actual, expected, atol=1e-4, rtol=1e-3)
+
+
+def test_to_onnx_ckpt_path_loads_weights_before_export(tmp_path):
+    """ckpt_path's state_dict is loaded into the module before tracing."""
+    module = _make_srcnn_module(example_input_shape=(1, 32, 32))
+    trained = _make_srcnn_module(example_input_shape=(1, 32, 32))
+    with torch.no_grad():
+        for p in trained.model.parameters():
+            p.add_(1.0)
+    assert not torch.equal(module.model.feat[0].weight, trained.model.feat[0].weight)
+
+    ckpt_path = tmp_path / "trained.ckpt"
+    torch.save({"state_dict": trained.state_dict()}, ckpt_path)
+
+    onnx_path = tmp_path / "model.onnx"
+    to_onnx(module, onnx_path, ckpt_path=ckpt_path)
+
+    # The live module itself now carries the checkpoint's weights...
+    assert torch.equal(module.model.feat[0].weight, trained.model.feat[0].weight)
+
+    # ...and so does the exported graph.
+    trained.model.eval()
+    x = torch.rand(1, 1, 32, 32)
+    with torch.no_grad():
+        expected = trained.model(x).numpy()
+    actual = _run_ort(onnx_path, x)
+    np.testing.assert_allclose(actual, expected, atol=1e-4, rtol=1e-3)
+
+
+def test_to_onnx_restores_training_mode(tmp_path):
+    """model.training is restored after export, whatever it was before."""
+    module = _make_srcnn_module(example_input_shape=(1, 16, 16))
+    module.model.train()
+
+    to_onnx(module, tmp_path / "model.onnx")
+
+    assert module.model.training is True
+
+
+def test_to_onnx_missing_onnx_raises_import_error_with_extra_hint(monkeypatch):
+    """Simulates `onnx` missing (sys.modules poisoning) -> ImportError mentioning the extra."""
+    monkeypatch.setitem(sys.modules, "onnx", None)
+    module = _make_srcnn_module(example_input_shape=(1, 16, 16))
+
+    with pytest.raises(ImportError, match=r"\[export\]"):
+        to_onnx(module, "unused.onnx")


### PR DESCRIPTION
> **Stacked on #30** (`chore/ci-tooling-hygiene`) — merge that first.

### Bare-model export, deliberately

Exports `module.model` only — not model+processor. Consumers have `sisr` importable and call `processor.extract`/`reconstruct` themselves, so the ONNX graph matches `SRLightning.forward` exactly and **makes no claim it cannot keep**.

This is cheap because `RGBProcessor.extract`/`reconstruct` are literal identity functions — for SRResNet the bare graph *is* already end-to-end. The gap exists only for SRCNN + `YChannelProcessor`, whose `reconstruct(sr, lr_rgb)` needs the LR RGB back for chroma: a two-input graph the bare export omits by design. **Documented as a stated limitation** — an SRCNN ONNX consumer outside Python must reimplement Y extraction and chroma upsampling.

### Measured parity

Against onnxruntime **CPU** (GitHub runners have no GPU), exported at one spatial size and inferred at a **different** one, so `dynamic_axes` is genuinely exercised rather than assumed:

| Model | Export → inference | Max abs diff |
|---|---|---|
| SRCNN | 48×48 → 30×70 | **6.7e-08** |
| SRResNet | 16×16 → 20×28 | **1.5e-07** |

Both at float32 machine epsilon.

### Both surfaces

`sisr.export.to_onnx(...)` is the real implementation; `sisr export` is a thin CLI wrapper.

`export` isn't a stock Lightning subcommand, so it needs a home: `LightningCLI` derives each subcommand's parser from a method of that name on `trainer_class`. `_ExportTrainer` exists solely to provide it, and changes nothing for `fit`/`validate`/`test`/`predict`. **No private Lightning APIs are called.**

Because `LightningCLI` resolves a parser for *every* registered subcommand at construction, a `trainer_class` without `export` used to fail as a bare `AttributeError` from inside Lightning. It now raises a `TypeError` naming the class and the fix (`399bfd0`).

**Durability:** that same unconditional resolution means essentially every existing `test_cli.py` test already exercises the export wiring — a Lightning bump breaking the mechanism would fail most of the CLI suite, not slip through silently.

### Optional extra, no import weight

`onnx`/`onnxruntime` live behind a `[export]` extra and are imported lazily. `import sisr`, `import sisr.cli`, and `import sisr.export` all succeed with them absent; attempting an export without them raises an `ImportError` naming the extra. Import weight is a first-class constraint in this repo — spawned processes pay a ~10s torch+lightning cold import.

Uses `torch.onnx.export(..., dynamo=False)` — the legacy exporter, since torch's new default needs `onnxscript`, outside this extra's scope.

### TensorRT: declined

NVIDIA-only, version-brittle, and CI has no GPU, so it would carry zero coverage and rot silently. The README instead documents the ONNX→TRT path via `trtexec`, with `--minShapes`/`--maxShapes` for the dynamic axes — no dependency, nothing to rot.

### CI

New `onnx-export` job feeding the unchanged `test` gate's `needs:`. Gate job names `test`/`build` are untouched (required-check contexts).

**Tests:** 216 → **226**. Docs are a separate commit (`00aea2a`). Reviewed independently: spec PASS, quality APPROVED, two Minor findings fixed.

Part of the 2026-07-31 triage delivery arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)