### PR TITLE
Quiet TensorBoard logging: wider cadences + per-image scalar gate

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -44,9 +44,10 @@ class BenchmarkImageLogger(Callback):
     SR output is center-padded when smaller than HR (``padding='valid'``) so
     all three panels share the same spatial size.
 
-    Per-image PSNR/SSIM scalars go under ``"per_image/{name}/psnr/{key}/{filename}"``
-    and ``"per_image/{name}/ssim/{key}/{filename}"``; per-set means under
-    ``"psnr/{name}/{key}"`` and ``"ssim/{name}/{key}"``.
+    Per-set means go under ``"psnr/{name}/{key}"`` and ``"ssim/{name}/{key}"``
+    every cycle. Per-image scalars under ``"per_image/{name}/psnr/{key}/{filename}"``
+    and ``"per_image/{name}/ssim/{key}/{filename}"`` are gated by
+    ``log_per_image_metrics`` (default off — see that arg).
 
     Border cropping is sourced from ``pl_module.eval_config.crop_border`` at
     the use site; this avoids dual-knob configuration drift.
@@ -62,16 +63,26 @@ class BenchmarkImageLogger(Callback):
             ``max_steps=100_000``) val fires ~100 times, so logging every 5
             runs gives ~20 image snapshots — enough to track visual
             progress without flooding TensorBoard storage.  Default ``5``.
+        log_per_image_metrics: Emit the ``per_image/...`` PSNR/SSIM scalars
+            (one series per image per key). Default ``False``: with N test
+            images and both PSNR/SSIM keyed by colorspace, this is
+            ``N * (psnr_keys + ssim_keys)`` TensorBoard tags — e.g. 76 series
+            for 19 images at template defaults, 1190 with BSD100 plus
+            ``separate_psnr``. The cost is tag-count (TensorBoard's scalar
+            pane stops being navigable), not bytes — these scalars are only
+            ~285 KB. Per-set means are unaffected and always logged.
     """
 
     def __init__(
         self,
         dataset_names: list[str] | None = None,
         log_every_n_val_runs: int = 5,
+        log_per_image_metrics: bool = False,
     ):
         super().__init__()
         self.dataset_names = list(dataset_names) if dataset_names else None
         self.log_every_n_val_runs = log_every_n_val_runs
+        self.log_per_image_metrics = log_per_image_metrics
 
         # Val: primary val is at idx 0, test sets at 1..N → {1: 'Set5', ...}
         # Test: only test sets present, at idx 0..N-1     → {0: 'Set5', ...}
@@ -305,12 +316,15 @@ class BenchmarkImageLogger(Callback):
         pl_module: lightning.LightningModule,
         should_log_images: bool,
     ):
-        """Log per-set means and (optionally) image strips for buffered batches.
+        """Log per-set means and (optionally) per-image scalars/image strips.
 
         Shared between :meth:`on_validation_epoch_end` and
         :meth:`on_test_epoch_end`. Looks up the TensorBoard logger from
-        ``trainer.loggers``; silently skips image emission for sets whose
-        logger is missing.
+        ``trainer.loggers``; silently skips per-image/image emission for
+        sets whose logger is missing. Per-image scalar emission is gated by
+        ``self.log_per_image_metrics``, independent of *should_log_images*
+        (which gates only the image strips) — the two concerns cost
+        differently (tag count vs. bytes) and are configured separately.
         """
         step = trainer.global_step
 
@@ -328,7 +342,7 @@ class BenchmarkImageLogger(Callback):
                 mean_ssim = sum(s[5][key] for s in samples) / len(samples)
                 pl_module.log(f"ssim/{dataset_name}/{key}", mean_ssim, add_dataloader_idx=False)
 
