### PR TITLE
Rewrite README and CONTRIBUTING for length and clarity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,137 +1,77 @@
 # Contributing
 
-Thanks for your interest in `single-image-super-resolution` — a PyTorch Lightning
-framework for reproducing single-image super-resolution (SISR) papers. This guide
-covers how to set up a development environment, run the tests, and land a change.
+## Setup
 
-## Development setup
-
-Requires **Python ≥ 3.12**.
+Requires Python 3.12+.
 
 ```bash
-# Clone your fork:
 git clone https://github.com/YeapJieShen/single-image-super-resolution.git
 cd single-image-super-resolution
 
-# Create an isolated environment (conda shown; any virtualenv works):
-conda create -n sisr python=3.13
-conda activate sisr
-
-# Install uv into the environment, then install the project with dev extras:
-pip install uv
-python -m uv pip install -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
-Invoke it as `python -m uv`, not bare `uv`: uv resolves `VIRTUAL_ENV` ahead of the active
-conda env, so the bare binary installs into whatever virtualenv happens to be active,
-while `python -m uv` targets the interpreter you just activated.
+[uv](https://github.com/astral-sh/uv) is a faster alternative if you prefer it:
+`python -m uv pip install -e ".[dev]"`.
 
-`uv` is a much faster drop-in replacement for `pip install`. Installing it *into* the
-environment keeps it self-contained — removing the environment removes uv with it. Plain
-`pip install -e ".[dev]"` remains fully supported; CI's **build** check verifies the
-end-user `pip install .` path on all four matrix legs.
+On a CUDA GPU, install the `torch` / `torchvision` wheels from PyTorch's index first, as
+described in the [README](README.md#install).
 
-The `[dev]` extra adds the test and lint toolchain (`pytest`, `pytest-cov`,
-`pytest-xdist`, `pyyaml`, `ruff`). `pyproject.toml` is the single source of truth for
-dependencies — there is no `requirements.txt`.
-
-If you develop on a CUDA GPU, install the CUDA `torch` / `torchvision` wheels from
-PyTorch's own index **first** (the `+cu###` wheels are not on PyPI), then install the
-project — see the README's *GPU / CUDA notes*.
-
-## Running the tests
+## Tests
 
 ```bash
-# Full suite:
-pytest
-
-# With coverage (matches CI):
-pytest --cov=sisr --cov-report=term
+pytest                                  # full suite
+pytest --cov=sisr --cov-report=term     # with coverage, as CI runs it
 ```
 
-Tests live under `tests/`, mirroring the `sisr/` package layout
-(e.g. `sisr/training/lightning_module.py` → `tests/training/test_lightning_module.py`).
+`tests/` mirrors `sisr/`, so `sisr/training/lightning_module.py` maps to
+`tests/training/test_lightning_module.py`.
 
-### Strict-warnings policy
+Warnings are errors (`filterwarnings = ["error", ...]`). If your change raises a new one,
+fix the cause. Only add an ignore for a third-party deprecation you can't control, with a
+comment saying why.
 
-The suite runs under `filterwarnings = ["error", ...]`: **any unexpected warning fails
-the test run.** A short, explicit ignore-list in `pyproject.toml` covers known upstream
-deprecations only. If your change surfaces a new warning, fix the cause rather than
-broadening the ignore-list; add a narrowly-scoped ignore only for a genuine third-party
-deprecation you cannot control, and note why.
+When you fix a bug, add a test that fails before the fix and passes after. Name it after
+the failure it catches.
 
-### Regression tests
+**Debugging a dataset?** The templates use `num_workers: 16`, so `__getitem__` runs in
+subprocesses where breakpoints never fire. Run with
+`--data.train_dataloader_kwargs.num_workers=0` to get it back in-process.
 
-When you fix a bug, add one test that **fails on the old behavior and passes on the new**.
-Name it after what the failure catches, not after the fix.
+## Making a change
 
-### Debugging dataset code
+Branch off `main`, add tests with your change, run `pytest`, open a PR. Three checks have
+to pass: **test** (pytest + coverage), **build** (`pip install .` and imports work), and
+**lint** (`ruff check` + `ruff format --check`). `main` keeps linear history.
 
