### PR TITLE
Report Y-channel PSNR by default and ship the paper's range (P2.9, P2.10)

### DIFF
--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -80,16 +80,18 @@ class SRCNNTrainingConfig(SRTrainingConfig):
 class SRCNNEvalConfig(SREvalConfig):
     """SRCNN-paper-faithful eval defaults.
 
-    Reports PSNR on both RGB and the YCbCr triplet (the literature
-    usually quotes Y-channel PSNR for SRCNN), and excludes the outer
-    ``scale=3`` pixels per the standard SR-evaluation convention.
+    Reports PSNR on RGB and Y — the paper's own metric (Dong et al. quote
+    Y-channel only; the full YCbCr aggregate reads optimistically high
+    since chroma planes are far smoother than luma) — and excludes the
+    outer ``scale=3`` pixels per the standard SR-evaluation convention.
 
     Args:
         crop_border: Overrides the base default to ``3`` (outer pixels
             excluded before PSNR / SSIM at the standard ``x3`` scale).
-        psnr_channels: Overrides the base default to
-            ``['RGB', 'YCbCr']`` (the literature reports both).
+        psnr_channels: Overrides the base default to ``['RGB', 'Y']`` —
+            ``'Y'`` is the paper's own metric; ``'RGB'`` is a supplementary
+            aggregate.
     """
 
     crop_border: int = 3
-    psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "YCbCr"])
+    psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "Y"])

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -70,16 +70,18 @@ class SRResNetTrainingConfig(SRTrainingConfig):
 class SRResNetEvalConfig(SREvalConfig):
     """SRResNet-paper-faithful eval defaults.
 
-    Reports PSNR on RGB and YCbCr (literature typically quotes Y-channel
-    for SRResNet too); excludes the outer ``scale=4`` pixels before
+    Reports PSNR on RGB and Y — Ledig et al. quote Y-channel only (the full
+    YCbCr aggregate reads optimistically high since chroma planes are far
+    smoother than luma); excludes the outer ``scale=4`` pixels before
     computing PSNR / SSIM, matching the standard SR-evaluation convention.
 
     Args:
         crop_border: Overrides the base default to ``4`` (outer pixels
             excluded before PSNR / SSIM at the standard ``x4`` scale).
-        psnr_channels: Overrides the base default to
-            ``['RGB', 'YCbCr']`` (the literature reports both).
+        psnr_channels: Overrides the base default to ``['RGB', 'Y']`` —
+            ``'Y'`` is the paper's own metric; ``'RGB'`` is a supplementary
+            aggregate.
     """
 
     crop_border: int = 4
-    psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "YCbCr"])
+    psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "Y"])

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -33,11 +33,22 @@ import torch
 from ..models.base import SRModel
 from ..processors.base import SRProcessor
 
-# Per-colorspace channel names, in report order. Doubles as the set of
-# supported ``psnr_channels`` entries (validated in `SREvalConfig.__post_init__`).
+# Colorspace entries map to their sub-channel names, expanded only when
+# separate_psnr=True; single-channel entries (e.g. 'Y') map to () since
+# there's nothing further to decompose — this lets a bare channel name be
+# requested as a first-class psnr_channels entry (e.g. ['RGB', 'Y'] for the
+# paper's Y-only metric without YCbCr's smoother-chroma-diluted aggregate).
+# Doubles as the set of supported ``psnr_channels`` entries (validated in
+# `SREvalConfig.__post_init__`).
 _PSNR_CHANNEL_NAMES: dict[str, tuple[str, ...]] = {
     "RGB": ("R", "G", "B"),
     "YCbCr": ("Y", "Cb", "Cr"),
+    "R": (),
+    "G": (),
+    "B": (),
+    "Y": (),
+    "Cb": (),
+    "Cr": (),
 }
 
 
@@ -139,10 +150,13 @@ class SREvalConfig:
             computing PSNR / SSIM.  Standard SR-evaluation convention is to
             crop the outer ``scale`` pixels (e.g. ``crop_border=3`` for x3).
 
