### PR TITLE
Clamp SR output to [0, 1] before scoring (P4.14)

### DIFF
--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -225,11 +225,20 @@ class SRLightning(lightning.LightningModule):
 
         Returns:
             ``(sr_model_out, sr_rgb)`` — the raw model output in the model IO
-            colorspace, and the reconstructed SR RGB.
+            colorspace, and the reconstructed SR RGB clamped to ``[0, 1]``.
         """
         model_input = self.processor.extract(lr_img)
         sr_model_out = self.model(model_input)
         sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
+        # Clamp display-space output only, here, once — every reconstruct()
+        # consumer (_forward_sr's callers, predict_step) reads through this
+        # one line, so PSNR/SSIM never diverge from what an 8-bit image would
+        # score (P4.14). sr_model_out (the loss target) is untouched: clamping
+        # it would kill gradients on saturated pixels. Idempotent where
+        # reconstruct() already clamps (YCbCrProcessor/YChannelProcessor's
+        # ycbcr_to_rgb) — don't move this into forward() or a processor, or
+        # the bound would depend on training colorspace again.
+        sr_rgb = sr_rgb.clamp(0.0, 1.0)
         return sr_model_out, sr_rgb
 
     def _forward_sr(
@@ -250,9 +259,10 @@ class SRLightning(lightning.LightningModule):
             hr_img: HR batch, RGB ``float32`` in ``[0, 1]``.
 
         Returns:
-            ``(sr_model_out, sr_rgb, hr_cropped)`` — the raw model output in
-            the model IO colorspace, the reconstructed SR RGB, and HR
-            center-cropped to the SR spatial size.
+            ``(sr_model_out, sr_rgb, hr_cropped)`` — the raw (unclamped)
+            model output in the model IO colorspace, the reconstructed SR RGB
+            clamped to ``[0, 1]``, and HR center-cropped to the SR spatial
+            size.
         """
         sr_model_out, sr_rgb = self._forward_lr(lr_img)
         hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_rgb.shape[-2:])
@@ -276,8 +286,8 @@ class SRLightning(lightning.LightningModule):
             hr_img: HR batch, RGB ``float32`` in ``[0, 1]``.
 
         Returns:
-            ``(sr_rgb, hr_cropped)`` — SR RGB and HR center-cropped to the SR
-            spatial size, both RGB ``float32``.
+            ``(sr_rgb, hr_cropped)`` — SR RGB clamped to ``[0, 1]`` and HR
+            center-cropped to the SR spatial size, both RGB ``float32``.
         """
         _, sr_rgb, hr_cropped = self._forward_sr(lr_img, hr_img)
         return sr_rgb, hr_cropped
@@ -300,8 +310,9 @@ class SRLightning(lightning.LightningModule):
 
         Returns:
             ``(loss, lr_img, hr_img, sr_rgb, hr_cropped)``. ``loss`` is a
-            scalar tensor; ``sr_rgb`` and ``hr_cropped`` are RGB tensors
-            with matching spatial size.
+            scalar tensor computed on the unclamped model output; ``sr_rgb``
+            (clamped to ``[0, 1]``) and ``hr_cropped`` are RGB tensors with
+            matching spatial size.
         """
         lr_img, hr_img = batch
 

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -643,6 +643,96 @@ def test_predict_rgb_matches_step_forward_path_y_channel(srcnn_y_lit: SRLightnin
 
 
 # ---------------------------------------------------------------------------
+# P4.14 — metric-path clamp to [0, 1], applied once in _forward_lr
+# ---------------------------------------------------------------------------
+
+
+def _overshooting_rgb_lit() -> SRLightning:
+    """SRCNN + RGBProcessor (identity reconstruct) with the tail conv biased
+    hugely positive, so sr_rgb genuinely overshoots [0, 1] on any input — the
+    scenario the P4.14 clamp exists for."""
+    model = SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same")
+    torch.nn.init.constant_(model.recon.bias, 5.0)
+    return SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def test_step_clamps_sr_rgb_but_not_the_loss_target():
+    """Regression (P4.14): sr_rgb returned by _step is clamped to [0, 1] even
+    though the model genuinely overshoots, while the loss — read from
+    sr_model_out, never sr_rgb — is exactly the unclamped MSE. A clamp that
+    leaked into the loss would kill gradients on saturated pixels (constraint
+    1) and would also make this hand-computed loss equal the "wrong_loss"
+    below instead."""
+    lit = _overshooting_rgb_lit()
+    lr = torch.rand(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    hr = torch.rand(1, 3, 8, 8, generator=torch.Generator().manual_seed(1))
+
+    sr_model_out, _ = lit._forward_lr(lr)
+    assert sr_model_out.max() > 1.0, "fixture must genuinely overshoot [0, 1]"
+
+    loss, _, _, sr_rgb, hr_cropped = lit._step((lr, hr))
+
+    assert sr_rgb.min() >= 0.0
+    assert sr_rgb.max() <= 1.0
+
+    expected_loss = torch.nn.functional.mse_loss(sr_model_out, hr_cropped)
+    torch.testing.assert_close(loss, expected_loss)
+
+    wrong_loss = torch.nn.functional.mse_loss(sr_rgb, hr_cropped)
+    assert not torch.allclose(loss, wrong_loss)
+
+
+def test_step_psnr_matches_hand_clamped_reference_not_raw_output():
+    """Regression (P4.14): PSNR scored on the validation_step path must equal
+    a hand-clamped reference computed from the raw model output, not the PSNR
+    the unclamped output would give — proving overshoot is being penalised
+    away rather than silently scored."""
+    lit = _overshooting_rgb_lit()
+    lr = torch.rand(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    hr = torch.rand(1, 3, 8, 8, generator=torch.Generator().manual_seed(1))
+
+    sr_model_out, _ = lit._forward_lr(lr)
+    _, _, _, sr_rgb, hr_cropped = lit._step((lr, hr))
+
+    scored_psnr = SRLightning._mean_psnr(sr_rgb, hr_cropped)
+    hand_clamped_psnr = SRLightning._mean_psnr(sr_model_out.clamp(0.0, 1.0), hr_cropped)
+    unclamped_psnr = SRLightning._mean_psnr(sr_model_out, hr_cropped)
+
+    torch.testing.assert_close(scored_psnr, hand_clamped_psnr)
+    assert not torch.allclose(scored_psnr, unclamped_psnr)
+
+
+def test_predict_rgb_clamps_for_benchmark_logger_consumer():
+    """Regression (P4.14): predict_rgb — the seam BenchmarkImageLogger reads
+    for benchmark/test-set metrics — must return the same clamped sr_rgb as
+    the validation_step path, not a re-implemented, unclamped forward."""
+    lit = _overshooting_rgb_lit()
+    lr = torch.rand(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    hr = torch.rand(1, 3, 8, 8, generator=torch.Generator().manual_seed(1))
+
+    sr_rgb, _ = lit.predict_rgb(lr, hr)
+    assert sr_rgb.min() >= 0.0
+    assert sr_rgb.max() <= 1.0
+
+
+def test_predict_step_output_also_clamped_via_shared_forward_lr():
+    """predict_step shares _forward_lr with _forward_sr (see its docstring),
+    so the same clamp covers it as a side effect — locks that the seam really
+    is shared rather than duplicated across the two call sites."""
+    lit = _overshooting_rgb_lit()
+    lr = torch.rand(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    out = lit.predict_step(lr, batch_idx=0)
+    assert out.min() >= 0.0
+    assert out.max() <= 1.0
+
+
+# ---------------------------------------------------------------------------
 # P2.2 — no dead stateful metric accumulator
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
PSNR/SSIM scored the raw network output, which overshoots `[0, 1]`. Published SR numbers are computed on 8-bit images, i.e. implicitly clamped. Overshoot is pure penalty — clamping can only help — so our figures sat below what the same weights would score under the standard protocol.

**One line of behaviour change**, in `SRLightning._forward_lr`, immediately after `processor.reconstruct(...)`.

## Why there, specifically

`_forward_lr` is the **only** place `reconstruct()` is ever called. Every consumer reads through it — `_forward_sr` (which feeds `_step`, so both `training_step` and `validation_step`) and `predict_rgb` (which feeds `BenchmarkImageLogger`), plus `predict_step` directly. One line covers all of them with no parallel edit.

Placing it one level up in `_forward_sr` would have been wrong, and an **existing invariant test caught it**: `test_forward_lr_matches_forward_sr_sr_component` asserts the two paths are bit-identical. That equality is not vacuous — the seeded fixture already overshoots to `-0.127`, so clamping in only one path would have reintroduced exactly the path-divergence the codebase deliberately closed.

## The four constraints, each verified rather than assumed

1. **The loss is untouched.** `sr_model_out` is returned separately and never clamped — clamping it would kill gradients on saturated pixels. A test biases a tail conv to force genuine overshoot, then asserts the loss equals `mse_loss(sr_model_out, hr_cropped)` exactly *and* differs from `mse_loss(sr_rgb, hr_cropped)`, which is what a leaked clamp would produce.
2. **`SRResNet.forward`'s `clamp_output`/`clamp_minmax` untouched.** Their correct bounds depend on the training processor; using them here would reintroduce that coupling. No model file is in the diff.
3. **No processor touched.** `YCbCrProcessor` already clamps via `ycbcr_to_rgb` while the RGB processors do not — that asymmetry (SRCNN accidentally clamped, SRResNet not) *is* the bug. Fixing it in a processor would make clamping depend on training colourspace. The new clamp is idempotent on the already-clamped path.
4. **Both metric consumers covered**, each with its own test — `validation_step` and `BenchmarkImageLogger`'s seam.

RED→GREEN was confirmed by commenting the clamp out: all four new tests fail, one showing PSNR at `-13.07` unclamped versus `4.997` clamped.

## Measured effect

- Forced overshoot (output range `[4.81, 5.34]`): **−13.13 dB → +5.00 dB**. The clamp turns a nonsensical negative score into a coherent one.
- Realistic untrained SRResNet (mild overshoot to `1.027`): **+0.0001 dB**. Small because random-init weights barely saturate; the 0.05–0.2 dB figure applies to trained models.

## Note

This changes reported numbers — upward, by removing a penalty. Combined with #48 and #50, `psnr/val/Y` has now changed meaning three times in this arc, so a run from before is not comparable to one after despite the identical key name.

`362 passed, 1 skipped` (358 baseline, +4 new, **0 existing tests modified**). `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)