-To step through `Dataset.__getitem__` (SRCNN/SRResNet dataset code, `sisr/imresize.py`,
-etc.) with breakpoints, run with `--data.train_dataloader_kwargs.num_workers=0`:
+Commits:
 
-```bash
-sisr fit --config templates/config.srcnn.template.yaml --data.train_dataloader_kwargs.num_workers=0
-```
+- Imperative subject, for example "Add ...", "Fix ...", "Remove ...".
+- Docs-only changes go in their own commit, never mixed with code.
 
-The tracked templates set `num_workers: 16`, so by default every `__getitem__` call runs
-in a `DataLoader` worker **subprocess** — breakpoints set in the main process never fire
-there. `num_workers=0` runs the dataset in-process instead, at the cost of losing
-parallel data loading; use it only for debugging, not for real training runs.
+## Style
 
-## The change workflow
-
-1. Branch off `main`.
-2. Make your change; add or update tests alongside it.
-3. Run `pytest` locally and make sure it is green.
-4. Open a pull request against `main`.
-
-All PRs must pass three GitHub Actions checks before they can merge:
-
-- **test** — installs `.[dev]` and runs `pytest` with coverage (uploaded to Codecov).
-- **build** — verifies `pip install .` and that `sisr` / `sisr.cli.main` import cleanly.
-- **lint** — `ruff check` and `ruff format --check`.
-
-`main` uses linear history (rebase/squash, no merge commits) and requires PRs.
-
-## Commit conventions
-
-- **Imperative subject line** ("Add …", "Fix …", "Refactor …", "Document …").
-- Where a commit closes a tracked item, reference it in the subject
-  (e.g. a PR number like `(#12)`).
-- **Keep documentation-only changes in commits separate from code changes.** A commit
-  either touches code or touches docs, not both.
-
-## Code style
-
-- **Terse code, minimal comments.** Comment only non-obvious *why*, never narrate *what*.
-- **Google-style docstrings** on every public class / function / method in `sisr/`
-  (one-line summary opener, then `Args:` / `Returns:` / `Raises:` when the signature
-  warrants). Class-level `Args:` documents `__init__`; `__init__` itself stays bare.
-- **Modern type hints** — PEP 585 (`list`, `dict`, `tuple`) and PEP 604 (`X | None`);
-  import `Callable` / `Sequence` from `collections.abc`.
-- **No backward-compatibility shims when refactoring.** Prefer clean breaks — drop the
-  old API, remove the unused parameter, delete the dead branch.
+- Terse code. Comment the non-obvious *why*, never the *what*.
+- Google-style docstrings on everything public in `sisr/`. Class docstrings document
+  `__init__` args; `__init__` itself stays bare.
+- Modern type hints: `list[str]`, `X | None`, and `collections.abc` for `Callable` /
+  `Sequence`.
+- No back-compat shims. Drop the old API, delete the dead branch.
 
 ## Adding a new architecture
 
-The training stack is generic: one `SRLightning` module composes an `SRModel`
-(pure tensor network) with an `SRProcessor` (colorspace adapter), fed by a generic
-`SRDataModule`. To add an architecture you do **not** write a new Lightning subclass —
-instead:
+You don't write a Lightning module. `SRLightning` already composes an `SRModel` with an
+`SRProcessor`, fed by `SRDataModule`.
 
-1. Subclass `sisr.models.base.SRModel` with your network (`forward`, `self._hparams`,
-   and an optional `reset_parameters(**kwargs)` init hook).
-2. Define `<Arch>TrainingConfig` / `<Arch>EvalConfig` dataclasses with the paper's
-   defaults (mirroring `sisr/models/srcnn/config.py`).
-3. Pick an existing `SRProcessor` (`RGBProcessor`, `RGBSignedOutputProcessor`,
-   `YChannelProcessor`, `YCbCrProcessor`) or add a new one.
-4. Copy a template in `templates/`, point `model.model` / `model.processor` /
-   `model.training_config` / `model.eval_config` and each dataset `class_path` at your
-   new classes, and run `sisr fit --config <your.yaml>`.
+1. Subclass `sisr.models.base.SRModel`: `forward`, `self._hparams`, and optionally
+   `reset_parameters(**kwargs)` for a paper-faithful init.
+2. Add `<Arch>TrainingConfig` / `<Arch>EvalConfig` with the paper's defaults, copying the
+   shape of `sisr/models/srcnn/config.py`.
+3. Pick a processor (`RGBProcessor`, `RGBSignedOutputProcessor`, `YChannelProcessor`,
+   `YCbCrProcessor`) or write one.
+4. Copy a template, repoint the `class_path`s, run `sisr fit`.
 
 ## License
 
