### PR TITLE
Correct SRCNN paper init std to 0.001 (P1.1)

### DIFF
--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -26,7 +26,7 @@ class SRCNNTrainingConfig(SRTrainingConfig):
     uses a per-layer learning rate of ``1e-4`` for the feature-extraction
     and non-linear-mapping layers and ``1e-5`` for the reconstruction layer
     — i.e. the last layer learns 10× slower. Weight initialization follows
-    the paper's Gaussian schedule (``N(0, 0.01)`` with zero biases); set
+    the paper's Gaussian schedule (``N(0, 0.001)`` with zero biases); set
     ``init_strategy='default'`` to fall back to PyTorch's built-in init.
     Override any field in YAML to deviate.
 
@@ -37,15 +37,16 @@ class SRCNNTrainingConfig(SRTrainingConfig):
             init via ``SRCNN.reset_parameters`` in
             ``SRLightning``'s constructor;
             ``'default'`` skips it and uses PyTorch's defaults.
-        init_mean / init_std: Gaussian parameters used by
-            ``init_strategy='paper'``; inherited from
-            ``SRTrainingConfig`` with defaults
-            ``0.0`` / ``0.01`` matching the SRCNN paper. Override in YAML
-            to deviate.
+        init_mean: Gaussian mean for ``init_strategy='paper'``; inherited
+            from ``SRTrainingConfig`` (``0.0``, matching the paper).
+        init_std: Gaussian std for ``init_strategy='paper'``; overrides
+            the shared base's ``0.01`` to ``0.001``, the value the SRCNN
+            paper actually specifies. Override in YAML to deviate.
     """
 
     layer_lrs: list[float] | None = field(default_factory=lambda: [1.0e-4, 1.0e-4, 1.0e-5])
     init_strategy: Literal["default", "paper"] = "paper"
+    init_std: float = 0.001
 
     def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
         """Extend the base checks with SRCNN's ``num_channels``/processor correlation.

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -99,7 +99,7 @@ class SRCNN(SRModel):
                 f"Got num_filters={num_filters} and kernel_sizes={kernel_sizes}."
             )
 
-    def reset_parameters(self, mean: float = 0.0, std: float = 0.01):
+    def reset_parameters(self, mean: float = 0.0, std: float = 0.001):
         """Gaussian weight init + zero biases, per the SRCNN paper (https://arxiv.org/pdf/1501.00092).
 
         Args:

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -66,13 +66,16 @@ class SRTrainingConfig:
             Subclasses pin a paper-faithful default (e.g. ``SRCNNTrainingConfig``
             uses ``'paper'``).
 
-        init_mean: Mean of the Gaussian used by SRCNN's
-            ``init_strategy='paper'``. Other paper-init implementations may
-            ignore this. Defaults to ``0.0``.
+        init_mean: Mean of the Gaussian for ``init_strategy='paper'``
+            implementations. Not itself paper-derived — this shared base
+            has no single paper to match; architectures with a paper init
+            (e.g. ``SRCNNTrainingConfig``) override with their actual value.
+            Defaults to ``0.0``.
 
-        init_std: Std of the Gaussian used by SRCNN's
-            ``init_strategy='paper'``. Other paper-init implementations may
-            ignore this. Defaults to ``0.01``.
+        init_std: Std of the Gaussian for ``init_strategy='paper'``
+            implementations. Not itself paper-derived — see ``init_mean``;
+            e.g. ``SRCNNTrainingConfig`` overrides this to ``0.001``, the
+            value its paper specifies. Defaults to ``0.01``.
     """
 
     layer_lrs: list[float] | None = None

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -44,11 +44,14 @@ def test_srcnn_eval_config_psnr_channels_independent_per_instance():
 
 
 def test_srcnn_training_config_init_defaults():
-    """Paper-faithful init lives on SRCNNTrainingConfig after migration."""
+    """Paper-faithful init lives on SRCNNTrainingConfig after migration.
+
+    init_std=0.001 per Dong et al. §Training; SRCNNTrainingConfig overrides
+    the shared base's 0.01 (which is not itself a paper value)."""
     cfg = SRCNNTrainingConfig()
     assert cfg.init_strategy == "paper"
     assert cfg.init_mean == 0.0
