### PR TITLE
Fix --ckpt_path failing to reload any checkpoint this project saves

### DIFF
--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -31,7 +31,8 @@ already assigns ``torch.backends.cudnn.benchmark``, and it coordinates with
 """
 
 import sys
-from typing import Literal
+from pathlib import Path
+from typing import Any, Literal
 
 import torch
 from lightning.pytorch import Trainer
@@ -39,6 +40,59 @@ from lightning.pytorch.cli import LightningCLI
 
 from .export import to_onnx
 from .training import SRDataModule, SRLightning
+
+# Checkpoints saved before SRLightning.__init__ stopped flattening self.hparams for
+# TensorBoard display (see its docstring) stored ONLY these two dataclasses' fields —
+# under '/'-joined keys, e.g. 'training_config/example_input_shape/0' — plus incidental
+# 'model/*'/'processor'/'criterion' entries that were never part of the loadable
+# contract. _reconstruct_ckpt_hparams rebuilds exactly what current SRLightning saves.
+_CKPT_HPARAM_KEYS = ("training_config", "eval_config")
+
+
+def _reconstruct_ckpt_hparams(hparams: dict[str, Any], sep: str = "/") -> dict[str, Any]:
+    """Rebuild a checkpoint's training_config/eval_config overrides for ``--ckpt_path``.
+
+    Tolerates both the current nested ``hyper_parameters`` format (each key already
+    a plain dict, e.g. ``{"training_config": {...}}``) and the legacy '/'-flattened
+    one older checkpoints carry (e.g. ``training_config/example_input_shape/0``).
+    ``LightningCLI._parse_ckpt_path`` re-parses ``hyper_parameters`` verbatim as CLI
+    options (``model.<key>``); a literal ``/`` in a key isn't a valid option-name
+    character, so every legacy checkpoint failed to reload via ``--ckpt_path``
+    (``fit`` resume, ``validate``, ``test``, ``export``) with a jsonargparse
+    ``SystemExit``. Non-config entries (``model/*``, ``processor``, ``criterion``,
+    ``_instantiator``) are dropped — they were TensorBoard-only in old checkpoints,
+    and the ``--config`` file required alongside ``--ckpt_path`` already supplies
+    those classes.
+
+    Args:
+        hparams: The checkpoint's raw ``hyper_parameters`` dict, in either format.
+        sep: Separator ``SRLightning._flatten_hparams`` joins path segments with.
+
+    Returns:
+        A nested dict with at most ``training_config`` / ``eval_config`` keys,
+        each a plain dict of field overrides, lists restored from their
+        ``'0'``/``'1'``/... index encoding.
+    """
+    nested: dict[str, Any] = {}
+    for compound_key, value in hparams.items():
+        parts = compound_key.split(sep)
+        if parts[0] not in _CKPT_HPARAM_KEYS:
+            continue
+        node = nested
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node[parts[-1]] = value
+
+    def _delistify(node: Any) -> Any:
+        if not isinstance(node, dict):
+            return node
+        node = {k: _delistify(v) for k, v in node.items()}
+        keys = list(node)
+        if keys and keys == [str(i) for i in range(len(keys))]:
+            return [node[str(i)] for i in range(len(keys))]
+        return node
+
+    return _delistify(nested)
 
 
 class _ExportTrainer(Trainer):
@@ -143,6 +197,33 @@ class SRLightningCLI(LightningCLI):
         precision = self.config[self.subcommand].matmul_precision
         if precision is not None:
             torch.set_float32_matmul_precision(precision)
+
+    def _parse_ckpt_path(self) -> None:
+        """Reload ``--ckpt_path`` hyperparameters via ``_reconstruct_ckpt_hparams`` first.
+
+        Duplicates ``LightningCLI._parse_ckpt_path`` (``lightning/pytorch/cli.py``)
+        with one substitution: the raw ``hyper_parameters`` dict is rebuilt through
+        :func:`_reconstruct_ckpt_hparams` before being handed to
+        ``parser.parse_object``, so both the current nested format and checkpoints
+        saved before that fix (which reload with a jsonargparse ``SystemExit``
+        otherwise — see that function's docstring) work through every subcommand
+        that accepts ``--ckpt_path`` (``fit`` resume, ``validate``, ``test``, ``export``).
+        """
+        if not self.config.get("subcommand"):
+            return
+        ckpt_path = self.config[self.config.subcommand].get("ckpt_path")
+        if not (ckpt_path and Path(ckpt_path).is_file()):
+            return
+        ckpt = torch.load(ckpt_path, weights_only=True, map_location="cpu")
+        hparams = _reconstruct_ckpt_hparams(ckpt.get("hyper_parameters", {}))
+        if not hparams:
+            return
+        hparams = {self.config.subcommand: {"model": hparams}}
+        try:
+            self.config = self.parser.parse_object(hparams, self.config)
+        except SystemExit:
+            sys.stderr.write("Parsing of ckpt_path hyperparameters failed!\n")
+            raise
 
     @staticmethod
     def subcommands() -> dict[str, set[str]]:

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -81,10 +81,6 @@ class SRLightning(lightning.LightningModule):
                 f"SRProcessor."
             )
 
-        self.save_hyperparameters(
-            ignore=["model", "processor", "criterion", "optimizer", "lr_scheduler"]
-        )
-
         self.model = model
         self.processor = processor
         self.training_config = training_config or SRTrainingConfig()
@@ -101,13 +97,27 @@ class SRLightning(lightning.LightningModule):
                 std=self.training_config.init_std,
             )
 
-        # Merge model.hparams + processor identity into Lightning hparams for TensorBoard HParams.
-        # Configs are expanded via dataclasses.asdict so each field becomes its own HParams column.
-        self._hparams = self._flatten_hparams(
+        # Save exactly this plain dict — bypasses save_hyperparameters' frame/given_hparams
+        # introspection, so the checkpoint's `hyper_parameters` is identical whether this
+        # module is built directly or via SRLightningCLI. dataclasses.asdict (not the live
+        # training_config/eval_config objects) keeps it weights_only=True loadable and free
+        # of the two dataclass types, which torch.load's safe-globals allowlist doesn't know.
+        # This dict is what LightningCLI._parse_ckpt_path reads back and re-parses as CLI
+        # options (model.<key>) on `--ckpt_path` reload — it must stay nested, not flattened
+        # with _flatten_hparams' '/' separator, which jsonargparse can't parse as an option name.
+        self.save_hyperparameters(
             {
-                **self._hparams,
                 "training_config": dataclasses.asdict(self.training_config),
                 "eval_config": dataclasses.asdict(self.eval_config),
+            }
+        )
+
+        # TensorBoard-only view: flattened (see _flatten_hparams) and enriched with the
+        # model's own hparams + processor/criterion identity for HParams columns. Kept off
+        # self.hparams (and so off the checkpoint) — on_train_start logs this instead.
+        self._tb_hparams = self._flatten_hparams(
+            {
+                **self.hparams,
                 "model": model.hparams,
                 "processor": type(processor).__name__,
                 "criterion": type(self.criterion).__name__,
@@ -417,7 +427,7 @@ class SRLightning(lightning.LightningModule):
             **{f"ssim/val/{k}": 0.0 for k in self.eval_config.ssim_keys},
         }
         for tb in tb_loggers:
-            tb.log_hyperparams(self.hparams, metrics)
+            tb.log_hyperparams(self._tb_hparams, metrics)
 
     def test_step(
         self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int, dataloader_idx: int = 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,9 @@ import sys
 import warnings
 from pathlib import Path
 
+import lightning
 import pytest
+import torch
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -319,4 +321,257 @@ def test_template_disables_default_hp_metric(template_path: Path):
     assert tb.init_args.default_hp_metric is False, (
         f"{template_path.name} does not disable the hp_metric placeholder. "
         f"Add `default_hp_metric: false` under the TensorBoardLogger init_args."
+    )
+
+
+# ---------------------------------------------------------------------------
+# --ckpt_path round trip (real checkpoint, not fast_dev_run — which disables
+# checkpointing entirely and so never exercises this)
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(args: list[str]) -> None:
+    """Run SRLightningCLI in-process for the given args, restoring sys.argv after.
+
+    Mirrors ``_resolve``'s argv save/restore, but with ``run=True`` (the
+    default) so the subcommand actually executes — needed here since the
+    checkpoint round trip requires a real ``fit`` and a real second parse of
+    ``--ckpt_path`` through ``LightningCLI._parse_ckpt_path``, not just config
+    resolution.
+    """
+    from sisr.cli import SRLightningCLI
+    from sisr.training import SRDataModule, SRLightning
+
+    saved_argv = sys.argv
+    sys.argv = saved_argv[:1]
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", message="GPU available but not used.*")
+            warnings.filterwarnings(
+                "ignore", category=lightning.pytorch.utilities.warnings.PossibleUserWarning
+            )
+            SRLightningCLI(
+                model_class=SRLightning,
+                datamodule_class=SRDataModule,
+                auto_configure_optimizers=False,
+                save_config_callback=None,
+                args=args,
+            )
+    finally:
+        sys.argv = saved_argv
+
+
+def _build_srcnn_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path) -> tuple[Path, Path]:
+    """Run a real (non-``fast_dev_run``) one-step ``fit`` and return (config_path, ckpt_path).
+
+    ``fast_dev_run`` disables checkpointing entirely, so a real ``ModelCheckpoint``
+    with ``every_n_train_steps=1`` is wired in instead to guarantee a ``.ckpt`` file
+    after exactly one training step over the tiny fixture images.
+    """
+    ckpt_dir = tmp_path / "checkpoints"
+    config = {
+        "model": {
+            "model": {
+                "class_path": "sisr.models.srcnn.SRCNN",
+                "init_args": {
+                    "num_channels": 3,
+                    "num_filters": [64, 32],
+                    "kernel_sizes": [9, 1, 5],
+                    "padding": 0,
+                },
+            },
+            "processor": {"class_path": "sisr.processors.RGBProcessor"},
+            "eval_config": {
+                "class_path": "sisr.training.SREvalConfig",
+                "init_args": {"crop_border": 0},
+            },
+        },
+        "optimizer": {"class_path": "torch.optim.SGD", "init_args": {"lr": 1.0e-4}},
+        "data": {
+            "train_dataset": {
+                "class_path": "sisr.datasets.srcnn.TrainDataset",
+                "init_args": {
+                    "img_dir": str(tiny_rgb_image_dir),
+                    "subimg_size": 33,
+                    "stride": 14,
+                    "scale": 2,
+                    "use_tqdm": False,
+                    "cache_dir": str(tmp_path / ".lmdb_cache"),
+                },
+            },
+            "val_dataset": {
+                "class_path": "sisr.datasets.srcnn.ValidationDataset",
+                "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+            },
+            "train_dataloader_kwargs": {"batch_size": 2, "num_workers": 0},
+            "val_dataloader_kwargs": {"batch_size": 1, "num_workers": 0},
+        },
+        "trainer": {
+            "max_epochs": 1,
+            "max_steps": 1,
+            "limit_train_batches": 1,
+            "limit_val_batches": 1,
+            "num_sanity_val_steps": 0,
+            "accelerator": "cpu",
+            "devices": 1,
+            "logger": False,
+            "enable_progress_bar": False,
+            "enable_model_summary": False,
+            "default_root_dir": str(tmp_path),
+            "callbacks": [
+                {
+                    "class_path": "lightning.pytorch.callbacks.ModelCheckpoint",
+                    "init_args": {
+                        "dirpath": str(ckpt_dir),
+                        "filename": "sr-test",
+                        "every_n_train_steps": 1,
+                        "save_top_k": -1,
+                    },
+                }
+            ],
+        },
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+
+    _run_cli(["fit", "--config", str(config_path)])
+
+    ckpt_files = sorted(ckpt_dir.glob("*.ckpt"))
+    assert ckpt_files, "fit did not write a checkpoint"
+    return config_path, ckpt_files[-1]
+
+
+def test_ckpt_path_round_trips_a_real_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path):
+    """Regression: `--ckpt_path` must reload a checkpoint this project actually writes.
+
+    Before the fix, ``SRLightning.__init__`` overwrote ``self._hparams`` with a
+    '/'-flattened dict (built for clean TensorBoard HParams columns).
+    ``LightningCLI._parse_ckpt_path`` reads the checkpoint's ``hyper_parameters``
+    verbatim and re-parses it as CLI options (``model.<key>``), so a key like
+    ``training_config/example_input_shape/0`` became an unparseable option name
+    and every ``--ckpt_path`` invocation (fit resume, validate, test, export)
+    raised ``SystemExit`` with "Parsing of ckpt_path hyperparameters failed!".
+
+    Reloads the freshly-written checkpoint via ``validate --ckpt_path`` — the
+    same code path ``fit`` (resume), ``test``, and ``export`` all share.
+    """
+    config_path, ckpt_path = _build_srcnn_checkpoint(tiny_rgb_image_dir, tmp_path)
+
+    # Confirms the actual root cause is fixed, not just that nothing raised below:
+    # hyper_parameters keys must not use the '/' TensorBoard-flattening separator,
+    # which jsonargparse can't parse back as a CLI option name.
+    raw = torch.load(ckpt_path, weights_only=True, map_location="cpu")
+    saved_hparams = raw["hyper_parameters"]
+    assert saved_hparams, "checkpoint has no hyper_parameters"
+    assert not any("/" in k for k in saved_hparams), (
+        f"hyper_parameters keys must not contain '/': {list(saved_hparams)}"
+    )
+
+    # The actual regression: before the fix, this raised SystemExit from
+    # LightningCLI._parse_ckpt_path failing to parse the '/'-keyed hparams.
+    _run_cli(["validate", "--config", str(config_path), "--ckpt_path", str(ckpt_path)])
+
+
+def test_ckpt_path_reloads_a_legacy_flattened_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path):
+    """Regression: `--ckpt_path` must also reload checkpoints saved *before* the fix.
+
+    This project already has long training runs whose only checkpoints predate
+    the fix — resuming or testing them must keep working, not just newly-written
+    checkpoints. Fabricates that scenario by taking a real checkpoint this branch
+    writes and rewriting its ``hyper_parameters`` back into the pre-fix
+    '/'-flattened shape (what ``SRLightning.__init__`` used to save, including the
+    incidental ``processor``/``criterion`` entries), then reloads it exactly as
+    ``sisr test``/``fit --ckpt_path`` would.
+    """
+    from sisr.training.lightning_module import SRLightning
+
+    config_path, ckpt_path = _build_srcnn_checkpoint(tiny_rgb_image_dir, tmp_path)
+
+    raw = torch.load(ckpt_path, weights_only=True, map_location="cpu")
+    legacy_hparams = SRLightning._flatten_hparams(raw["hyper_parameters"])
+    legacy_hparams["processor"] = "RGBProcessor"
+    legacy_hparams["criterion"] = "MSELoss"
+    raw["hyper_parameters"] = legacy_hparams
+    torch.save(raw, ckpt_path)
+
+    # Must not raise — this is exactly the legacy-checkpoint scenario --ckpt_path failed on.
+    _run_cli(["validate", "--config", str(config_path), "--ckpt_path", str(ckpt_path)])
+
+
+def test_reconstruct_ckpt_hparams_unflattens_legacy_keys():
+    """Legacy '/'-flattened hyper_parameters reconstruct into nested
+    training_config/eval_config dicts, lists restored from their '0'/'1'/...
+    index encoding; model/*, processor, criterion, and _instantiator (never part
+    of the loadable contract) are dropped."""
+    from sisr.cli import _reconstruct_ckpt_hparams
+
+    legacy = {
+        "training_config/example_input_shape/0": 3,
+        "training_config/example_input_shape/1": 24,
+        "training_config/example_input_shape/2": 24,
+        "training_config/init_strategy": "default",
+        "eval_config/crop_border": 4,
+        "eval_config/psnr_channels/0": "RGB",
+        "eval_config/psnr_channels/1": "YCbCr",
+        "model/scale": 4,
+        "model/kernel_sizes/0": 9,
+        "processor": "RGBSignedOutputProcessor",
+        "criterion": "MSELoss",
+        "_instantiator": "lightning.pytorch.cli.instantiate_module",
+    }
+    assert _reconstruct_ckpt_hparams(legacy) == {
+        "training_config": {"example_input_shape": [3, 24, 24], "init_strategy": "default"},
+        "eval_config": {"crop_border": 4, "psnr_channels": ["RGB", "YCbCr"]},
+    }
+
+
+def test_reconstruct_ckpt_hparams_passes_through_current_nested_format():
+    """The current (post-fix) nested hyper_parameters format round-trips unchanged."""
+    from sisr.cli import _reconstruct_ckpt_hparams
+
+    nested = {
+        "training_config": {"layer_lrs": None, "init_strategy": "paper"},
+        "eval_config": {"crop_border": 3, "psnr_channels": ["RGB", "Y"]},
+    }
+    assert _reconstruct_ckpt_hparams(nested) == nested
+
+
+# Resuming into the same checkpoint dirpath the first fit call already populated
+# is exactly what a real resume does in production and is harmless here — silence
+# the resulting benign UserWarning rather than route the resumed run to a second
+# dirpath, which would be less faithful to how --ckpt_path resume is actually used.
+@pytest.mark.filterwarnings("ignore:Checkpoint directory .* exists and is not empty.:UserWarning")
+def test_fit_resume_via_ckpt_path_is_not_just_validate_test(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """Regression: ``fit --ckpt_path`` (resume) shares the same broken code path as
+    ``validate``/``test``/``export`` — ``_parse_ckpt_path`` runs unconditionally for
+    every subcommand — and this project runs 1M-step jobs that resume from
+    checkpoints, so resume specifically must keep working, not just fresh eval runs.
+    """
+    config_path, ckpt_path = _build_srcnn_checkpoint(tiny_rgb_image_dir, tmp_path)
+
+    # A fresh cache_dir for the resumed run: reusing the first run's LMDB cache_dir
+    # from a second Trainer in the same process trips a Windows file-lock/rebuild
+    # race in LMDBCache (its still-open write env blocks the new readonly open) —
+    # unrelated to this regression, so sidestep it rather than fight it here.
+    resume_config = yaml.safe_load(config_path.read_text())
+    resume_config["data"]["train_dataset"]["init_args"]["cache_dir"] = str(
+        tmp_path / ".lmdb_cache_resume"
+    )
+    resume_config_path = tmp_path / "config_resume.yaml"
+    resume_config_path.write_text(yaml.safe_dump(resume_config))
+
+    # Must not raise; --trainer.max_steps=2 forces the resumed run past the
+    # checkpoint's already-reached step 1, proving training actually continues.
+    _run_cli(
+        [
+            "fit",
+            "--config",
+            str(resume_config_path),
+            "--ckpt_path",
+            str(ckpt_path),
+            "--trainer.max_steps=2",
+        ]
     )

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -401,7 +401,9 @@ def test_on_train_start_logs_hparams_with_val_metrics(srcnn_rgb_lit: SRLightning
     expected_metrics = {f"psnr/val/{k}": 0.0 for k in srcnn_rgb_lit.eval_config.psnr_keys}
     expected_metrics.update({f"ssim/val/{k}": 0.0 for k in srcnn_rgb_lit.eval_config.ssim_keys})
 
-    assert params_arg == srcnn_rgb_lit.hparams
+    # The TB-only flattened view (_tb_hparams), not self.hparams — the latter must stay
+    # nested/unflattened so checkpoints round-trip through --ckpt_path (see lightning_module.py).
+    assert params_arg == srcnn_rgb_lit._tb_hparams
     assert metrics_arg == expected_metrics
 
 
@@ -594,8 +596,8 @@ def test_paper_init_polymorphic_on_non_overriding_subclass():
     # No exception = success. (The actual weights are whatever PyTorch's default init produced.)
 
 
-def test_saved_hparams_contain_processor_name():
-    """The processor's class name is saved into Lightning hparams for TensorBoard distinction."""
+def test_saved_tb_hparams_contain_processor_name():
+    """The processor's class name is saved into the TB-only hparams view for TensorBoard."""
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
@@ -604,8 +606,10 @@ def test_saved_hparams_contain_processor_name():
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
-    # Lightning's self.hparams is a flat dict after the _flatten_hparams step.
-    assert lit.hparams.get("processor") == "RGBProcessor"
+    assert lit._tb_hparams.get("processor") == "RGBProcessor"
+    # Regression guard: self.hparams (what checkpoints save) must NOT carry this —
+    # it's ignored on purpose so --ckpt_path reload never has to reparse it.
+    assert "processor" not in lit.hparams
 
 
 # ---------------------------------------------------------------------------
@@ -752,10 +756,11 @@ def test_val_metrics_hold_no_stateful_accumulators(srcnn_y_lit: SRLightning):
 # ---------------------------------------------------------------------------
 
 
-def test_hparams_expand_nested_config_fields():
+def test_tb_hparams_expand_nested_config_fields():
     """Regression (P2.4): training_config/eval_config dataclasses expand into
     individual HParams columns (via dataclasses.asdict) using the '/' separator,
-    instead of a single stringified blob under the bare key."""
+    instead of a single stringified blob under the bare key — in the TB-only
+    flattened view, since self.hparams itself must stay nested (see below)."""
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(
         model=model,
@@ -764,12 +769,37 @@ def test_hparams_expand_nested_config_fields():
         eval_config=SREvalConfig(crop_border=7),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
-    flat = dict(lit.hparams)
+    flat = dict(lit._tb_hparams)
     assert flat.get("eval_config/crop_border") == 7
     assert flat.get("training_config/init_strategy") == "default"
     # regression guard: no stringified dataclass blob under the bare key
     assert "eval_config" not in flat
     assert "training_config" not in flat
+
+
+def test_hparams_stay_nested_plain_dicts_for_checkpoint_reload():
+    """Regression: self.hparams (what Lightning writes into the checkpoint's
+    `hyper_parameters`) must stay a plain nested dict — no '/'-flattening and
+    no live SRTrainingConfig/SREvalConfig objects. LightningCLI._parse_ckpt_path
+    re-parses this dict as CLI options (model.<key>), so a '/' in a key breaks
+    every --ckpt_path invocation, and a live dataclass object there breaks
+    weights_only=True checkpoint loading."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(crop_border=7),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    assert lit.hparams["eval_config"] == {
+        "crop_border": 7,
+        "psnr_channels": ["RGB"],
+        "separate_psnr": False,
+        "ssim_channels": ["RGB", "Y"],
+    }
+    assert isinstance(lit.hparams["training_config"], dict)
+    assert not any("/" in k for k in lit.hparams)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `SRLightning.__init__` overwrote `self._hparams` with a `/`-flattened dict built for clean TensorBoard HParams columns, so every saved checkpoint's `hyper_parameters` carried keys like `training_config/example_input_shape/0`. `LightningCLI._parse_ckpt_path` re-parses that dict verbatim as CLI options (`model.<key>`); jsonargparse rejects a literal `/` in an option name, so `fit` resume, `validate`, `test`, and `export` all failed on any `--ckpt_path`.
- `self.hparams` now holds only a plain, nested (`dataclasses.asdict`) `training_config`/`eval_config` dict, saved via an explicit `save_hyperparameters(...)` call so it's identical whether `SRLightning` is built directly or through the CLI, and safe under `weights_only=True` loading. The flattened, TensorBoard-only view moves to `self._tb_hparams`, which `on_train_start` now logs instead of `self.hparams`.
- Existing checkpoints (including a live 17-hour SRResNet run) were saved with the old flattened `hyper_parameters` and can't be regenerated, so `SRLightningCLI` also gets a `_parse_ckpt_path` override (`_reconstruct_ckpt_hparams`) that rebuilds the current nested shape from either format before reparsing — already-saved checkpoints keep loading too.

## Verification

- New regression tests in `tests/test_cli.py`: a real (non-`fast_dev_run`) one-step `fit` writes an actual checkpoint, then `validate`/`fit --ckpt_path` reload it through the CLI; a companion test rewrites that checkpoint's `hyper_parameters` into the legacy `/`-flattened shape and confirms it still reloads; unit tests for `_reconstruct_ckpt_hparams` directly.
- Ran the exact real-world repro against the project's live checkpoint (`experiments/SRResNet/20260802-paper-range/checkpoints/sr-940000-psnr_val_RGB=28.8497.ckpt`) via a scratch-copied config (`save_dir` redirected away from the real experiment directory) — it now completes a full Set5/Set14 test run instead of raising `SystemExit`, reproducing the project's documented benchmark numbers.
- Full suite: 368 passed, 1 skipped (pre-existing, no `data/` in this checkout). `ruff check` / `ruff format --check` clean.

## Test plan

- [x] `PYTHONPATH="$PWD" python -m pytest` — 368 passed, 1 skipped
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] Reproduced the failure on unfixed code, then confirmed the fix resolves it against the real checkpoint
- [x] Confirmed no files were modified under `experiments/SRResNet/20260802-paper-range/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)