### PR TITLE
Unify SRCNN/SRResNet raw-HR caches; add advisory build lock

### DIFF
--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -16,6 +16,7 @@ torch-free; colorspace math lives in :mod:`sisr.colorspace` for this reason.
 
 import os
 import shutil
+import time
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from contextlib import contextmanager
@@ -140,9 +141,20 @@ class LMDBCache:
     After construction the cache is read-only. Call :meth:`get` to
     retrieve individual entries, or :meth:`get_env` for direct LMDB access.
 
+    Two independent processes building the same cache (same *cache_dir*,
+    *name*, *checksum*) race by design — LMDB itself already serialises
+    writers and ``__checksum__`` is written last, so a half-built cache is
+    never mistaken for a complete one. An advisory file lock (see
+    :meth:`_acquire_lock`) exists only to *avoid duplicate work*, not to
+    provide correctness: a losing process polls for the winner's result and
+    joins it, but if the winner never finishes (e.g. it crashed while
+    holding the lock) the loser builds anyway once *lock_timeout* elapses.
+    Waiting forever on a stale lock is the one failure mode this must never
+    have; rebuilding a cache that already exists is merely wasted time.
+
     Args:
         cache_dir: Parent directory for the LMDB database.
-        name: Prefix used in the LMDB folder name (e.g. ``'srcnn_hr'``).
+        name: Prefix used in the LMDB folder name (e.g. ``'hr_raw'``).
         checksum: Hex digest identifying the current configuration; a
             mismatch triggers a rebuild.
         length: Total number of entries that will be stored.
@@ -152,6 +164,9 @@ class LMDBCache:
             :class:`LMDBCacheBuildContext`. ``None`` with no valid cache
             found raises ``RuntimeError``.
         use_tqdm: Whether to display a progress bar during the build.