-            if should_log_images:
+            if should_log_images or self.log_per_image_metrics:
                 tb_logger = next(
                     (
                         logger
@@ -342,18 +356,22 @@ class BenchmarkImageLogger(Callback):
 
                 experiment = tb_logger.experiment
                 for filename, lr, sr, hr, psnr_dict, ssim_dict in samples:
-                    for key, psnr_val in psnr_dict.items():
-                        experiment.add_scalar(
-                            f"per_image/{dataset_name}/psnr/{key}/{filename}",
-                            psnr_val,
-                            global_step=step,
-                        )
-                    for key, ssim_val in ssim_dict.items():
-                        experiment.add_scalar(
-                            f"per_image/{dataset_name}/ssim/{key}/{filename}",
-                            ssim_val,
-                            global_step=step,
-                        )
+                    if self.log_per_image_metrics:
+                        for key, psnr_val in psnr_dict.items():
+                            experiment.add_scalar(
+                                f"per_image/{dataset_name}/psnr/{key}/{filename}",
+                                psnr_val,
+                                global_step=step,
+                            )
+                        for key, ssim_val in ssim_dict.items():
+                            experiment.add_scalar(
+                                f"per_image/{dataset_name}/ssim/{key}/{filename}",
+                                ssim_val,
+                                global_step=step,
+                            )
+
+                    if not should_log_images:
+                        continue
 
                     # Triptych: bicubic | SR | HR, all at HR size.
                     # The bicubic panel is the LR upsampled to HR via bicubic

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -73,10 +73,10 @@ data:
 trainer:
   max_epochs: -1
   max_steps: 1000000
-  val_check_interval: 20000
+  val_check_interval: 50000
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
-  log_every_n_steps: 500
+  log_every_n_steps: 1000
   deterministic: false
   # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
   # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
@@ -107,7 +107,7 @@ trainer:
         logging_interval: step
     - class_path: sisr.training.GradNormLogger
       init_args:
-        log_every_n_steps: 2000
+        log_every_n_steps: 5000
     # Throughput/hardware diagnostics — extra per-step logging overhead, so commented
     # out by default. DeviceStatsMonitor works as-is; ThroughputMonitor additionally
     # needs a batch_size_fn (batches are (lr, hr) tuples, not plain tensors — no

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -76,10 +76,10 @@ data:
 trainer:
   max_epochs: -1
   max_steps: 1000000
-  val_check_interval: 20000
+  val_check_interval: 50000
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
-  log_every_n_steps: 500
+  log_every_n_steps: 1000
   deterministic: false
   # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
   # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
@@ -110,7 +110,7 @@ trainer:
         logging_interval: step
     - class_path: sisr.training.GradNormLogger
       init_args:
-        log_every_n_steps: 2000
+        log_every_n_steps: 5000
     # Throughput/hardware diagnostics — extra per-step logging overhead, so commented
     # out by default. DeviceStatsMonitor works as-is; ThroughputMonitor additionally
     # needs a batch_size_fn (batches are (lr, hr) tuples, not plain tensors — no

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -469,13 +469,15 @@ def test_benchmark_validation_epoch_end_logs_means():
 
 
 def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path: Path, monkeypatch):
-    """When on the log interval, _flush_buffer must actually call
-    experiment.add_image once (the bicubic|SR|HR strip) and experiment.add_scalar
-    for the per-image psnr + ssim. The old test only checked it didn't raise, so
-    a silently-skipped emit would have passed."""
+    """With log_per_image_metrics=True and on the log interval, _flush_buffer
+    must actually call experiment.add_image once (the bicubic|SR|HR strip) and
+    experiment.add_scalar for the per-image psnr + ssim. The old test only
+    checked it didn't raise, so a silently-skipped emit would have passed."""
     import lightning.pytorch.loggers as pl_loggers
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(
+        dataset_names=["Set5"], log_every_n_val_runs=1, log_per_image_metrics=True
+    )
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
@@ -506,6 +508,77 @@ def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path:
     assert tag == "Set5/img_0"
     assert strip.ndim == 3 and strip.shape[0] == 3  # (C, H, W) triptych
     # One psnr scalar (RGB) + one ssim scalar for the single buffered image.
+    scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
+    assert scalar_tags == ["per_image/Set5/psnr/RGB/img_0", "per_image/Set5/ssim/RGB/img_0"]
+
+
+def test_benchmark_default_omits_per_image_scalars_but_keeps_set_means(tmp_path: Path, monkeypatch):
+    """log_per_image_metrics defaults to False: image strips still log (gated
+    only by should_log_images), but no per_image/... scalar is emitted. Per-set
+    mean psnr/ssim (via pl_module.log) are unaffected by this flag entirely."""
+    import lightning.pytorch.loggers as pl_loggers
+
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    assert cb.log_per_image_metrics is False
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    pl_module = MagicMock()
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    cb._buffer["Set5"] = [
+        (
+            "img_0",
+            torch.rand(3, 4, 4),
+            torch.rand(3, 4, 4),
+            torch.rand(3, 4, 4),
+            {"RGB": 30.0},
+            {"RGB": 0.9},
+        ),
+    ]
+    tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
+    experiment = tb_logger.experiment
+    add_image = MagicMock(wraps=experiment.add_image)
+    add_scalar = MagicMock(wraps=experiment.add_scalar)
+    monkeypatch.setattr(experiment, "add_image", add_image)
+    monkeypatch.setattr(experiment, "add_scalar", add_scalar)
+
+    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
+    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    tb_logger.finalize("success")
+
+    add_image.assert_called_once()  # image strip unaffected by the flag
+    add_scalar.assert_not_called()  # no per_image/... scalar emitted
+    log_keys = [call.args[0] for call in pl_module.log.call_args_list]
+    assert "psnr/Set5/RGB" in log_keys
+    assert "ssim/Set5/RGB" in log_keys
+
+
+def test_benchmark_log_per_image_metrics_decoupled_from_image_strips(tmp_path: Path, monkeypatch):
+    """log_per_image_metrics=True must emit per-image scalars even on a val run
+    where should_log_images is False (log_every_n_val_runs throttles images,
+    not per-image metrics) — proving the two concerns are independently gated."""
+    import lightning.pytorch.loggers as pl_loggers
+
+    cb = BenchmarkImageLogger(
+        dataset_names=["Set5"], log_every_n_val_runs=99, log_per_image_metrics=True
+    )
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    pl_module = MagicMock()
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    assert cb._on_image_log_interval() is False  # confirms should_log_images will be False
+    cb._buffer["Set5"] = [
+        ("img_0", None, None, None, {"RGB": 30.0}, {"RGB": 0.9}),
+    ]
+    tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
+    experiment = tb_logger.experiment
+    add_image = MagicMock(wraps=experiment.add_image)
+    add_scalar = MagicMock(wraps=experiment.add_scalar)
+    monkeypatch.setattr(experiment, "add_image", add_image)
+    monkeypatch.setattr(experiment, "add_scalar", add_scalar)
+
+    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
+    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    tb_logger.finalize("success")
+
+    add_image.assert_not_called()  # images still throttled
     scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
     assert scalar_tags == ["per_image/Set5/psnr/RGB/img_0", "per_image/Set5/ssim/RGB/img_0"]
 


### PR DESCRIPTION
## Why

A finished 1M-step SRResNet run wrote a **779 MB** TensorBoard event file. The CSV logger received the **identical scalar stream** and wrote **243 KB**. Scalars are therefore ~0.03% of the file; image strips (50 val cycles x 19 images per bicubic|SR|HR strip, ~820 KB per cycle) are essentially all of it.

BSD100 is now in fit-time validation (feeds both `val_dataloader` during fit and `test_dataloader`), taking strips from 19 to 119 per logged cycle. Per the standing decision, BSD100 stays in fit-time val -- this PR does not move it to test-only; ~1.3 GB event files per run are the accepted cost.

## Part A -- wider cadences (both templates)

- `trainer.val_check_interval`: 20000 -> 50000
- `GradNormLogger.log_every_n_steps`: 2000 -> 5000
- `trainer.log_every_n_steps`: 500 -> 1000
- `BenchmarkImageLogger.log_every_n_val_runs` stays 1 -- strips every val cycle; the reduction comes from the val cadence instead.

Not touched: `max_steps`/`batch_size` (owned by a separate stacked PR that raises `val_check_interval` further, to 500000, for the SRCNN template specifically).

**Costs, so they're chosen rather than discovered:** the val PSNR curve drops from 50 points to 20 over a 1M-step run; `SRCheckpoint` now selects top-k from 20 candidates instead of 50.

## Part B -- decouple per-image scalars from image strips

`BenchmarkImageLogger._flush_buffer` emitted per-image PSNR/SSIM scalars only inside the image-strip branch, welding two independent concerns together. At template defaults that's 19 images x (2 psnr + 2 ssim) = 76 TensorBoard series, 190 with `separate_psnr: true`, and 1190 with BSD100 + `separate_psnr`. The cost is **tag count**, not bytes (~285 KB) -- TensorBoard's scalar pane stops being navigable well before that.

Added a `log_per_image_metrics: bool = False` constructor flag, following the `WeightHistogramLogger` precedent (its default was raised 100 -> 10000 for the same reason: quiet default wins). Neither template gets an explicit entry for it. Per-set means (`psnr/{set}/{key}`, `ssim/{set}/{key}`) are unaffected and always logged regardless of this flag.

`cli test`'s `on_test_epoch_end` still passes `should_log_images=True` unconditionally -- correct for a one-shot final eval, unchanged by this PR.

## Test plan

- [x] New test: default (`log_per_image_metrics=False`) omits `per_image/...` scalars but per-set means and image strips still log.
- [x] New test: `log_per_image_metrics=True` emits `per_image/...` scalars even on a val run where `should_log_images` is False (proves the two concerns are independently gated).
- [x] Existing add_image/add_scalar regression test updated to pass `log_per_image_metrics=True` explicitly (previously relied on the now-changed default).
- [x] Both templates resolve: `sisr.cli fit --config templates/config.{srcnn,srresnet}.template.yaml --print_config`, exit 0, new values confirmed present (`val_check_interval: 50000`, `log_every_n_steps: 1000`, `GradNormLogger.log_every_n_steps: 5000`).
- [x] Full suite: 349 passed, 1 skipped (base branch: 347 passed, 1 skipped, plus the two new tests above).
- [x] `ruff check .` and `ruff format --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)