-    assert cfg.init_std == 0.01
+    assert cfg.init_std == 0.001
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/srcnn/test_model.py
+++ b/tests/models/srcnn/test_model.py
@@ -110,6 +110,26 @@ def test_reset_parameters_zeroes_bias_and_sets_weight_std():
             assert 0.005 < m.weight.std().item() < 0.02
 
 
+def test_reset_parameters_default_std_matches_paper_not_tenfold_larger():
+    """Dong et al. Sec. Training specifies std=0.001 for the weight-init
+    Gaussian; a 10x-too-large default (0.01, previously the bug here) inflates
+    variance 100x and would land the realized std far outside this band.
+    Weights are pooled across every Conv2d (~20k elements) so the sample std
+    is tight enough that only a real std defect, not sampling noise, can fail
+    this."""
+    torch.manual_seed(0)
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    model.reset_parameters()  # exercise reset_parameters' own default, not an explicit std
+    weights = torch.cat(
+        [m.weight.flatten() for m in model.modules() if isinstance(m, torch.nn.Conv2d)]
+    )
+    realized_std = weights.std().item()
+    assert 0.0008 < realized_std < 0.0012, (
+        f"expected ~0.001 (paper std); got {realized_std} -- the old 0.01 default "
+        f"would land ~10x above this band"
+    )
+
+
 def test_init_only_args_rejected():
     """custom_init / init_mean / init_std were moved to SRCNNTrainingConfig."""
     with pytest.raises(TypeError):


### PR DESCRIPTION
**PR 3 of a stack — bases off #46.** Merge #45 → #46 → this.

## The bug

SRCNN's paper-faithful weight init used a standard deviation **10× too large**, under a docstring asserting it matched the paper. Dong et al. (arXiv 1501.00092), §Training:

> Filter weights of each layer are initialized by drawing randomly from a Gaussian distribution with zero mean and standard deviation **0.001** (and 0 for biases).

The code used `0.01`. That is 10× in std, **100× in variance**. `SRCNNTrainingConfig.init_strategy` defaults to `'paper'`, so it fired on every default SRCNN run — with fan-in 81 on the 9×9 first layer, the initial pre-activation std moves ~0.009 → ~0.09, into a plain SGD+momentum optimiser with no adaptive rescaling to absorb it.

**The docstring is why this survived.** It claimed fidelity, so nobody re-derived it. That is the real defect class here, not the digit.

## Where the constant lives

`0.001` is an *SRCNN paper value*, but `init_std` sits on the generic `SRTrainingConfig` base shared by every architecture. Putting a paper constant there would be the same mistake one level down.

So: an explicit `init_std: float = 0.001` **override on `SRCNNTrainingConfig`**, plus `SRCNN.reset_parameters`'s own default (SRCNN-specific code). The shared base keeps `0.01` — it has no paper to match — and its docstring, which claimed these were "matching the SRCNN paper", now says plainly that the base is not paper-derived and that architectures override it with their real value.

## SRResNet: confirmed unaffected, by tracing not assumption

`SRLightning.__init__` calls `reset_parameters(mean=…, std=…)` only when `init_strategy == 'paper'`; `SRResNetTrainingConfig` defaults to `'default'`, so it never fires. And `sisr/models/srresnet/model.py` has no `reset_parameters` override, so it inherits `SRModel`'s `**kwargs`-absorbing no-op — the values would be ignored even if flipped. Doubly inert.

## Tests

- **Updated:** `test_srcnn_training_config_init_defaults` asserted the old `0.01`. Other `0.01` occurrences were checked and left — they test the *base* default or an explicitly-passed value, not the SRCNN paper default.
- **Added:** `test_reset_parameters_default_std_matches_paper_not_tenfold_larger` — pools weights across every `Conv2d` (~20k elements) and asserts the realised std falls in `(0.0008, 0.0012)`. With that many pooled samples the sampling-noise band is ~±0.5%, so the ±20% tolerance is ~40× the noise floor and won't flake, while the old `0.01` lands ~8× above the upper bound and fails decisively.

Both halves are covered: the config override *and* the model's own default.

## Verification

- `333 passed, 1 skipped` (baseline 332 + 1 new; skip is `test_imresize.py`'s byte-equality check, `data/reference` absent from worktrees)
- `ruff check` clean, `ruff format --check` clean
- Run with `CUDA_VISIBLE_DEVICES=""` — a training run owns the GPU

Doc-only changes are a separate commit per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)