### PR TITLE
Enforce Google-style docstrings via ruff pydocstyle (P4.15)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,10 +128,31 @@ line-length = 100
 # is nothing to suppress. Do not add it to `ignore`: ruff warns "rules have been
 # removed and ignoring them has no effect" on every run, which is noise in a required
 # check. The isinstance(x, A | B) style it enforced is now convention, not lint.
-select = ["E", "F", "I", "UP", "B"]
+# D: pydocstyle (P4.15) — makes "Google-style docstrings on public API" (a stated
+# project non-negotiable) enforceable instead of review-only. D105 (undocumented
+# magic method) is ignored because dunder semantics are defined by the language,
+# not by us. D107 (undocumented __init__) is ignored because Google style documents
+# constructor args in the *class* docstring, which this repo already does —
+# requiring an __init__ docstring too would push against the very convention being
+# enforced.
+# Limitation worth knowing: D417 (missing Args entry) fires only on *partially*
+# documented functions, not undocumented ones — a docstring with its whole Args:
+# section deleted passes with D fully enabled (verified empirically with a
+# two-function probe; preview DOC rules were silent on it too). So this catches
+# half-documented functions and formatting drift, not the wholesale Args: deletion
+# that motivated adding it. That guardrail stays human review.
+select = ["E", "F", "I", "UP", "B", "D"]
+ignore = ["D105", "D107"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 # Re-export hubs import names purely to surface them under short class paths.
 # Names in __all__ are already treated as used; this documents the intent and
 # covers any future __init__.py that omits __all__.
 "__init__.py" = ["F401"]
+# Tests carry ~400 D violations, ~135 of them D103 (undocumented public function).
+# Test *names* are the documentation here; writing hundreds of docstrings to
+# satisfy a linter is churn, not clarity.
+"tests/**" = ["D"]

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -1,10 +1,10 @@
-"""LightningCLI entrypoint for SR training.
+r"""LightningCLI entrypoint for SR training.
 
 Usage:
     sisr fit --config templates/config.srcnn.template.yaml
-    sisr test --config templates/config.srcnn.template.yaml \\
+    sisr test --config templates/config.srcnn.template.yaml \
               --ckpt_path <best.ckpt>
-    sisr export --config templates/config.srcnn.template.yaml \\
+    sisr export --config templates/config.srcnn.template.yaml \
                 --output_path model.onnx --ckpt_path <best.ckpt>
 
 The ``sisr`` console script is registered by ``pyproject.toml``; ``python -m

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -138,8 +138,7 @@ def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
 
 
 class TrainDataset(SRDataset):
-    """Dataset that serves deterministic LR/HR sub-image pairs, HR served from
-    an LMDB cache of full raw images.
+    """Dataset serving deterministic LR/HR sub-image pairs, HR held in an LMDB cache.
 
     On first instantiation with a given set of files, every HR image is
     decoded once and stored whole (uint8, RGB) in an LMDB database — see the
@@ -260,8 +259,7 @@ class TrainDataset(SRDataset):
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def _compute_grid(self) -> tuple[list[tuple[int, int]], list[int], list[int], int]:
-        """Reads image dimensions (without decoding pixels) to compute the
-        deterministic sub-image grid for every source image.
+        """Computes the deterministic sub-image grid from image dimensions alone.
 
         Single source of truth for the patch grid: :meth:`__len__` and
         :meth:`__getitem__`'s O(1) index -> ``(top, left)`` lookup both derive

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -53,8 +53,7 @@ def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
 
 
 class TrainDataset(SRDataset):
-    """Random-crop HR/LR pairs for SRResNet-style training, HR served from an
-    LMDB cache of full raw images.
+    """Random-crop HR/LR pairs for SRResNet-style training, HR held in an LMDB cache.
 
     On first instantiation with a given set of parameters, every HR image is
     decoded once and stored whole (uint8, RGB, with its own ``(H, W)`` header)

--- a/sisr/processors/rgb.py
+++ b/sisr/processors/rgb.py
@@ -9,13 +9,16 @@ class RGBProcessor(SRProcessor):
     """No-op processor: model trains and emits RGB directly."""
 
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Return lr_rgb unchanged — RGB in, RGB out."""
         return lr_rgb
 
     def reconstruct(self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Return sr_model_out unchanged — already RGB."""
         return sr_model_out
 
     @property
     def model_channels(self) -> int:
+        """Number of model IO channels — 3 (RGB)."""
         return 3
 
 
@@ -40,14 +43,18 @@ class RGBSignedOutputProcessor(SRProcessor):
     """
 
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Return lr_rgb unchanged; the model consumes RGB in ``[0, 1]``."""
         return lr_rgb
 
     def extract_target(self, hr_rgb: torch.Tensor) -> torch.Tensor:
+        """Map HR from ``[0, 1]`` to the model's ``[-1, 1]`` output range."""
         return hr_rgb * 2.0 - 1.0
 
     def reconstruct(self, sr_model_out: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Map the model's ``[-1, 1]`` output back to ``[0, 1]``."""
         return (sr_model_out + 1.0) / 2.0
 
     @property
     def model_channels(self) -> int:
+        """Number of model IO channels — 3 (RGB)."""
         return 3

--- a/sisr/processors/y_channel.py
+++ b/sisr/processors/y_channel.py
@@ -18,9 +18,11 @@ class YChannelProcessor(SRProcessor):
     """
 
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Return the Y channel of lr_rgb, converted to YCbCr."""
         return rgb_to_ycbcr(lr_rgb)[:, 0:1]
 
     def reconstruct(self, sr_y: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Stitch sr_y with bicubic-upsampled LR Cb/Cr, then convert back to RGB."""
         lr_ycbcr = rgb_to_ycbcr(lr_rgb)
         cbcr = F.interpolate(
             lr_ycbcr[:, 1:],
@@ -32,4 +34,5 @@ class YChannelProcessor(SRProcessor):
 
     @property
     def model_channels(self) -> int:
+        """Number of model IO channels — 1 (Y)."""
         return 1

--- a/sisr/processors/ycbcr.py
+++ b/sisr/processors/ycbcr.py
@@ -11,11 +11,14 @@ class YCbCrProcessor(SRProcessor):
     """Full YCbCr processor: model trains on YCbCr, output converted to RGB."""
 
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Convert lr_rgb to YCbCr."""
         return rgb_to_ycbcr(lr_rgb)
 
     def reconstruct(self, sr_ycbcr: torch.Tensor, lr_rgb: torch.Tensor) -> torch.Tensor:
+        """Convert the model's YCbCr output back to RGB."""
         return ycbcr_to_rgb(sr_ycbcr)
 
     @property
     def model_channels(self) -> int:
+        """Number of model IO channels — 3 (YCbCr)."""
         return 3

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -23,9 +23,9 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 
 class BenchmarkImageLogger(Callback):
-    """Log per-image bicubic|SR|HR composites and scalar PSNR/SSIM to TensorBoard
-    for one or more held-out test/benchmark dataloaders (Set5, Set14, …).
+    """Logs bicubic|SR|HR image composites and PSNR/SSIM to TensorBoard for held-out sets.
 
+    Covers one or more held-out test/benchmark dataloaders (Set5, Set14, …).
     Fires during *both* validation and test stages:
 
     * **During `cli fit` / `cli validate`** — `SRDataModule.val_dataloader()`
@@ -447,8 +447,9 @@ class GradNormLogger(Callback):
 
 
 class WeightHistogramLogger(Callback):
-    """Log the weights of the model as histograms to TensorBoard periodically,
-    grouped by parameter prefixes (e.g., model.feat, model.mapping, model.recon).
+    """Logs model weights as TensorBoard histograms, grouped by parameter prefix.
+
+    Groups by prefix, e.g. ``model.feat``, ``model.mapping``, ``model.recon``.
 
     Args:
         log_every_n_steps (int): Log histograms every *n* training steps.


### PR DESCRIPTION
"Google-style docstrings on public API" is a stated project non-negotiable that was enforced by **review alone**. This makes it a gate.

Not theoretical: a comment sweep earlier in this arc stripped `Args:` blocks from public callables and would have passed CI untouched.

## Config

```toml
select = ["E", "F", "I", "UP", "B", "D"]
ignore = ["D105", "D107"]

[tool.ruff.lint.pydocstyle]
convention = "google"

[tool.ruff.lint.per-file-ignores]
"tests/**" = ["D"]
```

**`D107` (undocumented `__init__`) ignored** — and this is the one worth getting right, because it's the largest single category (19 of 43). Google style documents constructor arguments in the **class** docstring, which this repo already does. Requiring an `__init__` docstring as well would push against the very convention being enforced, for 19 pointless additions.

**`D105`** — dunder semantics are defined by the language, not by us.

**`tests/**` exempt** — 403 violations there, 135 of them undocumented test functions whose *names* are the documentation.

## Violations: measured, then fixed properly

`sisr/` **43** before → **0** after. With the two ignores applied, exactly **19** needed real work: 13 D102, 5 D205, 1 D301.

- **D102** — every one is an override of `SRProcessor`'s abstract interface (`extract`, `reconstruct`, `extract_target`, `model_channels`). Required public contract members, not helpers masquerading as public, so each got a real one-line summary — e.g. *"Map HR from `[0, 1]` to the model's `[-1, 1]` output range."*
- **D205** — these were summary sentences wrapped onto a second physical line. pydocstyle only treats the *first* line as the summary, so each was tightened to one line with the detail moved into the following paragraph — rather than inserting a blank line mid-sentence, which would satisfy the rule while making the docstring worse.
- **D301** — `sisr/cli.py`'s module docstring now uses `r"""`, with identical rendered content.

**No `# noqa` anywhere, and `ignore` was not widened to make numbers disappear.**

## The limitation is documented in the config, deliberately

Recorded inline in `pyproject.toml`, matching how that file already documents its UP038 history:

> **D417 fires only on *partially* documented functions, not undocumented ones.** A docstring with its whole `Args:` section deleted passes with `D` fully enabled — verified with a two-function probe; preview `DOC` rules were silent too. So this catches half-documented functions and formatting drift, **not** the wholesale deletion that motivated adding it. That guardrail stays human review.

Without that written down, the next person assumes the lint covers it. Confirmed live by injecting a partial `Args:` block: `D417 Missing argument description ... 'beta'`.

## Verification

- `ruff check .` clean **with `D` enabled** — the point of the PR.
- `ruff format --check` clean.
- `362 passed, 1 skipped` — unchanged, as docstring edits should be.

Config and fixes are separate commits.

## Reviewer note

The implementer flagged, fairly, that `"tests/**" = ["D"]` is broader than its stated rationale: it exempts D100/D101 and the D200-family too, not just the D103 name-is-the-doc case. Left as-is — the 403 are dominated by D103/D205/D209 and a partial carve-out would be fussier to maintain — but the gap is named rather than silently absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)