### PR TITLE
Drop the cv2 degradation backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,28 +28,18 @@ watch reconstruction quality improve run-over-run.
 
 ### Degradation protocol (how LR is generated)
 
-Both datasets derive their LR input from HR via bicubic resizing, selectable per-dataset
-via `resize_backend`:
-
-- **`'matlab'` (default, tracked templates use it).** A vendored (not a dependency),
-  MATLAB-`imresize`-compatible bicubic resize — antialiased (MATLAB widens the
-  interpolation kernel by the scale factor on downscale; this widening *is* the
-  low-pass, so no separate blur step is used or accepted with this backend) and using
-  MATLAB's own bicubic coefficient (a=-0.5, vs. OpenCV's a=-0.75). This makes the LR
-  **inputs** directly comparable to published papers, most of which generate their
-  benchmark LR images with real MATLAB. See `sisr/imresize.py` for the implementation
-  and its license/attribution header, and `tests/test_imresize.py` for verification.
-  Byte-exact inputs alone don't make **reported** PSNR/SSIM comparable, though:
-  Y-channel figures here use BT.601 full-range Y (`sisr/colorspace.py`), while the
-  literature's published Y-channel numbers use MATLAB `rgb2ycbcr`'s studio-range
-  convention — a known, exact `20·log10(255/219) ≈ 1.3219 dB` offset, not an unknown one.
-- **`'cv2'` (opt-in).** Plain `cv2.INTER_CUBIC`, no antialiasing of its own. SRCNN's
-  `blur_sigma` (a pre-resize Gaussian blur) only has an effect on this path — passing
-  `blur_sigma` together with `resize_backend='matlab'` raises `ValueError` at
-  construction, since MATLAB's kernel widening already *is* the low-pass and stacking
-  an explicit blur on top would push PSNR away from published values, not toward them.
-  This backend exists solely to keep LMDB caches built before the `'matlab'` backend
-  existed reproducible; new work should use the default.
+Both datasets derive their LR input from HR via a vendored (not a dependency),
+MATLAB-`imresize`-compatible bicubic resize — antialiased (MATLAB widens the
+interpolation kernel by the scale factor on downscale; this widening *is* the
+low-pass, so no separate blur step is used) and using MATLAB's own bicubic
+coefficient (a=-0.5, vs. OpenCV's a=-0.75). This makes the LR **inputs** directly
+comparable to published papers, most of which generate their benchmark LR images
+with real MATLAB. See `sisr/imresize.py` for the implementation and its
+license/attribution header, and `tests/test_imresize.py` for verification.
+Byte-exact inputs alone don't make **reported** PSNR/SSIM comparable, though:
+Y-channel figures here use BT.601 full-range Y (`sisr/colorspace.py`), while the
+literature's published Y-channel numbers use MATLAB `rgb2ycbcr`'s studio-range
+convention — a known, exact `20·log10(255/219) ≈ 1.3219 dB` offset, not an unknown one.
 
 **Honest limit:** without access to real MATLAB, this project cannot prove
 byte-identity with MATLAB's `imresize` from first principles. `tests/test_imresize.py`
@@ -59,10 +49,9 @@ strongest available claim short of running MATLAB itself. That test is skipped
 (not a failure) when the reference archive hasn't been fetched locally; see the
 test file's module docstring for the source URL and checksum.
 
-Switching `resize_backend` (or the one-time move from AlbumentationsX to
-`sisr.imresize`) invalidates previously-built LMDB caches and renumbers any
-previously recorded benchmark figure — expected, one-time costs of the change,
-not a bug.
+The one-time move from AlbumentationsX to `sisr.imresize` invalidated previously-built
+LMDB caches and renumbered any previously recorded benchmark figure — expected,
+a one-time cost of the change, not a bug.
 
 ### Reproducibility note
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,6 @@ dependencies = [
     "numpy>=1.26",
     "tqdm>=4.66",
     "tensorboard>=2.16",
-    # cv2 is imported directly by sisr/imresize.py (cv2.resize / cv2.GaussianBlur, the 'cv2' resize
-    # backend) and sisr/datasets/srcnn.py (cv2.GaussianBlur). Headless variant avoids X11/Qt baggage
-    # and matches CI/non-GUI use.
-    "opencv-python-headless>=4.10",
 ]
 
 [project.optional-dependencies]

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -1,65 +1,33 @@
 """SRCNN-style data pipeline.
 
-LR is generated from HR via (optional blur →) bicubic-down → bicubic-up so
-the LR patches share the spatial size of the HR patches (pre-upsampled SRCNN
-formulation). :class:`TrainDataset` caches whole decoded HR images (raw,
-uint8) through :class:`~sisr.cache.LMDBCache`, mirroring
-:mod:`sisr.datasets.srresnet` — decoding a source image once and slicing its
-deterministic sub-images out at load time is far cheaper than re-decoding,
-and it decouples the cache from every LR-generation parameter (``scale``,
-``blur_sigma``, ``resize_backend``) as well as the sub-image grid itself
-(``subimg_size``, ``stride``): none of them affect the raw bytes stored, only
-what gets sliced/degraded from them at read time. :class:`ValidationDataset`
-generates LR pairs on the fly for full images.
+LR is generated from HR via bicubic-down → bicubic-up so the LR patches share
+the spatial size of the HR patches (pre-upsampled SRCNN formulation).
+:class:`TrainDataset` caches whole decoded HR images (raw, uint8) through
+:class:`~sisr.cache.LMDBCache`, mirroring :mod:`sisr.datasets.srresnet` —
+decoding a source image once and slicing its deterministic sub-images out at
+load time is far cheaper than re-decoding, and it decouples the cache from
+every LR-generation parameter (``scale``) as well as the sub-image grid
+itself (``subimg_size``, ``stride``): none of them affect the raw bytes
+stored, only what gets sliced/degraded from them at read time.
+:class:`ValidationDataset` generates LR pairs on the fly for full images.
 
-The resize/degradation backend is selectable (see :mod:`sisr.imresize`):
-``'matlab'`` (default) is antialiased and needs no separate blur step;
-``'cv2'`` has no antialiasing of its own, so ``blur_sigma`` stands in for it
-and only has an effect on that path.
+LR degradation uses MATLAB-compatible antialiased bicubic resizing (see
+:mod:`sisr.imresize`): its kernel widening on downscale is itself the
+low-pass filter, so no separate blur step is needed.
 """
 
 import bisect
 import hashlib
-import math
 from collections.abc import Iterator
 from pathlib import Path
 
-import cv2
 import numpy as np
 import torch
 from PIL import Image
 
 from ..cache import LMDBCache, LMDBCacheBuildContext
-from ..imresize import ResizeBackend, resize
+from ..imresize import resize
 from .base import SRDataset
-
-
-def _check_blur_sigma(resize_backend: ResizeBackend, blur_sigma: float | None) -> float | None:
-    """Validates the ``blur_sigma``/``resize_backend`` pairing at construction time.
-
-    ``'matlab'``'s antialiasing kernel widening already acts as the low-pass
-    filter; stacking an explicit Gaussian blur on top would double-blur and
-    push PSNR away from published values, so setting ``blur_sigma`` with it
-    is rejected outright rather than silently ignored. ``'cv2'`` has no
-    antialiasing of its own, so it falls back to the historical default of
-    ``1.0`` when unset.
-
-    Returns:
-        ``None`` for ``'matlab'``; a concrete sigma for ``'cv2'``.
-
-    Raises:
-        ValueError: If ``resize_backend='matlab'`` and *blur_sigma* is set.
-    """
-    if resize_backend == "matlab":
-        if blur_sigma is not None:
-            raise ValueError(
-                "blur_sigma is meaningless with resize_backend='matlab': its antialiasing "
-                "kernel widening already is the low-pass filter, so an explicit Gaussian blur "
-                "on top only double-blurs and pushes PSNR away from published values. Pass "
-                "resize_backend='cv2' if you need blur_sigma, or omit blur_sigma for 'matlab'."
-            )
-        return None
-    return 1.0 if blur_sigma is None else blur_sigma
 
 
 def _grid_dims(
@@ -97,14 +65,8 @@ def _iter_patch_origins(
             yield row * stride, col * stride
 
 
-def _degrade(
-    hr_arr: np.ndarray,
-    scale: int,
-    kernel: int | None,
-    blur_sigma: float | None,
-    resize_backend: ResizeBackend,
-) -> np.ndarray:
-    """Derives an LR array from an HR array: (optional blur →) bicubic-down → bicubic-up.
+def _degrade(hr_arr: np.ndarray, scale: int) -> np.ndarray:
+    """Derives an LR array from an HR array: bicubic-down → bicubic-up.
 
     Restores *hr_arr*'s original spatial size (SRCNN's pre-upsampled
     formulation). Shared by :class:`TrainDataset` (per sub-image, at read
@@ -112,11 +74,8 @@ def _degrade(
     recipe cannot drift between the two.
     """
     h, w = hr_arr.shape[:2]
-    to_degrade = hr_arr
-    if kernel is not None:
-        to_degrade = cv2.GaussianBlur(hr_arr, (kernel, kernel), sigmaX=blur_sigma)
-    down = resize(to_degrade, (h // scale, w // scale), backend=resize_backend)
-    return resize(down, (h, w), backend=resize_backend)
+    down = resize(hr_arr, (h // scale, w // scale))
+    return resize(down, (h, w))
 
 
 def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
@@ -155,8 +114,8 @@ class TrainDataset(SRDataset):
     A SHA-256 checksum over the file manifest (plus a format tag) is stored
     inside the LMDB so subsequent runs over the same files skip the build
     entirely — the checksum no longer depends on
-    ``subimg_size``/``stride``/``scale``/``blur_sigma``/``resize_backend``,
-    since none of them affect the raw bytes written.
+    ``subimg_size``/``stride``/``scale``, since none of them affect the raw
+    bytes written.
 
     Reference:
         Image Super-Resolution Using Deep Convolutional Networks
@@ -167,18 +126,6 @@ class TrainDataset(SRDataset):
         subimg_size: Spatial size of the square sub-images to extract.
         stride: Step size of the sliding window used for sub-image extraction.
         scale: Downscaling factor for generating LR sub-images.
-        blur_sigma: Only meaningful (and must be set) on the ``'cv2'``
-            backend, which has no antialiasing of its own; falls back to
-            ``1.0`` if left ``None`` there. Must be ``None`` on ``'matlab'``
-            (the default) — its kernel widening already is the antialiasing
-            low-pass, so an explicit blur on top only double-blurs; passing
-            a value raises ``ValueError``.
-        resize_backend: ``'matlab'`` (default) — MATLAB-compatible
-            antialiased bicubic, comparable to published paper numbers.
-            ``'cv2'`` — no antialiasing; kept only so pre-existing LMDB
-            caches stay reproducible. See :mod:`sisr.imresize`. Only affects
-            LR derivation — the HR cache stores raw pixels regardless, so
-            switching backends never invalidates it.
         use_tqdm: Whether to display a progress bar during the LMDB build.
         cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
         build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
@@ -187,8 +134,7 @@ class TrainDataset(SRDataset):
             loading.
 
     Raises:
-        ValueError: If no image files are found in ``img_dir``, or if
-            *blur_sigma* is set together with ``resize_backend='matlab'``.
+        ValueError: If no image files are found in ``img_dir``.
     """
 
     def __init__(
@@ -197,8 +143,6 @@ class TrainDataset(SRDataset):
         subimg_size: int,
         stride: int,
         scale: int,
-        blur_sigma: float | None = None,
-        resize_backend: ResizeBackend = "matlab",
         use_tqdm: bool = False,
         cache_dir: str | Path | None = None,
         build_num_workers: int | None = None,
@@ -209,12 +153,7 @@ class TrainDataset(SRDataset):
         self.sub_img_size = subimg_size
         self.stride = stride
         self.scale = scale
-        self.blur_sigma = _check_blur_sigma(resize_backend, blur_sigma)
-        self.resize_backend = resize_backend
         self.build_num_workers = build_num_workers
-        self._kernel = (
-            2 * math.ceil(3.0 * self.blur_sigma) + 1 if self.blur_sigma is not None else None
-        )  # odd, covers +/-3 sigma
 
         cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
         checksum = self._compute_checksum()
@@ -244,12 +183,12 @@ class TrainDataset(SRDataset):
         """Computes a SHA-256 checksum over the file manifest only.
 
         The cache stores whole raw HR images, so — unlike the LR-patch cache
-        this replaced — none of ``subimg_size``/``stride``/``scale``/
-        ``blur_sigma``/``resize_backend`` enter the hash: they only affect
-        what gets sliced and degraded at read time, never what is written to
-        LMDB. The ``format=srcnn_hr_v1`` tag (paired with a new LMDB cache
-        ``name``, see :meth:`__init__`) ensures a pre-HR-only cache is never
-        misread under this format rather than rebuilt.
+        this replaced — none of ``subimg_size``/``stride``/``scale`` enter the
+        hash: they only affect what gets sliced and degraded at read time,
+        never what is written to LMDB. The ``format=srcnn_hr_v1`` tag (paired
+        with a new LMDB cache ``name``, see :meth:`__init__`) ensures a
+        pre-HR-only cache is never misread under this format rather than
+        rebuilt.
 
         Returns:
             A hex-encoded SHA-256 digest string.
@@ -348,9 +287,7 @@ class TrainDataset(SRDataset):
                 top : top + self.sub_img_size, left : left + self.sub_img_size, :
             ].copy()
 
-        lr_subimg = _degrade(
-            hr_subimg, self.scale, self._kernel, self.blur_sigma, self.resize_backend
-        )
+        lr_subimg = _degrade(hr_subimg, self.scale)
 
         return self._to_tensor(lr_subimg), self._to_tensor(hr_subimg)
 
@@ -360,43 +297,23 @@ class ValidationDataset(SRDataset):
 
     Unlike :class:`TrainDataset` this dataset does not extract sub-images.
     Each item is a full image pair where the low-resolution version is
-    produced by (optionally, ``'cv2'``-only) Gaussian-blurring, then
-    bicubic-downsampling and bicubic-upsampling back to the original size.
+    produced by bicubic-downsampling and bicubic-upsampling back to the
+    original size.
 
     Args:
         img_dir (str | Path): Directory containing the high-resolution
             images.
         scale (int): Downscaling factor for generating low-resolution images.
-        blur_sigma (float | None): Sigma of the Gaussian blur applied before
-            downsampling.  Must match :class:`TrainDataset` to keep train/val
-            LR generation consistent. Same ``resize_backend`` pairing rules
-            as :class:`TrainDataset` apply (``None``-only on ``'matlab'``,
-            defaults to ``1.0`` on ``'cv2'``).
-        resize_backend (ResizeBackend): ``'matlab'`` (default) or ``'cv2'``;
-            see :class:`TrainDataset` / :mod:`sisr.imresize`.
 
     Raises:
-        ValueError: If no image files are found in ``img_dir``, or if
-            *blur_sigma* is set together with ``resize_backend='matlab'``.
+        ValueError: If no image files are found in ``img_dir``.
     """
 
-    def __init__(
-        self,
-        img_dir: str | Path,
-        scale: int,
-        blur_sigma: float | None = None,
-        resize_backend: ResizeBackend = "matlab",
-    ):
+    def __init__(self, img_dir: str | Path, scale: int):
         super().__init__()
 
         self._index_images(img_dir)
         self.scale = scale
-        self.blur_sigma = _check_blur_sigma(resize_backend, blur_sigma)
-        self.resize_backend = resize_backend
-
-        self._kernel = (
-            2 * math.ceil(3.0 * self.blur_sigma) + 1 if self.blur_sigma is not None else None
-        )  # odd, covers ±3σ
 
     def __len__(self) -> int:
         return len(self.img_paths)
@@ -413,6 +330,6 @@ class ValidationDataset(SRDataset):
         """
         path = self.img_paths[idx]
         arr = self._load_rgb(path)  # HWC uint8 RGB
-        lr_arr = _degrade(arr, self.scale, self._kernel, self.blur_sigma, self.resize_backend)
+        lr_arr = _degrade(arr, self.scale)
 
         return self._to_tensor(lr_arr), self._to_tensor(arr)

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -10,10 +10,8 @@ the cached raw array, on every ``__getitem__`` call.
 :class:`ValidationDataset` serves full images cropped to a multiple of
 ``scale``, uncached (each is decoded once per epoch, no repetition).
 
-The resize backend is selectable (see :mod:`sisr.imresize`): ``'matlab'``
-(default) is antialiased and comparable to published paper numbers;
-``'cv2'`` has no antialiasing and is kept only so caches built before this
-module existed stay reproducible.
+LR is derived via MATLAB-compatible antialiased bicubic resizing (see
+:mod:`sisr.imresize`), comparable to published paper numbers.
 """
 
 import hashlib
@@ -26,7 +24,7 @@ import torch
 from PIL import Image
 
 from ..cache import LMDBCache, LMDBCacheBuildContext
-from ..imresize import ResizeBackend, resize
+from ..imresize import resize
 from .base import SRDataset
 
 # (height, width) as little-endian uint32 each, prefixed to every cached HR
@@ -87,12 +85,6 @@ class TrainDataset(SRDataset):
             length is ``len(images) * crops_per_image``). Each draw re-reads
             the same cached array (a cheap mmap access, not a decode) and
             takes an independently random crop. Defaults to ``1``.
-        resize_backend: ``'matlab'`` (default) — MATLAB-compatible
-            antialiased bicubic, comparable to published paper numbers.
-            ``'cv2'`` — no antialiasing; kept so LMDB caches built before
-            this module existed stay reproducible. See :mod:`sisr.imresize`.
-            Only the LR derivation is affected — the HR cache stores raw
-            pixels regardless, so switching backends never invalidates it.
         use_tqdm: Whether to display a progress bar during the LMDB build.
         cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
         build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
@@ -111,7 +103,6 @@ class TrainDataset(SRDataset):
         scale: int,
         hr_crop_size: int,
         crops_per_image: int = 1,
-        resize_backend: ResizeBackend = "matlab",
         use_tqdm: bool = False,
         cache_dir: str | Path | None = None,
         build_num_workers: int | None = None,
@@ -125,7 +116,6 @@ class TrainDataset(SRDataset):
         self.scale = scale
         self.hr_crop_size = hr_crop_size
         self.crops_per_image = crops_per_image
-        self.resize_backend = resize_backend
         self.build_num_workers = build_num_workers
         self.lr_size = hr_crop_size // scale
 
@@ -222,7 +212,7 @@ class TrainDataset(SRDataset):
             left = random.randint(0, w - self.hr_crop_size)
             hr_arr = arr[top : top + self.hr_crop_size, left : left + self.hr_crop_size, :].copy()
 
-        lr_arr = resize(hr_arr, (self.lr_size, self.lr_size), backend=self.resize_backend)
+        lr_arr = resize(hr_arr, (self.lr_size, self.lr_size))
         lr_tensor = self._to_tensor(lr_arr)
         hr_tensor = self._to_tensor(hr_arr)
 
@@ -240,19 +230,16 @@ class ValidationDataset(SRDataset):
     Args:
         img_dir (str | Path): Directory containing the high-resolution images.
         scale (int): Upscaling factor.
-        resize_backend (ResizeBackend): ``'matlab'`` (default) or ``'cv2'``;
-            see :class:`TrainDataset` / :mod:`sisr.imresize`.
 
     Raises:
         ValueError: If no images are found in ``img_dir``.
     """
 
-    def __init__(self, img_dir: str | Path, scale: int, resize_backend: ResizeBackend = "matlab"):
+    def __init__(self, img_dir: str | Path, scale: int):
         super().__init__()
 
         self._index_images(img_dir)
         self.scale = scale
-        self.resize_backend = resize_backend
 
     def __len__(self) -> int:
         return len(self.img_paths)
@@ -272,9 +259,7 @@ class ValidationDataset(SRDataset):
         w_crop = w - (w % self.scale)
         hr_arr = arr[:h_crop, :w_crop, :]  # deterministic exact-corner crop
 
-        lr_arr = resize(
-            hr_arr, (h_crop // self.scale, w_crop // self.scale), backend=self.resize_backend
-        )
+        lr_arr = resize(hr_arr, (h_crop // self.scale, w_crop // self.scale))
 
         lr_tensor = self._to_tensor(lr_arr)
         hr_tensor = self._to_tensor(hr_arr)

--- a/sisr/imresize.py
+++ b/sisr/imresize.py
@@ -30,10 +30,10 @@ All arithmetic runs in float64 throughout (MATLAB computes ``imresize`` in
 double; a float32 port drifts by fractions of a level -- invisible until a
 uint8 cast turns it into scattered +/-1 errors).
 
-The two real deltas this closes vs. ``cv2.INTER_CUBIC``: MATLAB widens the
-kernel by ``1/scale`` when downscaling (antialiasing -- cv2 does not
-antialias at all, the dominant term) and the bicubic coefficient differs
-(MATLAB a=-0.5, OpenCV a=-0.75).
+The two real deltas this closes vs. a naive OpenCV-style bicubic resize:
+MATLAB widens the kernel by ``1/scale`` when downscaling (antialiasing --
+OpenCV does not antialias at all, the dominant term) and the bicubic
+coefficient differs (MATLAB a=-0.5, OpenCV a=-0.75).
 
 ------------------------------------------------------------------------------
 MIT License
@@ -61,14 +61,10 @@ SOFTWARE.
 """
 
 from math import ceil
-from typing import Literal
 
-import cv2
 import numpy as np
 
 _KERNEL_WIDTH = 4.0  # bicubic support width; MATLAB's a=-0.5 coefficient (OpenCV uses a=-0.75)
-
-ResizeBackend = Literal["matlab", "cv2"]
 
 
 def _cubic(x: np.ndarray) -> np.ndarray:
@@ -191,29 +187,18 @@ def matlab_imresize(image: np.ndarray, output_shape: tuple[int, int]) -> np.ndar
     return arr[:, :, 0] if flag2d else arr
 
 
-def resize(
-    image: np.ndarray, size: tuple[int, int], backend: ResizeBackend = "matlab"
-) -> np.ndarray:
+def resize(image: np.ndarray, size: tuple[int, int]) -> np.ndarray:
     """Resizes a uint8 image to ``(height, width) = size``.
+
+    MATLAB-``imresize``-compatible antialiased bicubic (a=-0.5), so benchmark
+    numbers stay comparable to published papers. Thin wrapper over
+    :func:`matlab_imresize`, kept as the stable import site for callers.
 
     Args:
         image: uint8 array, ``(H, W)`` or ``(H, W, C)``.
         size: Target ``(height, width)``.
-        backend: ``'matlab'`` (default) -- antialiased bicubic, a=-0.5,
-            matching MATLAB's ``imresize`` so benchmark numbers are
-            comparable to published papers. ``'cv2'`` -- ``cv2.INTER_CUBIC``
-            (a=-0.75, no antialiasing); kept only so LMDB caches built
-            before this module existed stay reproducible.
 
     Returns:
         Resized uint8 array.
-
-    Raises:
-        ValueError: If *backend* is not ``'matlab'`` or ``'cv2'``.
     """
-    if backend == "matlab":
-        return matlab_imresize(image, size)
-    if backend == "cv2":
-        height, width = size
-        return cv2.resize(image, (width, height), interpolation=cv2.INTER_CUBIC)
-    raise ValueError(f"Unknown resize backend {backend!r}; expected 'matlab' or 'cv2'.")
+    return matlab_imresize(image, size)

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -28,9 +28,8 @@ model:
     class_path: sisr.models.srcnn.SRCNNEvalConfig
 
 data:
-  # resize_backend defaults to 'matlab' (antialiased bicubic, comparable to published
-  # paper numbers) below. blur_sigma is omitted to match: it's only meaningful on
-  # resize_backend: cv2, kept solely to reproduce pre-matlab-backend LMDB caches.
+  # LR is derived via MATLAB-compatible antialiased bicubic resizing (see
+  # sisr/imresize.py), comparable to published paper numbers.
   train_dataset:
     class_path: sisr.datasets.srcnn.TrainDataset
     init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -31,8 +31,8 @@ model:
     class_path: sisr.models.srresnet.SRResNetEvalConfig
 
 data:
-  # resize_backend defaults to 'matlab' (antialiased bicubic, comparable to published
-  # paper numbers) below; 'cv2' exists solely to reproduce pre-matlab-backend LMDB caches.
+  # LR is derived via MATLAB-compatible antialiased bicubic resizing (see
+  # sisr/imresize.py), comparable to published paper numbers.
   train_dataset:
     class_path: sisr.datasets.srresnet.TrainDataset
     init_args:

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -21,8 +21,7 @@ def shared_srcnn_train_ds(tmp_path_factory) -> TrainDataset:
 
     Module-scoped so the LMDB build runs once instead of once per test;
     build_num_workers=1 forces PR 1's inline (no ProcessPool) build path, which
-    keeps it safe when the whole run is under pytest-xdist workers. Uses the
-    default resize_backend='matlab' (blur_sigma stays None to match).
+    keeps it safe when the whole run is under pytest-xdist workers.
     """
     img_dir = tmp_path_factory.mktemp("shared_srcnn_hr")
     rng = np.random.default_rng(seed=0)
@@ -102,10 +101,9 @@ def test_train_dataset_cache_reuse_skips_rebuild(tiny_rgb_image_dir: Path):
 
 
 def test_train_dataset_cache_independent_of_grid_params(tiny_rgb_image_dir: Path):
-    """The cache stores whole images, so changing subimg_size/stride/scale/
-    blur_sigma/resize_backend over the same file set must NOT trigger a
-    rebuild (contrast the pre-HR-only cache, whose checksum baked all of
-    those in)."""
+    """The cache stores whole images, so changing subimg_size/stride/scale
+    over the same file set must NOT trigger a rebuild (contrast the
+    pre-HR-only cache, whose checksum baked all of those in)."""
     cache_dir = tiny_rgb_image_dir / ".lmdb_cache_shared_grid"
     _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8, scale=2, cache_dir=cache_dir)
     with patch("sisr.datasets.srcnn._process_hr_image") as mock_proc:
@@ -114,8 +112,6 @@ def test_train_dataset_cache_independent_of_grid_params(tiny_rgb_image_dir: Path
             subimg_size=24,
             stride=10,
             scale=4,
-            resize_backend="cv2",
-            blur_sigma=2.0,
             cache_dir=cache_dir,
         )
         mock_proc.assert_not_called()
@@ -143,8 +139,8 @@ def test_train_dataset_checksum_change_triggers_rebuild(tmp_path: Path):
 
 def test_train_dataset_checksum_ignores_grid_and_lr_params(shared_srcnn_train_ds: TrainDataset):
     """_compute_checksum must depend only on the file manifest (+ a format
-    tag) -- not on subimg_size/stride/scale/blur_sigma/resize_backend, since
-    the HR-only cache stores raw pixels unaffected by any of them."""
+    tag) -- not on subimg_size/stride/scale, since the HR-only cache stores
+    raw pixels unaffected by any of them."""
     import hashlib
 
     ds = shared_srcnn_train_ds
@@ -154,18 +150,12 @@ def test_train_dataset_checksum_ignores_grid_and_lr_params(shared_srcnn_train_ds
     assert ds._compute_checksum() == expected
 
 
-def test_train_dataset_backend_and_grid_do_not_affect_checksum(tiny_rgb_image_dir: Path):
-    ds_a = _make_train(
-        tiny_rgb_image_dir, subimg_size=20, stride=8, scale=2, resize_backend="matlab"
-    )
-    ds_b = _make_train(
-        tiny_rgb_image_dir,
-        subimg_size=24,
-        stride=10,
-        scale=4,
-        resize_backend="cv2",
-        blur_sigma=1.5,
-    )
+def test_train_dataset_grid_params_do_not_affect_checksum(tiny_rgb_image_dir: Path):
+    """The HR cache stores raw pixels only; degradation/grid parameters are
+    applied at read time, so two datasets differing only in
+    subimg_size/stride/scale must produce the same checksum."""
+    ds_a = _make_train(tiny_rgb_image_dir, subimg_size=20, stride=8, scale=2)
+    ds_b = _make_train(tiny_rgb_image_dir, subimg_size=24, stride=10, scale=4)
     assert ds_a._compute_checksum() == ds_b._compute_checksum()
 
 
@@ -301,51 +291,6 @@ def test_train_dataset_hr_subimage_matches_exact_grid_position(tiny_rgb_image_di
 
 
 # ---------------------------------------------------------------------------
-# resize_backend / blur_sigma construction guard (INIT.11)
-# ---------------------------------------------------------------------------
-
-
-def test_train_dataset_matlab_backend_rejects_blur_sigma(tiny_rgb_image_dir: Path):
-    with pytest.raises(ValueError, match="matlab"):
-        _make_train(tiny_rgb_image_dir, resize_backend="matlab", blur_sigma=1.0)
-
-
-def test_train_dataset_cv2_backend_defaults_blur_sigma_when_unset(tiny_rgb_image_dir: Path):
-    ds = _make_train(tiny_rgb_image_dir, resize_backend="cv2")
-    assert ds.blur_sigma == 1.0
-
-
-def test_train_dataset_cv2_backend_uses_provided_blur_sigma(tiny_rgb_image_dir: Path):
-    ds = _make_train(tiny_rgb_image_dir, resize_backend="cv2", blur_sigma=2.5)
-    assert ds.blur_sigma == 2.5
-
-
-def test_train_dataset_matlab_is_the_default_backend(tiny_rgb_image_dir: Path):
-    ds = _make_train(tiny_rgb_image_dir)
-    assert ds.resize_backend == "matlab"
-    assert ds.blur_sigma is None
-
-
-def test_train_dataset_matlab_and_cv2_backends_produce_different_lr(tiny_rgb_image_dir: Path):
-    """The two backends implement different bicubic kernels/antialiasing, so
-    the same crop must not degrade identically under each."""
-    ds_matlab = _make_train(tiny_rgb_image_dir, resize_backend="matlab")
-    ds_cv2 = _make_train(
-        tiny_rgb_image_dir, resize_backend="cv2", cache_dir=tiny_rgb_image_dir / ".lmdb_cache_cv2"
-    )
-    lr_matlab, _ = ds_matlab[0]
-    lr_cv2, _ = ds_cv2[0]
-    assert not torch.allclose(lr_matlab, lr_cv2)
-
-
-def test_validation_dataset_matlab_backend_rejects_blur_sigma(tiny_rgb_image_dir: Path):
-    with pytest.raises(ValueError, match="matlab"):
-        ValidationDataset(
-            img_dir=tiny_rgb_image_dir, scale=2, resize_backend="matlab", blur_sigma=1.0
-        )
-
-
-# ---------------------------------------------------------------------------
 # ValidationDataset
 # ---------------------------------------------------------------------------
 
@@ -363,20 +308,6 @@ def test_validation_dataset_serves_full_image_pairs(tiny_rgb_image_dir: Path):
 def test_validation_dataset_no_images_raises(tmp_path: Path):
     with pytest.raises(ValueError, match="No images"):
         ValidationDataset(img_dir=tmp_path, scale=2)
-
-
-def test_validation_dataset_blur_sigma_propagates(tiny_rgb_image_dir: Path):
-    """On the 'cv2' backend, ValidationDataset accepts and uses blur_sigma, so
-    two datasets with different sigmas produce different LR outputs."""
-    ds_a = ValidationDataset(
-        img_dir=tiny_rgb_image_dir, scale=2, resize_backend="cv2", blur_sigma=0.1
-    )
-    ds_b = ValidationDataset(
-        img_dir=tiny_rgb_image_dir, scale=2, resize_backend="cv2", blur_sigma=3.0
-    )
-    lr_a, _ = ds_a[0]
-    lr_b, _ = ds_b[0]
-    assert not torch.allclose(lr_a, lr_b), "different blur_sigma must produce different LR"
 
 
 def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):

--- a/tests/datasets/test_srresnet.py
+++ b/tests/datasets/test_srresnet.py
@@ -35,7 +35,7 @@ def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
     Recovers the returned HR crop as uint8 and re-runs the dataset's own
     resize primitive as the reference; the crop is random, but LR and HR come
     from one call, so the reference is exact. A regression to a different
-    interpolation/backend fails here."""
+    interpolation fails here."""
     import numpy as np
 
     from sisr.imresize import resize
@@ -51,10 +51,10 @@ def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
     assert 0.0 <= hr.min() <= hr.max() <= 1.0
 
     # Reference: recover the HR crop as uint8 HWC and re-run the dataset's own
-    # resize primitive (backend='matlab', the dataset's default).
+    # resize primitive (MATLAB-compatible bicubic).
     hr_uint8 = (hr.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
     lr_size = 16 // 4
-    lr_expected_arr = resize(hr_uint8, (lr_size, lr_size), backend="matlab")
+    lr_expected_arr = resize(hr_uint8, (lr_size, lr_size))
     lr_expected = torch.from_numpy(lr_expected_arr).permute(2, 0, 1).float().div(255.0)
     torch.testing.assert_close(lr, lr_expected, atol=1e-6, rtol=0)
 
@@ -168,8 +168,7 @@ def test_train_dataset_cache_reuse_skips_rebuild(tiny_rgb_image_dir: Path):
 
 def test_train_dataset_cache_independent_of_crop_params(tiny_rgb_image_dir: Path):
     """The cache stores whole images, so changing hr_crop_size/crops_per_image/
-    scale over the same file set must NOT trigger a rebuild (contrast SRCNN,
-    whose checksum bakes in sub_img_size/stride/scale/blur_sigma)."""
+    scale over the same file set must NOT trigger a rebuild."""
     cache_dir = tiny_rgb_image_dir / ".lmdb_cache"
     TrainDataset(
         img_dir=tiny_rgb_image_dir,
@@ -256,7 +255,10 @@ def test_train_dataset_build_num_workers_1_builds_inline(tiny_rgb_image_dir: Pat
 
 def test_train_dataset_checksum_ignores_crop_params(tiny_rgb_image_dir: Path):
     """_compute_checksum must depend only on the file manifest, not on
-    hr_crop_size/crops_per_image/scale."""
+    hr_crop_size/crops_per_image/scale -- the HR cache stores raw pixels only,
+    with every degradation/grid parameter applied at read time, so two
+    datasets differing in any of them must produce the same checksum and
+    never trigger an unnecessary rebuild."""
     ds_a = TrainDataset(
         img_dir=tiny_rgb_image_dir,
         scale=2,
@@ -273,69 +275,6 @@ def test_train_dataset_checksum_ignores_crop_params(tiny_rgb_image_dir: Path):
         build_num_workers=1,
     )
     assert ds_a._compute_checksum() == ds_b._compute_checksum()
-
-
-# ---------------------------------------------------------------------------
-# resize_backend (INIT.11) — no blur_sigma param here; SRResNet never had one.
-# ---------------------------------------------------------------------------
-
-
-def test_train_dataset_matlab_is_the_default_backend(tiny_rgb_image_dir: Path):
-    ds = TrainDataset(
-        img_dir=tiny_rgb_image_dir,
-        scale=2,
-        hr_crop_size=16,
-        cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
-        build_num_workers=1,
-    )
-    assert ds.resize_backend == "matlab"
-
-
-def test_train_dataset_matlab_and_cv2_backends_produce_different_lr(tiny_rgb_image_dir: Path):
-    # Separate cache_dir per dataset: both backends key to the same checksum
-    # (see test below), and LMDB disallows two live environments on one path
-    # within a single process, which reading from both here would trip.
-    ds_matlab = TrainDataset(
-        img_dir=tiny_rgb_image_dir,
-        scale=4,
-        hr_crop_size=16,
-        resize_backend="matlab",
-        cache_dir=tiny_rgb_image_dir / ".lmdb_cache_matlab",
-        build_num_workers=1,
-    )
-    ds_cv2 = TrainDataset(
-        img_dir=tiny_rgb_image_dir,
-        scale=4,
-        hr_crop_size=16,
-        resize_backend="cv2",
-        cache_dir=tiny_rgb_image_dir / ".lmdb_cache_cv2",
-        build_num_workers=1,
-    )
-    lr_matlab, _ = ds_matlab[0]
-    lr_cv2, _ = ds_cv2[0]
-    assert not torch.allclose(lr_matlab, lr_cv2)
-
-
-def test_train_dataset_backend_does_not_affect_checksum(tiny_rgb_image_dir: Path):
-    """The HR cache stores raw pixels only; the resize backend is applied at
-    read time, so switching it must not trigger an unnecessary cache rebuild."""
-    ds_matlab = TrainDataset(
-        img_dir=tiny_rgb_image_dir,
-        scale=2,
-        hr_crop_size=16,
-        resize_backend="matlab",
-        cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
-        build_num_workers=1,
-    )
-    ds_cv2 = TrainDataset(
-        img_dir=tiny_rgb_image_dir,
-        scale=2,
-        hr_crop_size=16,
-        resize_backend="cv2",
-        cache_dir=tiny_rgb_image_dir / ".lmdb_cache",
-        build_num_workers=1,
-    )
-    assert ds_matlab._compute_checksum() == ds_cv2._compute_checksum()
 
 
 # ---------------------------------------------------------------------------
@@ -367,18 +306,6 @@ def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):
     lr_b, hr_b = ds[0]
     assert torch.equal(lr_a, lr_b), "validation LR must be deterministic"
     assert torch.equal(hr_a, hr_b), "validation HR must be deterministic"
-
-
-def test_validation_dataset_matlab_is_the_default_backend(tiny_rgb_image_dir: Path):
-    assert ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2).resize_backend == "matlab"
-
-
-def test_validation_dataset_matlab_and_cv2_backends_produce_different_lr(tiny_rgb_image_dir: Path):
-    ds_matlab = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=4, resize_backend="matlab")
-    ds_cv2 = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=4, resize_backend="cv2")
-    lr_matlab, _ = ds_matlab[0]
-    lr_cv2, _ = ds_cv2[0]
-    assert not torch.allclose(lr_matlab, lr_cv2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_imresize.py
+++ b/tests/test_imresize.py
@@ -126,35 +126,14 @@ def test_matlab_imresize_output_is_uint8_and_clipped():
 
 
 # ---------------------------------------------------------------------------
-# resize() backend dispatcher
+# resize()
 # ---------------------------------------------------------------------------
 
 
-def test_resize_matlab_backend_matches_matlab_imresize():
+def test_resize_matches_matlab_imresize():
     rng = np.random.default_rng(2)
     img = rng.integers(0, 256, size=(24, 24, 3), dtype=np.uint8)
-    assert np.array_equal(resize(img, (8, 8), backend="matlab"), matlab_imresize(img, (8, 8)))
-
-
-def test_resize_cv2_backend_matches_cv2_directly():
-    import cv2
-
-    rng = np.random.default_rng(3)
-    img = rng.integers(0, 256, size=(24, 24, 3), dtype=np.uint8)
-    expected = cv2.resize(img, (8, 8), interpolation=cv2.INTER_CUBIC)
-    assert np.array_equal(resize(img, (8, 8), backend="cv2"), expected)
-
-
-def test_resize_defaults_to_matlab_backend():
-    rng = np.random.default_rng(4)
-    img = rng.integers(0, 256, size=(24, 24, 3), dtype=np.uint8)
     assert np.array_equal(resize(img, (8, 8)), matlab_imresize(img, (8, 8)))
-
-
-def test_resize_unknown_backend_raises():
-    img = np.zeros((4, 4, 3), dtype=np.uint8)
-    with pytest.raises(ValueError, match="pillow"):
-        resize(img, (2, 2), backend="pillow")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes the `'cv2'` resize backend entirely; `sisr/imresize.py`'s `resize()` is now MATLAB-only (the `ResizeBackend` alias, `backend` parameter, cv2 branch, and `import cv2` are all gone; `matlab_imresize` and the vendored algorithm are untouched).
- Removes `resize_backend` from both `sisr/datasets/srcnn.py` and `sisr/datasets/srresnet.py`, and removes SRCNN's `blur_sigma`/`_check_blur_sigma()`/`cv2.GaussianBlur` call — blur only ever stood in for cv2's missing antialiasing, so it has no purpose once that backend is gone.
- **Drops the `opencv-python-headless` dependency from `pyproject.toml`.** Verified zero remaining `cv2` call sites under `sisr/` and confirmed every `cv2` reference in `tests/` was testing the cv2 backend itself (including the pass-through oracle), so it wasn't needed as a dev dependency either.
- Updates both templates' comment blocks and the README's degradation-protocol section to describe the single MATLAB path instead of a choice between backends.
- Re-expresses the "LMDB cache checksum is independent of degradation backend" test invariant against a surviving parameter (two datasets differing only in `scale`/`hr_crop_size` now assert equal checksums) instead of letting that coverage disappear.

This is a pre-release repo with a clean-break, no-back-compat-shims policy — the cv2 backend existed only to reproduce caches built before the vendored MATLAB `imresize` landed, which is no longer a live concern.

## Test plan

- [x] `git ls-files | xargs grep -n "cv2\|resize_backend\|blur_sigma\|ResizeBackend"` returns nothing.
- [x] Full suite: `347 passed, 1 skipped` (down from a 363-test baseline: 15 cv2/backend-specific tests removed, and `test_imresize.py`'s byte-equality check skips in this worktree since `data/` isn't present — 363 − 15 = 348 = 347 passed + 1 skipped).
- [x] Both templates resolve: `python -m sisr.cli fit --config templates/config.srcnn.template.yaml --print_config` and the srresnet equivalent both exit 0.
- [x] `ruff check .` and `ruff format --check .` clean.
- [x] `grep -rn "import cv2" sisr/` empty — package has no remaining cv2 dependency at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)