### PR TITLE
Extend SRCNN training budget toward the paper's backprop count

### DIFF
--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -61,7 +61,7 @@ data:
         img_dir: data/BSD100_HR
         scale: *scale
   train_dataloader_kwargs:
-    batch_size: 64
+    batch_size: 64             # not specified by the paper; this project's choice
     num_workers: 16
     pin_memory: true
     persistent_workers: true
@@ -72,8 +72,13 @@ data:
 
 trainer:
   max_epochs: -1
-  max_steps: 1000000
-  val_check_interval: 50000
+  # Paper gives 8e8 backprops, not steps; reading that as per-sample updates (the
+  # mini-batch reading implies implausible iters/sec on 2014 hardware) puts
+  # 1e7 steps * batch 64 = 6.4e8, ~0.8x the paper's figure. Approximation, not a quote.
+  max_steps: 10000000
+  # 20 validation cycles over the run (max_steps / val_check_interval) — matches the
+  # logging budget. Revisit this if max_steps changes, or event files balloon.
+  val_check_interval: 500000
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
   log_every_n_steps: 1000


### PR DESCRIPTION
## Summary
- Scales the SRCNN template's `trainer.max_steps` from 1M to 10M and `val_check_interval` from 50K to 500K (keeping 20 validation cycles over the run).
- `train_dataloader_kwargs.batch_size` stays 64 (unchanged), now with a comment: the paper does not specify a batch size, so 64 is this project's choice.
- The 10M step count is an approximation: Dong et al. state the budget as "the same number of backpropagations (i.e., 8x10^8)", not a step count. Reading that as per-sample updates (the mini-batch-iteration reading would imply thousands of iterations/sec on 2014 hardware, which isn't credible) gives 10M steps x batch 64 = 6.4x10^8 samples, ~0.8x the paper's figure. That reading is an inference documented in the comment, not something the paper states verbatim -- no code enforces `batch * max_steps ~ 8e8` as an invariant.
- SRResNet's template is untouched; its `max_steps: 1000000` / `val_check_interval: 50000` remain correct for its 1M-step schedule.

## Test plan
- [x] `sisr.cli fit --config templates/config.srcnn.template.yaml --print_config`: resolves `max_steps: 10000000`, `val_check_interval: 500000`, `batch_size: 64`.
- [x] Same command for `config.srresnet.template.yaml`: resolves `max_steps: 1000000`, `val_check_interval: 50000` (unchanged).
- [x] Full suite: 349 passed, 1 skipped (matches base).
- [x] `ruff check .` / `ruff format --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)