-        psnr_channels: Colorspaces in which PSNR is reported.  Supported
-            values are ``'RGB'`` and ``'YCbCr'``.  Multiple entries are
-            allowed (e.g. ``['RGB', 'YCbCr']`` produces both
-            ``psnr/val/RGB`` and ``psnr/val/YCbCr``).
+        psnr_channels: Colorspaces or bare single channels PSNR is reported
+            for.  Supported values are ``'RGB'``, ``'YCbCr'``, and any
+            individual channel name (``'R'``, ``'G'``, ``'B'``, ``'Y'``,
+            ``'Cb'``, ``'Cr'``).  Multiple entries are allowed (e.g.
+            ``['RGB', 'Y']`` produces ``psnr/val/RGB`` and ``psnr/val/Y`` —
+            the paper-comparable Y-only metric, without YCbCr's
+            three-channel aggregate diluting it with smoother chroma planes).
 
         separate_psnr: When ``True``, also reports PSNR for each individual
             channel within each requested colorspace (e.g. ``'RGB'`` adds
@@ -158,8 +172,8 @@ class SREvalConfig:
         """Validate ``psnr_channels`` at construction.
 
         Raises:
-            ValueError: If any entry is not a supported colorspace
-                (``'RGB'`` or ``'YCbCr'``).
+            ValueError: If any entry is not a supported colorspace or
+                single-channel name (see ``_PSNR_CHANNEL_NAMES``).
         """
         valid = tuple(_PSNR_CHANNEL_NAMES)
         invalid = [c for c in self.psnr_channels if c not in valid]
@@ -174,10 +188,13 @@ class SREvalConfig:
     def psnr_keys(self) -> list[str]:
         """Ordered PSNR metric keys this config requests.
 
-        For each colorspace in ``psnr_channels`` (in order), per-channel keys
-        are emitted first when ``separate_psnr`` is ``True``, followed by the
-        aggregate colorspace key itself — e.g. ``psnr_channels=['RGB']`` with
-        ``separate_psnr=True`` yields ``['R', 'G', 'B', 'RGB']``.
+        For each entry in ``psnr_channels`` (in order), per-channel keys are
+        emitted first when ``separate_psnr`` is ``True``, followed by the
+        entry itself — e.g. ``psnr_channels=['RGB']`` with
+        ``separate_psnr=True`` yields ``['R', 'G', 'B', 'RGB']``. Bare
+        single-channel entries (e.g. ``'Y'``) have no sub-channels to expand
+        (``_PSNR_CHANNEL_NAMES['Y'] == ()``), so they always contribute
+        exactly one key regardless of ``separate_psnr``.
 
         This is the seam consumed by ``SRLightning`` (val metric logging /
         HParams registration) and ``BenchmarkImageLogger`` (benchmark PSNR
@@ -185,7 +202,7 @@ class SREvalConfig:
         derived, so the two consumers cannot disagree.
 
         Returns:
-            Ordered list of PSNR keys, e.g. ``['RGB', 'YCbCr']`` or
+            Ordered list of PSNR keys, e.g. ``['RGB', 'Y']`` or
             ``['R', 'G', 'B', 'RGB', 'Y', 'Cb', 'Cr', 'YCbCr']``.
         """
         keys: list[str] = []

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -19,7 +19,9 @@ model:
       num_residual_blocks: 16
       padding: same
   processor:
-    class_path: sisr.processors.RGBProcessor
+    # Paper's range (Ledig et al. §3.2): LR [0,1] in, HR/target [-1,1].
+    # Use RGBProcessor instead to reproduce pre-2026-08-02 runs.
+    class_path: sisr.processors.RGBSignedOutputProcessor
   training_config:
     class_path: sisr.models.srresnet.SRResNetTrainingConfig
     init_args:

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -13,9 +13,12 @@ def test_srcnn_training_config_paper_defaults():
 
 
 def test_srcnn_eval_config_paper_defaults():
+    """Regression (P2.9): defaults must report the paper's own Y-channel
+    metric, not the YCbCr 3-channel aggregate (which reads optimistically
+    high since chroma planes are far smoother than luma)."""
     cfg = SRCNNEvalConfig()
     assert cfg.crop_border == 3
-    assert cfg.psnr_channels == ["RGB", "YCbCr"]
+    assert cfg.psnr_channels == ["RGB", "Y"]
     assert cfg.separate_psnr is False
 
 
@@ -40,7 +43,7 @@ def test_srcnn_eval_config_psnr_channels_independent_per_instance():
     a = SRCNNEvalConfig()
     b = SRCNNEvalConfig()
     a.psnr_channels.append("X")
-    assert b.psnr_channels == ["RGB", "YCbCr"]
+    assert b.psnr_channels == ["RGB", "Y"]
 
 
 def test_srcnn_training_config_init_defaults():

--- a/tests/models/srresnet/test_config.py
+++ b/tests/models/srresnet/test_config.py
@@ -19,10 +19,14 @@ def test_srresnet_training_config_paper_defaults():
 
 
 def test_srresnet_eval_config_paper_defaults():
-    """SRResNet paper defaults: x4 border crop; RGB+YCbCr PSNR breakdown."""
+    """SRResNet paper defaults: x4 border crop; RGB+Y PSNR.
+
+    Regression (P2.9): defaults must report the paper's own Y-channel
+    metric, not the YCbCr 3-channel aggregate (which reads optimistically
+    high since chroma planes are far smoother than luma)."""
     cfg = SRResNetEvalConfig()
     assert cfg.crop_border == 4
-    assert cfg.psnr_channels == ["RGB", "YCbCr"]
+    assert cfg.psnr_channels == ["RGB", "Y"]
     assert cfg.separate_psnr is False
 
 
@@ -39,7 +43,7 @@ def test_srresnet_eval_config_psnr_channels_independent_per_instance():
     a = SRResNetEvalConfig()
     b = SRResNetEvalConfig()
     a.psnr_channels.append("X")
-    assert b.psnr_channels == ["RGB", "YCbCr"]
+    assert b.psnr_channels == ["RGB", "Y"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,12 +92,13 @@ def test_srresnet_config_resolves_in_process():
         SRResNetEvalConfig,
         SRResNetTrainingConfig,
     )
-    from sisr.processors import RGBProcessor
+    from sisr.processors import RGBSignedOutputProcessor
 
     cli = _resolve("--config", str(SRRESNET_TEMPLATE))
     m = cli.model
     assert isinstance(m.model, SRResNet)
-    assert isinstance(m.processor, RGBProcessor)
+    # P2.10: the template ships the paper's [-1, 1] HR/target range.
+    assert isinstance(m.processor, RGBSignedOutputProcessor)
     assert isinstance(m.training_config, SRResNetTrainingConfig)
     assert isinstance(m.eval_config, SRResNetEvalConfig)
     assert m.eval_config.crop_border == 4  # inherited-default check

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -51,6 +51,15 @@ def test_eval_config_rejects_unknown_psnr_channel():
         SREvalConfig(psnr_channels=["RGB", "HSV"])
 
 
+def test_eval_config_rejects_unknown_psnr_channel_still_raises_alongside_bare_y():
+    """Regression (P2.9): adding bare single-channel entries to the allowlist
+    must not widen it into accepting arbitrary strings — 'HSV' stays invalid
+    even though 'Y' is now first-class."""
+    SREvalConfig(psnr_channels=["RGB", "Y"])  # valid — must not raise
+    with pytest.raises(ValueError, match="psnr_channels"):
+        SREvalConfig(psnr_channels=["RGB", "HSV"])
+
+
 # ---------------------------------------------------------------------------
 # psnr_keys (INIT.16) — the public seam B1/C1 depend on
 # ---------------------------------------------------------------------------
@@ -65,14 +74,28 @@ def test_eval_config_rejects_unknown_psnr_channel():
         (["YCbCr"], True),
         (["RGB", "YCbCr"], False),
         (["RGB", "YCbCr"], True),
+        (["Y"], False),
+        (["Y"], True),
+        (["RGB", "Y"], False),
+        (["RGB", "Y"], True),
     ],
 )
 def test_psnr_keys_matches_legacy_loop_derivation(psnr_channels, separate_psnr):
     """psnr_keys must reproduce exactly the loop SRLightning.__init__ used to
     inline (self._psnr_keys) before this property existed. Downstream PRs
     (benchmark PSNR-key selection, TensorBoard tag rename) depend on this
-    exact ordering."""
-    channel_names = {"RGB": ("R", "G", "B"), "YCbCr": ("Y", "Cb", "Cr")}
+    exact ordering. Bare single-channel entries (P2.9) map to () — nothing to
+    expand — so they always contribute exactly one key."""
+    channel_names = {
+        "RGB": ("R", "G", "B"),
+        "YCbCr": ("Y", "Cb", "Cr"),
+        "R": (),
+        "G": (),
+        "B": (),
+        "Y": (),
+        "Cb": (),
+        "Cr": (),
+    }
     legacy_keys: list[str] = []
     for cs in psnr_channels:
         if separate_psnr:
@@ -81,6 +104,13 @@ def test_psnr_keys_matches_legacy_loop_derivation(psnr_channels, separate_psnr):
 
     cfg = SREvalConfig(psnr_channels=psnr_channels, separate_psnr=separate_psnr)
     assert cfg.psnr_keys == legacy_keys
+
+
+def test_psnr_keys_bare_y_entry_yields_exactly_one_key():
+    """Regression (P2.9): a bare 'Y' entry must not decompose into anything
+    else — it is already a single channel, unlike 'YCbCr'."""
+    cfg = SREvalConfig(psnr_channels=["RGB", "Y"])
+    assert cfg.psnr_keys == ["RGB", "Y"]
 
 
 def test_psnr_keys_is_not_a_dataclass_field():


### PR DESCRIPTION
Two changes that make the shipped defaults match the papers.

## P2.9 — neither model emitted a paper-comparable PSNR

Both eval configs defaulted to `psnr_channels=['RGB','YCbCr']` with `separate_psnr=False`, so the only luma-ish key was `psnr/val/YCbCr` — PSNR over the **three-channel** tensor, `MSE = (MSE_Y + MSE_Cb + MSE_Cr)/3`. Chroma planes are far smoother than luma, so that aggregate reads optimistically high and is not the metric either paper reports. Both quote **Y-channel only**.

**Fix: `psnr_channels` now accepts a bare channel entry**, and both defaults become `['RGB', 'Y']` → exactly `psnr/val/RGB` and `psnr/val/Y`.

The alternative — flipping `separate_psnr` to `True` — also works but drags in R/G/B/Cb/Cr as collateral, and conflates "give me per-channel breakdowns" with "give me the paper's metric".

The implementation needed **no new logic**. `_PSNR_CHANNEL_NAMES` is the single source of truth for both the validation allowlist and key expansion, so each bare channel simply maps to `()`:

```python
"RGB": ("R", "G", "B"), "YCbCr": ("Y", "Cb", "Cr"),
"R": (), "G": (), "B": (), "Y": (), "Cb": (), "Cr": (),
```

`psnr_keys`' existing `extend(...)`-then-`append(cs)` then yields exactly one key for a bare channel. `_build_psnr_tensors` already precomputed `Y`/`Cb`/`Cr` whenever any of `{YCbCr, Y, Cb, Cr}` was requested, so it was untouched too.

All three `psnr_keys` consumers were checked, not assumed: `SRLightning` (val logging + HParams), `BenchmarkImageLogger`, and `SRCheckpoint.setup`'s monitor validation.

## P2.10 — the paper's range was not what shipped

`RGBSignedOutputProcessor` existed but the tracked SRResNet template still paired with `RGBProcessor`, so an out-of-the-box `sisr fit` trained entirely in `[0,1]`. Template now points at the signed processor, with a two-line note that `RGBProcessor` reproduces pre-2026-08-02 runs.

`config.srcnn.template.yaml` is untouched — SRCNN trains Y in `[0,1]` via `YChannelProcessor` and is already correct.

Verified by `--print_config`: processor resolves to `RGBSignedOutputProcessor`, eval config to `psnr_channels: [RGB, Y]`, `crop_border: 4`.

## Note: this renumbers recorded SRResNet baselines

Expected and one-time. Worth knowing what the numbers should look like — a run on the previous defaults plateaued at Set5 30.56 raw Y-PSNR, which under P2.8's still-open full-range convention is `+1.3225 dB` from the literature's studio-range figure, i.e. ~31.89 vs the paper's 32.05. The new `psnr/val/Y` key reports that same raw value; **P2.8 is what will make it directly comparable.**

## Tests

`340 passed, 1 skipped` (334 baseline + 6). Existing tests pinning the old defaults were updated — the parametrized `psnr_keys` test gained bare-channel cases rather than being duplicated. New: one confirming a bare `'Y'` yields exactly one key (no decomposition, unlike `YCbCr`), and one confirming the widened allowlist did **not** loosen validation — `'HSV'` still raises.

`ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)