### PR TITLE
Correct paper claims and shipped-doc drift (P5.12, P5.13)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,11 @@ parallel data loading; use it only for debugging, not for real training runs.
 3. Run `pytest` locally and make sure it is green.
 4. Open a pull request against `main`.
 
-All PRs must pass two GitHub Actions checks before they can merge:
+All PRs must pass three GitHub Actions checks before they can merge:
 
 - **test** — installs `.[dev]` and runs `pytest` with coverage (uploaded to Codecov).
 - **build** — verifies `pip install .` and that `sisr` / `sisr.cli.main` import cleanly.
+- **lint** — `ruff check` and `ruff format --check`.
 
 `main` uses linear history (rebase/squash, no merge commits) and requires PRs.
 
@@ -123,8 +124,8 @@ instead:
    and an optional `reset_parameters(**kwargs)` init hook).
 2. Define `<Arch>TrainingConfig` / `<Arch>EvalConfig` dataclasses with the paper's
    defaults (mirroring `sisr/models/srcnn/config.py`).
-3. Pick an existing `SRProcessor` (`RGBProcessor`, `YChannelProcessor`, `YCbCrProcessor`)
-   or add a new one.
+3. Pick an existing `SRProcessor` (`RGBProcessor`, `RGBSignedOutputProcessor`,
+   `YChannelProcessor`, `YCbCrProcessor`) or add a new one.
 4. Copy a template in `templates/`, point `model.model` / `model.processor` /
    `model.training_config` / `model.eval_config` and each dataset `class_path` at your
    new classes, and run `sisr fit --config <your.yaml>`.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ via `resize_backend`:
   MATLAB-`imresize`-compatible bicubic resize — antialiased (MATLAB widens the
   interpolation kernel by the scale factor on downscale; this widening *is* the
   low-pass, so no separate blur step is used or accepted with this backend) and using
-  MATLAB's own bicubic coefficient (a=-0.5, vs. OpenCV's a=-0.75). This is what makes
-  PSNR/SSIM numbers comparable to published papers, most of which generate their
+  MATLAB's own bicubic coefficient (a=-0.5, vs. OpenCV's a=-0.75). This makes the LR
+  **inputs** directly comparable to published papers, most of which generate their
   benchmark LR images with real MATLAB. See `sisr/imresize.py` for the implementation
   and its license/attribution header, and `tests/test_imresize.py` for verification.
+  Byte-exact inputs alone don't make **reported** PSNR/SSIM comparable, though:
+  Y-channel figures here use BT.601 full-range Y (`sisr/colorspace.py`), while the
+  literature's published Y-channel numbers use MATLAB `rgb2ycbcr`'s studio-range
+  convention — a known, exact `20·log10(255/219) ≈ 1.3225 dB` offset, not an unknown one.
 - **`'cv2'` (opt-in).** Plain `cv2.INTER_CUBIC`, no antialiasing of its own. SRCNN's
   `blur_sigma` (a pre-resize Gaussian blur) only has an effect on this path — passing
   `blur_sigma` together with `resize_backend='matlab'` raises `ValueError` at
@@ -208,8 +212,8 @@ Lightning subclass:
 1. Subclass `sisr.models.base.SRModel` with your network.
 2. Define `<Arch>TrainingConfig` / `<Arch>EvalConfig` dataclasses with the paper's
    defaults (see `sisr/models/srcnn/config.py`).
