### PR TITLE
Use full-precision BT.601 chroma coefficients

### DIFF
--- a/sisr/colorspace.py
+++ b/sisr/colorspace.py
@@ -28,11 +28,15 @@ import torch
 # [16/255, 235/255] and Cb/Cr to [16/255, 240/255].
 
 _RGB_TO_Y = (0.299, 0.587, 0.114)
-_RGB_TO_CB = (-0.169, -0.331, 0.500)  # output offset +0.5
-_RGB_TO_CR = (0.500, -0.419, -0.081)  # output offset +0.5
+# Ratios of MATLAB's published rgb2ycbcr studio-range matrix (see
+# rgb_to_ycbcr_studio below) over the chroma legal-range scale of 224 —
+# kept as literal ratios rather than pre-divided decimals so the MATLAB
+# source constants stay visible and transcription cannot silently drift.
+_RGB_TO_CB = (-37.797 / 224, -74.203 / 224, 112 / 224)  # output offset +0.5
+_RGB_TO_CR = (112 / 224, -93.786 / 224, -18.214 / 224)  # output offset +0.5
 _YCBCR_TO_R = 1.402  # cr coefficient
-_YCBCR_TO_G_CB = -0.344  # cb coefficient
-_YCBCR_TO_G_CR = -0.714  # cr coefficient
+_YCBCR_TO_G_CB = -0.344136  # cb coefficient
+_YCBCR_TO_G_CR = -0.714136  # cr coefficient
 _YCBCR_TO_B = 1.772  # cb coefficient
 
 # BT.601 studio-range ("limited"/"TV" range) rescale, applied on top of the

--- a/tests/processors/test_y_channel.py
+++ b/tests/processors/test_y_channel.py
@@ -42,9 +42,9 @@ def test_y_channel_reconstruct_same_size_roundtrips_to_lr():
         rgb_to_ycbcr(lr)[:, 1:], size=(16, 16), mode="bicubic", align_corners=False
     )
     assert torch.equal(same, rgb_to_ycbcr(lr)[:, 1:])  # bicubic@same-size == identity
-    # Tolerance 1e-3: the BT.601 coeffs in sisr.colorspace are truncated to 3 dp, so
-    # the forward/inverse matrices aren't perfect inverses (worst-case ~5e-4).
-    assert torch.allclose(out, lr, atol=1e-3)
+    # sisr.colorspace's BT.601 coefficients are full-precision (see its tests),
+    # so the forward/inverse matrices are near-perfect inverses (worst-case ~1.4e-6).
+    assert torch.allclose(out, lr, atol=2e-6)
 
 
 def test_y_channel_reconstruct_upscaled_stitches_bicubic_chroma():

--- a/tests/processors/test_ycbcr.py
+++ b/tests/processors/test_ycbcr.py
@@ -39,7 +39,7 @@ def test_ycbcr_reconstruct_matches_bt601_inverse_not_just_clamp():
     # Hand-computed BT.601 full-range inverse (coefficients from sisr.colorspace).
     cb, cr = 0.1, -0.1
     r = 0.5 + 1.402 * cr
-    g = 0.5 - 0.344 * cb - 0.714 * cr
+    g = 0.5 - 0.344136 * cb - 0.714136 * cr
     b = 0.5 + 1.772 * cb
     expected = torch.tensor([r, g, b]).view(1, 3, 1, 1).expand(1, 3, 2, 2)
 
