### PR TITLE
Trim verbose comments to non-obvious why only

### DIFF
--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -32,8 +32,8 @@ class LMDBCacheBuildContext:
     Provides helpers for writing data into the LMDB being built.
 
     Args:
-        env (lmdb.Environment): The open LMDB environment (writable).
-        use_tqdm (bool): Whether progress bars should be displayed.
+        env: The open, writable LMDB environment.
+        use_tqdm: Whether to display progress bars.
     """
 
     def __init__(self, env: lmdb.Environment, use_tqdm: bool = False):
@@ -44,7 +44,7 @@ class LMDBCacheBuildContext:
         """Writes a batch of key-value pairs in a single transaction.
 
         Args:
-            pairs (Sequence[tuple[str, bytes]]): Sequence of ``(key, value)`` tuples to write.
+            pairs: Sequence of ``(key, value)`` tuples to write.
         """
         txn = self.env.begin(write=True)
         for key, value in pairs:
@@ -61,27 +61,24 @@ class LMDBCacheBuildContext:
     ) -> None:
         """Processes *items* and writes the results to LMDB.
 
-        The worker function *process_fn* must be a top-level (picklable)
-        callable returning a list of ``(key, value_bytes)`` tuples.  With more
-        than one effective worker a ``ProcessPoolExecutor`` runs a sliding
-        window of *num_workers* in-flight jobs while the main process writes
-        completed results; with ``<= 1`` effective worker the jobs run inline in
-        the calling process (no subprocess).
+        *process_fn* must be a top-level (picklable) callable returning a
+        list of ``(key, value_bytes)`` tuples. With more than one effective
+        worker a ``ProcessPoolExecutor`` runs a sliding window of
+        *num_workers* in-flight jobs while the main process writes completed
+        results; with ``<= 1`` effective worker the jobs run inline (no
+        subprocess).
 
         Args:
-            items (Sequence[Any]): One item per job (e.g. a list of image paths).
-            process_fn (Callable[..., list[tuple[str, bytes]]]): Top-level callable invoked per
-                item.  Receives ``(item, *extra_args)`` and returns keyed pairs.
-            process_args (Sequence[Sequence[Any]], optional): Per-item extra arguments for
-                *process_fn*. If ``None``, each job calls ``process_fn(item)``.
-                If provided, must have the same length as *items* and
-                each element is unpacked as positional args.
-            num_workers (int | None): Maximum number of parallel worker
-                processes.  ``None`` resolves to ``min(os.cpu_count() or 1,
-                len(items))``.  When the effective count is ``<= 1`` (a single
-                core, a lone item, or an explicit ``1``) the build runs inline
-                with no ``ProcessPoolExecutor``.
-            desc (str): Description shown in the ``tqdm`` progress bar.
+            items: One item per job (e.g. a list of image paths).
+            process_fn: Top-level callable invoked per item as
+                ``(item, *extra_args)``, returning its keyed pairs.
+            process_args: Per-item extra arguments for *process_fn*, unpacked
+                as positional args. ``None`` calls ``process_fn(item)`` with
+                no extras.
+            num_workers: Maximum parallel workers. ``None`` resolves to
+                ``min(os.cpu_count() or 1, len(items))``; an effective count
+                ``<= 1`` runs inline with no ``ProcessPoolExecutor``.
+            desc: Description shown on the ``tqdm`` progress bar.
         """
         n_items = len(items)
         if num_workers is None:
@@ -90,9 +87,8 @@ class LMDBCacheBuildContext:
 
         pbar = tqdm(total=n_items, desc=desc, unit="item") if self.use_tqdm else None
 
-        # Inline (no-pool) build. With <= 1 effective worker the
-        # ProcessPoolExecutor spawn/import cost — plus the hazard of nesting a
-        # pool inside a test/xdist worker — isn't worth it, so run jobs here.
+        # <= 1 effective worker: skip the pool. Its spawn/import cost, plus the
+        # hazard of nesting one inside a test/xdist worker, isn't worth it here.
         if num_workers <= 1:
             for i in range(n_items):
                 args = (items[i],)
@@ -138,30 +134,24 @@ class LMDBCache:
     """A checksum-validated LMDB key-value store with parallel build support.
 
     On construction the cache checks whether a valid LMDB database
-    already exists (matched by *checksum*).  If not, it calls
-    ``build_fn`` to populate the database from scratch using a pool of
-    worker processes.
+    already exists (matched by *checksum*). If not, it calls ``build_fn``
+    to populate the database from scratch using a pool of worker processes.
 
-    After construction the cache is read-only.  Call :meth:`get` to
-    retrieve individual entries, or :meth:`get_env` for direct LMDB
-    access.
+    After construction the cache is read-only. Call :meth:`get` to
+    retrieve individual entries, or :meth:`get_env` for direct LMDB access.
 
     Args:
-        cache_dir (str | Path): Parent directory for the LMDB database.
-        name (str): Prefix used in the LMDB folder name
-            (e.g. ``'srcnn_hr'``).
-        checksum (str): Hex digest that uniquely identifies the current
-            configuration.  A mismatch triggers a rebuild.
-        length (int): Total number of entries that will be stored.
-        map_size (int): Maximum size of the LMDB database in bytes.
-        metadata (dict[str, str] | None): Extra key-value pairs to persist alongside the data
-            (e.g. ``{'channels': '3', 'subimg_size': '33'}``).
-        build_fn (Callable[[LMDBCacheBuildContext], None] | None): A callable that populates the
-            database.  It receives a single :class:`LMDBCacheBuildContext` argument exposing
-            a ``write_batch`` helper and an ``env`` handle.  If
-            ``None`` and no valid cache is found, a ``RuntimeError``
-            is raised.
-        use_tqdm (bool): Whether to display a progress bar during the build.
+        cache_dir: Parent directory for the LMDB database.
+        name: Prefix used in the LMDB folder name (e.g. ``'srcnn_hr'``).
+        checksum: Hex digest identifying the current configuration; a
+            mismatch triggers a rebuild.
+        length: Total number of entries that will be stored.
+        map_size: Maximum size of the LMDB database in bytes.
+        metadata: Extra key-value pairs to persist alongside the data.
+        build_fn: Populates the database, receiving a single
+            :class:`LMDBCacheBuildContext`. ``None`` with no valid cache
+            found raises ``RuntimeError``.
+        use_tqdm: Whether to display a progress bar during the build.
     """
 
     def __init__(
@@ -191,31 +181,20 @@ class LMDBCache:
 
     @property
     def path(self) -> Path:
-        """Path to the LMDB database directory.
-
-        Returns:
-            The path where the LMDB database is stored.
-        """
+        """Path to the LMDB database directory."""
         return self._lmdb_path
 
     @property
     def length(self) -> int:
-        """Number of entries stored in the cache.
-
-        Returns:
-            The number of entries.
-        """
+        """Number of entries stored in the cache."""
         return self._length
 
     def get_env(self) -> lmdb.Environment:
         """Returns the LMDB environment, opening it lazily on first call.
 
-        Each ``DataLoader`` worker process must call this independently
-        because LMDB memory-mapped environments cannot be shared across
-        processes created via ``spawn``.
-
-        Returns:
-            A read-only LMDB environment.
+        Each ``DataLoader`` worker process must call this independently:
+        LMDB memory-mapped environments cannot be shared across processes
+        created via ``spawn``.
         """
         if self._env is None:
             self._env = lmdb.open(str(self._lmdb_path), readonly=True, lock=False)
@@ -225,7 +204,7 @@ class LMDBCache:
         """Reads a single value from the cache.
 
         Args:
-            key (str): The string key to look up.
+            key: The string key to look up.
 
         Returns:
             The raw bytes stored under *key*, or ``None`` if absent.
@@ -252,7 +231,7 @@ class LMDBCache:
         actually enter the ``with``.
 
         Args:
-            key (str): The string key to look up.
+            key: The string key to look up.
 
         Yields:
             A ``memoryview`` onto the raw value bytes, or ``None`` if *key* is
@@ -266,11 +245,11 @@ class LMDBCache:
         """Reads multiple values from the cache in a single transaction.
 
         Args:
-            keys (Sequence[str]): Sequence of string keys to look up.
+            keys: Sequence of string keys to look up.
 
         Returns:
-            A list of raw bytes (or ``None`` for missing keys), in the
-            same order as *keys*.
+            A list of raw bytes (or ``None`` for missing keys), in the same
+            order as *keys*.
         """
         env = self.get_env()
         results = []
@@ -281,14 +260,7 @@ class LMDBCache:
         return results
 
     def _try_load(self, checksum: str) -> bool:
-        """Validates an existing LMDB by comparing its stored checksum.
-
-        Args:
-            checksum (str): The expected checksum to validate against.
-
-        Returns:
-            ``True`` if the cache is valid and ready to use.
-        """
+        """Validates an existing LMDB against *checksum*; ``True`` if ready to use."""
         if not self._lmdb_path.exists():
             return False
         try:
@@ -302,10 +274,9 @@ class LMDBCache:
             env.close()
             return True
         except (lmdb.Error, OSError):
-            # Only a genuinely unreadable cache (LMDB corruption, disk/OS
-            # error) counts as "stale" — drop it and rebuild. Anything else
-            # (KeyboardInterrupt, data-shape bugs, ...) must propagate so a
-            # broken system isn't silently mistaken for a stale cache.
+            # Only a genuinely unreadable cache (corruption, disk/OS error)
+            # counts as stale and gets dropped; anything else must propagate
+            # rather than be silently mistaken for a stale cache.
             if self._lmdb_path.exists():
                 shutil.rmtree(self._lmdb_path)
             return False
@@ -318,18 +289,7 @@ class LMDBCache:
         build_fn: Callable[[LMDBCacheBuildContext], None],
         use_tqdm: bool,
     ) -> None:
-        """Creates a fresh LMDB and delegates population to *build_fn*.
-
-        Args:
-            checksum (str): The checksum to store for future validation.
-            length (int): The number of entries that will be stored.
-            map_size (int): The maximum size of the LMDB database in bytes.
-            build_fn (Callable[[LMDBCacheBuildContext], None]): A callable that populates the
-                database.  It receives a single :class:`LMDBCacheBuildContext` argument exposing
-                a ``write_batch`` helper and an ``env`` handle. Must populate the database with
-                exactly *length* entries.
-            use_tqdm (bool): Whether to display a progress bar during the build.
-        """
+        """Creates a fresh LMDB; *build_fn* must populate it with exactly *length* entries."""
         if self._lmdb_path.exists():
             shutil.rmtree(self._lmdb_path)
 
@@ -338,7 +298,7 @@ class LMDBCache:
         ctx = LMDBCacheBuildContext(env=env, use_tqdm=use_tqdm)
         build_fn(ctx)
 
-        # Write metadata — __checksum__ last for incomplete-build detection
+        # __checksum__ written last so an interrupted build reads as stale, not complete.
         txn = env.begin(write=True)
         txn.put(b"__length__", str(length).encode())
         for k, v in self._metadata.items():

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -64,6 +64,8 @@ class _ExportTrainer(Trainer):
         """Export ``model`` to ONNX — thin wrapper around ``sisr.export.to_onnx``.
 
         Args:
+            model: Model to export.
+            datamodule: Unused — see the comment below.
             output_path: Destination ``.onnx`` file path.
             ckpt_path: Optional checkpoint whose weights are loaded into
                 ``model`` before export.

--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -57,10 +57,6 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
         are kept — an allowlist rather than the old ``glob('*.*')``, which
         matched non-image files and dropped extensionless ones by accident.
 
-        Args:
-            img_dir (str | Path): Directory containing the high-resolution
-                images.
-
         Raises:
             ValueError: If no allowlisted image files are found in ``img_dir``.
         """
@@ -75,14 +71,7 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
 
     @staticmethod
     def _load_rgb(path: str | Path) -> np.ndarray:
-        """Load an image file as an ``(H, W, 3)`` uint8 RGB array.
-
-        Args:
-            path (str | Path): Image file path.
-
-        Returns:
-            The decoded image as an HWC uint8 RGB ``numpy`` array.
-        """
+        """Load an image file as an ``(H, W, 3)`` uint8 RGB array."""
         return np.array(Image.open(path).convert("RGB"))
 
     @staticmethod
@@ -91,14 +80,7 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
 
         Byte-identical replacement for the removed AlbumentationsX
         ``ToFloat(255.0)`` + ``ToTensorV2()`` chain (probed against
-        albumentations 2.1.0 with this project's exact call-site
-        parameters).
-
-        Args:
-            image: ``uint8`` array, HWC.
-
-        Returns:
-            ``float32`` tensor, CHW, values in ``[0, 1]``.
+        albumentations 2.1.0 with this project's exact call-site parameters).
         """
         return torch.from_numpy(image).permute(2, 0, 1).float().div(255.0)
 

--- a/sisr/datasets/predict.py
+++ b/sisr/datasets/predict.py
@@ -23,8 +23,7 @@ class PredictDataset(SRDataset):
     exactly as it does for the paired training/validation datasets.
 
     Args:
-        img_dir (str | Path): Directory containing the LR images to run
-            inference on.
+        img_dir: Directory of LR images to run inference on.
 
     Raises:
         ValueError: If no image files are found in ``img_dir``, or if two
@@ -53,7 +52,7 @@ class PredictDataset(SRDataset):
         """Returns the LR RGB tensor at ``idx``.
 
         Args:
-            idx (int): Zero-based image index.
+            idx: Zero-based image index.
 
         Returns:
             ``float32`` tensor of shape ``(3, H, W)`` in ``[0, 1]``.

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -44,10 +44,6 @@ def _check_blur_sigma(resize_backend: ResizeBackend, blur_sigma: float | None) -
     antialiasing of its own, so it falls back to the historical default of
     ``1.0`` when unset.
 
-    Args:
-        resize_backend: ``'matlab'`` or ``'cv2'``.
-        blur_sigma: The value passed in, or ``None``.
-
     Returns:
         ``None`` for ``'matlab'``; a concrete sigma for ``'cv2'``.
 
