### PR TITLE
Wire BSD100 into default templates and imresize evidence (INIT.19)

### DIFF
--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -56,6 +56,11 @@ data:
       init_args:
         img_dir: data/Set14_HR
         scale: *scale
+    BSD100:
+      class_path: sisr.datasets.srcnn.ValidationDataset
+      init_args:
+        img_dir: data/BSD100_HR
+        scale: *scale
   train_dataloader_kwargs:
     batch_size: 64
     num_workers: 16

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -58,6 +58,11 @@ data:
       init_args:
         img_dir: data/Set14_HR
         scale: *scale
+    BSD100:
+      class_path: sisr.datasets.srresnet.ValidationDataset
+      init_args:
+        img_dir: data/BSD100_HR
+        scale: *scale
   train_dataloader_kwargs:
     batch_size: 16
     num_workers: 16

--- a/tests/test_imresize.py
+++ b/tests/test_imresize.py
@@ -15,22 +15,28 @@ Reference data (not committed — ``data/`` is gitignored):
     Source: https://cv.snu.ac.kr/research/EDSR/benchmark.tar
     (Lim et al., "Enhanced Deep Residual Networks for Single Image
     Super-Resolution", CVPRW 2017 — the EDSR authors' own benchmark
-    distribution; Set5/Set14 HR + MATLAB-``imresize``-generated
+    distribution; Set5/Set14/B100 HR + MATLAB-``imresize``-generated
     ``LR_bicubic`` X2/X3/X4 pairs, the same lineage BasicSR/EDSR-derived
     repos distribute.)
     SHA-256 of the full 250112000-byte tar: 80c21c333bbf6ceb5308b7243761f82
     84478274413a97b96f1d63e9045fd93e8
 
 To enable the byte-equality test, download that URL, verify the checksum,
-then extract only the ``Set5`` and ``Set14`` subtrees into::
+then extract only the ``Set5``, ``Set14`` and ``B100`` subtrees into::
 
     data/reference/Set5/{HR,LR_bicubic/{X2,X3,X4}}
     data/reference/Set14/{HR,LR_bicubic/{X2,X3,X4}}
+    data/reference/B100/{HR,LR_bicubic/{X2,X3,X4}}
 
-e.g. ``tar -xf benchmark.tar --wildcards 'benchmark/Set5/*' 'benchmark/Set14/*'``
-then move both dirs under ``data/reference/``. The test skips cleanly (not
-an error, not a silent no-op) when that directory is absent, so CI stays
-hermetic and contributors without the archive get a green suite.
+e.g. (Windows ``tar`` needs ``--force-local`` or a ``C:`` path is parsed as
+a remote host, and ``--wildcards`` for the subtree globs to expand)::
+
+    tar --force-local -xf benchmark.tar --wildcards \
+        'benchmark/Set5/*' 'benchmark/Set14/*' 'benchmark/B100/*'
+
+then move all three dirs under ``data/reference/``. The test skips cleanly
+(not an error, not a silent no-op) when that directory is absent, so CI
+stays hermetic and contributors without the archive get a green suite.
 """
 
 from pathlib import Path
@@ -158,7 +164,7 @@ def test_resize_unknown_backend_raises():
 
 def _reference_cases() -> list[tuple[str, Path, Path, int]]:
     cases = []
-    for dataset in ("Set5", "Set14"):
+    for dataset in ("Set5", "Set14", "B100"):
         hr_dir = REFERENCE_DIR / dataset / "HR"
         if not hr_dir.is_dir():
             continue


### PR DESCRIPTION
## Summary

Ledig et al. Table 2 (SRResNet x4) reports Set5, Set14 **and BSD100**
(27.58 / 0.7620), but this repo only ever benchmarked the first two —
`BSD100_HR` (100 PNGs) was already fetched and sitting unused on disk.

- **`templates/config.srcnn.template.yaml` / `config.srresnet.template.yaml`**:
  add a `BSD100` entry to `test_datasets`, mirroring the existing
  `Set5`/`Set14` entries exactly (same `class_path`, same `init_args`
  shape, `img_dir: data/BSD100_HR`, `scale: *scale`).

  This ships in the shipped default templates rather than a separate
  benchmarking config. BSD100 images are ~0.15 MP each vs DIV2K's
  ~2 MP, so evaluating all 100 of them costs roughly what 7 DIV2K
  validation images cost — the runtime objection that made this a
  judgement call doesn't survive the numbers.

- **`tests/test_imresize.py`**: the MATLAB reference pairs for B100
  are already on disk at `data/reference/B100/{HR,LR_bicubic/X{2,3,4}}`
  (400 files, same EDSR `benchmark.tar` lineage as Set5/Set14), but
  `_reference_cases()` hardcoded `("Set5", "Set14")`. Adding `"B100"`
  widens the byte-equality evidence from **57 to 357 cases**
  (Set5: 15, Set14: 42, B100: 300). Also updated the module docstring's
  extraction instructions to name B100 in both the path listing and
  the example `tar` command, folding in two Windows gotchas:
  `--force-local` (otherwise a `C:` path is parsed as a remote host)
  and `--wildcards` (required for the subtree globs).

## Test plan

- [x] `tests/test_imresize.py -v`: 12 passed, including
      `test_matlab_imresize_matches_real_matlab_reference_data`
      actually running (not skipped) over 357 cases — confirmed via
      `len(_reference_cases())`.
- [x] Full suite: `363 passed` (unchanged count/baseline — this PR adds
      no new test functions, only more parametrized cases inside the
      existing one).
- [x] Both templates resolve through jsonargparse
      (`sisr.cli fit --config ... --print_config`) with `BSD100`
      present in `test_datasets` for both SRCNN (scale 3) and
      SRResNet (scale 4).
- [x] `ruff check .` and `ruff format --check .` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)