@@ -50,12 +50,13 @@ def test_ycbcr_reconstruct_matches_bt601_inverse_not_just_clamp():
 def test_ycbcr_roundtrip_recovers_input():
     """extract -> reconstruct approximately recovers the input RGB.
 
-    Tolerance is 1e-3 because the BT.601 coefficients in :mod:`sisr.colorspace`
-    are truncated to 3 decimal places (e.g. ``-0.169`` vs the exact
-    ``-0.168736``), so the forward and inverse matrices aren't perfect
-    inverses. Observed worst-case error is ~5e-4 across the chroma channels.
+    Tolerance is 2e-6: the BT.601 coefficients in :mod:`sisr.colorspace` are
+    now full-precision ratios of MATLAB's published matrix, so the forward
+    and inverse matrices are near-perfect inverses (observed worst-case
+    error ~1.3e-6 across the chroma channels — see test_colorspace.py's
+    round-trip test for the same bound derived directly).
     """
     p = YCbCrProcessor()
     lr = torch.rand(2, 3, 8, 8)
     roundtrip = p.reconstruct(p.extract(lr), lr_rgb=lr)
-    assert torch.allclose(roundtrip, lr, atol=1e-3)
+    assert torch.allclose(roundtrip, lr, atol=2e-6)

--- a/tests/test_colorspace.py
+++ b/tests/test_colorspace.py
@@ -37,20 +37,36 @@ def test_rgb_to_ycbcr_known_values_black():
 
 
 def test_rgb_to_ycbcr_known_values_red():
-    # Pure red: (1, 0, 0) -> Y=0.299, Cb=0.5−0.169, Cr=0.5+0.500
+    # Pure red: (1, 0, 0) -> Y=0.299, Cb=0.5-37.797/224, Cr=0.5+112/224
     x = torch.tensor([[[[1.0]], [[0.0]], [[0.0]]]])
     y = rgb_to_ycbcr(x)
-    expected = torch.tensor([[[[0.299]], [[0.331]], [[1.000]]]])
-    assert torch.allclose(y, expected, atol=1e-5)
+    expected = torch.tensor([[[[0.299]], [[0.5 - 37.797 / 224]], [[1.000]]]])
+    assert torch.allclose(y, expected, atol=1e-6)
+
+
+def test_rgb_to_ycbcr_coefficients_match_matlab_matrix():
+    """Locks the full-precision BT.601 chroma coefficients to MATLAB's
+    published rgb2ycbcr studio-range matrix (divided by the 224 chroma
+    scale) so the old 3-decimal truncation (~2.6e-4/~3.1e-4 error) cannot
+    silently return."""
+    from sisr.colorspace import _RGB_TO_CB, _RGB_TO_CR, _RGB_TO_Y
+
+    assert _RGB_TO_Y == pytest.approx((65.481 / 219, 128.553 / 219, 24.966 / 219), abs=1e-12)
+    assert _RGB_TO_CB == pytest.approx((-37.797 / 224, -74.203 / 224, 112 / 224), abs=1e-12)
+    assert _RGB_TO_CR == pytest.approx((112 / 224, -93.786 / 224, -18.214 / 224), abs=1e-12)
 
 
 def test_round_trip_within_coefficient_precision():
-    # BT.601 coefficients are 3-decimal-place; round-trip error floor ~5e-4.
+    # Full-precision BT.601 chroma ratios drop the round-trip error floor
+    # from ~5e-4 (3-decimal-place truncation) to ~1.3e-6, the residual from
+    # the inverse G coefficients' own 6-decimal literals plus float32
+    # rounding (a bound confirmed at the unit-cube vertices, since the
+    # round trip is affine in R/G/B).
     torch.manual_seed(0)
     x = torch.rand(1, 3, 16, 16)
     y = ycbcr_to_rgb(rgb_to_ycbcr(x))
     err = (y - x).abs().max().item()
-    assert err < 5e-4
+    assert err < 2e-6
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`sisr/colorspace.py` stored its BT.601 Cb/Cr coefficients truncated to 3 decimal places, missing MATLAB's published `rgb2ycbcr` matrix by up to **~3.1e-4**. This replaces them with full-precision values:

- `_RGB_TO_CB`, `_RGB_TO_CR`: expressed as exact ratios of MATLAB's published studio-range matrix (`65.481/128.553/24.966`, `-37.797/-74.203/112.000`, `112.000/-93.786/-18.214`) divided by the chroma legal-range scale of **224** — kept as literal ratios (not pre-divided decimals) so the MATLAB source constants stay visible in the code and transcription can't silently drift.
- `_YCBCR_TO_G_CB` / `_YCBCR_TO_G_CR` (the inverse's G-channel coefficients): extended from 3 to 6 decimal places (`-0.344` → `-0.344136`, `-0.714` → `-0.714136`), the standard "exact" BT.601 precision.
- `_RGB_TO_Y` and the inverse's R/B coefficients (`_YCBCR_TO_R = 1.402`, `_YCBCR_TO_B = 1.772`) are **unchanged** — they were already exact (`Kr=0.299`, `Kb=0.114` give `2*(1-Kr)=1.402`, `2*(1-Kb)=1.772` exactly).

### Coefficient diff vs MATLAB's matrix

| | old (truncated) | new (full-precision) | max\|diff\| |
|---|---|---|---|
| Y | `(0.299, 0.587, 0.114)` | unchanged | `0.0` (exact) |
| Cb | `(-0.169, -0.331, 0.500)` | `(-0.168737, -0.331263, 0.500)` | `2.634e-4` |
| Cr | `(0.500, -0.419, -0.081)` | `(0.500, -0.418688, -0.081313)` | `3.125e-4` |

### Round-trip tolerance

`tests/test_colorspace.py::test_round_trip_within_coefficient_precision`'s tolerance (whose comment attributed a "~5e-4 error floor" to exactly this truncation) tightened from **5e-4 → 2e-6**. Measured worst case is **~1.31e-6**, a bound confirmed exact by evaluating all 8 vertices of the RGB unit cube (the round trip is affine, so its extrema land on vertices). The residual is no longer float-precision noise but the inherent inconsistency of MATLAB's own 3-decimal-published forward matrix against the analytically-exact `Kr`/`Kg`/`Kb`-derived inverse — tightening further would require abandoning the published MATLAB constants, so 2e-6 is the honest floor. The same two round-trip tests in `tests/processors/test_y_channel.py` and `tests/processors/test_ycbcr.py` (previously `atol=1e-3`, also citing the truncation) were tightened to `2e-6` as well, and one hand-computed expected-value test in `test_ycbcr.py` had its literal `-0.344`/`-0.714` updated to match the module's new constants (it happened to still pass before, by a coefficient-difference cancellation specific to that test's symmetric `cb=-cr` inputs — not a general guarantee).

Added `test_rgb_to_ycbcr_coefficients_match_matlab_matrix`, asserting `_RGB_TO_Y`/`_RGB_TO_CB`/`_RGB_TO_CR` against MATLAB's published matrix to `abs=1e-12`, so the truncation can't silently return.

### Two consequences

1. **This changes SRCNN's training colorspace.** `rgb_to_ycbcr` (full-range) is what `YChannelProcessor`/`YCbCrProcessor` feed the model, so any previously-trained SRCNN checkpoint's Cb/Cr inputs are renumbered by the diffs above. There is no SRCNN checkpoint worth preserving, so this is acceptable — flagging it explicitly rather than glossing over it.
2. **Published metrics are unaffected.** Every paper-comparable figure is Y-channel PSNR/SSIM, and luma was already exact. Verified directly: converting the same random RGB batch through old vs. new coefficients gives a Y-channel max\|diff\| of **exactly 0.0** (bit-identical); only Cb (`2.62e-4`) and Cr (`3.10e-4`) move. Only Cb/Cr PSNR and the non-standard 3-channel YCbCr aggregate are affected.

The two BT.601 variants (`rgb_to_ycbcr` full-range vs. `rgb_to_ycbcr_studio` metric-only) are untouched and not unified — this PR only tightens the shared full-range coefficients both build on.

## Test plan

- [x] `PYTHONPATH="$PWD" python -m pytest -q` → **363 passed, 1 skipped** (the skip is `test_imresize.py`'s reference-data check, expected in a worktree without `data/`)
- [x] `ruff check .` → all checks passed
- [x] `ruff format --check .` → 57 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)