@@ -72,20 +68,8 @@ def _grid_dims(
     """Returns the ``(n_rows, n_cols)`` sliding-window sub-image grid for one image.
 
     Single source of truth for the deterministic patch grid: :func:`_iter_patch_origins`
-    (the enumeration used by tests and the module docstring) and
-    :meth:`TrainDataset.__getitem__` (an O(1) index -> origin lookup, since the
-    cache no longer stores one entry per patch) both derive positions from
-    this, so they can never silently disagree and misalign an index.
-
-    Args:
-        height (int): Full image height in pixels.
-        width (int): Full image width in pixels.
-        scale (int): Downscaling factor; each axis is cropped to a multiple of it.
-        sub_img_size (int): Side length of the square sub-image window.
-        stride (int): Step size of the sliding window.
-
-    Returns:
-        ``(n_rows, n_cols)`` — the number of valid window positions per axis.
+    and :meth:`TrainDataset.__getitem__`'s O(1) index -> origin lookup both derive
+    positions from this, so they can never silently disagree and misalign an index.
     """
     h_crop = height - (height % scale)
     w_crop = width - (width % scale)
@@ -106,16 +90,6 @@ def _iter_patch_origins(
     Built on :func:`_grid_dims` so this enumeration and
     :meth:`TrainDataset.__getitem__`'s O(1) index -> origin math can never
     disagree about ordering or count.
-
-    Args:
-        height (int): Full image height in pixels.
-        width (int): Full image width in pixels.
-        scale (int): Downscaling factor; each axis is cropped to a multiple of it.
-        sub_img_size (int): Side length of the square sub-image window.
-        stride (int): Step size of the sliding window.
-
-    Yields:
-        ``(top, left)`` pixel offsets of each sub-image's top-left corner.
     """
     n_rows, n_cols = _grid_dims(height, width, scale, sub_img_size, stride)
     for row in range(n_rows):
@@ -136,17 +110,6 @@ def _degrade(
     formulation). Shared by :class:`TrainDataset` (per sub-image, at read
     time) and :class:`ValidationDataset` (per full image) so the degradation
     recipe cannot drift between the two.
-
-    Args:
-        hr_arr (np.ndarray): ``(H, W, 3)`` uint8 RGB array.
-        scale (int): Downscaling factor.
-        kernel (int | None): Odd Gaussian kernel size, or ``None`` on ``'matlab'``.
-        blur_sigma (float | None): Gaussian sigma paired with *kernel*; ignored if
-            *kernel* is ``None``.
-        resize_backend (ResizeBackend): ``'matlab'`` or ``'cv2'``.
-
-    Returns:
-        The degraded array, same ``(H, W, 3)`` shape as *hr_arr*.
     """
     h, w = hr_arr.shape[:2]
     to_degrade = hr_arr
@@ -165,10 +128,6 @@ def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
     LR derivation both moved to :meth:`TrainDataset.__getitem__`, so the build
     only has to decode once per image — independent of
     ``subimg_size``/``stride``/``scale``.
-
-    Args:
-        path (Path): File path of the high-resolution image.
-        idx (int): This image's position in the manifest — determines its LMDB key.
 
     Returns:
         A single-element list ``[(f'hr_{idx:08d}', raw_bytes)]`` where
@@ -205,36 +164,28 @@ class TrainDataset(SRDataset):
         https://arxiv.org/pdf/1501.00092
 
     Args:
-        img_dir (str | Path): Directory containing the high-resolution
-            images.
-        subimg_size (int): Spatial size of the square sub-images to extract.
-        stride (int): Step size of the sliding window used for sub-image
-            extraction.
-        scale (int): Downscaling factor for generating low-resolution
-            sub-images.
-        blur_sigma (float | None): Sigma of the Gaussian blur applied before
-            downsampling. Only meaningful (and must be set) on the ``'cv2'``
-            backend, which has no antialiasing of its own; falls back to the
-            historical default of ``1.0`` if left ``None`` there. Must be
-            ``None`` on ``'matlab'`` (the default) — its kernel widening
-            already is the antialiasing low-pass, so an explicit blur on top
-            only double-blurs; passing a value raises ``ValueError``.
-        resize_backend (ResizeBackend): ``'matlab'`` (default) — MATLAB-
-            compatible antialiased bicubic, comparable to published paper
-            numbers. ``'cv2'`` — ``cv2.INTER_CUBIC``, no antialiasing;
-            kept so LMDB caches built before this module existed stay
-            reproducible. See :mod:`sisr.imresize`. Only the LR derivation
-            is affected — the HR cache stores raw pixels regardless, so
+        img_dir: Directory of HR images.
+        subimg_size: Spatial size of the square sub-images to extract.
+        stride: Step size of the sliding window used for sub-image extraction.
+        scale: Downscaling factor for generating LR sub-images.
+        blur_sigma: Only meaningful (and must be set) on the ``'cv2'``
+            backend, which has no antialiasing of its own; falls back to
+            ``1.0`` if left ``None`` there. Must be ``None`` on ``'matlab'``
+            (the default) — its kernel widening already is the antialiasing
+            low-pass, so an explicit blur on top only double-blurs; passing
+            a value raises ``ValueError``.
+        resize_backend: ``'matlab'`` (default) — MATLAB-compatible
+            antialiased bicubic, comparable to published paper numbers.
+            ``'cv2'`` — no antialiasing; kept only so pre-existing LMDB
+            caches stay reproducible. See :mod:`sisr.imresize`. Only affects
+            LR derivation — the HR cache stores raw pixels regardless, so
             switching backends never invalidates it.
-        use_tqdm (bool): Whether to display a progress bar during the LMDB
-            build.  Defaults to ``False``.
-        cache_dir (str | Path | None): Directory in which to store the
-            LMDB cache.  Defaults to ``img_dir / '.lmdb_cache'``.
-        build_num_workers (int | None): Number of worker processes for the
-            one-time LMDB build.  ``None`` (default) uses
-            ``min(os.cpu_count() or 1, num_images)``; a value that resolves to
-            ``<= 1`` effective workers runs an inline, no-subprocess build.
-            Only affects cache construction, not data loading.
+        use_tqdm: Whether to display a progress bar during the LMDB build.
+        cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
+        build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
+            1, num_images)``; ``<= 1`` effective workers runs an inline,
+            no-subprocess build. Only affects cache construction, not data
+            loading.
 
     Raises:
         ValueError: If no image files are found in ``img_dir``, or if

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -41,10 +41,6 @@ def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
     Top-level (not a method) so it can be pickled by ``ProcessPoolExecutor``
     across all platforms, mirroring :func:`sisr.datasets.srcnn._process_hr_image`.
 
-    Args:
-        path (Path): File path of the high-resolution image.
-        idx (int): This image's position in the manifest — determines its LMDB key.
-
     Returns:
         A single-element list ``[(f'hr_{idx:08d}', header + raw_bytes)]`` where
         *header* is :data:`_SHAPE_HEADER`-packed ``(h, w)`` and *raw_bytes* is
@@ -85,29 +81,25 @@ class TrainDataset(SRDataset):
         Adversarial Network (https://arxiv.org/pdf/1609.04802)
 
     Args:
-        img_dir (str | Path): Directory containing the high-resolution images.
-        scale (int): Upscaling factor. ``hr_crop_size`` must be divisible by it.
-        hr_crop_size (int): Side length of the square HR crop.
-        crops_per_image (int): Number of random crops drawn per image per
-            epoch (the dataset length is ``len(images) * crops_per_image``).
-            Each draw re-reads the same cached array (a cheap mmap access, not
-            a decode) and takes an independently random crop. Defaults to ``1``.
-        resize_backend (ResizeBackend): ``'matlab'`` (default) — MATLAB-
-            compatible antialiased bicubic, comparable to published paper
-            numbers. ``'cv2'`` — ``cv2.INTER_CUBIC``, no antialiasing; kept
-            so LMDB caches built before this module existed stay
-            reproducible. See :mod:`sisr.imresize`. Only the LR derivation
-            is affected — the HR cache stores raw pixels regardless, so
-            switching backends never invalidates it.
-        use_tqdm (bool): Whether to display a progress bar during the LMDB
-            build. Defaults to ``False``.
-        cache_dir (str | Path | None): Directory in which to store the LMDB
-            cache. Defaults to ``img_dir / '.lmdb_cache'``.
-        build_num_workers (int | None): Number of worker processes for the
-            one-time LMDB build. ``None`` (default) uses
-            ``min(os.cpu_count() or 1, num_images)``; a value that resolves to
-            ``<= 1`` effective workers runs an inline, no-subprocess build.
-            Only affects cache construction, not data loading.
+        img_dir: Directory of HR images.
+        scale: Upscaling factor. ``hr_crop_size`` must be divisible by it.
+        hr_crop_size: Side length of the square HR crop.
+        crops_per_image: Random crops drawn per image per epoch (the dataset
+            length is ``len(images) * crops_per_image``). Each draw re-reads
+            the same cached array (a cheap mmap access, not a decode) and
+            takes an independently random crop. Defaults to ``1``.
+        resize_backend: ``'matlab'`` (default) — MATLAB-compatible
+            antialiased bicubic, comparable to published paper numbers.
+            ``'cv2'`` — no antialiasing; kept so LMDB caches built before
+            this module existed stay reproducible. See :mod:`sisr.imresize`.
+            Only the LR derivation is affected — the HR cache stores raw
+            pixels regardless, so switching backends never invalidates it.
+        use_tqdm: Whether to display a progress bar during the LMDB build.
+        cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
+        build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
+            1, num_images)``; ``<= 1`` effective workers runs an inline,
+            no-subprocess build. Only affects cache construction, not data
+            loading.
 
     Raises:
         ValueError: If no images are found, or ``hr_crop_size`` is not

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -10,23 +10,19 @@ from sisr.models.base import SRModel
 
 
 class SRCNN(SRModel):
-    """SRCNN (Super-Resolution Convolutional Neural Network) model for single image
-    super-resolution. The architecture consists of three main parts: feature extraction,
-    non-linear mapping, and reconstruction.
+    """SRCNN: feature extraction, non-linear mapping, and reconstruction, in three conv stacks.
 
     Reference:
     - Image Super-Resolution Using Deep Convolutional Networks: https://arxiv.org/pdf/1501.00092
 
     Args:
-        num_channels (int): The number of channels in the input and output images (e.g., 3 for
-            RGB, 1 for Y channel).
-        num_filters (tuple[int, ...]): A tuple containing the number of filters for each
-            convolutional layer (e.g., (64, 32, 1) for the original SRCNN architecture).
-        kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each
-            convolutional layer (e.g., (9, 1, 5) for the original SRCNN architecture).
-        padding (str | int): The padding type or size for the convolutional layers.
-            Can be 'valid', 'same', or an integer specifying the number of pixels to pad.
-            Default is 'valid'.
+        num_channels: Input/output channel count (e.g. 3 for RGB, 1 for Y).
+        num_filters: Filter count per conv layer (e.g. ``(64, 32, 1)`` for
+            the original architecture).
+        kernel_sizes: Kernel size per conv layer (e.g. ``(9, 1, 5)`` for the
+            original architecture).
+        padding: ``'valid'``, ``'same'``, or an explicit pixel count.
+            Defaults to ``'valid'``.
     """
 
     def __init__(
@@ -75,18 +71,7 @@ class SRCNN(SRModel):
         )
 
     def _check_architecture(self, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...]):
-        """Validates the architecture parameters for the SRCNN model.
-
-        Args:
-            num_filters (tuple[int, ...]): A tuple containing the number of filters for each
-                convolutional layer.
-            kernel_sizes (tuple[int, ...]): A tuple containing the kernel sizes for each
-                convolutional layer.
-
-        Raises:
-            ValueError: If num_filters or kernel_sizes are not tuples, if they have different
-                lengths, or if any of their elements are not positive integers.
-        """
+        """Validates num_filters/kernel_sizes are same-length positive-int tuples."""
         for i, name in zip(
             [num_filters, kernel_sizes], ["num_filters", "kernel_sizes"], strict=False
         ):
@@ -115,15 +100,11 @@ class SRCNN(SRModel):
             )
 
     def reset_parameters(self, mean: float = 0.0, std: float = 0.01):
-        """Initializes the weights of the convolutional layers using a normal distribution and
-        sets the biases to zero. Following the initialization method described in the original
-        SRCNN paper (https://arxiv.org/pdf/1501.00092).
+        """Gaussian weight init + zero biases, per the SRCNN paper (https://arxiv.org/pdf/1501.00092).
 
         Args:
-            mean (float): The mean of the normal distribution for weight initialization.
-                Default is 0
-            std (float): The standard deviation of the normal distribution for weight
-                initialization. Default is 0.01
+            mean: Mean of the weight-init normal distribution.
+            std: Standard deviation of the weight-init normal distribution.
         """
         for module in self.modules():
             if isinstance(module, torch.nn.Conv2d):
@@ -136,7 +117,7 @@ class SRCNN(SRModel):
         clamp_output: bool = False,
         clamp_minmax: tuple[float, float] = (0.0, 1.0),
     ) -> torch.Tensor:
-        """Forward pass of the SRCNN model.
+        """Forward pass: feature extraction -> non-linear mapping -> reconstruction.
 
         clamp_output is a direct-call convenience for offline inference: the
         SRLightning training and validation paths always call model(x) without
@@ -144,15 +125,14 @@ class SRCNN(SRModel):
         calls used to clip the raw output into a displayable range.
 
         Args:
-            x (torch.Tensor): Input tensor of shape (batch_size, num_channels, height, width)
-            clamp_output (bool): Whether to clamp the output to clamp_minmax. Only
-                honoured on direct model(x, clamp_output=True) calls; the SRLightning
-                pipeline never sets it. Default is False.
-            clamp_minmax (tuple[float, float]): The minimum and maximum values for clamping
-                the output. Default is (0.0, 1.0).
+            x: Input tensor, shape ``(B, num_channels, H, W)``.
+            clamp_output: Whether to clamp the output to clamp_minmax. Only
+                honoured on direct ``model(x, clamp_output=True)`` calls; the
+                SRLightning pipeline never sets it.
+            clamp_minmax: Min/max values for clamping the output.
 
         Returns:
-            torch.Tensor: Output tensor of shape (batch_size, num_channels, height, width)
+            Output tensor, same shape as *x*.
         """
         x = self.feat(x)
         x = self.mapping(x)

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -12,14 +12,12 @@ from sisr.models.base import SRModel
 
 
 class SRResidualBlock(torch.nn.Module):
-    """A single residual block used in SRResNet.
-    Each block applies two convolutional layers with batch normalization,
-    and adds the input (identity) as a skip connection.
+    """A single residual block: two conv+BN layers with an identity skip connection.
 
     Args:
-        channels (int): Number of input and output channels.
-        kernel_size (int): Kernel size for both convolutional layers.
-        padding (str | int): Padding for the convolutional layers. Default is 'same'.
+        channels: Input/output channel count.
+        kernel_size: Kernel size for both conv layers.
+        padding: Padding for the conv layers. Defaults to ``'same'``.
     """
 
     def __init__(self, channels: int, kernel_size: int, padding: str | int = "same"):
@@ -37,13 +35,13 @@ class SRResidualBlock(torch.nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass of the residual block.
+        """Forward pass: identity + two conv+BN layers.
 
         Args:
-            x (torch.Tensor): Input tensor of shape (batch_size, channels, height, width).
+            x: Input tensor, shape ``(B, channels, H, W)``.
 
         Returns:
-            torch.Tensor: Output tensor of shape (batch_size, channels, height, width).
+            Output tensor, same shape as *x*.
         """
         identity = x
         x = self.block1(x)
@@ -52,13 +50,12 @@ class SRResidualBlock(torch.nn.Module):
 
 
 class SRUpsampleBlock(torch.nn.Module):
-    """An upsampling block used in SRResNet that increases spatial resolution using sub-pixel
-    convolution.
+    """Sub-pixel convolution upsampling block: conv -> PixelShuffle -> PReLU.
 
     Args:
-        channels (int): Number of input channels.
-        scale (int): Upscaling factor. Default is 2.
-        kernel_size (int): Kernel size for the convolutional layer. Default is 3.
+        channels: Input channel count.
+        scale: Upscaling factor. Defaults to ``2``.
+        kernel_size: Kernel size for the conv layer. Defaults to ``3``.
     """
 
     def __init__(self, channels: int, scale: int = 2, kernel_size: int = 3):
@@ -73,35 +70,30 @@ class SRUpsampleBlock(torch.nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass of the upsample block.
+        """Forward pass.
 
         Args:
-            x (torch.Tensor): Input tensor of shape (batch_size, channels, height, width).
+            x: Input tensor, shape ``(B, channels, H, W)``.
 
         Returns:
-            torch.Tensor: Output tensor with height and width scaled by the upscaling factor.
+            Output tensor with H/W scaled by *scale*.
         """
         return self.upsample(x)
 
 
 class SRResNet(SRModel):
-    """SRResNet (Super-Resolution Residual Network) model for single image super-resolution.
-    The architecture consists of an initial feature extraction block, a series of residual blocks
-    with a skip connection, sub-pixel upsample blocks, and a final reconstruction layer.
+    """SRResNet: head conv, residual blocks with a skip connection, sub-pixel upsampling, tail conv.
 
     Reference:
     - Photo-Realistic Single Image Super-Resolution Using a Generative Adversarial Network: https://arxiv.org/pdf/1609.04802
 
     Args:
-        scale (int): The upscaling factor. Must be a power of 2.
-        in_out_channels (int): Number of channels in the input and output images (e.g., 3 for
-            RGB). Default is 3.
-        hidden_channel (int): Number of feature channels used in the residual and upsample
-            blocks. Default is 64.
-        kernel_sizes (tuple[int, ...]): Kernel sizes for the head, residual, and tail
-            convolutional layers. Default is (9, 3, 9).
-        num_residual_blocks (int): Number of residual blocks in the network. Default is 16.
-        padding (str | int): Padding for the convolutional layers. Default is 'same'.
+        scale: Upscaling factor. Must be a power of 2.
+        in_out_channels: Input/output channel count (e.g. 3 for RGB).
+        hidden_channel: Feature channel count used in the residual/upsample blocks.
+        kernel_sizes: Kernel sizes for the head, residual, and tail conv layers.
+        num_residual_blocks: Number of residual blocks in the network.
+        padding: Padding for the conv layers. Defaults to ``'same'``.
     """
 
     def __init__(
@@ -162,31 +154,14 @@ class SRResNet(SRModel):
         )
 
     def _check_scale(self, scale: int):
-        """Validates that the scale factor is a power of 2.
-
-        Args:
-            scale (int): The upscaling factor.
-
-        Raises:
-            ValueError: If scale is not a positive integer or not a power of 2.
-        """
+        """Validates that scale is a positive power of 2."""
         if not isinstance(scale, int) or scale < 1:
             raise ValueError(f"scale must be a positive integer. Got {scale}.")
         if (scale & (scale - 1)) != 0:
             raise ValueError(f"scale must be a power of 2. Got {scale}.")
 
     def _check_architecture(self, kernel_sizes: tuple[int, ...], num_residual_blocks: int):
-        """Validates the architecture parameters for the SRResNet model.
-
-        Args:
-            kernel_sizes (tuple[int, ...]): Kernel sizes for the head, residual,
-                and tail convolutional layers.
-            num_residual_blocks (int): Number of residual blocks in the network.
-
-        Raises:
-            ValueError: If kernel_sizes is not a length-3 tuple of positive
-                integers, or if num_residual_blocks is not a positive integer.
-        """
+        """Validates kernel_sizes (length-3, positive ints) and num_residual_blocks (positive)."""
         if not isinstance(kernel_sizes, tuple):
             raise ValueError(f"kernel_sizes must be a tuple. Got {type(kernel_sizes)}.")
         if len(kernel_sizes) != 3:
@@ -209,7 +184,7 @@ class SRResNet(SRModel):
         clamp_output: bool = False,
         clamp_minmax: tuple[float, float] = (-1.0, 1.0),
     ) -> torch.Tensor:
-        """Forward pass of the SRResNet model.
+        """Forward pass: head -> residual blocks -> upsample -> tail.
 
         clamp_output is a direct-call convenience for offline inference: the
         SRLightning training and validation paths always call model(x) without
@@ -217,18 +192,16 @@ class SRResNet(SRModel):
         calls used to clip the raw output into a displayable range.
 
         Args:
-            x (torch.Tensor): Input tensor of shape (batch_size, in_out_channels, height, width).
-            clamp_output (bool): Whether to clamp the output to clamp_minmax. Only
-                honoured on direct model(x, clamp_output=True) calls; the SRLightning
-                pipeline never sets it. Default is False.
-            clamp_minmax (tuple[float, float]): Bounds for clamping. Defaults to the
-                paper's ``[-1, 1]`` output range (Ledig et al. §3.2, via
-                ``RGBSignedOutputProcessor``); pass ``(0.0, 1.0)`` for weights trained
-                under ``RGBProcessor``.
+            x: Input tensor, shape ``(B, in_out_channels, H, W)``.
+            clamp_output: Whether to clamp the output to clamp_minmax. Only
+                honoured on direct ``model(x, clamp_output=True)`` calls; the
+                SRLightning pipeline never sets it.
+            clamp_minmax: Bounds for clamping. Defaults to the paper's ``[-1, 1]``
+                output range (Ledig et al. §3.2, via ``RGBSignedOutputProcessor``);
+                pass ``(0.0, 1.0)`` for weights trained under ``RGBProcessor``.
 
         Returns:
-            torch.Tensor: Output tensor of shape (batch_size, in_out_channels, height * scale,
-            width * scale).
+            Output tensor, shape ``(B, in_out_channels, H*scale, W*scale)``.
         """
         x = self.head(x)
         identity = x

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -94,11 +94,9 @@ class BenchmarkImageLogger(Callback):
         when not supplied at construction time.
 
         Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being trained
-                (unused).
-            stage (str): Lightning trainer stage (unused — both val and
-                test mappings are built up-front).
+            trainer: The active trainer.
+            pl_module: Unused.
+            stage: Unused — both val and test mappings are built up-front.
         """
         if self.dataset_names is None:
             dm = getattr(trainer, "datamodule", None)
@@ -113,9 +111,8 @@ class BenchmarkImageLogger(Callback):
         """Clear buffers and bump the val-run counter.
 
         Args:
-            trainer (lightning.Trainer): The active trainer (unused).
-            pl_module (lightning.LightningModule): The model being
-                evaluated (unused).
+            trainer: Unused.
+            pl_module: Unused.
         """
         self._val_run_count += 1
         self._buffer = {name: [] for name in self.dataset_names}
@@ -135,16 +132,13 @@ class BenchmarkImageLogger(Callback):
         sets, not the primary val loader at idx 0).
 
         Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being