-3. Pick an `SRProcessor` (`RGBProcessor`, `YChannelProcessor`, `YCbCrProcessor`) or add
-   one.
+3. Pick an `SRProcessor` (`RGBProcessor`, `RGBSignedOutputProcessor`,
+   `YChannelProcessor`, `YCbCrProcessor`) or add one.
 4. Copy a template, point the `class_path`s at your new classes, and `sisr fit`.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -22,9 +22,11 @@ from sisr.training.config import SREvalConfig, SRTrainingConfig
 class SRResNetTrainingConfig(SRTrainingConfig):
     """SRResNet-paper-faithful training defaults.
 
-    The paper trains on full RGB (selected at the YAML layer by pairing
-    with :class:`~sisr.processors.RGBProcessor`) using Adam (lr 1e-4) and
-    no per-layer LRs.
+    The paper trains on full RGB using Adam (lr 1e-4) and no per-layer LRs.
+    Colorspace *and* intensity range are both selected at the YAML layer by
+    the processor: :class:`~sisr.processors.RGBSignedOutputProcessor` for
+    the paper's LR ``[0, 1]`` / HR ``[-1, 1]`` asymmetry,
+    :class:`~sisr.processors.RGBProcessor` for plain ``[0, 1]`` throughout.
 
     The paper does not specify a weight-initialization scheme.
     ``init_strategy='paper'`` is reserved for a future PR that wires up a

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -26,11 +26,12 @@ class SRResNetTrainingConfig(SRTrainingConfig):
     with :class:`~sisr.processors.RGBProcessor`) using Adam (lr 1e-4) and
     no per-layer LRs.
 
-    Weight initialization in the paper is implicit (Kaiming-style for PReLU
-    activations). ``init_strategy='paper'`` is reserved for a future PR
-    that wires this up via :meth:`SRResNet.reset_parameters`. Today the
-    field defaults to ``'default'`` so SRResNet ships with PyTorch's
-    built-in init; flipping to ``'paper'`` is currently a no-op because
+    The paper does not specify a weight-initialization scheme.
+    ``init_strategy='paper'`` is reserved for a future PR that wires up a
+    project-chosen init (e.g. Kaiming-style for the PReLU activations) via
+    :meth:`SRResNet.reset_parameters`. Today the field defaults to
+    ``'default'`` so SRResNet ships with PyTorch's built-in init; flipping
+    to ``'paper'`` is currently a no-op because
     :meth:`SRModel.reset_parameters` (the inherited base) does nothing.
     The field exists now so a future PR can add the implementation without
     a YAML schema change.

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -1,6 +1,7 @@
 seed_everything: 42
 
-# TF32 matmul/conv on Ampere+ GPUs — free lever, no precision opt-in (unlike bf16-mixed below).
+# TF32 matmul on Ampere+ GPUs. Measured no-op on this repo's conv stacks: conv runs
+# through cuDNN, whose allow_tf32 already defaults True — kept for matmul-heavy archs.
 matmul_precision: high
 
 optimizer:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -1,6 +1,7 @@
 seed_everything: 42
 
-# TF32 matmul/conv on Ampere+ GPUs — free lever, no precision opt-in (unlike bf16-mixed below).
+# TF32 matmul on Ampere+ GPUs. Measured no-op on this repo's conv stacks: conv runs
+# through cuDNN, whose allow_tf32 already defaults True — kept for matmul-heavy archs.
 matmul_precision: high
 
 optimizer:


### PR DESCRIPTION
Docs-only. Every item is a factual claim in a tracked file that was wrong.

## 1. A fabricated paper claim

`SRResNetTrainingConfig`'s docstring asserted *"Weight initialization in the paper is implicit (Kaiming-style for PReLU activations)."* **Verified against the full text of Ledig et al.: the paper contains no discussion of weight initialization anywhere.** Now states that plainly and marks the Kaiming idea as a project choice reserved for future work, not the paper's.

This sat in a file whose entire job is recording what the paper specifies — the same failure mode as P1.1, where a docstring claiming `0.01` "matched the SRCNN paper" kept anyone from re-deriving a 10x-wrong value.

## 2. `CONTRIBUTING.md` undercounted required checks

Said **two** (`test`, `build`). The `main-protection` ruleset has required **three** since 2026-07-31 — `lint` is its own top-level job, confirmed against `.github/workflows/test.yml` rather than assumed.

## 3. Incomplete processor list, in two files

`README.md` and `CONTRIBUTING.md` both listed three processors; `RGBSignedOutputProcessor` was missing. README's own ONNX section already discussed it, so the file contradicted itself. Authoritative set taken from `__all__`.

## 4. README overstated paper comparability

Claimed byte-exact `imresize` *"is what makes PSNR/SSIM numbers comparable to published papers."* Byte-exact **inputs** do not imply comparable **reported numbers** while P2.8 is open. Softened to a claim about the LR inputs, with the metric-convention caveat named as what it is — a known, exact `20*log10(255/219) ~= 1.3225 dB` offset, not an unknown.

## 5. Both templates oversold `matmul_precision`

Described as *"a standard free lever"*. It was **measured as a no-op** on these conv stacks: `set_float32_matmul_precision` governs matmul, while conv goes through cuDNN whose `allow_tf32` already defaults `True`. The key is kept (harmless); the claim of benefit is gone.

## 6. The processor now selects range, not just colorspace

`SRResNetTrainingConfig` named only `RGBProcessor` as the paper's pairing. That was complete when colorspace was a processor's whole job — it now reads as endorsing the wrong one, since `RGBSignedOutputProcessor` carries the paper's `[-1,1]` output range.

## Verification

`334 passed, 1 skipped` — **unchanged**, which is the point: any movement would mean a docs-only PR touched behaviour. `ruff check` / `ruff format --check` clean. Both templates re-verified through `--print_config`.

Deliberately not changed: `sisr/cli.py`'s `matmul_precision` docstring describes only the mechanism and never claims a benefit for this repo, so it isn't false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)