### PR TITLE
Compute Y-channel metrics in BT.601 studio range and report Y SSIM (P2.8, P3.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ via `resize_backend`:
   Byte-exact inputs alone don't make **reported** PSNR/SSIM comparable, though:
   Y-channel figures here use BT.601 full-range Y (`sisr/colorspace.py`), while the
   literature's published Y-channel numbers use MATLAB `rgb2ycbcr`'s studio-range
-  convention — a known, exact `20·log10(255/219) ≈ 1.3225 dB` offset, not an unknown one.
+  convention — a known, exact `20·log10(255/219) ≈ 1.3219 dB` offset, not an unknown one.
 - **`'cv2'` (opt-in).** Plain `cv2.INTER_CUBIC`, no antialiasing of its own. SRCNN's
   `blur_sigma` (a pre-resize Gaussian blur) only has an effect on this path — passing
   `blur_sigma` together with `resize_backend='matlab'` raises `ValueError` at

--- a/sisr/colorspace.py
+++ b/sisr/colorspace.py
@@ -1,9 +1,21 @@
-"""BT.601 full-range RGB <-> YCbCr conversion.
+"""BT.601 RGB <-> YCbCr conversion, full-range and studio-range.
 
-BT.601 full-range YCbCr is the project's working chroma space. These pure
-tensor functions live on their own so the
-:class:`~sisr.processors.SRProcessor` subclasses and any external callers can
-convert colorspaces without depending on Lightning or model code.
+Two distinct ranges live here, deliberately kept apart:
+
+* **Full-range** (:func:`rgb_to_ycbcr` / :func:`ycbcr_to_rgb`) is the
+  project's *training* chroma space — what :class:`~sisr.processors.SRProcessor`
+  subclasses (``YChannelProcessor``, ``YCbCrProcessor``) feed the model.
+  Changing these would silently renumber a trained model's inputs and
+  invalidate existing checkpoints, so they are frozen.
+* **Studio-range** (:func:`rgb_to_ycbcr_studio`) is the *metric* colorspace —
+  what MATLAB's ``rgb2ycbcr``, BasicSR's ``bgr2ycbcr(y_only=...)``, and every
+  published SR benchmark actually score against. It exists solely for
+  :class:`~sisr.training.lightning_module.SRLightning`'s PSNR/SSIM
+  computation and must never be used as a processor's colorspace.
+
+Do not "unify" these two — that is the one mistake this split guards against.
+These pure tensor functions live on their own so callers can convert
+colorspaces without depending on Lightning or model code.
 """
 
 import torch
@@ -12,7 +24,7 @@ import torch
 # Both colorspaces are normalised to [0, 1]. Cb and Cr have a +0.5 offset on
 # their stored representation so that signed chroma values in [-0.5, +0.5]
 # map onto unsigned [0, 1]. This is the *full-range* (a.k.a. "JPEG") variant
-# of BT.601 — distinct from the studio-range variant which scales Y to
+# of BT.601 — distinct from the studio-range variant below, which scales Y to
 # [16/255, 235/255] and Cb/Cr to [16/255, 240/255].
 
 _RGB_TO_Y = (0.299, 0.587, 0.114)
@@ -22,6 +34,19 @@ _YCBCR_TO_R = 1.402  # cr coefficient
 _YCBCR_TO_G_CB = -0.344  # cb coefficient
 _YCBCR_TO_G_CR = -0.714  # cr coefficient
 _YCBCR_TO_B = 1.772  # cb coefficient
+
+# BT.601 studio-range ("limited"/"TV" range) rescale, applied on top of the
+# full-range YCbCr above. Luma occupies 219 of 255 levels ([16, 235]); chroma
+# occupies 224 of 255 levels ([16, 240], centered on 128) — the two scales
+# differ, so collapsing them to one constant would itself be a fidelity bug.
+# A full-range diff scales by exactly one of these two factors on conversion,
+# so PSNR computed in studio range sits a *constant*, algebraically exact
+# 20*log10(255/219) dB above full-range for Y (and 20*log10(255/224) dB for
+# Cb/Cr) — see tests/test_colorspace.py for the identity this predicts.
+_STUDIO_Y_SCALE = 219 / 255
+_STUDIO_Y_OFFSET = 16 / 255
+_STUDIO_C_SCALE = 224 / 255
+_STUDIO_C_OFFSET = 128 / 255
 
 
 def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
@@ -58,3 +83,29 @@ def ycbcr_to_rgb(img: torch.Tensor) -> torch.Tensor:
     g = y + _YCBCR_TO_G_CB * cb + _YCBCR_TO_G_CR * cr
     b = y + _YCBCR_TO_B * cb
     return torch.cat([r, g, b], dim=1).clamp(0.0, 1.0)
+
+
+def rgb_to_ycbcr_studio(img: torch.Tensor) -> torch.Tensor:
+    """Convert a normalised RGB tensor to YCbCr (BT.601 studio-range) — metric only.
+
+    Rescales :func:`rgb_to_ycbcr`'s full-range output onto the studio
+    ("limited"/"TV") range MATLAB's ``rgb2ycbcr`` and the SR literature
+    report PSNR/SSIM against. This is a one-way conversion for scoring —
+    there is no ``ycbcr_to_rgb_studio``, since nothing reconstructs an
+    image from it. Do not feed this to a model; every :class:`SRProcessor`
+    trains in full-range (see module docstring).
+
+    Args:
+        img (torch.Tensor): RGB tensor of shape ``(B, 3, H, W)`` with
+            values in ``[0, 1]``.
+
+    Returns:
+        torch.Tensor: YCbCr tensor of shape ``(B, 3, H, W)``, Y in
+        ``[16/255, 235/255]``, Cb/Cr in ``[16/255, 240/255]``.
+    """
+    full = rgb_to_ycbcr(img)
+    y, cb, cr = full[:, 0:1], full[:, 1:2], full[:, 2:3]
+    y = _STUDIO_Y_OFFSET + _STUDIO_Y_SCALE * y
+    cb = _STUDIO_C_OFFSET + _STUDIO_C_SCALE * (cb - 0.5)
+    cr = _STUDIO_C_OFFSET + _STUDIO_C_SCALE * (cr - 0.5)
+    return torch.cat([y, cb, cr], dim=1)

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -45,8 +45,8 @@ class BenchmarkImageLogger(Callback):
     all three panels share the same spatial size.
 
     Per-image PSNR/SSIM scalars go under ``"per_image/{name}/psnr/{key}/{filename}"``
-    and ``"per_image/{name}/ssim/{filename}"``; per-set means under
-    ``"psnr/{name}/{key}"`` and ``"ssim/{name}"``.
+    and ``"per_image/{name}/ssim/{key}/{filename}"``; per-set means under
+    ``"psnr/{name}/{key}"`` and ``"ssim/{name}/{key}"``.
 
     Border cropping is sourced from ``pl_module.eval_config.crop_border`` at
     the use site; this avoids dual-knob configuration drift.
@@ -275,16 +275,19 @@ class BenchmarkImageLogger(Callback):
             # seam, and duplicating it here would recreate the divergence P2.1
             # removed. Keys now come from eval_config, so this is a value
             # lookup only — the callback no longer decides *which* keys exist.
-            psnr_tensors = pl_module._build_psnr_tensors(sr_4d, hr_4d)
+            metric_tensors = pl_module._build_metric_tensors(sr_4d, hr_4d)
             psnr_dict = {
                 key: torchmetrics.functional.image.peak_signal_noise_ratio(
-                    *psnr_tensors[key], data_range=1.0
+                    *metric_tensors[key], data_range=1.0
                 ).item()
                 for key in pl_module.eval_config.psnr_keys
             }
-            ssim = torchmetrics.functional.image.structural_similarity_index_measure(
-                sr_4d, hr_4d, data_range=1.0
-            )
+            ssim_dict = {
+                key: torchmetrics.functional.image.structural_similarity_index_measure(
+                    *metric_tensors[key], data_range=1.0
+                ).item()
+                for key in pl_module.eval_config.ssim_keys
+            }
             self._buffer[dataset_name].append(
                 (
                     filename,
@@ -292,7 +295,7 @@ class BenchmarkImageLogger(Callback):
                     sr[i].cpu() if should_log_images else None,
                     hr_img[i].cpu() if should_log_images else None,
                     psnr_dict,
-                    ssim.item(),
+                    ssim_dict,
                 )
             )
 
@@ -316,12 +319,14 @@ class BenchmarkImageLogger(Callback):
                 continue
 
             psnr_keys = samples[0][4].keys()
-            mean_ssim = sum(s for *_, s in samples) / len(samples)
+            ssim_keys = samples[0][5].keys()
 
             for key in psnr_keys:
                 mean_psnr = sum(s[4][key] for s in samples) / len(samples)
                 pl_module.log(f"psnr/{dataset_name}/{key}", mean_psnr, add_dataloader_idx=False)
-            pl_module.log(f"ssim/{dataset_name}", mean_ssim, add_dataloader_idx=False)
+            for key in ssim_keys:
+                mean_ssim = sum(s[5][key] for s in samples) / len(samples)
+                pl_module.log(f"ssim/{dataset_name}/{key}", mean_ssim, add_dataloader_idx=False)
 
             if should_log_images:
                 tb_logger = next(
@@ -336,16 +341,19 @@ class BenchmarkImageLogger(Callback):
                     continue
 
                 experiment = tb_logger.experiment
-                for filename, lr, sr, hr, psnr_dict, ssim in samples:
+                for filename, lr, sr, hr, psnr_dict, ssim_dict in samples:
                     for key, psnr_val in psnr_dict.items():
                         experiment.add_scalar(
                             f"per_image/{dataset_name}/psnr/{key}/{filename}",
                             psnr_val,
                             global_step=step,
                         )
-                    experiment.add_scalar(
-                        f"per_image/{dataset_name}/ssim/{filename}", ssim, global_step=step
-                    )
+                    for key, ssim_val in ssim_dict.items():
+                        experiment.add_scalar(
+                            f"per_image/{dataset_name}/ssim/{key}/{filename}",
+                            ssim_val,
+                            global_step=step,
+                        )
 
                     # Triptych: bicubic | SR | HR, all at HR size.
                     # The bicubic panel is the LR upsampled to HR via bicubic
@@ -519,8 +527,8 @@ class SRCheckpoint(ModelCheckpoint):
 
     Args:
         monitor_metric: The validation metric to monitor. Any ``psnr/val/{key}``
-            logged by the lightning module (e.g. ``"psnr/val/Y"``,
-            ``"psnr/val/YCbCr"``) or ``"ssim/val"``.
+            or ``ssim/val/{key}`` logged by the lightning module (e.g.
+            ``"psnr/val/Y"``, ``"psnr/val/YCbCr"``, ``"ssim/val/RGB"``).
         save_top_k: Number of best checkpoints to keep.
         dirpath: Directory to save checkpoints.
         filename_prefix: Prefix for checkpoint filenames.
@@ -563,8 +571,8 @@ class SRCheckpoint(ModelCheckpoint):
         ``val_loop._has_run``) — with a long ``val_check_interval`` that is a
         late, expensive-to-reach crash. This moves the same failure to
         startup by checking ``monitor`` against ``pl_module.eval_config.psnr_keys``
-        (the same seam ``SRLightning`` logs val PSNR from) up front, before
-        any training happens.
+        / ``ssim_keys`` (the same seams ``SRLightning`` logs val PSNR/SSIM
+        from) up front, before any training happens.
 
         Args:
             trainer: The active trainer.
@@ -584,13 +592,13 @@ class SRCheckpoint(ModelCheckpoint):
         if stage != "fit":
             return
         valid_metrics = {f"psnr/val/{key}" for key in pl_module.eval_config.psnr_keys}
-        valid_metrics.add("ssim/val")
+        valid_metrics |= {f"ssim/val/{key}" for key in pl_module.eval_config.ssim_keys}
         if self.monitor is not None and self.monitor not in valid_metrics:
             raise MisconfigurationException(
                 f"`SRCheckpoint(monitor_metric={self.monitor!r})` does not match any "
                 f"metric `SRLightning` will log: {sorted(valid_metrics)}. HINT: check "
-                f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or monitor "
-                f"`ssim/val`."
+                f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or "
+                f"`eval_config.ssim_channels`."
             )
 
 

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -6,8 +6,8 @@ Split into two classes by lifecycle:
   learning rates, paper-init knobs, and the example input shape used to log
   the model graph to TensorBoard.
 * ``SREvalConfig`` controls validation/test metric computation —
-  boundary-pixel exclusion (``crop_border``) and which colorspaces PSNR is
-  reported in.
+  boundary-pixel exclusion (``crop_border``) and which colorspaces PSNR/SSIM
+  are reported in.
 
 Per-architecture defaults live in subclasses next to the model code (e.g.
 ``sisr.models.srcnn.SRCNNTrainingConfig``); a YAML user picks them via
@@ -17,8 +17,9 @@ overrides individual fields with ``init_args``.
 The colorspace the model trains in is no longer a string field here; it is
 expressed by the choice of processor (see ``sisr.processors``).
 
-``SRTrainingConfig.validate_against`` / ``SREvalConfig.psnr_keys`` are the
-config-side half of the correlated-field validation seam: fields like
+``SRTrainingConfig.validate_against`` / ``SREvalConfig.psnr_keys`` /
+``SREvalConfig.ssim_keys`` are the config-side half of the correlated-field
+validation seam: fields like
 ``num_channels`` (model) and ``class_path`` (processor) live in sibling
 objects a single dataclass ``__post_init__`` cannot see across, so the
 cross-object check happens once both are constructed, orchestrated by
@@ -36,11 +37,14 @@ from ..processors.base import SRProcessor
 # Colorspace entries map to their sub-channel names, expanded only when
 # separate_psnr=True; single-channel entries (e.g. 'Y') map to () since
 # there's nothing further to decompose — this lets a bare channel name be
-# requested as a first-class psnr_channels entry (e.g. ['RGB', 'Y'] for the
-# paper's Y-only metric without YCbCr's smoother-chroma-diluted aggregate).
-# Doubles as the set of supported ``psnr_channels`` entries (validated in
-# `SREvalConfig.__post_init__`).
-_PSNR_CHANNEL_NAMES: dict[str, tuple[str, ...]] = {
+# requested as a first-class psnr_channels/ssim_channels entry (e.g.
+# ['RGB', 'Y'] for the paper's Y-only metric without YCbCr's
+# smoother-chroma-diluted aggregate).
+# Doubles as the set of supported ``psnr_channels``/``ssim_channels`` entries
+# (validated in `SREvalConfig.__post_init__`) — shared by both metric
+# families so PSNR and SSIM cannot silently diverge on which colorspace
+# names are legal.
+_CHANNEL_SUBNAMES: dict[str, tuple[str, ...]] = {
     "RGB": ("R", "G", "B"),
     "YCbCr": ("Y", "Cb", "Cr"),
     "R": (),
@@ -157,32 +161,48 @@ class SREvalConfig:
             ``['RGB', 'Y']`` produces ``psnr/val/RGB`` and ``psnr/val/Y`` —
             the paper-comparable Y-only metric, without YCbCr's
             three-channel aggregate diluting it with smoother chroma planes).
+            ``Y``/``Cb``/``Cr``/``YCbCr`` are scored in BT.601 studio range
+            (the literature's convention); ``RGB``/``R``/``G``/``B`` are
+            unaffected.
 
         separate_psnr: When ``True``, also reports PSNR for each individual
             channel within each requested colorspace (e.g. ``'RGB'`` adds
             ``psnr/val/R`` / ``psnr/val/G`` / ``psnr/val/B`` alongside
             the aggregate ``psnr/val/RGB``).
+
+        ssim_channels: Colorspaces or bare single channels SSIM is reported
+            for. Same allowlist and studio-range treatment as
+            ``psnr_channels``; no ``separate_ssim`` counterpart to
+            ``separate_psnr`` exists because per-channel R/G/B or Cb/Cr SSIM
+            has no established convention to reproduce. Defaults to
+            ``['RGB', 'Y']`` (not just ``['RGB']`` like ``psnr_channels``) so
+            the paper-comparable Y-SSIM ships out of the box — unlike PSNR,
+            RGB-SSIM cannot be corrected to Y-SSIM after the fact by a
+            constant offset, so there is no reason to gate it behind an
+            architecture-specific subclass.
     """
 
     crop_border: int = 0
     psnr_channels: list[str] = field(default_factory=lambda: ["RGB"])
     separate_psnr: bool = False
+    ssim_channels: list[str] = field(default_factory=lambda: ["RGB", "Y"])
 
     def __post_init__(self) -> None:
-        """Validate ``psnr_channels`` at construction.
+        """Validate ``psnr_channels`` and ``ssim_channels`` at construction.
 
         Raises:
-            ValueError: If any entry is not a supported colorspace or
-                single-channel name (see ``_PSNR_CHANNEL_NAMES``).
+            ValueError: If any entry of either field is not a supported
+                colorspace or single-channel name (see ``_CHANNEL_SUBNAMES``).
         """
-        valid = tuple(_PSNR_CHANNEL_NAMES)
-        invalid = [c for c in self.psnr_channels if c not in valid]
-        if invalid:
-            raise ValueError(
-                f"SREvalConfig.psnr_channels entries must be one of "
-                f"{list(valid)}; got unsupported {invalid}. Fix "
-                f"model.eval_config.init_args.psnr_channels in your YAML."
-            )
+        valid = tuple(_CHANNEL_SUBNAMES)
+        for field_name in ("psnr_channels", "ssim_channels"):
+            invalid = [c for c in getattr(self, field_name) if c not in valid]
+            if invalid:
+                raise ValueError(
+                    f"SREvalConfig.{field_name} entries must be one of "
+                    f"{list(valid)}; got unsupported {invalid}. Fix "
+                    f"model.eval_config.init_args.{field_name} in your YAML."
+                )
 
     @property
     def psnr_keys(self) -> list[str]:
@@ -193,7 +213,7 @@ class SREvalConfig:
         entry itself — e.g. ``psnr_channels=['RGB']`` with
         ``separate_psnr=True`` yields ``['R', 'G', 'B', 'RGB']``. Bare
         single-channel entries (e.g. ``'Y'``) have no sub-channels to expand
-        (``_PSNR_CHANNEL_NAMES['Y'] == ()``), so they always contribute
+        (``_CHANNEL_SUBNAMES['Y'] == ()``), so they always contribute
         exactly one key regardless of ``separate_psnr``.
 
         This is the seam consumed by ``SRLightning`` (val metric logging /
@@ -208,6 +228,24 @@ class SREvalConfig:
         keys: list[str] = []
         for cs in self.psnr_channels:
             if self.separate_psnr:
-                keys.extend(_PSNR_CHANNEL_NAMES[cs])
+                keys.extend(_CHANNEL_SUBNAMES[cs])
             keys.append(cs)
         return keys
+
+    @property
+    def ssim_keys(self) -> list[str]:
+        """Ordered SSIM metric keys this config requests.
+
+        Mirrors ``psnr_keys`` over ``ssim_channels`` instead, minus the
+        ``separate_psnr`` expansion step — there is no ``separate_ssim``,
+        so each entry contributes exactly itself, in order.
+
+        This is the seam consumed by ``SRLightning`` (val metric logging /
+        HParams registration / checkpoint-monitor validation) and
+        ``BenchmarkImageLogger`` (benchmark SSIM key selection), same as
+        ``psnr_keys``.
+
+        Returns:
+            Ordered list of SSIM keys, e.g. ``['RGB', 'Y']``.
+        """
+        return list(self.ssim_channels)

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -29,7 +29,7 @@ class SRDataModule(lightning.LightningDataModule):
       so they fire during every val cycle of ``cli fit`` for monitoring
       (driven by :class:`~sisr.training.callbacks.BenchmarkImageLogger`).
       ``dataloader_idx == 0`` is the primary held-out validation loader and
-      drives ``loss/val`` / ``psnr/val`` / ``ssim/val``.
+      drives ``loss/val`` / ``psnr/val/*`` / ``ssim/val/*``.
     * :meth:`test_dataloader` returns the test loaders only, for
       ``cli test --ckpt_path <path>`` final evaluation.
 

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -44,7 +44,8 @@ class SRLightning(lightning.LightningModule):
             example_input_shape, init_*). Defaults to base
             :class:`SRTrainingConfig` (uniform LR, no paper init).
         eval_config: Per-architecture evaluation settings (crop_border,
-            psnr_channels, separate_psnr). Defaults to base :class:`SREvalConfig`.
+            psnr_channels, separate_psnr, ssim_channels). Defaults to base
+            :class:`SREvalConfig`.
         criterion: Loss instance. Defaults to :class:`torch.nn.MSELoss`.
         optimizer: ``OptimizerCallable`` populated from top-level YAML
             ``optimizer:``. Defaults to :class:`torch.optim.Adam`.
@@ -146,19 +147,21 @@ class SRLightning(lightning.LightningModule):
 
         return result
 
-    def _build_psnr_tensors(
+    def _build_metric_tensors(
         self, sr: torch.Tensor, hr: torch.Tensor
     ) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
-        """Pre-computes (sr, hr) RGB tensor pairs for every tracked PSNR key.
+        """Pre-computes (sr, hr) tensor pairs for every tracked PSNR/SSIM key.
 
-        Colorspace conversions are performed at most once per call. ``Y`` /
+        Shared by both metric families (over the union of ``psnr_keys`` and
+        ``ssim_keys``) so a requested colorspace conversion happens at most
+        once per call regardless of how many metrics consume it. ``Y`` /
         ``Cb`` / ``Cr`` / ``YCbCr`` are converted via ``rgb_to_ycbcr_studio`` —
-        BT.601 studio range, the literature's PSNR convention (MATLAB's
-        ``rgb2ycbcr``, BasicSR's ``bgr2ycbcr``) — not the full-range
-        ``rgb_to_ycbcr`` the processors train in (see ``sisr.colorspace``
-        module docstring). ``RGB``/``R``/``G``/``B`` are untouched either way.
+        BT.601 studio range, the literature's PSNR/SSIM convention — not the
+        full-range ``rgb_to_ycbcr`` the processors train in (see
+        ``sisr.colorspace`` module docstring). ``RGB``/``R``/``G``/``B`` are
+        untouched either way.
         """
-        keys = set(self.eval_config.psnr_keys)
+        keys = set(self.eval_config.psnr_keys) | set(self.eval_config.ssim_keys)
         tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
         if keys & {"RGB", "R", "G", "B"}:
@@ -354,30 +357,33 @@ class SRLightning(lightning.LightningModule):
             sr = sr[..., n:-n, n:-n]
             hr_cropped = hr_cropped[..., n:-n, n:-n]
 
-        psnr_tensors = self._build_psnr_tensors(sr, hr_cropped)
+        metric_tensors = self._build_metric_tensors(sr, hr_cropped)
 
         # add_dataloader_idx=False keeps metric names clean — needed because the
         # primary val loader is at idx 0 of a list that also contains test loaders.
         self.log("loss/val", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
-        primary = self.eval_config.psnr_channels[0]
+        primary_psnr = self.eval_config.psnr_channels[0]
         for key in self.eval_config.psnr_keys:
-            sr_t, hr_t = psnr_tensors[key]
+            sr_t, hr_t = metric_tensors[key]
             self.log(
                 f"psnr/val/{key}",
                 self._mean_psnr(sr_t, hr_t),
-                prog_bar=(key == primary),
+                prog_bar=(key == primary_psnr),
                 on_step=False,
                 add_dataloader_idx=False,
             )
-        self.log(
-            "ssim/val",
-            torchmetrics.functional.image.structural_similarity_index_measure(
-                sr, hr_cropped, data_range=1.0
-            ),
-            prog_bar=True,
-            on_step=False,
-            add_dataloader_idx=False,
-        )
+        primary_ssim = self.eval_config.ssim_channels[0]
+        for key in self.eval_config.ssim_keys:
+            sr_t, hr_t = metric_tensors[key]
+            self.log(
+                f"ssim/val/{key}",
+                torchmetrics.functional.image.structural_similarity_index_measure(
+                    sr_t, hr_t, data_range=1.0
+                ),
+                prog_bar=(key == primary_ssim),
+                on_step=False,
+                add_dataloader_idx=False,
+            )
 
     def on_train_start(self) -> None:
         """Register val metric tags with TensorBoard's HParams tab.
@@ -397,7 +403,7 @@ class SRLightning(lightning.LightningModule):
             return
         metrics = {
             **{f"psnr/val/{k}": 0.0 for k in self.eval_config.psnr_keys},
-            "ssim/val": 0.0,
+            **{f"ssim/val/{k}": 0.0 for k in self.eval_config.ssim_keys},
         }
         for tb in tb_loggers:
             tb.log_hyperparams(self.hparams, metrics)

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -18,7 +18,7 @@ import torchvision
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 
-from ..colorspace import rgb_to_ycbcr
+from ..colorspace import rgb_to_ycbcr_studio
 from ..models.base import SRModel
 from ..processors import SRProcessor
 from .config import SREvalConfig, SRTrainingConfig
@@ -151,7 +151,12 @@ class SRLightning(lightning.LightningModule):
     ) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
         """Pre-computes (sr, hr) RGB tensor pairs for every tracked PSNR key.
 
-        Colorspace conversions are performed at most once per call.
+        Colorspace conversions are performed at most once per call. ``Y`` /
+        ``Cb`` / ``Cr`` / ``YCbCr`` are converted via ``rgb_to_ycbcr_studio`` —
+        BT.601 studio range, the literature's PSNR convention (MATLAB's
+        ``rgb2ycbcr``, BasicSR's ``bgr2ycbcr``) — not the full-range
+        ``rgb_to_ycbcr`` the processors train in (see ``sisr.colorspace``
+        module docstring). ``RGB``/``R``/``G``/``B`` are untouched either way.
         """
         keys = set(self.eval_config.psnr_keys)
         tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
@@ -163,8 +168,8 @@ class SRLightning(lightning.LightningModule):
             tensors["B"] = (sr[:, 2:3], hr[:, 2:3])
 
         if keys & {"YCbCr", "Y", "Cb", "Cr"}:
-            sr_ycc = rgb_to_ycbcr(sr)
-            hr_ycc = rgb_to_ycbcr(hr)
+            sr_ycc = rgb_to_ycbcr_studio(sr)
+            hr_ycc = rgb_to_ycbcr_studio(hr)
             tensors["YCbCr"] = (sr_ycc, hr_ycc)
             tensors["Y"] = (sr_ycc[:, 0:1], hr_ycc[:, 0:1])
             tensors["Cb"] = (sr_ycc[:, 1:2], hr_ycc[:, 1:2])

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -96,7 +96,7 @@ trainer:
         save_top_k: 3
     - class_path: sisr.training.SRCheckpoint
       init_args:
-        monitor_metric: ssim/val
+        monitor_metric: ssim/val/RGB
         save_top_k: 3
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -98,7 +98,7 @@ trainer:
         save_top_k: 3
     - class_path: sisr.training.SRCheckpoint
       init_args:
-        monitor_metric: ssim/val
+        monitor_metric: ssim/val/RGB
         save_top_k: 3
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -20,6 +20,8 @@ def test_srcnn_eval_config_paper_defaults():
     assert cfg.crop_border == 3
     assert cfg.psnr_channels == ["RGB", "Y"]
     assert cfg.separate_psnr is False
+    # Not overridden — inherits the base SREvalConfig default.
+    assert cfg.ssim_channels == ["RGB", "Y"]
 
 
 def test_srcnn_training_config_subclass():

--- a/tests/models/srresnet/test_config.py
+++ b/tests/models/srresnet/test_config.py
@@ -28,6 +28,8 @@ def test_srresnet_eval_config_paper_defaults():
     assert cfg.crop_border == 4
     assert cfg.psnr_channels == ["RGB", "Y"]
     assert cfg.separate_psnr is False
+    # Not overridden — inherits the base SREvalConfig default.
+    assert cfg.ssim_channels == ["RGB", "Y"]
 
 
 def test_srresnet_training_config_subclass():

--- a/tests/test_colorspace.py
+++ b/tests/test_colorspace.py
@@ -1,6 +1,9 @@
+import math
+
+import pytest
 import torch
 
-from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb
+from sisr.colorspace import rgb_to_ycbcr, rgb_to_ycbcr_studio, ycbcr_to_rgb
 
 
 def test_rgb_to_ycbcr_shape_and_dtype():
@@ -48,3 +51,99 @@ def test_round_trip_within_coefficient_precision():
     y = ycbcr_to_rgb(rgb_to_ycbcr(x))
     err = (y - x).abs().max().item()
     assert err < 5e-4
+
+
+# ---------------------------------------------------------------------------
+# rgb_to_ycbcr_studio (P2.8) — BT.601 studio range, metric-only
+# ---------------------------------------------------------------------------
+
+
+def test_rgb_to_ycbcr_studio_shape_and_dtype():
+    x = torch.rand(2, 3, 8, 8, dtype=torch.float32)
+    y = rgb_to_ycbcr_studio(x)
+    assert y.shape == (2, 3, 8, 8)
+    assert y.dtype == torch.float32
+
+
+def test_rgb_to_ycbcr_studio_known_values_white():
+    # White: full-range Y=1, Cb=Cr=0.5 -> studio Y=16/255+219/255=235/255,
+    # Cb=Cr=128/255 (chroma stays centered — white has no color).
+    x = torch.ones(1, 3, 1, 1)
+    y = rgb_to_ycbcr_studio(x)
+    expected = torch.tensor([[[[235 / 255]], [[128 / 255]], [[128 / 255]]]])
+    assert torch.allclose(y, expected, atol=1e-6)
+
+
+def test_rgb_to_ycbcr_studio_known_values_black():
+    # Black: full-range Y=0 -> studio Y=16/255 (the legal-range floor).
+    x = torch.zeros(1, 3, 1, 1)
+    y = rgb_to_ycbcr_studio(x)
+    expected = torch.tensor([[[[16 / 255]], [[128 / 255]], [[128 / 255]]]])
+    assert torch.allclose(y, expected, atol=1e-6)
+
+
+def test_rgb_to_ycbcr_studio_differs_from_full_range():
+    """Hard constraint check: the studio-range conversion is a distinct
+    function, not an in-place change to rgb_to_ycbcr's behaviour — see
+    test_rgb_to_ycbcr_known_values_white/black for proof rgb_to_ycbcr
+    itself is unchanged."""
+    x = torch.rand(1, 3, 4, 4, generator=torch.Generator().manual_seed(0))
+    assert not torch.allclose(rgb_to_ycbcr(x), rgb_to_ycbcr_studio(x))
+
+
+def _psnr(a: torch.Tensor, b: torch.Tensor, data_range: float = 1.0) -> torch.Tensor:
+    mse = torch.mean((a - b) ** 2)
+    return 10 * torch.log10(torch.tensor(data_range**2) / mse)
+
+
+def test_y_channel_studio_psnr_offset_matches_algebraic_identity():
+    """The decisive test (P2.8): studio-range Y is an affine rescale of
+    full-range Y by a constant factor (219/255, offset 16/255) — the diff
+    (and hence MSE) scales by (219/255)**2 regardless of the actual image
+    content, so PSNR_studio - PSNR_full is the *exact* constant
+    20*log10(255/219) for any pair of images with nonzero error. This is the
+    algebraic fact the empirical Set5/Set14 corroboration in triage P2.8
+    (30.56 raw + 1.3225 ~= 31.89 vs. the paper's 32.05) depends on.
+    """
+    expected_delta = 20 * math.log10(255 / 219)
+    g = torch.Generator().manual_seed(0)
+    for _ in range(5):
+        sr = torch.rand(2, 3, 16, 16, generator=g)
+        hr = torch.rand(2, 3, 16, 16, generator=g)
+
+        sr_y_full = rgb_to_ycbcr(sr)[:, 0:1]
+        hr_y_full = rgb_to_ycbcr(hr)[:, 0:1]
+        sr_y_studio = rgb_to_ycbcr_studio(sr)[:, 0:1]
+        hr_y_studio = rgb_to_ycbcr_studio(hr)[:, 0:1]
+
+        psnr_full = _psnr(sr_y_full, hr_y_full)
+        psnr_studio = _psnr(sr_y_studio, hr_y_studio)
+
+        delta = (psnr_studio - psnr_full).item()
+        assert delta == pytest.approx(expected_delta, abs=1e-4)
+
+
+def test_chroma_channels_use_the_224_scale_not_the_luma_scale():
+    """BT.601's studio-range chroma legal range is [16, 240] (224/255), not
+    [16, 235] (219/255) like luma — MATLAB's rgb2ycbcr and BasicSR's
+    bgr2ycbcr both preserve this luma/chroma asymmetry. Cb/Cr's studio-full
+    PSNR delta is therefore 20*log10(255/224), a *different* constant from
+    Y's 20*log10(255/219) — collapsing the two to one constant would itself
+    be a fidelity bug, so this locks the distinction in rather than assuming
+    it."""
+    expected_chroma_delta = 20 * math.log10(255 / 224)
+    expected_luma_delta = 20 * math.log10(255 / 219)
+    assert expected_chroma_delta != pytest.approx(expected_luma_delta, abs=1e-3)
+
+    g = torch.Generator().manual_seed(1)
+    sr = torch.rand(2, 3, 16, 16, generator=g)
+    hr = torch.rand(2, 3, 16, 16, generator=g)
+
+    for channel in (1, 2):  # Cb, Cr
+        sr_full = rgb_to_ycbcr(sr)[:, channel : channel + 1]
+        hr_full = rgb_to_ycbcr(hr)[:, channel : channel + 1]
+        sr_studio = rgb_to_ycbcr_studio(sr)[:, channel : channel + 1]
+        hr_studio = rgb_to_ycbcr_studio(hr)[:, channel : channel + 1]
+
+        delta = (_psnr(sr_studio, hr_studio) - _psnr(sr_full, hr_full)).item()
+        assert delta == pytest.approx(expected_chroma_delta, abs=1e-4)

--- a/tests/test_colorspace.py
+++ b/tests/test_colorspace.py
@@ -103,7 +103,7 @@ def test_y_channel_studio_psnr_offset_matches_algebraic_identity():
     content, so PSNR_studio - PSNR_full is the *exact* constant
     20*log10(255/219) for any pair of images with nonzero error. This is the
     algebraic fact the empirical Set5/Set14 corroboration in triage P2.8
-    (30.56 raw + 1.3225 ~= 31.89 vs. the paper's 32.05) depends on.
+    (30.56 raw + 1.3219 ~= 31.88 vs. the paper's 32.05) depends on.
     """
     expected_delta = 20 * math.log10(255 / 219)
     g = torch.Generator().manual_seed(0)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -4,7 +4,7 @@
 def test_public_exports():
     from sisr.cache import LMDBCache, LMDBCacheBuildContext  # noqa: F401
     from sisr.cli import main  # noqa: F401
-    from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb  # noqa: F401
+    from sisr.colorspace import rgb_to_ycbcr, rgb_to_ycbcr_studio, ycbcr_to_rgb  # noqa: F401
     from sisr.datasets.srcnn import TrainDataset, ValidationDataset  # noqa: F401
     from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig  # noqa: F401
     from sisr.models.srresnet.model import (  # noqa: F401

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -330,9 +330,9 @@ def test_srcheckpoint_setup_accepts_monitor_matching_psnr_keys(tmp_path: Path):
 
 @_ignore_gpu_warning
 def test_srcheckpoint_setup_accepts_val_ssim_monitor(tmp_path: Path):
-    """ssim/val is always logged regardless of psnr_keys and must be accepted."""
-    pl_module = _make_real_pl_module()
-    ckpt = SRCheckpoint(monitor_metric="ssim/val", dirpath=str(tmp_path))
+    """ssim/val/{key} for any key in eval_config.ssim_keys must be accepted."""
+    pl_module = _make_real_pl_module()  # ssim_channels defaults to ['RGB', 'Y']
+    ckpt = SRCheckpoint(monitor_metric="ssim/val/RGB", dirpath=str(tmp_path))
     ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")  # must not raise
 
 
@@ -357,7 +357,8 @@ def test_srcheckpoint_setup_error_lists_valid_metrics(tmp_path: Path):
     with pytest.raises(MisconfigurationException) as exc_info:
         ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")
     assert "psnr/val/RGB" in str(exc_info.value)
-    assert "ssim/val" in str(exc_info.value)
+    assert "ssim/val/RGB" in str(exc_info.value)
+    assert "ssim/val/Y" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------
@@ -431,12 +432,13 @@ def test_benchmark_validation_batch_end_collects_for_test_loader():
         dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 2
-    # Each entry: (filename, lr|None, sr|None, hr|None, psnr_dict, ssim).
+    # Each entry: (filename, lr|None, sr|None, hr|None, psnr_dict, ssim_dict).
     fname, lr, sr, hr, psnr, ssim = cb._buffer["Set5"][0]
     assert fname == "Set5_000"
     assert lr is not None and sr is not None and hr is not None
     assert "RGB" in psnr
-    assert isinstance(ssim, float)
+    assert "RGB" in ssim and "Y" in ssim  # eval_config.ssim_channels default
+    assert isinstance(ssim["RGB"], float)
 
 
 def test_benchmark_validation_epoch_end_logs_means():
@@ -449,18 +451,21 @@ def test_benchmark_validation_epoch_end_logs_means():
     # Hand-populate buffer with two entries; image tensors set None so the
     # image-strip branch is skipped (covered by the next test).
     cb._buffer["Set5"] = [
-        ("img_0", None, None, None, {"RGB": 30.0}, 0.9),
-        ("img_1", None, None, None, {"RGB": 32.0}, 0.85),
+        ("img_0", None, None, None, {"RGB": 30.0}, {"RGB": 0.9}),
+        ("img_1", None, None, None, {"RGB": 32.0}, {"RGB": 0.85}),
     ]
     trainer = SimpleNamespace(global_step=42, loggers=[])
     cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
     # Two log calls per dataset: psnr + ssim.
     log_keys = [call.args[0] for call in pl_module.log.call_args_list]
     assert "psnr/Set5/RGB" in log_keys
-    assert "ssim/Set5" in log_keys
+    assert "ssim/Set5/RGB" in log_keys
     # Mean PSNR = (30.0 + 32.0) / 2 = 31.0
     psnr_call = next(c for c in pl_module.log.call_args_list if c.args[0] == "psnr/Set5/RGB")
     assert psnr_call.args[1] == pytest.approx(31.0)
+    # Mean SSIM = (0.9 + 0.85) / 2 = 0.875
+    ssim_call = next(c for c in pl_module.log.call_args_list if c.args[0] == "ssim/Set5/RGB")
+    assert ssim_call.args[1] == pytest.approx(0.875)
 
 
 def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path: Path, monkeypatch):
@@ -482,7 +487,7 @@ def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path:
             torch.rand(3, 4, 4),
             torch.rand(3, 4, 4),
             {"RGB": 30.0},
-            0.9,
+            {"RGB": 0.9},
         ),
     ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
@@ -502,7 +507,7 @@ def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path:
     assert strip.ndim == 3 and strip.shape[0] == 3  # (C, H, W) triptych
     # One psnr scalar (RGB) + one ssim scalar for the single buffered image.
     scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
-    assert scalar_tags == ["per_image/Set5/psnr/RGB/img_0", "per_image/Set5/ssim/img_0"]
+    assert scalar_tags == ["per_image/Set5/psnr/RGB/img_0", "per_image/Set5/ssim/RGB/img_0"]
 
 
 def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path, monkeypatch):
@@ -527,7 +532,7 @@ def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path,
     lr = torch.rand(3, 4, 4)
     sr = torch.rand(3, 16, 16)
     hr = torch.rand(3, 16, 16)
-    cb._buffer["Set5"] = [("img_0", lr, sr, hr, {"RGB": 30.0}, 0.9)]
+    cb._buffer["Set5"] = [("img_0", lr, sr, hr, {"RGB": 30.0}, {"RGB": 0.9})]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
     cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
@@ -562,7 +567,7 @@ def test_benchmark_image_strips_upsample_lr_to_hr_size(tmp_path: Path, monkeypat
             torch.rand(3, 16, 16),
             torch.rand(3, 16, 16),
             {"RGB": 30.0},
-            0.9,
+            {"RGB": 0.9},
         ),
     ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
@@ -611,12 +616,13 @@ def test_benchmark_test_epoch_end_logs_means():
     pl_module = MagicMock()
     cb.on_test_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
     cb._buffer["Set5"] = [
-        ("img_0", None, None, None, {"RGB": 28.0}, 0.7),
+        ("img_0", None, None, None, {"RGB": 28.0}, {"RGB": 0.7}),
     ]
     trainer = SimpleNamespace(global_step=0, loggers=[])
     cb.on_test_epoch_end(trainer=trainer, pl_module=pl_module)
     log_keys = [call.args[0] for call in pl_module.log.call_args_list]
     assert "psnr/Set5/RGB" in log_keys
+    assert "ssim/Set5/RGB" in log_keys
 
 
 # ---------------------------------------------------------------------------
@@ -696,9 +702,10 @@ def test_benchmark_collect_batch_crops_per_eval_config():
         dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 1
-    _, _, _, _, psnr_dict, ssim = cb._buffer["Set5"][0]
+    _, _, _, _, psnr_dict, ssim_dict = cb._buffer["Set5"][0]
     assert "RGB" in psnr_dict
-    assert isinstance(ssim, float)
+    assert "RGB" in ssim_dict
+    assert isinstance(ssim_dict["RGB"], float)
 
 
 def test_benchmark_collect_batch_routes_through_processor():
@@ -732,14 +739,15 @@ def test_benchmark_collect_batch_routes_through_processor():
         dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 1
-    _, lr_cached, sr_cached, hr_cached, psnr_dict, ssim = cb._buffer["Set5"][0]
+    _, lr_cached, sr_cached, hr_cached, psnr_dict, ssim_dict = cb._buffer["Set5"][0]
     # All cached tensors are full RGB (reconstruct stitched SR-Y with bicubic Cb/Cr).
     assert lr_cached.shape == (3, 16, 16)
     assert sr_cached.shape == (3, 16, 16)
     assert hr_cached.shape == (3, 16, 16)
     assert "RGB" in psnr_dict
     assert "YCbCr" in psnr_dict
-    assert isinstance(ssim, float)
+    assert "RGB" in ssim_dict and "Y" in ssim_dict  # eval_config.ssim_channels default
+    assert isinstance(ssim_dict["RGB"], float)
 
 
 def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_false():

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -21,6 +21,10 @@ def test_sr_eval_config_defaults():
     assert cfg.crop_border == 0
     assert cfg.psnr_channels == ["RGB"]
     assert cfg.separate_psnr is False
+    # Unlike psnr_channels, the base already defaults to ['RGB', 'Y'] — SSIM
+    # has no post-hoc PSNR-style dB correction, so the paper-comparable
+    # Y-SSIM ships without waiting for an architecture subclass to add it.
+    assert cfg.ssim_channels == ["RGB", "Y"]
 
 
 def test_sr_eval_config_psnr_channels_isolated_per_instance():
@@ -31,6 +35,13 @@ def test_sr_eval_config_psnr_channels_isolated_per_instance():
     assert b.psnr_channels == ["RGB"], "default_factory must produce a fresh list per instance"
 
 
+def test_sr_eval_config_ssim_channels_isolated_per_instance():
+    a = SREvalConfig()
+    b = SREvalConfig()
+    a.ssim_channels.append("YCbCr")
+    assert b.ssim_channels == ["RGB", "Y"], "default_factory must produce a fresh list per instance"
+
+
 def test_sr_training_config_field_names():
     """Reduced surface check — guards against accidental field renames."""
     names = {f.name for f in fields(SRTrainingConfig)}
@@ -39,7 +50,7 @@ def test_sr_training_config_field_names():
 
 def test_sr_eval_config_field_names():
     names = {f.name for f in fields(SREvalConfig)}
-    assert names == {"crop_border", "psnr_channels", "separate_psnr"}
+    assert names == {"crop_border", "psnr_channels", "separate_psnr", "ssim_channels"}
 
 
 def test_eval_config_rejects_unknown_psnr_channel():
@@ -58,6 +69,23 @@ def test_eval_config_rejects_unknown_psnr_channel_still_raises_alongside_bare_y(
     SREvalConfig(psnr_channels=["RGB", "Y"])  # valid — must not raise
     with pytest.raises(ValueError, match="psnr_channels"):
         SREvalConfig(psnr_channels=["RGB", "HSV"])
+
+
+def test_eval_config_rejects_unknown_ssim_channel():
+    """(P3.8): ssim_channels reuses the same allowlist as psnr_channels, and
+    the error names the offending field so it's actionable."""
+    SREvalConfig(ssim_channels=["RGB", "Y", "YCbCr"])  # valid — must not raise
+    with pytest.raises(ValueError, match="ssim_channels"):
+        SREvalConfig(ssim_channels=["RGB", "HSV"])
+
+
+def test_eval_config_rejects_unknown_channel_in_either_field_independently():
+    """psnr_channels and ssim_channels are validated independently — an
+    invalid entry in one must not be masked by the other being valid."""
+    with pytest.raises(ValueError, match="psnr_channels"):
+        SREvalConfig(psnr_channels=["HSV"], ssim_channels=["RGB"])
+    with pytest.raises(ValueError, match="ssim_channels"):
+        SREvalConfig(psnr_channels=["RGB"], ssim_channels=["HSV"])
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +146,33 @@ def test_psnr_keys_is_not_a_dataclass_field():
     it silently becoming a constructor argument / dataclasses.asdict() entry."""
     names = {f.name for f in fields(SREvalConfig)}
     assert "psnr_keys" not in names
+
+
+# ---------------------------------------------------------------------------
+# ssim_keys (P3.8) — mirrors psnr_keys, minus the separate_psnr expansion
+# ---------------------------------------------------------------------------
+
+
+def test_ssim_keys_default_matches_ssim_channels_default():
+    cfg = SREvalConfig()
+    assert cfg.ssim_keys == ["RGB", "Y"]
+
+
+@pytest.mark.parametrize(
+    "ssim_channels",
+    [["RGB"], ["Y"], ["RGB", "Y"], ["YCbCr"], ["RGB", "YCbCr", "Cb"]],
+)
+def test_ssim_keys_equals_ssim_channels_verbatim(ssim_channels):
+    """Unlike psnr_keys, ssim_keys never expands a colorspace into
+    sub-channels — there is no separate_ssim flag — so it always equals
+    ssim_channels itself, in order."""
+    cfg = SREvalConfig(ssim_channels=ssim_channels)
+    assert cfg.ssim_keys == ssim_channels
+
+
+def test_ssim_keys_is_not_a_dataclass_field():
+    names = {f.name for f in fields(SREvalConfig)}
+    assert "ssim_keys" not in names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -99,15 +99,16 @@ def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
     trainer.fit(module, datamodule=datamodule)
     fit_metrics = set(trainer.callback_metrics)
     # Module-logged: training_step + validation_step on the primary val loader (idx 0).
-    assert {"loss/train", "loss/val", "psnr/val/RGB", "ssim/val"} <= fit_metrics
+    # ssim/val/{RGB,Y} — eval_config.ssim_channels defaults to ['RGB', 'Y'].
+    assert {"loss/train", "loss/val", "psnr/val/RGB", "ssim/val/RGB", "ssim/val/Y"} <= fit_metrics
     # Callback-logged for the Set5 test loader (val_dataloader idx 1) — proves
     # BenchmarkImageLogger auto-discovered the datamodule's test set and ran.
-    assert {"psnr/Set5/RGB", "ssim/Set5"} <= fit_metrics
+    assert {"psnr/Set5/RGB", "ssim/Set5/RGB", "ssim/Set5/Y"} <= fit_metrics
 
     trainer.test(module, datamodule=datamodule)
     test_metrics = set(trainer.callback_metrics)
     # test_step is a no-op; these come solely from BenchmarkImageLogger.on_test_*.
-    assert {"psnr/Set5/RGB", "ssim/Set5"} <= test_metrics
+    assert {"psnr/Set5/RGB", "ssim/Set5/RGB", "ssim/Set5/Y"} <= test_metrics
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -264,6 +264,29 @@ def test_build_psnr_tensors_ycbcr_does_conversion():
     assert not torch.equal(sr_ycc, sr)
 
 
+def test_build_psnr_tensors_ycbcr_uses_studio_range_not_full_range():
+    """Regression (P2.8): the metric-side YCbCr conversion must be BT.601
+    studio range, not the full-range conversion SRProcessor subclasses train
+    in — locked by comparing against sisr.colorspace directly."""
+    from sisr.colorspace import rgb_to_ycbcr, rgb_to_ycbcr_studio
+
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(psnr_channels=["YCbCr"]),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    sr = torch.rand(1, 3, 4, 4, generator=torch.Generator().manual_seed(3))
+    hr = torch.rand(1, 3, 4, 4, generator=torch.Generator().manual_seed(4))
+    tensors = lit._build_psnr_tensors(sr, hr)
+    sr_ycc, hr_ycc = tensors["YCbCr"]
+    torch.testing.assert_close(sr_ycc, rgb_to_ycbcr_studio(sr))
+    torch.testing.assert_close(hr_ycc, rgb_to_ycbcr_studio(hr))
+    assert not torch.allclose(sr_ycc, rgb_to_ycbcr(sr))
+
+
 def test_flatten_hparams_handles_nested():
     flat = SRLightning._flatten_hparams(
         {

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -210,7 +210,7 @@ def test_configure_optimizers_no_scheduler_returns_bare(srcnn_rgb_lit: SRLightni
 
 
 # ---------------------------------------------------------------------------
-# test_step / build_psnr_tensors / flatten_hparams
+# test_step / build_metric_tensors / flatten_hparams
 # ---------------------------------------------------------------------------
 
 
@@ -222,15 +222,44 @@ def test_test_step_is_no_op(srcnn_rgb_lit: SRLightning):
     assert out is None
 
 
-def test_build_psnr_tensors_rgb_only(srcnn_rgb_lit: SRLightning):
+def test_build_metric_tensors_rgb_only_when_neither_metric_requests_y():
+    """Only the RGB family is built when both psnr_channels and ssim_channels
+    are pinned to ['RGB'] — unlike the base SREvalConfig default, which also
+    pulls in 'Y' via ssim_channels (see the union test below)."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(psnr_channels=["RGB"], ssim_channels=["RGB"]),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
     sr = torch.rand(1, 3, 4, 4)
     hr = torch.rand(1, 3, 4, 4)
-    tensors = srcnn_rgb_lit._build_psnr_tensors(sr, hr)
-    # eval_config.psnr_channels=['RGB'], separate_psnr=False -> only 'RGB' tracked.
-    assert "RGB" in tensors
+    tensors = lit._build_metric_tensors(sr, hr)
+    assert set(tensors) == {"RGB", "R", "G", "B"}
 
 
-def test_build_psnr_tensors_with_separate_psnr_includes_per_channel():
+def test_build_metric_tensors_union_of_psnr_and_ssim_keys():
+    """Regression (P3.8): a colorspace requested only by ssim_channels (not
+    psnr_channels) must still get a tensor entry — the tensor map is built
+    from the *union* of psnr_keys and ssim_keys, not psnr_keys alone, so
+    SSIM-only keys aren't silently missing."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(psnr_channels=["RGB"], ssim_channels=["RGB", "Y"]),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    sr = torch.rand(1, 3, 4, 4)
+    hr = torch.rand(1, 3, 4, 4)
+    tensors = lit._build_metric_tensors(sr, hr)
+    assert "Y" in tensors
+
+
+def test_build_metric_tensors_with_separate_psnr_includes_per_channel():
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
@@ -241,11 +270,11 @@ def test_build_psnr_tensors_with_separate_psnr_includes_per_channel():
     )
     sr = torch.rand(1, 3, 4, 4)
     hr = torch.rand(1, 3, 4, 4)
-    tensors = lit._build_psnr_tensors(sr, hr)
+    tensors = lit._build_metric_tensors(sr, hr)
     assert {"R", "G", "B", "RGB"} <= set(tensors)
 
 
-def test_build_psnr_tensors_ycbcr_does_conversion():
+def test_build_metric_tensors_ycbcr_does_conversion():
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
@@ -256,7 +285,7 @@ def test_build_psnr_tensors_ycbcr_does_conversion():
     )
     sr = torch.rand(1, 3, 4, 4)
     hr = torch.rand(1, 3, 4, 4)
-    tensors = lit._build_psnr_tensors(sr, hr)
+    tensors = lit._build_metric_tensors(sr, hr)
     assert "YCbCr" in tensors
     sr_ycc, hr_ycc = tensors["YCbCr"]
     # YCbCr first channel (Y) must differ from input R-channel — verifies
@@ -264,7 +293,7 @@ def test_build_psnr_tensors_ycbcr_does_conversion():
     assert not torch.equal(sr_ycc, sr)
 
 
-def test_build_psnr_tensors_ycbcr_uses_studio_range_not_full_range():
+def test_build_metric_tensors_ycbcr_uses_studio_range_not_full_range():
     """Regression (P2.8): the metric-side YCbCr conversion must be BT.601
     studio range, not the full-range conversion SRProcessor subclasses train
     in — locked by comparing against sisr.colorspace directly."""
@@ -280,7 +309,7 @@ def test_build_psnr_tensors_ycbcr_uses_studio_range_not_full_range():
     )
     sr = torch.rand(1, 3, 4, 4, generator=torch.Generator().manual_seed(3))
     hr = torch.rand(1, 3, 4, 4, generator=torch.Generator().manual_seed(4))
-    tensors = lit._build_psnr_tensors(sr, hr)
+    tensors = lit._build_metric_tensors(sr, hr)
     sr_ycc, hr_ycc = tensors["YCbCr"]
     torch.testing.assert_close(sr_ycc, rgb_to_ycbcr_studio(sr))
     torch.testing.assert_close(hr_ycc, rgb_to_ycbcr_studio(hr))
@@ -370,7 +399,7 @@ def test_on_train_start_logs_hparams_with_val_metrics(srcnn_rgb_lit: SRLightning
     metrics_arg = args[1] if len(args) > 1 else kwargs.get("metrics")
 
     expected_metrics = {f"psnr/val/{k}": 0.0 for k in srcnn_rgb_lit.eval_config.psnr_keys}
-    expected_metrics["ssim/val"] = 0.0
+    expected_metrics.update({f"ssim/val/{k}": 0.0 for k in srcnn_rgb_lit.eval_config.ssim_keys})
 
     assert params_arg == srcnn_rgb_lit.hparams
     assert metrics_arg == expected_metrics


### PR DESCRIPTION
The metric half of paper comparability. The arc made the *inputs* byte-exact; nothing had checked the convention the *outputs* are computed in.

## P2.8 — the metric used the wrong BT.601 variant

`sisr/colorspace.py` is BT.601 **full-range** ("JPEG"). Every published SR figure — MATLAB `rgb2ycbcr`, BasicSR, the `daala` tools Ledig et al. used — is **studio/limited range**. The error term scales by a constant, so a full-range Y-PSNR sits exactly `20·log10(255/219) = 1.3219 dB` below the literature's.

**Not a flag on the existing function — a separate `rgb_to_ycbcr_studio`.** `rgb_to_ycbcr` is also `YChannelProcessor`'s **training** colorspace, so a default-off keyword would leave a live footgun: a future caller flips it, or someone "unifies" the default, and a trained model's inputs silently renumber. A distinctly named one-way function makes that impossible by construction. The module docstring now says which range is training-side and which is metric-side, and not to merge them.

Routed through the single shared tensor-map builder, so `SRLightning` and `BenchmarkImageLogger` both pick it up — no second code path.

### Correction to the brief I wrote

I specified that the `20·log10(255/219)` identity should hold across the whole Y/Cb/Cr family. **That is wrong and the implementer was right to refuse it.** BT.601 studio range uses **219/255 for luma but 224/255 for chroma**. Chroma's true delta is `20·log10(255/224) ≈ 1.1258 dB`, and the 3-channel aggregate isn't a constant at all. The correct per-channel scales are implemented, the identity test is scoped to Y, and a companion test locks in that chroma deliberately differs.

Verified against MATLAB's published coefficients (`Y = 16 + 65.481R + 128.553G + 24.966B`, etc.):

```
Y  max|diff| = 3.3e-16   <- exact
Cb max|diff| = 2.3e-04
Cr max|diff| = 2.7e-04

Y  studio-full = +1.32192 dB   expected 20*log10(255/219) = +1.32192  OK
Cb studio-full = +1.12584 dB   expected 20*log10(255/224) = +1.12584  OK
```

**Y — the channel the papers actually quote — matches MATLAB exactly.** The chroma residual is inherited from `sisr/colorspace.py`'s 3-decimal BT.601 chroma coefficients (`-0.169` vs MATLAB's `-0.168737`), a pre-existing property this PR doesn't introduce and doesn't worsen. Filed separately.

### Also: the quoted constant was wrong

I had been writing **1.3225 dB**; it is **1.3219**. The computed assertions were always right — only the prose restating them was wrong, including in the README this repo shipped last hour. Corrected here. Same failure mode as P1.1: a stated constant nobody re-derives because it looks checked.

## P3.8 — Y-channel SSIM

SSIM was hardcoded to RGB in two places. The papers quote **y-channel** SSIM, and unlike PSNR there's no constant to apply afterwards — there was simply no comparable number available.

Adds `SREvalConfig.ssim_channels`, mirroring `psnr_channels` and reusing the same channel machinery and tensor map rather than growing a parallel system. Defaults to `['RGB', 'Y']` **on the base**, since SSIM has no post-hoc correction and there's no reason to gate it behind an architecture subclass.

**Key shape changes: `ssim/val` → `ssim/val/{key}`.** That breaks three things, all updated: `SRCheckpoint`'s valid-metric set, both templates' `monitor_metric: ssim/val`, and `BenchmarkImageLogger`'s per-sample scalar (now a per-key dict, matching how PSNR already worked). Every `ssim/` occurrence was grepped before and after.

## Verification

- `358 passed, 1 skipped` (340 baseline). Each commit independently green — verified by isolating them, not assumed.
- `ruff check` / `ruff format --check` clean.
- Both templates re-resolved: `monitor_metric: ssim/val/RGB`, `ssim_channels` present.

## Note

This changes what `psnr/val/Y` **means** — same key, different convention. Runs before and after this PR are not comparable on that key despite the matching name. An existing run plateaued at Set5 30.56 raw; after this PR the equivalent should read ≈ 31.88 natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)