+        lock_poll_interval: Seconds between checks for a concurrent
+            builder's result while waiting on its lock.
+        lock_timeout: Seconds to wait on a held lock before building anyway.
     """
 
     def __init__(
@@ -164,6 +179,8 @@ class LMDBCache:
         metadata: dict[str, str] | None = None,
         build_fn: Callable[[LMDBCacheBuildContext], None] | None = None,
         use_tqdm: bool = False,
+        lock_poll_interval: float = 0.5,
+        lock_timeout: float = 600.0,
     ):
         self._cache_dir = Path(cache_dir)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
@@ -177,7 +194,14 @@ class LMDBCache:
                 raise RuntimeError(
                     f"No valid LMDB cache found at {self._lmdb_path} and no build_fn was provided."
                 )
-            self._build(checksum, length, map_size, build_fn, use_tqdm)
+            if self._acquire_lock(checksum, lock_poll_interval, lock_timeout):
+                try:
+                    # Re-check: a concurrent builder may have finished (and released
+                    # its lock) between our first _try_load and winning this one.
+                    if not self._try_load(checksum):
+                        self._build(checksum, length, map_size, build_fn, use_tqdm)
+                finally:
+                    self._release_lock()
 
     @property
     def path(self) -> Path:
@@ -260,26 +284,79 @@ class LMDBCache:
         return results
 
     def _try_load(self, checksum: str) -> bool:
-        """Validates an existing LMDB against *checksum*; ``True`` if ready to use."""
+        """Validates an existing LMDB against *checksum*; ``True`` if ready to use.
+
+        Failing to even *open* the environment is presumed genuine corruption
+        (bad format, truncated files) and the directory is dropped so a later
+        call can rebuild it. A failure *after* a successful open — reading the
+        transaction — is treated as merely not-ready-yet, without deleting
+        anything: opened with ``lock=False``, this read can raise on Windows
+        while a concurrent writer *in another process* is still active (the
+        exact scenario :meth:`_acquire_lock` exists for), even though nothing
+        is actually corrupt. Deleting the directory there would destroy that
+        other process's in-progress or just-finished build instead of merely
+        costing this call a retry.
+        """
         if not self._lmdb_path.exists():
             return False
         try:
             env = lmdb.open(str(self._lmdb_path), readonly=True, lock=False)
-            with env.begin(write=False) as txn:
-                stored = txn.get(b"__checksum__")
-                if stored is None or stored.decode() != checksum:
-                    env.close()
-                    return False
-                self._length = int(txn.get(b"__length__").decode())
-            env.close()
-            return True
         except (lmdb.Error, OSError):
-            # Only a genuinely unreadable cache (corruption, disk/OS error)
-            # counts as stale and gets dropped; anything else must propagate
-            # rather than be silently mistaken for a stale cache.
             if self._lmdb_path.exists():
                 shutil.rmtree(self._lmdb_path)
             return False
+
+        try:
+            with env.begin(write=False) as txn:
+                stored = txn.get(b"__checksum__")
+                if stored is None or stored.decode() != checksum:
+                    return False
+                self._length = int(txn.get(b"__length__").decode())
+            return True
+        except (lmdb.Error, OSError):
+            return False
+        finally:
+            env.close()
+
+    def _lock_path(self) -> Path:
+        """Sentinel path for the advisory build lock, scoped to this checksum."""
+        return self._lmdb_path.with_name(self._lmdb_path.name + ".build.lock")
+
+    def _acquire_lock(self, checksum: str, poll_interval: float, timeout: float) -> bool:
+        """Becomes the sole builder for *checksum*, or waits on whoever already is.
+
+        Returns:
+            ``True`` if the caller should proceed to build — either it won
+            the lock outright, or it waited out *timeout* without seeing a
+            valid cache appear (a stale/crashed lock holder must not deadlock
+            every later run, so this falls through to a duplicate build
+            rather than waiting forever). ``False`` if a concurrent builder
+            produced a valid cache while waiting — :meth:`_try_load` has
+            already refreshed :attr:`_length` in that case.
+        """
+        lock_path = self._lock_path()
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            pass
+        else:
+            os.write(fd, str(os.getpid()).encode())
+            os.close(fd)
+            return True
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._try_load(checksum):
+                return False
+            time.sleep(poll_interval)
+        return True
+
+    def _release_lock(self) -> None:
+        """Removes the lock sentinel this process created in :meth:`_acquire_lock`."""
+        try:
+            self._lock_path().unlink()
+        except FileNotFoundError:
+            pass
 
     def _build(
         self,

--- a/sisr/datasets/hr_cache.py
+++ b/sisr/datasets/hr_cache.py
@@ -1,0 +1,88 @@
+"""Architecture-neutral raw-HR cache primitives, shared by every train dataset.
+
+SRCNN's and SRResNet's train datasets cache the exact same thing for a given
+directory of HR images: one whole decoded RGB array per image, headered with
+its own ``(height, width)`` so the value is self-describing — recoverable
+from the cache alone even if the source files are gone (this is what let a
+``DIV2K_train_HR`` wipe be recovered from the cache once already). Unifying
+the cache name, format tag, and build function here — rather than
+duplicating them per architecture, or having one borrow the other's — means
+the same image directory produces exactly one cache regardless of which
+architecture's dataset builds it first.
+
+Deliberately torch-free, like :mod:`sisr.cache`: :func:`process_hr_image` is
+the function pickled to ``ProcessPoolExecutor`` build workers, and a spawned
+worker re-imports *its own defining module* to unpickle it — this one, not
+whichever dataset module happens to call it.
+"""
+
+import hashlib
+import struct
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+CACHE_NAME = "hr_raw"
+FORMAT_TAG = "hr_rgb_v1"
+
+# (height, width), little-endian uint32 each, prefixed to every cached value so
+# a per-image shape travels with its pixel data in one LMDB read. SRCNN's
+# TrainDataset re-derives sizes from the source files before ever reading the
+# cache and so never needs this back — it is kept uniformly anyway, because it
+# is what makes a cached value self-describing rather than dependent on the
+# source files still existing.
+HEADER = struct.Struct("<II")
+
+
+def process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
+    """Decodes one HR image and returns its single, headered LMDB entry.
+
+    Top-level (not a method) so it can be pickled by ``ProcessPoolExecutor``
+    on spawn platforms. Shared by every train dataset's build path, so a
+    cache built by one architecture is reused, not rebuilt, by another over
+    the same image files.
+
+    Returns:
+        A single-element list ``[(f'hr_{idx:08d}', header + raw_bytes)]``
+        where *header* is :data:`HEADER`-packed ``(h, w)`` and *raw_bytes* is
+        the ``(H, W, 3)`` uint8 RGB array's bytes.
+    """
+    arr = np.array(Image.open(path).convert("RGB"))
+    h, w = arr.shape[:2]
+    return [(f"hr_{idx:08d}", HEADER.pack(h, w) + arr.tobytes())]
+
+
+def compute_checksum(img_paths: Sequence[Path]) -> str:
+    """Computes a SHA-256 checksum over the file manifest plus :data:`FORMAT_TAG`.
+
+    Shared by every train dataset so an identical file set hashes identically
+    regardless of which architecture asks first. No degradation/grid
+    parameter enters this hash — the cache stores whole raw images, unaffected
+    by anything derived from them at read time.
+
+    Returns:
+        A hex-encoded SHA-256 digest string.
+    """
+    file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in img_paths)
+    canonical = "|".join([file_manifest, f"format={FORMAT_TAG}"])
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def estimate_map_size(sizes: Sequence[tuple[int, int]]) -> int:
+    """Converts each cached image's ``(h, w)`` into the LMDB ``map_size`` to request.
+
+    Exact sizes plus 10% slack. If it is ever exceeded, LMDB raises
+    ``MapFullError`` mid-build and the checksum is never written, so the
+    partial database reads as stale and is rebuilt rather than silently
+    serving truncated data.
+
+    Args:
+        sizes: Each cached image's ``(height, width)``.
+
+    Returns:
+        The requested ``map_size`` in bytes, floored at 64 MiB.
+    """
+    total = sum(HEADER.size + h * w * 3 for h, w in sizes)
+    return max(int(total * 1.1), 64 * 1024 * 1024)

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -2,13 +2,15 @@
 
 LR is generated from HR via bicubic-down → bicubic-up so the LR patches share
 the spatial size of the HR patches (pre-upsampled SRCNN formulation).
-:class:`TrainDataset` caches whole decoded HR images (raw, uint8) through
-:class:`~sisr.cache.LMDBCache`, mirroring :mod:`sisr.datasets.srresnet` —
-decoding a source image once and slicing its deterministic sub-images out at
-load time is far cheaper than re-decoding, and it decouples the cache from
-every LR-generation parameter (``scale``) as well as the sub-image grid
-itself (``subimg_size``, ``stride``): none of them affect the raw bytes
-stored, only what gets sliced/degraded from them at read time.
+:class:`TrainDataset` caches whole decoded HR images (raw, uint8, headered)
+through :mod:`~sisr.datasets.hr_cache`, shared verbatim with
+:mod:`sisr.datasets.srresnet` — the same image directory produces exactly one
+cache regardless of which architecture builds it first. Decoding a source
+image once and slicing its deterministic sub-images out at load time is far
+cheaper than re-decoding, and it decouples the cache from every
+LR-generation parameter (``scale``) as well as the sub-image grid itself
+(``subimg_size``, ``stride``): none of them affect the raw bytes stored, only
+what gets sliced/degraded from them at read time.
 :class:`ValidationDataset` generates LR pairs on the fly for full images.
 
 LR degradation uses MATLAB-compatible antialiased bicubic resizing (see
@@ -17,7 +19,6 @@ low-pass filter, so no separate blur step is needed.
 """
 
 import bisect