-This project is MIT-licensed and all of its dependencies are MIT-compatible.
-`sisr/imresize.py` vendors a small MIT-licensed MATLAB-`imresize` port rather than
-depending on it — see that file's header for the source repo and required attribution.
+MIT. Dependencies are MIT-compatible. `sisr/imresize.py` vendors an MIT-licensed
+MATLAB-`imresize` port, so keep its attribution header intact.

--- a/README.md
+++ b/README.md
@@ -1,229 +1,116 @@
 # single-image-super-resolution
 
+[![test](https://github.com/YeapJieShen/single-image-super-resolution/actions/workflows/test.yml/badge.svg)](https://github.com/YeapJieShen/single-image-super-resolution/actions/workflows/test.yml)
+[![build](https://github.com/YeapJieShen/single-image-super-resolution/actions/workflows/build.yml/badge.svg)](https://github.com/YeapJieShen/single-image-super-resolution/actions/workflows/build.yml)
 [![coverage](https://codecov.io/gh/YeapJieShen/single-image-super-resolution/branch/main/graph/badge.svg)](https://app.codecov.io/gh/YeapJieShen/single-image-super-resolution)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 
-**Reproduce single-image super-resolution (SISR) papers with one command.** Train any
-architecture through a single `LightningCLI` entrypoint — switching models is just
-pointing the config at a different network and dataset. Built on PyTorch Lightning; every
-experiment is one self-contained YAML.
+Reproduce single-image super-resolution papers without rewriting a training loop each
+time. Every architecture runs through one `LightningCLI` entrypoint, and an experiment is
+one self-contained YAML file.
 
-## Why this exists
+## Install
 
-SISR papers each ship their own training script, colorspace quirks, and evaluation
-protocol. This framework factors all of that into reusable parts — a generic
-`SRLightning` module (an `SRModel` network × an `SRProcessor` colorspace adapter), a
-generic `SRDataModule`, and per-paper behavior expressed in config dataclasses — so
-reproducing a paper means writing a config, not a new training loop.
-
-## Models
-
-| Model | Paper | LR input | Upsampling | Colorspace |
-|---|---|---|---|---|
-| **SRCNN** | [Image Super-Resolution Using Deep Convolutional Networks](https://arxiv.org/pdf/1501.00092) | Pre-upsampled to HR size (bicubic down → bicubic up) | None — same-resolution refinement | Y channel |
-| **SRResNet** | [Photo-Realistic Single Image Super-Resolution Using a GAN](https://arxiv.org/pdf/1609.04802) | Genuine low-resolution | ×`scale` sub-pixel convolution | RGB |
-
-During training and test evaluation, PSNR/SSIM are logged and **bicubic│SR│HR** image
-strips are written to TensorBoard for each benchmark set (Set5, Set14, …), so you can
-watch reconstruction quality improve run-over-run.
-
-### Degradation protocol (how LR is generated)
-
-Both datasets derive their LR input from HR via a vendored (not a dependency),
-MATLAB-`imresize`-compatible bicubic resize — antialiased (MATLAB widens the
-interpolation kernel by the scale factor on downscale; this widening *is* the
-low-pass, so no separate blur step is used) and using MATLAB's own bicubic
-coefficient (a=-0.5, vs. OpenCV's a=-0.75). This makes the LR **inputs** directly
-comparable to published papers, most of which generate their benchmark LR images
-with real MATLAB. See `sisr/imresize.py` for the implementation and its
-license/attribution header, and `tests/test_imresize.py` for verification.
-Byte-exact inputs alone don't make **reported** PSNR/SSIM comparable, though:
-Y-channel figures here use BT.601 full-range Y (`sisr/colorspace.py`), while the
-literature's published Y-channel numbers use MATLAB `rgb2ycbcr`'s studio-range
-convention — a known, exact `20·log10(255/219) ≈ 1.3219 dB` offset, not an unknown one.
-
-**Honest limit:** without access to real MATLAB, this project cannot prove
-byte-identity with MATLAB's `imresize` from first principles. `tests/test_imresize.py`
-asserts byte-exact reproduction against the standard Set5/Set14 bicubic LR pairs
-distributed by the EDSR authors (themselves generated with real MATLAB) — the
-strongest available claim short of running MATLAB itself. That test is skipped
-(not a failure) when the reference archive hasn't been fetched locally; see the
-test file's module docstring for the source URL and checksum.
-
-The one-time move from AlbumentationsX to `sisr.imresize` invalidated previously-built
-LMDB caches and renumbered any previously recorded benchmark figure — expected,
-a one-time cost of the change, not a bug.
-
-### Reproducibility note
-
-The tracked templates set `seed_everything: 42` **and** `trainer.deterministic: false`.
-That pairing is deliberate: `deterministic: false` allows cuDNN to pick
-non-deterministic (but faster) convolution algorithms, so **runs are not
-bit-for-bit reproducible** even with the same seed — a throughput trade worth
-knowing about explicitly in a paper-*reproduction* project, where "reproduction"
-means comparable metrics, not bit-identical checkpoints.
-
-## Quickstart
-
-Requires **Python ≥ 3.12**.
+Requires Python 3.12+.
 
 ```bash
-# 1. Install (CPU / default):
 pip install .
-
-# 2. Confirm the CLI is wired up:
 sisr --help
-
-# 3. Put HR images under data/ (e.g. data/DIV2K_train_HR, data/Set5_HR, …),
-#    then validate a config resolves without training:
-sisr fit --config templates/config.srcnn.template.yaml --print_config
-
-# 4. Train:
-sisr fit --config templates/config.srcnn.template.yaml
 ```
 
-`--print_config` dumps the fully resolved config and exits — a fast way to check a config
-before committing to a run (no dataset build happens at parse time).
-
-## Usage
-
-Training is configured entirely through YAML. Copy a template from
-[`templates/`](templates/), edit the dataset directories and experiment output paths,
-then:
-
-```bash
-# Train SRCNN (x3):
-sisr fit --config templates/config.srcnn.template.yaml
-
-# Train SRResNet (x4):
-sisr fit --config templates/config.srresnet.template.yaml
-```
-
-Per-run overrides can be passed on the CLI without editing the YAML (dot-notation;
-optimizer/scheduler args are top-level keys):
-
-```bash
-sisr fit --config templates/config.srcnn.template.yaml \
-    --trainer.max_steps=500000 --optimizer.init_args.lr=1e-3
-```
-
-After training, evaluate a checkpoint against the test sets:
-
-```bash
-sisr test --config templates/config.srcnn.template.yaml \
-    --ckpt_path path/to/best.ckpt
-```
-
-Test sets are also surfaced during `fit` (monitored each validation cycle). The `sisr`
-console script is registered by `pyproject.toml`; `python -m sisr.cli ...` works too.
-
-## ONNX export
-
-Trained models can be exported to ONNX for inference outside this framework — install
-the optional extra first:
-
-```bash
-pip install ".[export]"     # or: python -m uv pip install ".[export]"
-
-sisr export --config templates/config.srresnet.template.yaml \
-    --ckpt_path path/to/best.ckpt --output_path model.onnx
-```
-
-`sisr.export.to_onnx(...)` is the underlying function, for exporting from Python
-directly (e.g. right after `trainer.fit(...)`, without a checkpoint round-trip):
-
-```python
-from sisr.export import to_onnx
-
-to_onnx(sr_lightning_module, "model.onnx")
-```
-
-**What gets exported — the bare model, not the processor.** The graph is exactly
-`SRLightning.forward`: the wrapped `SRModel`, with no `SRProcessor` colorspace step.
-Consumers are expected to have `sisr` importable and call `processor.extract` /
-`processor.reconstruct` themselves — that keeps the graph honest about what it actually
-computes, rather than silently baking in Python-side pre/post-processing an ONNX runtime
-can't see.
-
-- **SRResNet with `RGBProcessor` is unaffected by this**: `extract` / `reconstruct` are
-  identity functions, so the exported graph already is the complete LR-RGB → SR-RGB
-  pipeline.
-- **SRResNet with `RGBSignedOutputProcessor` needs one step**: that processor trains the
-  model to emit `[-1, 1]` (the SRGAN paper's HR range), so the graph's output must be
-  rescaled by `(out + 1) / 2` to land back in `[0, 1]`. The input side needs nothing —
-  the model consumes `[0, 1]` either way.
-- **SRCNN is not**: it trains on the Y channel, so the exported graph only maps Y → Y. A
-  non-Python consumer of an SRCNN ONNX graph must reimplement the surrounding steps
-  itself — extract Y from the LR RGB image (`sisr.colorspace.rgb_to_ycbcr`), run the
-  graph, then bicubic-upsample the LR Cb/Cr channels back to the SR size and recombine
-  (`sisr.colorspace.ycbcr_to_rgb`). See `sisr/processors/y_channel.py` for the exact
-  reference implementation.
-
-The exported graph accepts **arbitrary spatial dimensions** (`dynamic_axes` on height and
-width) — it is not limited to the size in `training_config.example_input_shape`, which is
-only a TensorBoard-graph-logging dummy input.
-
-**Deploying to TensorRT.** This project does not depend on TensorRT (NVIDIA-only,
-version-brittle, and untestable in CI without a GPU runner). Convert the exported `.onnx`
-yourself with NVIDIA's `trtexec`, which ships with the TensorRT SDK:
-
-```bash
-trtexec --onnx=model.onnx --saveEngine=model.trt \
-    --minShapes=input:1x3x64x64 --optShapes=input:1x3x256x256 --maxShapes=input:1x3x1080x1920
-```
-
-(drop the batch/channel dims to match SRCNN's single-channel Y input). `--minShapes` /
-`--maxShapes` are required because of the dynamic H/W axes above.
-
-## GPU / CUDA notes
-
-The CUDA-built `torch` / `torchvision` wheels aren't on PyPI, so GPU users install them
-from PyTorch's own index **first** (pick the `cu###` matching your CUDA toolkit), then
-install the project — the second command sees `torch` already satisfied and resolves the
-rest from PyPI. Same convention as PyTorch's own
-[Get Started](https://pytorch.org/get-started/locally/) selector.
+On a CUDA machine, install the GPU wheels from PyTorch's index first (they aren't on
+PyPI), then the project:
 
 ```bash
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
 pip install .
-
-# or, with uv (inside the activated environment):
-python -m uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
-python -m uv pip install .
 ```
 
-The bundled templates set `accelerator: cuda`; change it to `cpu` to run without a GPU.
+## Quickstart
 
-## Extending it
+Bring your own HR images. Training and benchmark sets are downloaded separately and are
+not distributed here. Copy a template out of [`templates/`](templates/) and point its
+dataset paths at wherever yours live.
 
-The training stack is architecture-agnostic — adding a model does **not** require a new
-Lightning subclass:
+```bash
+# check the config resolves before committing to a run
+sisr fit --config templates/config.srresnet.template.yaml --print_config
 
-1. Subclass `sisr.models.base.SRModel` with your network.
-2. Define `<Arch>TrainingConfig` / `<Arch>EvalConfig` dataclasses with the paper's
-   defaults (see `sisr/models/srcnn/config.py`).
-3. Pick an `SRProcessor` (`RGBProcessor`, `RGBSignedOutputProcessor`,
-   `YChannelProcessor`, `YCbCrProcessor`) or add one.
-4. Copy a template, point the `class_path`s at your new classes, and `sisr fit`.
+# train
+sisr fit --config templates/config.srresnet.template.yaml
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
+# evaluate a checkpoint against the benchmark sets
+sisr test --config templates/config.srresnet.template.yaml --ckpt_path best.ckpt
+```
+
+Anything in the YAML can be overridden on the command line:
+
+```bash
+sisr fit --config my.yaml --trainer.max_steps=500000 --optimizer.init_args.lr=1e-3
+```
+
+PSNR/SSIM and bicubic│SR│HR image strips go to TensorBoard for every benchmark set, so you
+can watch quality improve during a run.
+
+## How it works
+
+Three pieces compose, and none of them know about each other:
+
+- **`SRModel`** is the network, a pure tensor function and nothing else.
+- **`SRProcessor`** adapts colorspace and range between the dataset's RGB and whatever the
+  model wants (Y channel, YCbCr, `[-1, 1]` RGB).
+- **`SRTrainingConfig` / `SREvalConfig`** hold the per-paper knobs: learning-rate schedule,
+  weight init, crop border, which colorspaces get scored.
+
+`SRLightning` glues them together and `SRDataModule` feeds them. Adding an architecture
+means writing a network and a config dataclass, not a new Lightning module. See
+[CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-architecture).
+
+## Models
+
+| Model | Paper | LR input | Upsampling |
+|---|---|---|---|
+| SRCNN | [Dong et al. 2015](https://arxiv.org/pdf/1501.00092) | pre-upsampled to HR size | none, same-resolution refinement |
+| SRResNet | [Ledig et al. 2017](https://arxiv.org/pdf/1609.04802) | true low-resolution | ×scale sub-pixel convolution |
+
+## Comparability
+
+Benchmark numbers only mean something if the inputs and the metrics match the papers', so
+both are pinned:
+
+- **LR generation** uses a vendored MATLAB-compatible `imresize`
+  ([`sisr/imresize.py`](sisr/imresize.py), MIT, attribution in the file header) rather than
+  OpenCV's bicubic. The two differ in ways that move PSNR: MATLAB antialiases by widening
+  the kernel on downscale, and uses `a = -0.5` where OpenCV uses `a = -0.75`. Downscaling
+  is verified byte-identical against the MATLAB-generated reference pairs distributed by
+  the [EDSR authors](https://github.com/sanghyun-son/EDSR-PyTorch).
+- **Metrics** are Y-channel PSNR/SSIM in BT.601 studio range (MATLAB's `rgb2ycbcr`
+  convention, which is what published figures use), computed on output clamped to `[0, 1]`.
+
+## ONNX export
+
+```bash
+pip install ".[export]"
+sisr export --config my.yaml --ckpt_path best.ckpt --output_path model.onnx
+```
+
+The exported graph is the **bare model**, with no processor attached, and it accepts
+arbitrary input sizes. For RGB models that graph is the whole pipeline. For Y-channel
+models like SRCNN the consumer has to extract Y and recombine chroma itself; see
+[`sisr/processors/y_channel.py`](sisr/processors/y_channel.py) for the reference
+implementation. `sisr.export.to_onnx()` does the same thing from Python.
 
 ## Development
 
 ```bash
-pip install -e ".[dev]"     # or: python -m uv pip install -e ".[dev]"
+pip install -e ".[dev]"
 pytest
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev loop, testing conventions, commit
-style, and code-style expectations.
-
-## Dependency notes
-
-`pyproject.toml` is the single source of truth for dependencies (no `requirements.txt`).
-All dependencies are MIT-compatible; the project itself is MIT-licensed (see below).
-`sisr/imresize.py` vendors (does not depend on) a small MIT-licensed MATLAB-`imresize`
-port — see that file's header for the source and attribution.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT, see [LICENSE](LICENSE). All dependencies are MIT-compatible.


### PR DESCRIPTION
## Summary

- README: 229 to 116 lines. Adds test/build/ruff/python/license badges alongside the existing coverage badge, tightens Install/Quickstart/How it works/Models/Comparability/ONNX export/Development sections.
- CONTRIBUTING: 137 to 77 lines. Keeps Setup, Tests, Making a change, Style, Adding a new architecture, License; drops the explanatory asides.
- Base is `chore/drop-cv2-backend` (#55, not yet merged): both files describe a cv2-free world, no `resize_backend` / `blur_sigma` mentions.
- No em dashes or en dashes anywhere in either file.
- "Downscaling is verified byte-identical" kept as-is (only the downscale direction has MATLAB reference evidence).
- No dataset directory enumeration in Quickstart, no results table, no benchmark numbers, no internal work codes.

## Test plan

- [x] `grep -n "—\|–" README.md CONTRIBUTING.md` returns nothing
- [x] `git ls-files | xargs grep -nE "cv2|resize_backend|blur_sigma"` returns nothing
- [x] Full suite: 347 passed, 1 skipped (matches base)
- [x] `ruff check .` and `ruff format --check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)