-                evaluated.
-            outputs (Any): The value returned by ``validation_step``
-                (unused — :class:`~sisr.training.SRLightning.validation_step`
-                returns ``None`` for idx >= 1).
-            batch (Any): ``(lr_img, hr_img)`` tuple from the test loader.
-            batch_idx (int): Index of the batch within the current
-                dataloader.
-            dataloader_idx (int): Index of the loader within
+            trainer: The active trainer.
+            pl_module: The model being evaluated.
+            outputs: Unused — :meth:`SRLightning.validation_step` returns
+                ``None`` for idx >= 1.
+            batch: ``(lr_img, hr_img)`` tuple from the test loader.
+            batch_idx: Index of the batch within the current dataloader.
+            dataloader_idx: Index of the loader within
                 ``trainer.val_dataloaders``.
         """
         if dataloader_idx not in self._val_mapping:
@@ -166,9 +160,8 @@ class BenchmarkImageLogger(Callback):
         """Log per-set means every val epoch; image strips every N val runs.
 
         Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being
-                evaluated.
+            trainer: The active trainer.
+            pl_module: The model being evaluated.
         """
         self._flush_buffer(
             trainer=trainer,
@@ -180,9 +173,8 @@ class BenchmarkImageLogger(Callback):
         """Clear buffers ahead of a test run.
 
         Args:
-            trainer (lightning.Trainer): The active trainer (unused).
-            pl_module (lightning.LightningModule): The model being
-                evaluated (unused).
+            trainer: Unused.
+            pl_module: Unused.
         """
         self._buffer = {name: [] for name in self.dataset_names}
 
@@ -201,16 +193,12 @@ class BenchmarkImageLogger(Callback):
         are test sets (no primary loader at idx 0).
 
         Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being
-                evaluated.
-            outputs (Any): The value returned by ``test_step`` (unused —
-                :class:`~sisr.training.SRLightning.test_step` returns
-                ``None``).
-            batch (Any): ``(lr_img, hr_img)`` tuple from the test loader.
-            batch_idx (int): Index of the batch within the current
-                dataloader.
-            dataloader_idx (int): Index of the loader within
+            trainer: The active trainer.
+            pl_module: The model being evaluated.
+            outputs: Unused — :meth:`SRLightning.test_step` returns ``None``.
+            batch: ``(lr_img, hr_img)`` tuple from the test loader.
+            batch_idx: Index of the batch within the current dataloader.
+            dataloader_idx: Index of the loader within
                 ``trainer.test_dataloaders``.
         """
         if dataloader_idx not in self._test_mapping:
@@ -230,9 +218,8 @@ class BenchmarkImageLogger(Callback):
         """Log per-set means and image strips at the end of ``cli test``.
 
         Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being
-                evaluated.
+            trainer: The active trainer.
+            pl_module: The model being evaluated.
         """
         self._flush_buffer(
             trainer=trainer,
@@ -260,21 +247,10 @@ class BenchmarkImageLogger(Callback):
         Shared between :meth:`on_validation_batch_end` and
         :meth:`on_test_batch_end`. Border cropping is sourced from
         ``pl_module.eval_config.crop_border`` at the use site.
-
-        Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being evaluated.
-            batch (Any): ``(lr_img, hr_img)`` tuple from the loader.
-            batch_idx (int): Index of the batch within the current
-                dataloader.
-            dataset_name (str): Name of the test set this batch comes from.
-            source_dataloaders: ``trainer.val_dataloaders`` or
-                ``trainer.test_dataloaders`` — used to recover the
-                underlying dataset for filename resolution.
-            dataloader_idx (int): Index into ``source_dataloaders``.
-            should_log_images (bool): When True the LR/SR/HR tensors are
-                cached for image-strip emission in :meth:`_flush_buffer`;
-                otherwise only scalar metrics are buffered.
+        *source_dataloaders* recovers the underlying dataset for filename
+        resolution. When *should_log_images*, LR/SR/HR tensors are cached for
+        image-strip emission in :meth:`_flush_buffer`; otherwise only scalar
+        metrics are buffered.
         """
         lr_img, hr_img = batch
 
@@ -332,14 +308,6 @@ class BenchmarkImageLogger(Callback):
         :meth:`on_test_epoch_end`. Looks up the TensorBoard logger from
         ``trainer.loggers``; silently skips image emission for sets whose
         logger is missing.
-
-        Args:
-            trainer (lightning.Trainer): The active trainer (used for
-                ``global_step`` and the TensorBoard logger lookup).
-            pl_module (lightning.LightningModule): Receives ``log()`` calls
-                for the per-set mean metrics.
-            should_log_images (bool): When True, bicubic|SR|HR image strips
-                are emitted to TensorBoard alongside the scalar means.
         """
         step = trainer.global_step
 
@@ -406,13 +374,6 @@ class BenchmarkImageLogger(Callback):
         Bicubic can overshoot for high-contrast inputs, so the output is
         clamped to the unit interval to keep the panel renderable as a
         normalized image.
-
-        Args:
-            img (torch.Tensor): Image tensor of shape ``(C, H, W)``.
-            target_hw (tuple): Target ``(H, W)`` spatial dimensions.
-
-        Returns:
-            torch.Tensor: Bicubic-resampled tensor of shape ``(C, target_H, target_W)``.
         """
         out = torch.nn.functional.interpolate(
             img.unsqueeze(0), size=target_hw, mode="bicubic", align_corners=False
@@ -421,15 +382,7 @@ class BenchmarkImageLogger(Callback):
 
     @staticmethod
     def _pad_to_match(img: torch.Tensor, target_hw: tuple) -> torch.Tensor:
-        """Zero-pad a ``(C, H, W)`` tensor to *target_hw* spatial size.
-
-        Args:
-            img (torch.Tensor): Image tensor of shape ``(C, H, W)``.
-            target_hw (tuple): Target ``(H, W)`` spatial dimensions.
-
-        Returns:
-            torch.Tensor: Padded tensor of shape ``(C, target_H, target_W)``.
-        """
+        """Zero-pad a ``(C, H, W)`` tensor to *target_hw* spatial size."""
         target_h, target_w = target_hw
         _, h, w = img.shape
 
@@ -471,8 +424,8 @@ class GradNormLogger(Callback):
         ``.item()`` accumulation loop).
 
         Args:
-            trainer (lightning.Trainer): The trainer instance.
-            pl_module (lightning.LightningModule): The model being trained.
+            trainer: The trainer instance.
+            pl_module: The model being trained.
         """
         if trainer.global_step % self.log_every_n_steps != 0:
             return
@@ -516,11 +469,11 @@ class WeightHistogramLogger(Callback):
         """Log grouped weights as histograms if on the right step cadence.
 
         Args:
-            trainer (lightning.Trainer): The trainer instance.
-            pl_module (lightning.LightningModule): The model being trained.
-            outputs (Any): The outputs of the model.
-            batch (Any): The current batch.
-            batch_idx (int): The index of the batch.
+            trainer: The trainer instance.
+            pl_module: The model being trained.
+            outputs: Unused.
+            batch: Unused.
+            batch_idx: Unused.
         """
         if trainer.global_step % self.log_every_n_steps != 0:
             return
@@ -565,15 +518,12 @@ class SRCheckpoint(ModelCheckpoint):
     handles ``/`` fine.
 
     Args:
-        monitor_metric (str): The validation metric to monitor.
-            Defaults to ``"psnr/val/RGB"``.  Use any ``psnr/val/{key}``
+        monitor_metric: The validation metric to monitor. Any ``psnr/val/{key}``
             logged by the lightning module (e.g. ``"psnr/val/Y"``,
             ``"psnr/val/YCbCr"``) or ``"ssim/val"``.
-        save_top_k (int): Number of best checkpoints to keep.
-            Defaults to ``3``.
-        dirpath (str | None): Directory to save checkpoints.
-        filename_prefix (str): Prefix for checkpoint filenames.
-            Defaults to ``"sr"``.
+        save_top_k: Number of best checkpoints to keep.
+        dirpath: Directory to save checkpoints.
+        filename_prefix: Prefix for checkpoint filenames.
         **kwargs: Extra keyword arguments forwarded to
             :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
     """
@@ -617,14 +567,14 @@ class SRCheckpoint(ModelCheckpoint):
         any training happens.
 
         Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being trained;
-                must expose ``eval_config`` (an :class:`SREvalConfig`).
-            stage (str): Lightning trainer stage. Only ``"fit"`` is checked —
-                the monitored tags are val-loop metrics, so they are never
-                logged under ``validate``/``test``/``predict`` and demanding
-                them there would reject configs that are perfectly valid for
-                the stage actually being run.
+            trainer: The active trainer.
+            pl_module: The model being trained; must expose ``eval_config``
+                (an :class:`SREvalConfig`).
+            stage: Lightning trainer stage. Only ``"fit"`` is checked — the
+                monitored tags are val-loop metrics, so they are never logged
+                under ``validate``/``test``/``predict`` and demanding them
+                there would reject configs that are perfectly valid for the
+                stage actually being run.
 
         Raises:
             MisconfigurationException: If ``monitor`` does not name a
@@ -685,20 +635,17 @@ class SRPredictionWriter(BasePredictionWriter):
         ``batch`` itself, which is a bare LR tensor with no filename.
 
         Args:
-            trainer (lightning.Trainer): The active trainer.
-            pl_module (lightning.LightningModule): The model being run
-                (unused).
-            prediction (torch.Tensor): ``SRLightning.predict_step`` output —
-                SR RGB batch, ``float32`` in ``[0, 1]``, shape
-                ``(B, 3, H, W)``.
-            batch_indices (Sequence[int] | None): Dataset indices of the
-                samples in this batch, supplied by Lightning's predict loop.
-            batch (Any): The input LR batch (unused — filenames come from
-                ``batch_indices``, not the tensor itself).
-            batch_idx (int): Index of the batch within the current
-                dataloader (unused).
-            dataloader_idx (int): Index of the predict loader — used only
-                when ``trainer.predict_dataloaders`` is a list.
+            trainer: The active trainer.
+            pl_module: Unused.
+            prediction: ``SRLightning.predict_step`` output — SR RGB batch,
+                ``float32`` in ``[0, 1]``, shape ``(B, 3, H, W)``.
+            batch_indices: Dataset indices of the samples in this batch,
+                supplied by Lightning's predict loop.
+            batch: Unused — filenames come from ``batch_indices``, not the
+                tensor itself.
+            batch_idx: Unused.
+            dataloader_idx: Index of the predict loader — used only when
+                ``trainer.predict_dataloaders`` is a list.
         """
         loader = trainer.predict_dataloaders
         if isinstance(loader, list | tuple):

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -122,14 +122,6 @@ class SRLightning(lightning.LightningModule):
 
         None values are dropped (they add noise without aiding comparison).
         Class objects are reduced to their ``__name__``.
-
-        Args:
-            hparams: Nested mapping of hparams (may contain dicts, lists,
-                tuples, scalars, or class objects).
-            sep: Separator used to join nested keys. Defaults to ``'/'``.
-
-        Returns:
-            Flat dict with ``sep``-joined keys and scalar leaves.
         """
         result = {}
 
@@ -157,18 +149,9 @@ class SRLightning(lightning.LightningModule):
     def _build_psnr_tensors(
         self, sr: torch.Tensor, hr: torch.Tensor
     ) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
-        """Pre-compute (sr, hr) tensor pairs for every tracked PSNR key.
+        """Pre-computes (sr, hr) RGB tensor pairs for every tracked PSNR key.
 
         Colorspace conversions are performed at most once per call.
-
-        Args:
-            sr: SR tensor of shape ``(B, 3, H, W)`` in RGB.
-            hr: HR tensor of shape ``(B, 3, H, W)`` in RGB.
-
-        Returns:
-            Mapping from PSNR key (``'RGB'``, ``'Y'``, ``'Cb'``, ...) to
-            ``(sr_subset, hr_subset)`` tensor pair ready for PSNR
-            computation.
         """
         keys = set(self.eval_config.psnr_keys)
         tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
@@ -197,13 +180,6 @@ class SRLightning(lightning.LightningModule):
         mean, so the result is invariant to the val ``batch_size``. This differs
         from pooling the whole batch into one PSNR — the deviation a stateful
         ``PeakSignalNoiseRatio`` with default ``dim`` would introduce.
-
-        Args:
-            sr: SR tensor of shape ``(B, C, H, W)`` in ``[0, 1]``.
-            hr: HR tensor of the same shape.
-
-        Returns:
-            Scalar tensor — the batch mean of the per-image PSNRs.
         """
         return torchmetrics.functional.image.peak_signal_noise_ratio(
             sr, hr, data_range=1.0, dim=(1, 2, 3), reduction="elementwise_mean"

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -1,7 +1,6 @@
 seed_everything: 42
 
-# TF32 matmul/conv kernels on Ampere+ GPUs (confirmed here: RTX 5060 Laptop, sm_120
-# Blackwell) — a standard free lever with no precision opt-in, unlike bf16-mixed below.
+# TF32 matmul/conv on Ampere+ GPUs — free lever, no precision opt-in (unlike bf16-mixed below).
 matmul_precision: high
 
 optimizer:
@@ -28,12 +27,9 @@ model:
     class_path: sisr.models.srcnn.SRCNNEvalConfig
 
 data:
-  # resize_backend defaults to 'matlab' (MATLAB-compatible antialiased bicubic,
-  # comparable to published paper numbers) on every dataset below. blur_sigma is
-  # omitted to match: it is only meaningful (and only accepted) on resize_backend:
-  # cv2, which has no antialiasing of its own and exists solely to reproduce LMDB
-  # caches built before the matlab backend existed. See README.md's benchmark
-  # protocol section.
+  # resize_backend defaults to 'matlab' (antialiased bicubic, comparable to published
+  # paper numbers) below. blur_sigma is omitted to match: it's only meaningful on
+  # resize_backend: cv2, kept solely to reproduce pre-matlab-backend LMDB caches.
   train_dataset:
     class_path: sisr.datasets.srcnn.TrainDataset
     init_args:
@@ -77,14 +73,13 @@ trainer:
   num_sanity_val_steps: -1
   log_every_n_steps: 500
   deterministic: false
-  # cuDNN autotunes a conv algorithm per input shape on first sight and caches it.
-  # Free here: every training step feeds the same fixed crop shape. Lightning ties this
-  # to `deterministic` above, which is why it belongs here rather than as a custom key.
+  # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
+  # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
+  # above, hence it lives here rather than as a custom key.
   benchmark: true
-  # bf16-mixed is a larger throughput lever than the two above, but this is a
-  # paper-reproduction repo: the shipped default must train in full fp32 so results stay
-  # comparable to the paper. Uncomment for your own runs on bf16-capable hardware (confirmed
-  # here via torch.cuda.is_bf16_supported()).
+  # bf16-mixed is a bigger throughput lever, but this is a paper-reproduction repo:
+  # the shipped default trains in full fp32 so results stay comparable. Uncomment for
+  # your own runs on bf16-capable hardware.
   # precision: bf16-mixed
   accelerator: cuda
   devices: [0]
@@ -108,11 +103,10 @@ trainer:
     - class_path: sisr.training.GradNormLogger
       init_args:
         log_every_n_steps: 2000
-    # Throughput/hardware diagnostics — commented out by default (extra per-step logging
-    # overhead); uncomment to profile a run. DeviceStatsMonitor works as-is.
-    # ThroughputMonitor additionally needs a `batch_size_fn` callable (dotted import path);
-    # batches here are (lr, hr) tuples, not plain tensors, so it needs a small project-side
-    # helper — none exists yet.
+    # Throughput/hardware diagnostics — extra per-step logging overhead, so commented
+    # out by default. DeviceStatsMonitor works as-is; ThroughputMonitor additionally
+    # needs a batch_size_fn (batches are (lr, hr) tuples, not plain tensors — no
+    # project-side helper exists yet).
     # - class_path: lightning.pytorch.callbacks.DeviceStatsMonitor
     # - class_path: lightning.pytorch.callbacks.ThroughputMonitor
     #   init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -1,7 +1,6 @@
 seed_everything: 42
 
-# TF32 matmul/conv kernels on Ampere+ GPUs (confirmed here: RTX 5060 Laptop, sm_120
-# Blackwell) — a standard free lever with no precision opt-in, unlike bf16-mixed below.
+# TF32 matmul/conv on Ampere+ GPUs — free lever, no precision opt-in (unlike bf16-mixed below).
 matmul_precision: high
 
 optimizer:
@@ -29,10 +28,8 @@ model:
     class_path: sisr.models.srresnet.SRResNetEvalConfig
 
 data:
-  # resize_backend defaults to 'matlab' (MATLAB-compatible antialiased bicubic,
-  # comparable to published paper numbers) on every dataset below; 'cv2' exists
-  # solely to reproduce LMDB caches built before the matlab backend existed.
-  # See README.md's benchmark protocol section.
+  # resize_backend defaults to 'matlab' (antialiased bicubic, comparable to published
+  # paper numbers) below; 'cv2' exists solely to reproduce pre-matlab-backend LMDB caches.
   train_dataset:
     class_path: sisr.datasets.srresnet.TrainDataset
     init_args:
@@ -76,14 +73,13 @@ trainer:
   num_sanity_val_steps: -1
   log_every_n_steps: 500
   deterministic: false
-  # cuDNN autotunes a conv algorithm per input shape on first sight and caches it.
-  # Free here: every training step feeds the same fixed crop shape. Lightning ties this
-  # to `deterministic` above, which is why it belongs here rather than as a custom key.
+  # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
+  # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
+  # above, hence it lives here rather than as a custom key.
   benchmark: true
-  # bf16-mixed is a larger throughput lever than the two above, but this is a
-  # paper-reproduction repo: the shipped default must train in full fp32 so results stay
-  # comparable to the paper. Uncomment for your own runs on bf16-capable hardware (confirmed
-  # here via torch.cuda.is_bf16_supported()).
+  # bf16-mixed is a bigger throughput lever, but this is a paper-reproduction repo:
+  # the shipped default trains in full fp32 so results stay comparable. Uncomment for
+  # your own runs on bf16-capable hardware.
   # precision: bf16-mixed
   accelerator: cuda
   devices: [0]
@@ -107,11 +103,10 @@ trainer:
     - class_path: sisr.training.GradNormLogger
       init_args:
         log_every_n_steps: 2000
-    # Throughput/hardware diagnostics — commented out by default (extra per-step logging
-    # overhead); uncomment to profile a run. DeviceStatsMonitor works as-is.
-    # ThroughputMonitor additionally needs a `batch_size_fn` callable (dotted import path);
-    # batches here are (lr, hr) tuples, not plain tensors, so it needs a small project-side
-    # helper — none exists yet.
+    # Throughput/hardware diagnostics — extra per-step logging overhead, so commented
+    # out by default. DeviceStatsMonitor works as-is; ThroughputMonitor additionally
+    # needs a batch_size_fn (batches are (lr, hr) tuples, not plain tensors — no
+    # project-side helper exists yet).
     # - class_path: lightning.pytorch.callbacks.DeviceStatsMonitor
     # - class_path: lightning.pytorch.callbacks.ThroughputMonitor
     #   init_args:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,20 +32,15 @@ def _resolve(*args: str):
     from sisr.cli import SRLightningCLI
     from sisr.training import SRDataModule, SRLightning
 
-    # LightningCLI warns when both `args=` and sys.argv[1:] are set (it sees
-    # pytest's own argv). The strict `filterwarnings=["error"]` would turn that
-    # into an error, so blank sys.argv for the duration of the parse.
+    # LightningCLI warns when both `args=` and sys.argv[1:] are set (it sees pytest's
+    # own argv); the strict global filterwarnings=error would turn that into a failure.
     saved_argv = sys.argv
     sys.argv = saved_argv[:1]
     try:
-        # Two framework-internal warnings fire only on the in-process path (the
-        # subprocess --print_config path never surfaced them) and would trip the
-        # global strict "error" filter, so suppress them locally — leaving the
-        # strict filter intact for our own code:
-        #   * jsonargparse DeprecationWarning: lightning's _add_instantiators
-        #     calls add_instantiator / instantiate_classes, deprecated in 4.49.
-        #   * "GPU available but not used": run=False instantiates the Trainer and
-        #     we force accelerator=cpu; harmless on a GPU dev box, absent on CI.
+        # Two framework-internal warnings only fire on this in-process path and would
+        # trip the strict "error" filter, so suppress them locally: jsonargparse's
+        # DeprecationWarning (lightning's deprecated add_instantiator call), and "GPU
+        # available but not used" (run=False + forced accelerator=cpu, harmless).
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             warnings.filterwarnings("ignore", message="GPU available but not used.*")

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -311,11 +311,9 @@ def _make_bare_trainer() -> lightning.Trainer:
     )
 
 
-# _make_bare_trainer logs a "GPU available but not used" PossibleUserWarning on
-# this CUDA-equipped dev box (accelerator="cpu" is deliberate — matches how the
-# templates run in CI, which has no GPU); harmless environment noise, not a
-# library-health signal, but the strict global `filterwarnings=error` config
-# would otherwise fail these tests on it. Same pattern as test_integration.py.
+# _make_bare_trainer's accelerator="cpu" (matching CI, which has no GPU) logs a
+# "GPU available but not used" warning on a CUDA dev box; harmless, but the
+# strict global filterwarnings=error would fail on it otherwise.
 _ignore_gpu_warning = pytest.mark.filterwarnings(
     "ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning"
 )

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -70,9 +70,8 @@ def _make_datamodule(image_dir: Path) -> SRDataModule:
 
 
 # num_workers=0 (tiny fixture) and accelerator="cpu" on a CUDA box both raise
-# lightning PossibleUserWarnings — config/environment noise, not a library-health
-# signal. Silence them for THIS test only so the strict global filter stays honest
-# and the test fails specifically on the real FutureWarning when the filter is stale.
+# PossibleUserWarnings — environment noise, not a library-health signal — so
+# silence them for this test only, leaving the strict global filter honest elsewhere.
 @pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
 def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
     tiny_rgb_image_dir: Path,


### PR DESCRIPTION
**PR 2 of a stack — bases off #45, not `main`.** Merge #45 first.

## What

Comments and docstrings drifted verbose: multi-paragraph inline essays, docstring prose restating what the next line plainly does, and the `name (type): The <name> to use.` pattern that just re-spells the parameter. This trims to the project's standing rule — **comments explain non-obvious *why* only**.

**15 files, +252 / −510.**

## What was deliberately kept

Terseness was not allowed to cost the hard-won reasons. Explicitly preserved: `sisr/cache.py`'s torch-free constraint, the LMDB `.copy()` use-after-free note in both dataset modules, the deliberately-uncached random crop, `sisr/export.py`'s `dynamo=False` and its scoped warning filters, `SRCheckpoint`'s `/`-sanitisation, and the `validate_against`-not-`__post_init__` reasoning.

`sisr/training/config.py` and the two model `config.py` files were left essentially untouched — their docstrings are dense but carry paper-specific values, not signature restatement.

## Public API kept its `Args:` blocks

An initial pass over-corrected and stripped `Args:` blocks wholesale; that was walked back. The rule applied: **public API keeps a complete `Args:` block** — every parameter documented, wording compressed (dropping the redundant `(type)` restatement the annotation already carries). Private `_`-prefixed helpers may collapse to one line or nothing. Never a partial block.

Worth noting: **ruff cannot enforce this.** `select` has no `D` rules, and even with them, D417 fires only on *partially* documented functions — a fully deleted `Args:` block passes. Verified empirically. Adding scoped `D` rules is queued separately, with that limitation recorded.

## Verification

Beyond the suite, the no-behaviour-change claim is **proven, not asserted** — comments never reach the AST, so every changed `.py` file was parsed at both revisions, docstring nodes stripped, and `ast.dump()` compared:

```
PASS — all 13 changed .py files are AST-identical
```

A second check confirmed the `Args:` walk-back landed: of 70 public callables with parameters, none lost a block it previously had.

- `332 passed, 1 skipped` (the skip is `test_imresize.py`'s byte-equality check — `data/reference` is gitignored and absent from the worktree; it runs in a normal checkout)
- `ruff check` clean, `ruff format --check` clean

## One removal worth flagging

The `(confirmed here: RTX 5060 Laptop, sm_120 Blackwell)` provenance was cut from the `matmul_precision` comment in both templates. That is correct but incidental — the provenance was vouching for a speedup that INIT.12 measured as a **no-op** on these conv stacks. Fixing the surrounding claim is queued as a separate docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)