-import hashlib
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -28,6 +29,8 @@ from PIL import Image
 from ..cache import LMDBCache, LMDBCacheBuildContext
 from ..imresize import resize
 from .base import SRDataset
+from .hr_cache import CACHE_NAME, FORMAT_TAG, HEADER, compute_checksum, estimate_map_size
+from .hr_cache import process_hr_image as _process_hr_image
 
 
 def _grid_dims(
@@ -76,24 +79,6 @@ def _degrade(hr_arr: np.ndarray, scale: int) -> np.ndarray:
     h, w = hr_arr.shape[:2]
     down = resize(hr_arr, (h // scale, w // scale))
     return resize(down, (h, w))
-
-
-def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
-    """Decodes one HR image and returns its single LMDB entry.
-
-    Top-level (not a method) so it can be pickled by ``ProcessPoolExecutor``
-    across all platforms, mirroring
-    :func:`sisr.datasets.srresnet._process_hr_image`. Sub-image extraction and
-    LR derivation both moved to :meth:`TrainDataset.__getitem__`, so the build
-    only has to decode once per image — independent of
-    ``subimg_size``/``stride``/``scale``.
-
-    Returns:
-        A single-element list ``[(f'hr_{idx:08d}', raw_bytes)]`` where
-        *raw_bytes* is the ``(H, W, 3)`` uint8 RGB array's bytes.
-    """
-    arr = np.array(Image.open(path).convert("RGB"))
-    return [(f"hr_{idx:08d}", arr.tobytes())]
 
 
 class TrainDataset(SRDataset):
@@ -161,20 +146,13 @@ class TrainDataset(SRDataset):
             self._compute_grid()
         )
 
-        # Exact sizes from image headers + 10% slack. If it is ever exceeded,
-        # lmdb raises MapFullError mid-build and the checksum is never written,
-        # so the partial DB reads as stale and is rebuilt rather than silently
-        # serving truncated data. Same unhandled-overflow behaviour as SRResNet's cache.
-        raw_bytes = sum(h * w * 3 for h, w in self._img_sizes)
-        map_size = max(int(raw_bytes * 1.1), 64 * 1024 * 1024)
-
         self._cache = LMDBCache(
             cache_dir=cache_dir,
-            name="srcnn_hr",
+            name=CACHE_NAME,
             checksum=checksum,
             length=len(self.img_paths),
-            map_size=map_size,
-            metadata={"format": "srcnn_hr_v1"},
+            map_size=estimate_map_size(self._img_sizes),
+            metadata={"format": FORMAT_TAG},
             build_fn=self._build,
             use_tqdm=use_tqdm,
         )
@@ -185,17 +163,15 @@ class TrainDataset(SRDataset):
         The cache stores whole raw HR images, so — unlike the LR-patch cache
         this replaced — none of ``subimg_size``/``stride``/``scale`` enter the
         hash: they only affect what gets sliced and degraded at read time,
-        never what is written to LMDB. The ``format=srcnn_hr_v1`` tag (paired
-        with a new LMDB cache ``name``, see :meth:`__init__`) ensures a
-        pre-HR-only cache is never misread under this format rather than
-        rebuilt.
+        never what is written to LMDB. Delegates to
+        :func:`~sisr.datasets.hr_cache.compute_checksum`, shared verbatim with
+        :mod:`sisr.datasets.srresnet` so the same file set hashes identically
+        regardless of which architecture asks first.
 
         Returns:
             A hex-encoded SHA-256 digest string.
         """
-        file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in self.img_paths)
-        canonical = "|".join([file_manifest, "format=srcnn_hr_v1"])
-        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        return compute_checksum(self.img_paths)
 
     def _compute_grid(self) -> tuple[list[tuple[int, int]], list[int], list[int], int]:
         """Computes the deterministic sub-image grid from image dimensions alone.
@@ -282,7 +258,9 @@ class TrainDataset(SRDataset):
                 raise KeyError(key)
             # Read-only view into the LMDB transaction's mmap page — sliced and
             # copied out below, before the `with` block ends and the view dies.
-            arr = np.frombuffer(buf, dtype=np.uint8).reshape(h, w, 3)
+            # (h, w) come from _compute_grid (the source file), not the header:
+            # only its byte offset matters here, consistent with SRResNet's read.
+            arr = np.frombuffer(buf, dtype=np.uint8, offset=HEADER.size).reshape(h, w, 3)
             hr_subimg = arr[
                 top : top + self.sub_img_size, left : left + self.sub_img_size, :
             ].copy()

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -2,11 +2,14 @@
 
 LR is the bicubic downscale of HR by ``scale`` (no upsample round-trip);
 the model is responsible for the ×``scale`` upsampling. :class:`TrainDataset`
-caches full decoded HR images (raw, uint8) through :class:`~sisr.cache.LMDBCache`
-— decoding a DIV2K PNG costs ~109ms, while the 96x96 crop kept from it costs
-~1ms, so re-decoding per crop is ~99% wasted work. The random crop itself is
-**not** cached (that would defeat crop randomness); it is drawn fresh, from
-the cached raw array, on every ``__getitem__`` call.
+caches full decoded HR images (raw, uint8, headered) through
+:mod:`~sisr.datasets.hr_cache`, shared verbatim with :mod:`sisr.datasets.srcnn`
+— the same image directory produces exactly one cache regardless of which
+architecture builds it first. Decoding a DIV2K PNG costs ~109ms, while the
+96x96 crop kept from it costs ~1ms, so re-decoding per crop is ~99% wasted
+work. The random crop itself is **not** cached (that would defeat crop
+randomness); it is drawn fresh, from the cached raw array, on every
+``__getitem__`` call.
 :class:`ValidationDataset` serves full images cropped to a multiple of
 ``scale``, uncached (each is decoded once per epoch, no repetition).
 
@@ -14,9 +17,7 @@ LR is derived via MATLAB-compatible antialiased bicubic resizing (see
 :mod:`sisr.imresize`), comparable to published paper numbers.
 """
 
-import hashlib
 import random
-import struct
 from pathlib import Path
 
 import numpy as np
@@ -26,28 +27,8 @@ from PIL import Image
 from ..cache import LMDBCache, LMDBCacheBuildContext
 from ..imresize import resize
 from .base import SRDataset
-
-# (height, width) as little-endian uint32 each, prefixed to every cached HR
-# value so a per-image shape (DIV2K images vary in size) travels with its
-# pixel data in one LMDB read instead of a second lookup.
-_SHAPE_HEADER = struct.Struct("<II")
-
-
-def _process_hr_image(path: Path, idx: int) -> list[tuple[str, bytes]]:
-    """Decodes one HR image and returns its single LMDB entry.
-
-    Top-level (not a method) so it can be pickled by ``ProcessPoolExecutor``
-    across all platforms, mirroring :func:`sisr.datasets.srcnn._process_hr_image`.
-
-    Returns:
-        A single-element list ``[(f'hr_{idx:08d}', header + raw_bytes)]`` where
-        *header* is :data:`_SHAPE_HEADER`-packed ``(h, w)`` and *raw_bytes* is
-        the ``(H, W, 3)`` uint8 RGB array's bytes.
-    """
-    arr = np.array(Image.open(path).convert("RGB"))
-    h, w = arr.shape[:2]
-    value = _SHAPE_HEADER.pack(h, w) + arr.tobytes()
-    return [(f"hr_{idx:08d}", value)]
+from .hr_cache import CACHE_NAME, FORMAT_TAG, HEADER, compute_checksum, estimate_map_size
+from .hr_cache import process_hr_image as _process_hr_image
 
 
 class TrainDataset(SRDataset):
@@ -121,19 +102,14 @@ class TrainDataset(SRDataset):
 
         cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
         checksum = self._compute_checksum()
-        # Exact sizes from image headers + 10% slack. If it is ever exceeded,
-        # lmdb raises MapFullError mid-build and the checksum is never written,
-        # so the partial DB reads as stale and is rebuilt rather than silently
-        # serving truncated data. Same unhandled-overflow behaviour as SRCNN's cache.
-        map_size = max(int(self._estimate_raw_bytes() * 1.1), 64 * 1024 * 1024)
 
         self._cache = LMDBCache(
             cache_dir=cache_dir,
-            name="srresnet_hr",
+            name=CACHE_NAME,
             checksum=checksum,
             length=len(self.img_paths),
-            map_size=map_size,
-            metadata={"format": "raw_rgb_v1"},
+            map_size=estimate_map_size(self._collect_sizes()),
+            metadata={"format": FORMAT_TAG},
             build_fn=self._build,
             use_tqdm=use_tqdm,
         )
@@ -143,30 +119,29 @@ class TrainDataset(SRDataset):
 
         No crop/scale parameter enters this hash: the cache stores whole raw
         images, so it is valid for any ``hr_crop_size``/``crops_per_image``/
-        ``scale`` combination over the same file set.
-        :meth:`sisr.datasets.srcnn.TrainDataset._compute_checksum` now does the
-        same — both datasets cache HR only.
+        ``scale`` combination over the same file set. Delegates to
+        :func:`~sisr.datasets.hr_cache.compute_checksum`, shared verbatim with
+        :mod:`sisr.datasets.srcnn` so the same file set hashes identically
+        regardless of which architecture asks first.
 
         Returns:
             A hex-encoded SHA-256 digest string.
         """
-        file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in self.img_paths)
-        canonical = "|".join([file_manifest, "format=raw_rgb_v1"])
-        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        return compute_checksum(self.img_paths)
 
-    def _estimate_raw_bytes(self) -> int:
-        """Sums each image's decoded byte size from its header, without decoding pixels.
+    def _collect_sizes(self) -> list[tuple[int, int]]:
+        """Reads each image's ``(h, w)`` from its file header, without decoding pixels.
 
         Returns:
-            Total bytes the LMDB build will write (header + raw RGB per image).
+            Each source image's ``(height, width)``, in :attr:`img_paths` order.
         """
-        total = 0
+        sizes = []
         for path in self.img_paths:
             img = Image.open(path)
             w, h = img.size
             img.close()
-            total += _SHAPE_HEADER.size + h * w * 3
-        return total
+            sizes.append((h, w))
+        return sizes
 
     def _build(self, ctx: LMDBCacheBuildContext) -> None:
         """Populates the LMDB cache by decoding each HR image once in parallel.
@@ -199,7 +174,7 @@ class TrainDataset(SRDataset):
         with self._cache.get_buffer(key) as buf:
             if buf is None:
                 raise KeyError(key)
-            h, w = _SHAPE_HEADER.unpack_from(buf, 0)
+            h, w = HEADER.unpack_from(buf, 0)
             if w < self.hr_crop_size or h < self.hr_crop_size:
                 raise ValueError(
                     f"Image {self.img_paths[img_idx].name} ({w}x{h}) is smaller than "
@@ -207,7 +182,7 @@ class TrainDataset(SRDataset):
                 )
             # Read-only view into the LMDB transaction's mmap page — sliced and
             # copied out below, before the `with` block ends and the view dies.
-            arr = np.frombuffer(buf, dtype=np.uint8, offset=_SHAPE_HEADER.size).reshape(h, w, 3)
+            arr = np.frombuffer(buf, dtype=np.uint8, offset=HEADER.size).reshape(h, w, 3)
             top = random.randint(0, h - self.hr_crop_size)
             left = random.randint(0, w - self.hr_crop_size)
             hr_arr = arr[top : top + self.hr_crop_size, left : left + self.hr_crop_size, :].copy()

--- a/tests/datasets/test_hr_cache.py
+++ b/tests/datasets/test_hr_cache.py
@@ -1,0 +1,211 @@
+"""Tests for the architecture-neutral raw-HR cache module.
+
+Covers the shared primitives directly (process_hr_image / compute_checksum /
+estimate_map_size), the import-weight guarantee for the worker entry point's
+own module, and cross-architecture cache sharing/pixel equivalence between
+SRCNN's and SRResNet's train datasets.
+"""
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from sisr.datasets.hr_cache import HEADER, compute_checksum, estimate_map_size, process_hr_image
+
+# ---------------------------------------------------------------------------
+# Import weight
+# ---------------------------------------------------------------------------
+
+
+def test_hr_cache_module_imports_no_torch():
+    """sisr.datasets.hr_cache must not pull torch in, directly or transitively.
+
+    This is the module process_hr_image actually lives in, and therefore the
+    module a spawned ProcessPoolExecutor build worker re-imports to unpickle
+    it -- regardless of which dataset module (srcnn/srresnet, both of which
+    do import torch) merely re-exports a reference to it. Asserting this on
+    sisr.cache alone would prove the wrong thing: the worker's entry point is
+    this module, not that one.
+    """
+    probe = "import sys, sisr.datasets.hr_cache; print('torch' in sys.modules)"
+    proc = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+    assert proc.stdout.strip() == "False", (
+        "sisr.datasets.hr_cache now imports torch (directly or transitively). "
+        "Every spawned LMDB build worker pays that import for nothing."
+    )
+
+
+# ---------------------------------------------------------------------------
+# process_hr_image / compute_checksum / estimate_map_size
+# ---------------------------------------------------------------------------
+
+
+def test_process_hr_image_returns_headered_value(tmp_path: Path):
+    rng = np.random.default_rng(seed=0)
+    arr = rng.integers(0, 256, size=(12, 20, 3), dtype=np.uint8)
+    path = tmp_path / "img.png"
+    Image.fromarray(arr).save(path)
+
+    [(key, value)] = process_hr_image(path, 3)
+
+    assert key == "hr_00000003"
+    h, w = HEADER.unpack_from(value, 0)
+    assert (h, w) == (12, 20)
+    payload = np.frombuffer(value, dtype=np.uint8, offset=HEADER.size).reshape(h, w, 3)
+    assert np.array_equal(payload, arr)
+
+
+def test_compute_checksum_depends_on_manifest_and_format_tag(tmp_path: Path):
+    rng = np.random.default_rng(seed=1)
+    paths = []
+    for i in range(2):
+        arr = rng.integers(0, 256, size=(10, 10, 3), dtype=np.uint8)
+        p = tmp_path / f"img_{i}.png"
+        Image.fromarray(arr).save(p)
+        paths.append(p)
+
+    file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in paths)
+    expected = hashlib.sha256(f"{file_manifest}|format=hr_rgb_v1".encode()).hexdigest()
+    assert compute_checksum(paths) == expected
+
+
+def test_estimate_map_size_includes_header_and_slack():
+    sizes = [(10, 20), (5, 5)]
+    expected_total = (HEADER.size + 10 * 20 * 3) + (HEADER.size + 5 * 5 * 3)
+    assert estimate_map_size(sizes) == max(int(expected_total * 1.1), 64 * 1024 * 1024)
+
+
+def test_estimate_map_size_floors_at_64_mib():
+    assert estimate_map_size([(1, 1)]) == 64 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Cross-architecture sharing (Task A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def varied_size_rgb_image_dir(tmp_path: Path) -> Path:
+    rng = np.random.default_rng(seed=2)
+    for i, (h, w) in enumerate([(40, 40), (48, 32), (30, 50)]):
+        arr = rng.integers(0, 256, size=(h, w, 3), dtype=np.uint8)
+        Image.fromarray(arr).save(tmp_path / f"img_{i:02d}.png")
+    return tmp_path
+
+
+def test_srresnet_build_is_reused_by_srcnn_same_files(varied_size_rgb_image_dir: Path):
+    """Building via one architecture must be reused, not rebuilt, by the other
+    over the identical file set -- the point of unifying the cache."""
+    from sisr.datasets.srcnn import TrainDataset as SRCNNTrainDataset
+    from sisr.datasets.srresnet import TrainDataset as SRResNetTrainDataset
+
+    cache_dir = varied_size_rgb_image_dir / ".lmdb_cache"
+
+    srresnet_ds = SRResNetTrainDataset(
+        img_dir=varied_size_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=cache_dir,
+        build_num_workers=1,
+    )
+
+    with patch("sisr.datasets.srcnn._process_hr_image") as mock_proc:
+        srcnn_ds = SRCNNTrainDataset(
+            img_dir=varied_size_rgb_image_dir,
+            subimg_size=16,
+            stride=8,
+            scale=2,
+            cache_dir=cache_dir,
+            build_num_workers=1,
+        )
+        mock_proc.assert_not_called()
+
+    assert srcnn_ds._cache.path == srresnet_ds._cache.path
+    assert srcnn_ds._compute_checksum() == srresnet_ds._compute_checksum()
+
+
+def test_srcnn_build_is_reused_by_srresnet_same_files(varied_size_rgb_image_dir: Path):
+    """Same guarantee in the other build order -- whichever architecture
+    builds first, the other must find and reuse it."""
+    from sisr.datasets.srcnn import TrainDataset as SRCNNTrainDataset
+    from sisr.datasets.srresnet import TrainDataset as SRResNetTrainDataset
+
+    cache_dir = varied_size_rgb_image_dir / ".lmdb_cache"
+
+    srcnn_ds = SRCNNTrainDataset(
+        img_dir=varied_size_rgb_image_dir,
+        subimg_size=16,
+        stride=8,
+        scale=2,
+        cache_dir=cache_dir,
+        build_num_workers=1,
+    )
+
+    with patch("sisr.datasets.srresnet._process_hr_image") as mock_proc:
+        srresnet_ds = SRResNetTrainDataset(
+            img_dir=varied_size_rgb_image_dir,
+            scale=2,
+            hr_crop_size=16,
+            cache_dir=cache_dir,
+            build_num_workers=1,
+        )
+        mock_proc.assert_not_called()
+
+    assert srcnn_ds._cache.path == srresnet_ds._cache.path
+
+
+def test_shared_cache_pixel_equivalence_across_architectures(varied_size_rgb_image_dir: Path):
+    """Sub-images/crops read through the shared cache by EITHER architecture
+    must be byte-identical to the raw source pixels -- proving the single
+    cache serves correct data down both read paths (header-skip offsets
+    differ: SRCNN ignores the header content, SRResNet parses it).
+
+    The two datasets are used sequentially, not concurrently: LMDB itself
+    refuses to open the same environment path twice in one process (a
+    same-process concern only -- separate training processes, the actual
+    production scenario, each open their own handle just fine), so the first
+    dataset's env is closed before the second is constructed.
+    """
+    from sisr.datasets.srcnn import TrainDataset as SRCNNTrainDataset
+    from sisr.datasets.srresnet import TrainDataset as SRResNetTrainDataset
+
+    cache_dir = varied_size_rgb_image_dir / ".lmdb_cache"
+    source = np.array(Image.open(sorted(varied_size_rgb_image_dir.glob("*.png"))[0]).convert("RGB"))
+
+    srcnn_ds = SRCNNTrainDataset(
+        img_dir=varied_size_rgb_image_dir,
+        subimg_size=16,
+        stride=16,
+        scale=2,
+        cache_dir=cache_dir,
+        build_num_workers=1,
+    )
+    # SRCNN's first sub-image is the deterministic (0, 0) corner.
+    _, hr_srcnn = srcnn_ds[0]
+    hr_srcnn_uint8 = (hr_srcnn.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
+    assert np.array_equal(hr_srcnn_uint8, source[:16, :16, :])
+    srcnn_ds._cache.get_env().close()  # release before srresnet_ds opens the same path
+
+    srresnet_ds = SRResNetTrainDataset(
+        img_dir=varied_size_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=cache_dir,
+        build_num_workers=1,
+    )
+    # SRResNet's crop is random, but must appear verbatim somewhere in the source.
+    _, hr_srresnet = srresnet_ds[0]
+    hr_srresnet_uint8 = (hr_srresnet.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
+    h, w = source.shape[:2]
+    found = any(
+        np.array_equal(source[top : top + 16, left : left + 16, :], hr_srresnet_uint8)
+        for top in range(0, h - 16 + 1)
+        for left in range(0, w - 16 + 1)
+    )
+    assert found, "SRResNet crop read through the shared cache does not match its source image"

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -145,7 +145,7 @@ def test_train_dataset_checksum_ignores_grid_and_lr_params(shared_srcnn_train_ds
 
     ds = shared_srcnn_train_ds
     file_manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in ds.img_paths)
-    expected_canonical = "|".join([file_manifest, "format=srcnn_hr_v1"])
+    expected_canonical = "|".join([file_manifest, "format=hr_rgb_v1"])
     expected = hashlib.sha256(expected_canonical.encode("utf-8")).hexdigest()
     assert ds._compute_checksum() == expected
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -363,3 +365,164 @@ def test_parallel_build_none_workers_builds_single_item_inline(tmp_path: Path):
         )
     mock_pool.assert_not_called()
     assert cache.get("n_7") == b"49"
+
+
+# ---------------------------------------------------------------------------
+# Advisory build lock
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_lock_uncontended_creates_sentinel_and_returns_true(tmp_path: Path):
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="lock",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    lock_path = cache._lock_path()
+    assert not lock_path.exists(), "the build's own lock must be released once it completes"
+
+    assert cache._acquire_lock("abc", poll_interval=0.01, timeout=0.05) is True
+    assert lock_path.exists()
+    assert lock_path.read_text() == str(os.getpid())
+
+
+def test_release_lock_removes_sentinel_and_is_idempotent(tmp_path: Path):
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="lock",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    cache._acquire_lock("abc", poll_interval=0.01, timeout=0.05)
+    assert cache._lock_path().exists()
+
+    cache._release_lock()
+    assert not cache._lock_path().exists()
+    cache._release_lock()  # must not raise when there is nothing to remove
+
+
+_RACE_WORKER_SCRIPT = """
+import sys, time
+from sisr.cache import LMDBCache
+
+def build(ctx):
+    with open(sys.argv[2], "a") as f:
+        f.write("build\\n")
+    time.sleep(0.3)
+    ctx.write_batch([("key_0", b"v0")])
+
+cache = LMDBCache(
+    cache_dir=sys.argv[1], name="race", checksum="racecs", length=1,
+    map_size=16 * 1024 * 1024, build_fn=build,
+    lock_poll_interval=0.02, lock_timeout=5.0,
+)
+with open(sys.argv[3], "w") as f:
+    f.write((cache.get("key_0") or b"").decode())
+"""
+
+
+def test_lmdb_cache_builds_exactly_once_across_two_racing_processes(tmp_path: Path):
+    """Two OS processes racing to build the identical (cache_dir, name,
+    checksum) -- two concurrent training runs pointed at one cache_dir, the
+    scenario this lock exists for -- must call build_fn exactly once; the
+    loser waits on the winner's lock and reuses its result.
+
+    Runs genuinely separate interpreters (not threads): LMDB itself refuses a
+    second Environment on the same path within one process, so an in-process
+    thread-based "race" would trip that same-process restriction rather than
+    exercising the actual cross-process lock this guards. Each process gets
+    its own result file -- two processes appending to one shared file isn't
+    reliably atomic on Windows and would make the harness itself flaky.
+    """
+    build_log = tmp_path / "build_log.txt"  # only the winner ever writes here
+    result_1, result_2 = tmp_path / "result_1.txt", tmp_path / "result_2.txt"
+    script = tmp_path / "race_worker.py"
+    script.write_text(_RACE_WORKER_SCRIPT)
+
+    p1 = subprocess.Popen(
+        [sys.executable, str(script), str(tmp_path), str(build_log), str(result_1)]
+    )
+    time.sleep(0.05)  # give p1 a head start so it wins the lock, not a coin flip
+    p2 = subprocess.Popen(
+        [sys.executable, str(script), str(tmp_path), str(build_log), str(result_2)]
+    )
+    assert p1.wait(timeout=15) == 0
+    assert p2.wait(timeout=15) == 0
+
+    assert build_log.read_text().splitlines() == ["build"], (
+        "build_fn must run exactly once across two racing processes"
+    )
+    assert result_1.read_text() == "v0"
+    assert result_2.read_text() == "v0"
+
+
+def test_acquire_lock_times_out_and_builds_anyway_on_stale_lock(tmp_path: Path):
+    """A lock sentinel with no corresponding valid cache (a crashed builder
+    that never released it) must not block forever: after lock_timeout
+    elapses, the caller proceeds to build rather than waiting indefinitely."""
+    name, checksum = "stale", "sc1"
+    lock_path = tmp_path / f"{name}_{checksum[:16]}.build.lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.write(fd, b"999999")  # simulates a crashed builder's leftover pid
+    os.close(fd)
+
+    call_count = []
+
+    def build(ctx: LMDBCacheBuildContext) -> None:
+        call_count.append(1)
+        ctx.write_batch([("key_0", b"v0")])
+
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name=name,
+        checksum=checksum,
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=build,
+        lock_poll_interval=0.02,
+        lock_timeout=0.1,
+    )
+    assert call_count == [1], "must build despite the stale lock once the timeout elapses"
+    assert cache.get("key_0") == b"v0"
+    assert not lock_path.exists(), "taking over from a stale lock should also clean it up"
+
+
+def test_acquire_lock_polling_returns_false_once_try_load_succeeds(tmp_path: Path):
+    """While waiting on a held lock, _try_load succeeding (a concurrent
+    builder finished) must end the poll and report "no build needed" --
+    without waiting anywhere near the full timeout.
+
+    _try_load itself is exercised elsewhere; this isolates _acquire_lock's
+    poll/timeout contract by faking it to report "valid" on its 3rd call,
+    rather than racing a second real LMDB build (which LMDB's own
+    same-process single-Environment-per-path rule makes unrepresentable with
+    threads -- see the cross-process test above for the real end-to-end path).
+    """
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="poll",
+        checksum="pc1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    lock_path = cache._lock_path()
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.close(fd)
+
+    calls = []
+
+    def fake_try_load(checksum):
+        calls.append(checksum)
+        return len(calls) >= 3
+
+    with patch.object(cache, "_try_load", side_effect=fake_try_load):
+        acquired = cache._acquire_lock("pc1", poll_interval=0.01, timeout=5.0)
+
+    assert acquired is False
+    assert calls == ["pc1", "pc1", "pc1"]


### PR DESCRIPTION
## Summary

- Unifies SRCNN's and SRResNet's train-dataset HR caches into one architecture-neutral module (`sisr/datasets/hr_cache.py`): same cache name (`hr_raw`), same format tag (`hr_rgb_v1`), same headered value shape, one shared `process_hr_image`. The same image directory now produces exactly one on-disk cache regardless of which architecture builds it first, instead of two ~6.3 GB copies of identical pixels.
- Fixes an import-weight bug this uncovered: the function pickled to a spawned `ProcessPoolExecutor` build worker was `_process_hr_image` living in `srcnn.py`/`srresnet.py` (both of which import torch directly) — a spawned worker unpickles a function by re-importing its *defining* module, so every build worker was paying torch's full cold-import cost. Confirmed with a real spawned-worker probe before (`torch` present) and after (`torch` absent); guarded by a new test on the worker entry point's actual module.
- Adds an advisory file lock (`O_CREAT|O_EXCL` sentinel) so two processes racing to build the same `cache_dir` don't duplicate the decode pass. A crashed builder's stale lock cannot deadlock a later run — a loser gives up after `lock_timeout` and builds anyway.
- Fixes a latent bug in `LMDBCache._try_load` surfaced by testing the lock against real concurrent processes: a `lock=False` reader can raise mid-read (not just fail to open) while a genuine writer in another process is still active, and the old code treated that identically to corruption, deleting the directory out from under the other process's in-progress build.

## Diagnosis: torch in the build worker (Task B)

Reproduced with a real `ProcessPoolExecutor` (not a guess): submitted the actual `_process_hr_image` reference from `sisr.datasets.srcnn`, then a second job in the same worker checking `sys.modules`.

- Before: `torch in worker sys.modules after _process_hr_image ran: True`
- After (via the new `sisr.datasets.hr_cache` module, both directly and through each dataset's re-exported alias): `False` in all three cases

## Cache sharing / pixel equivalence

New tests in `tests/datasets/test_hr_cache.py`:
- Build via SRResNet, then construct SRCNN over the same files — cache path and checksum match, `_process_hr_image` not called (no rebuild). Same in the other build order.
- Sub-images/crops read back through the shared cache by either architecture are byte-identical to the raw source pixels (SRCNN's fixed corner patch and SRResNet's random crop, found verbatim in the source).

## Concurrency

- Kept the lock in `sisr/cache.py` (stdlib only, torch-free), scoped per `(cache_dir, name, checksum)`.
- Two real OS processes racing to build the identical cache: `build_fn` runs exactly once; both processes end up with the correct value (`tests/test_cache.py::test_lmdb_cache_builds_exactly_once_across_two_racing_processes`). A stale lock with no valid cache behind it times out and builds anyway rather than blocking forever.
- Checked whether pytest-xdist workers already hit this race: no — each xdist worker gets its own `popen-gwN` temp root (verified empirically), so `tmp_path`/`tmp_path_factory` fixtures never collide across workers even with identical basenames, regardless of `--dist=loadscope`.

## Test plan

- [x] `PYTHONPATH="$PWD" python -m pytest -q` — base branch (`chore/drop-cv2-backend`) is 347 passed + 1 skipped; this branch is **360 passed + 1 skipped** (13 new tests, no regressions), also verified under `-n 2 --dist=loadscope` (CI's exact invocation).
- [x] `ruff check .` and `ruff format --check .` clean.
- [x] Cache-unification and pixel-equivalence tests pass, including cross-architecture reuse in both build orders.
- [x] Lock tests pass repeatedly (8 consecutive runs) including the real dual-process race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)