### PR TITLE
Add distributable weights checkpoint + provenance metadata

### DIFF
--- a/sisr/export.py
+++ b/sisr/export.py
@@ -8,6 +8,12 @@ oversight: a consumer of the exported graph is expected to have ``sisr``
 importable and call ``processor.extract`` / ``processor.reconstruct``
 themselves.
 
+The exported graph also carries the same provenance metadata as the checkpoint
+sinks (:func:`sisr.training.metadata.build_metadata`), written one field per
+``onnx.ModelProto.metadata_props`` entry rather than a single opaque JSON blob —
+Netron renders per-field props as a readable table, which is most of the value.
+``metadata_props`` is string->string only, so non-string fields are JSON-encoded.
+
 For :class:`~sisr.processors.RGBProcessor` architectures (SRResNet), those
 methods are identity functions, so the bare graph is already an end-to-end
 LR-RGB -> SR-RGB pipeline. Under
@@ -27,6 +33,7 @@ actually invoked.
 
 from __future__ import annotations
 
+import json
 import warnings
 from os import PathLike
 from typing import TYPE_CHECKING
@@ -89,9 +96,21 @@ def to_onnx(
     """
     _require_onnx()
 
+    global_step: int | None = None
+    epoch: int | None = None
+    monitor: str | None = None
+    monitor_value: float | None = None
     if ckpt_path is not None:
         checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=True)
         module.load_state_dict(checkpoint["state_dict"])
+        # Carry the source checkpoint's own provenance forward when present (only
+        # populated on checkpoints saved after SRLightning.on_save_checkpoint shipped;
+        # absent on older ones, in which case these stay None).
+        global_step = checkpoint.get("global_step")
+        epoch = checkpoint.get("epoch")
+        ckpt_training = checkpoint.get("sisr_meta", {}).get("training", {})
+        monitor = ckpt_training.get("monitor")
+        monitor_value = ckpt_training.get("monitor_value")
 
     if input_sample is None:
         shape = module.training_config.example_input_shape
@@ -138,3 +157,57 @@ def to_onnx(
             )
     finally:
         model.train(was_training)
+
+    _write_metadata_props(
+        module,
+        file_path,
+        global_step=global_step,
+        epoch=epoch,
+        monitor=monitor,
+        monitor_value=monitor_value,
+    )
+
+
+def _write_metadata_props(
+    module: SRLightning,
+    file_path: str | PathLike,
+    *,
+    global_step: int | None,
+    epoch: int | None,
+    monitor: str | None,
+    monitor_value: float | None,
+) -> None:
+    """Stamp the shared provenance metadata onto the just-exported ONNX file.
+
+    Loads the model ``torch.onnx.export`` just wrote, adds one
+    ``metadata_props`` entry per top-level :func:`~sisr.training.metadata.build_metadata`
+    field, and re-saves in place. ``metadata_props`` is ``string -> string`` only, so
+    ``str`` fields (``format``, ``created``) are stored as-is and every other
+    (dict-valued) field is JSON-encoded — per-field rather than one opaque blob, so a
+    tool like Netron renders them as a readable table.
+
+    Args:
+        module: The :class:`~sisr.training.SRLightning` instance that was exported.
+        file_path: Path to the ``.onnx`` file just written by ``torch.onnx.export``.
+        global_step: Forwarded to :func:`~sisr.training.metadata.build_metadata`.
+        epoch: Forwarded to :func:`~sisr.training.metadata.build_metadata`.
+        monitor: Forwarded to :func:`~sisr.training.metadata.build_metadata`.
+        monitor_value: Forwarded to :func:`~sisr.training.metadata.build_metadata`.
+    """
+    import onnx
+
+    from .training.metadata import build_metadata
+
+    meta = build_metadata(
+        module,
+        global_step=global_step,
+        epoch=epoch,
+        monitor=monitor,
+        monitor_value=monitor_value,
+    )
+    onnx_model = onnx.load(str(file_path))
+    for key, value in meta.items():
+        entry = onnx_model.metadata_props.add()
+        entry.key = key
+        entry.value = value if isinstance(value, str) else json.dumps(value)
+    onnx.save(onnx_model, str(file_path))

--- a/sisr/training/__init__.py
+++ b/sisr/training/__init__.py
@@ -9,6 +9,7 @@ from .callbacks import (
     GradNormLogger,
     SRCheckpoint,
     SRPredictionWriter,
+    SRWeightsCheckpoint,
     WeightHistogramLogger,
 )
 from .config import SREvalConfig, SRTrainingConfig
@@ -23,6 +24,7 @@ __all__ = [
     "BenchmarkImageLogger",
     "GradNormLogger",
     "SRCheckpoint",
+    "SRWeightsCheckpoint",
     "SRPredictionWriter",
     "WeightHistogramLogger",
 ]

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -6,12 +6,15 @@ N val cycles) and ``cli test`` (one-shot final eval).
 :class:`GradNormLogger` and :class:`WeightHistogramLogger` log diagnostic
 training signals; :class:`SRCheckpoint` is a thin
 :class:`~lightning.pytorch.callbacks.ModelCheckpoint` preset for SR metrics;
-:class:`SRPredictionWriter` writes ``cli predict`` output to disk as PNGs.
+:class:`SRWeightsCheckpoint` is a sibling preset that saves bare, optimizer-free
+``.pt`` weights instead; :class:`SRPredictionWriter` writes ``cli predict``
+output to disk as PNGs.
 """
 
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
+from weakref import proxy
 
 import lightning
 import torch
@@ -20,6 +23,8 @@ import torchmetrics.functional
 import torchvision
 from lightning.pytorch.callbacks import BasePredictionWriter, Callback, ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
+
+from .metadata import build_metadata
 
 
 class BenchmarkImageLogger(Callback):
@@ -525,6 +530,35 @@ class WeightHistogramLogger(Callback):
                 experiment.add_histogram(tb_name, param, global_step=trainer.global_step)
 
 
+def _validate_monitor_metric(
+    label: str, monitor: str | None, pl_module: lightning.LightningModule
+) -> None:
+    """Raise if ``monitor`` doesn't name a ``psnr/val/*`` or ``ssim/val/*`` metric.
+
+    Shared by :class:`SRCheckpoint` and :class:`SRWeightsCheckpoint`'s ``setup`` —
+    they are siblings under :class:`~lightning.pytorch.callbacks.ModelCheckpoint`,
+    not parent/child, so this check cannot be reused via ``super()`` across them.
+
+    Args:
+        label: Name of the calling class, for the error message only.
+        monitor: The ``monitor`` value to validate (``self.monitor``).
+        pl_module: The model being trained; must expose ``eval_config``.
+
+    Raises:
+        MisconfigurationException: If ``monitor`` does not name a metric
+            ``SRLightning`` will log during ``fit``.
+    """
+    valid_metrics = {f"psnr/val/{key}" for key in pl_module.eval_config.psnr_keys}
+    valid_metrics |= {f"ssim/val/{key}" for key in pl_module.eval_config.ssim_keys}
+    if monitor is not None and monitor not in valid_metrics:
+        raise MisconfigurationException(
+            f"`{label}(monitor_metric={monitor!r})` does not match any "
+            f"metric `SRLightning` will log: {sorted(valid_metrics)}. HINT: check "
+            f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or "
+            f"`eval_config.ssim_channels`."
+        )
+
+
 class SRCheckpoint(ModelCheckpoint):
     """Model checkpoint that monitors a super-resolution quality metric.
 
@@ -610,15 +644,131 @@ class SRCheckpoint(ModelCheckpoint):
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
             return
-        valid_metrics = {f"psnr/val/{key}" for key in pl_module.eval_config.psnr_keys}
-        valid_metrics |= {f"ssim/val/{key}" for key in pl_module.eval_config.ssim_keys}
-        if self.monitor is not None and self.monitor not in valid_metrics:
-            raise MisconfigurationException(
-                f"`SRCheckpoint(monitor_metric={self.monitor!r})` does not match any "
-                f"metric `SRLightning` will log: {sorted(valid_metrics)}. HINT: check "
-                f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or "
-                f"`eval_config.ssim_channels`."
-            )
+        _validate_monitor_metric("SRCheckpoint", self.monitor, pl_module)
+
+
+class SRWeightsCheckpoint(ModelCheckpoint):
+    """Model checkpoint that saves bare, optimizer-free SR model weights as ``.pt`` files.
+
+    A distributable sibling to :class:`SRCheckpoint`: that class produces resumable
+    ``.ckpt`` files (full training state — optimizer moments, LR scheduler, callback
+    state); this one produces ``.pt`` files containing only
+    ``pl_module.model.state_dict()`` (the bare :class:`~sisr.models.base.SRModel`, so
+    keys carry no ``model.`` wrapper prefix) plus the :func:`~sisr.training.metadata.build_metadata`
+    provenance dict. Both run side by side off the same validation metrics — top-k
+    selection, monitor validation (inherited from ``SRCheckpoint``'s ``setup``), and
+    filename formatting are inherited from :class:`~lightning.pytorch.callbacks.ModelCheckpoint`
+    unchanged; only :meth:`_save_checkpoint` — the single method that actually writes bytes
+    to disk — is overridden to swap the payload.
+
+    ``_save_checkpoint`` is a private Lightning method, unlike the rest of this class's
+    public-API surface. ``tests/training/test_callbacks.py``'s
+    ``test_sr_weights_checkpoint_writes_bare_payload_via_real_fit`` guards against a
+    future Lightning release routing saves through a different method: that test fails
+    loudly rather than silently letting saves fall back to full, optimizer-bearing
+    checkpoints under a misleadingly bare ``.pt`` extension.
+
+    ``FILE_EXTENSION`` (public) and a distinct default ``filename_prefix`` keep this
+    callback's top-k deletion pass from ever touching :class:`SRCheckpoint`'s files when
+    both share one ``dirpath`` — each callback only ever names/deletes files matching its
+    own ``filename``/``FILE_EXTENSION`` combination.
+
+    Args:
+        monitor_metric: The validation metric to monitor — same contract as
+            :class:`SRCheckpoint`.
+        save_top_k: Number of best weight files to keep.
+        dirpath: Directory to save weight files.
+        filename_prefix: Prefix for weight filenames. Defaults to ``'sr-weights'``,
+            distinct from ``SRCheckpoint``'s ``'sr'`` default.
+        mode: ``'max'`` or ``'min'`` — same contract as :class:`SRCheckpoint`.
+        **kwargs: Extra keyword arguments forwarded to
+            :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
+    """
+
+    FILE_EXTENSION = ".pt"
+
+    def __init__(
+        self,
+        monitor_metric: str = "psnr/val/RGB",
+        save_top_k: int = 3,
+        dirpath: str | None = None,
+        filename_prefix: str = "sr-weights",
+        mode: str = "max",
+        **kwargs: Any,
+    ):
+        label = monitor_metric.replace("/", "_")
+        filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
+        super().__init__(
+            monitor=monitor_metric,
+            mode=mode,
+            save_top_k=save_top_k,
+            dirpath=dirpath,
+            filename=filename,
+            auto_insert_metric_name=False,
+            **kwargs,
+        )
+
+    def setup(
+        self,
+        trainer: lightning.Trainer,
+        pl_module: lightning.LightningModule,
+        stage: str,
+    ) -> None:
+        """Validate ``monitor`` against the metrics ``SRLightning`` will log.
+
+        Same check as :meth:`SRCheckpoint.setup` (via the shared
+        ``_validate_monitor_metric`` helper — the two classes are siblings, not
+        parent/child, so the check can't be reused via ``super()`` across them).
+
+        Args:
+            trainer: The active trainer.
+            pl_module: The model being trained; must expose ``eval_config``.
+            stage: Lightning trainer stage. Only ``"fit"`` is checked — see
+                ``SRCheckpoint.setup``.
+
+        Raises:
+            MisconfigurationException: If ``monitor`` does not name a metric
+                ``SRLightning`` will log during ``fit``.
+        """
+        super().setup(trainer, pl_module, stage)
+        if stage != "fit":
+            return
+        _validate_monitor_metric("SRWeightsCheckpoint", self.monitor, pl_module)
+
+    def _save_checkpoint(self, trainer: lightning.Trainer, filepath: str) -> None:
+        """Write bare model weights + provenance metadata instead of a full checkpoint.
+
+        Overrides :meth:`ModelCheckpoint._save_checkpoint` — the private hook every
+        public save path (``_save_topk_checkpoint``, ``_save_none_monitor_checkpoint``,
+        ``_save_last_checkpoint``) funnels through — so ``save_top_k``/filename/removal
+        bookkeeping all keep working unmodified; only the on-disk payload changes.
+        Mirrors the base implementation's post-save bookkeeping (``_last_global_step_saved``,
+        ``_last_checkpoint_saved``, logger notification) so this callback stays a drop-in
+        peer of :class:`SRCheckpoint` from the trainer's point of view.
+
+        Args:
+            trainer: The active trainer — supplies ``lightning_module`` (for the bare
+                ``model.state_dict()`` and metadata) and ``global_step``/``current_epoch``.
+            filepath: Destination path, already formatted by ``ModelCheckpoint``
+                (``.pt`` via ``FILE_EXTENSION``).
+        """
+        pl_module = trainer.lightning_module
+        monitor_value = float(self.current_score) if self.current_score is not None else None
+        meta = build_metadata(
+            pl_module,
+            global_step=trainer.global_step,
+            epoch=trainer.current_epoch,
+            monitor=self.monitor,
+            monitor_value=monitor_value,
+        )
+        torch.save({"state_dict": pl_module.model.state_dict(), "meta": meta}, filepath)
+
+        self._last_global_step_saved = trainer.global_step
+        self._last_checkpoint_saved = filepath
+
+        if trainer.is_global_zero:
+            for logger in trainer.loggers:
+                logger.after_save_checkpoint(proxy(self))
 
 
 class SRPredictionWriter(BasePredictionWriter):

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -22,6 +22,7 @@ from ..colorspace import rgb_to_ycbcr_studio
 from ..models.base import SRModel
 from ..processors import SRProcessor
 from .config import SREvalConfig, SRTrainingConfig
+from .metadata import build_metadata
 
 
 class SRLightning(lightning.LightningModule):
@@ -471,6 +472,31 @@ class SRLightning(lightning.LightningModule):
         }
         for tb in tb_loggers:
             tb.log_hyperparams(self._tb_hparams, metrics)
+
+    def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        """Inject a ``sisr_meta`` provenance key into every saved ``.ckpt``.
+
+        Public, supported Lightning hook (unlike the private ``_save_checkpoint`` the
+        bare-weights ``SRWeightsCheckpoint`` callback must override instead). Adding a new
+        top-level key is safe for ``--ckpt_path`` resumption: ``LightningCLI._parse_ckpt_path``
+        reads only the ``hyper_parameters`` key to seed the model config, so ``sisr_meta``
+        is inert there. ``global_step``/``epoch`` are read back from ``checkpoint`` itself
+        (populated by Lightning before this hook runs) rather than ``self.trainer``, so the
+        metadata always describes the exact step being persisted. No ``monitor``/
+        ``monitor_value`` here — a full checkpoint isn't tied to any one monitored metric
+        (zero, one, or several ``SRCheckpoint`` callbacks may be watching independently);
+        that pairing only exists for :class:`~sisr.training.callbacks.SRWeightsCheckpoint`,
+        whose ``monitor`` is a well-defined single value.
+
+        Args:
+            checkpoint: The checkpoint dict Lightning is about to write to disk; mutated
+                in place to add ``checkpoint["sisr_meta"]``.
+        """
+        checkpoint["sisr_meta"] = build_metadata(
+            self,
+            global_step=checkpoint.get("global_step"),
+            epoch=checkpoint.get("epoch"),
+        )
 
     def test_step(
         self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int, dataloader_idx: int = 0

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -1,0 +1,110 @@
+"""Shared provenance-metadata builder for checkpoints and ONNX exports.
+
+One function, three sinks: :meth:`~sisr.training.lightning_module.SRLightning.on_save_checkpoint`
+(the full resumable ``.ckpt``), :class:`~sisr.training.callbacks.SRWeightsCheckpoint` (the bare
+distributable ``.pt``), and :func:`sisr.export.to_onnx` (the ``.onnx``'s ``metadata_props``) all
+call :func:`build_metadata` so the three payloads cannot drift apart — mirrors how
+``SREvalConfig.psnr_keys`` is the single derivation point for its three consumers.
+
+Deliberately omits dataset paths: Ultralytics' ``train_args`` leaks local filesystem layout into
+distributed files; this stays leak-free by construction. If dataset provenance is ever added,
+it must be names only, never paths.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import lightning
+import torch
+
+import sisr
+
+if TYPE_CHECKING:
+    from .lightning_module import SRLightning
+
+#: Bumped whenever the metadata shape changes incompatibly.
+FORMAT_VERSION = "sisr-meta-v1"
+
+
+def _to_plain(obj: Any) -> Any:
+    """Recursively convert tuples to lists for JSON- and weights_only-safety."""
+    if isinstance(obj, dict):
+        return {k: _to_plain(v) for k, v in obj.items()}
+    if isinstance(obj, list | tuple):
+        return [_to_plain(v) for v in obj]
+    return obj
+
+
+def _class_path(obj: Any) -> str:
+    """Dotted ``module.ClassName`` path for an instance's class — the YAML's own shape."""
+    cls = type(obj)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def build_metadata(
+    module: SRLightning,
+    *,
+    global_step: int | None = None,
+    epoch: int | None = None,
+    monitor: str | None = None,
+    monitor_value: float | None = None,
+) -> dict[str, Any]:
+    """Build the provenance-metadata dict shared by every distributable sisr artifact.
+
+    Args:
+        module: The :class:`~sisr.training.lightning_module.SRLightning` instance to
+            describe — supplies ``model``, ``processor``, ``training_config``, and
+            ``eval_config``.
+        global_step: Optimizer step at save time, when known (``None`` otherwise).
+        epoch: Training epoch at save time, when known (``None`` otherwise).
+        monitor: Name of the metric that triggered this specific save (e.g.
+            ``"psnr/val/RGB"``), when the sink is monitor-driven (``None`` otherwise).
+        monitor_value: Value of ``monitor`` at save time (``None`` otherwise).
+
+    Returns:
+        A dict tree containing only ``dict``/``list``/``str``/``int``/``float``/``bool``/
+        ``None`` values — safe for ``torch.save``/``torch.load(weights_only=True)`` and,
+        per top-level field, for JSON-encoding into ONNX ``metadata_props``.
+    """
+    model = module.model
+    processor = module.processor
+
+    scale = module.training_config.scale
+    if scale is None:
+        scale = model.hparams.get("scale")
+
+    return {
+        "format": FORMAT_VERSION,
+        "created": datetime.now(UTC).isoformat(),
+        "versions": {
+            # str(...) matters here: torch.__version__ is a TorchVersion (str
+            # subclass), which torch.load(weights_only=True) refuses to unpickle
+            # as an unlisted global. Coerce to plain str for every field.
+            "sisr": str(sisr.__version__),
+            "torch": str(torch.__version__),
+            "lightning": str(lightning.__version__),
+        },
+        "model": {
+            "class_path": _class_path(model),
+            "init_args": _to_plain(model.hparams),
+        },
+        "processor": {
+            "class_path": _class_path(processor),
+        },
+        "io": {
+            "scale": scale,
+            "input": model.input_contract,
+            "input_channels": processor.model_channels,
+            "output_range": list(processor.output_range),
+        },
+        "eval_config": _to_plain(dataclasses.asdict(module.eval_config)),
+        "training": {
+            "global_step": global_step,
+            "epoch": epoch,
+            "monitor": monitor,
+            "monitor_value": monitor_value,
+        },
+    }

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -110,6 +110,17 @@ trainer:
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
+    # Distributable, optimizer-free weights (.pt) alongside the resumable .ckpt files
+    # above — same monitors/top-k, so every checkpointed best also ships a bare-weights
+    # counterpart safe to hand out without leaking optimizer state.
+    - class_path: sisr.training.SRWeightsCheckpoint
+      init_args:
+        monitor_metric: psnr/val/RGB
+        save_top_k: 3
+    - class_path: sisr.training.SRWeightsCheckpoint
+      init_args:
+        monitor_metric: ssim/val/RGB
+        save_top_k: 3
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -108,6 +108,17 @@ trainer:
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
+    # Distributable, optimizer-free weights (.pt) alongside the resumable .ckpt files
+    # above — same monitors/top-k, so every checkpointed best also ships a bare-weights
+    # counterpart safe to hand out without leaking optimizer state.
+    - class_path: sisr.training.SRWeightsCheckpoint
+      init_args:
+        monitor_metric: psnr/val/RGB
+        save_top_k: 3
+    - class_path: sisr.training.SRWeightsCheckpoint
+      init_args:
+        monitor_metric: ssim/val/RGB
+        save_top_k: 3
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -6,6 +6,7 @@ suite stays green for contributors who don't install `.[export]`. The CI
 tests actually run somewhere.
 """
 
+import json
 import sys
 
 import numpy as np
@@ -150,3 +151,102 @@ def test_to_onnx_missing_onnx_raises_import_error_with_extra_hint(monkeypatch):
 
     with pytest.raises(ImportError, match=r"\[export\]"):
         to_onnx(module, "unused.onnx")
+
+
+# ---------------------------------------------------------------------------
+# metadata_props (provenance)
+# ---------------------------------------------------------------------------
+
+
+def test_to_onnx_writes_metadata_props(tmp_path):
+    """Every top-level build_metadata field lands as its own metadata_props
+    entry — per-field, not one opaque blob, so Netron renders a table.
+    str fields are stored as-is; every other field is JSON-encoded."""
+    module = _make_srcnn_module(example_input_shape=(1, 16, 16))
+    onnx_path = tmp_path / "model.onnx"
+
+    to_onnx(module, onnx_path)
+
+    onnx_model = onnx.load(str(onnx_path))
+    props = {p.key: p.value for p in onnx_model.metadata_props}
+    assert set(props.keys()) == {
+        "format",
+        "created",
+        "versions",
+        "model",
+        "processor",
+        "io",
+        "eval_config",
+        "training",
+    }
+    assert props["format"] == "sisr-meta-v1"  # stored as-is: already a str
+
+    model_field = json.loads(props["model"])
+    assert model_field["class_path"] == "sisr.models.srcnn.model.SRCNN"
+    assert model_field["init_args"] == {
+        "num_channels": 1,
+        "num_filters": [8, 4],
+        "kernel_sizes": [5, 1, 3],
+        "padding": 0,
+    }
+
+    io_field = json.loads(props["io"])
+    assert io_field["input"] == "pre_upsampled"
+    assert io_field["input_channels"] == 1
+    assert io_field["output_range"] == [0.0, 1.0]
+
+    training_field = json.loads(props["training"])
+    assert training_field == {
+        "global_step": None,
+        "epoch": None,
+        "monitor": None,
+        "monitor_value": None,
+    }
+
+
+def test_to_onnx_metadata_props_carry_ckpt_provenance_forward(tmp_path):
+    """When ckpt_path is given, the source checkpoint's own global_step/epoch/
+    sisr_meta.training (monitor, monitor_value) are carried into the exported
+    graph's metadata_props rather than left blank."""
+    module = _make_srcnn_module(example_input_shape=(1, 16, 16))
+    ckpt_path = tmp_path / "trained.ckpt"
+    torch.save(
+        {
+            "state_dict": module.state_dict(),
+            "global_step": 999,
+            "epoch": 3,
+            "sisr_meta": {"training": {"monitor": "psnr/val/RGB", "monitor_value": 31.2}},
+        },
+        ckpt_path,
+    )
+    onnx_path = tmp_path / "model.onnx"
+
+    to_onnx(module, onnx_path, ckpt_path=ckpt_path)
+
+    onnx_model = onnx.load(str(onnx_path))
+    props = {p.key: p.value for p in onnx_model.metadata_props}
+    training_field = json.loads(props["training"])
+    assert training_field == {
+        "global_step": 999,
+        "epoch": 3,
+        "monitor": "psnr/val/RGB",
+        "monitor_value": 31.2,
+    }
+
+
+def test_to_onnx_metadata_props_skip_cleanly_without_ckpt_sisr_meta(tmp_path):
+    """A ckpt_path saved before sisr_meta existed (no 'sisr_meta' key) must not
+    crash export — training fields simply stay None."""
+    module = _make_srcnn_module(example_input_shape=(1, 16, 16))
+    ckpt_path = tmp_path / "old_style.ckpt"
+    torch.save({"state_dict": module.state_dict()}, ckpt_path)
+    onnx_path = tmp_path / "model.onnx"
+
+    to_onnx(module, onnx_path, ckpt_path=ckpt_path)
+
+    onnx_model = onnx.load(str(onnx_path))
+    props = {p.key: p.value for p in onnx_model.metadata_props}
+    training_field = json.loads(props["training"])
+    assert training_field["monitor"] is None
+    assert training_field["monitor_value"] is None
+    assert training_field["global_step"] is None

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -20,5 +20,6 @@ def test_public_exports():
         SREvalConfig,
         SRLightning,
         SRTrainingConfig,
+        SRWeightsCheckpoint,
         WeightHistogramLogger,
     )

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import lightning
 import pytest
 import torch
+from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 from sisr.models.srcnn import SRCNN
@@ -18,6 +19,7 @@ from sisr.training import (
     SRLightning,
     SRPredictionWriter,
     SRTrainingConfig,
+    SRWeightsCheckpoint,
     WeightHistogramLogger,
 )
 
@@ -359,6 +361,158 @@ def test_srcheckpoint_setup_error_lists_valid_metrics(tmp_path: Path):
     assert "psnr/val/RGB" in str(exc_info.value)
     assert "ssim/val/RGB" in str(exc_info.value)
     assert "ssim/val/Y" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# SRWeightsCheckpoint
+# ---------------------------------------------------------------------------
+
+
+def test_sr_weights_checkpoint_file_extension_is_pt():
+    ckpt = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", dirpath="/tmp/x")
+    assert ckpt.FILE_EXTENSION == ".pt"
+
+
+def test_sr_weights_checkpoint_default_filename_prefix_is_sr_weights():
+    """Distinct from SRCheckpoint's 'sr' default so a shared dirpath's top-k
+    deletion passes can never mistake one callback's files for the other's."""
+    ckpt = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", dirpath="/tmp/x")
+    assert ckpt.filename.startswith("sr-weights-")
+
+
+def test_sr_weights_checkpoint_custom_filename_prefix():
+    ckpt = SRWeightsCheckpoint(
+        monitor_metric="psnr/val/RGB", dirpath="/tmp/x", filename_prefix="myrun"
+    )
+    assert ckpt.filename.startswith("myrun-")
+
+
+def test_sr_weights_checkpoint_default_max_mode():
+    ckpt = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", dirpath="/tmp/x")
+    assert ckpt.mode == "max"
+
+
+@_ignore_gpu_warning
+def test_sr_weights_checkpoint_setup_rejects_unknown_monitor(tmp_path: Path):
+    """setup() validation is inherited (delegated to SRCheckpoint.setup), so a
+    monitor eval_config never logs must raise at startup here too."""
+    pl_module = _make_real_pl_module()
+    ckpt = SRWeightsCheckpoint(monitor_metric="psnr/val/Y", dirpath=str(tmp_path))
+    with pytest.raises(MisconfigurationException, match=r"psnr/val/Y"):
+        ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")
+
+
+def test_sr_weights_checkpoint_save_checkpoint_is_actually_overridden():
+    """Cheap static guard: the override must exist as a distinct method, not
+    silently inherit ModelCheckpoint's (which would write full, optimizer-bearing
+    checkpoints under the .pt extension). The real, functional guard against a
+    Lightning release routing saves through a different private method entirely
+    is test_sr_weights_checkpoint_writes_bare_payload_via_real_fit below, which
+    exercises the actual save path end-to-end."""
+    assert SRWeightsCheckpoint._save_checkpoint is not ModelCheckpoint._save_checkpoint
+
+
+def _make_srcnn_datamodule(image_dir: Path):
+    """Tiny SRDataModule (3 fixture images) mirroring test_integration.py's helper —
+    real Trainer.fit needs a real datamodule to reach ModelCheckpoint's save path."""
+    from sisr.training import SRDataModule
+
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+            "use_tqdm": False,
+            "cache_dir": str(image_dir / ".lmdb_cache_weights_ckpt_test"),
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(image_dir), "scale": 2},
+    }
+    return SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        train_dataloader_kwargs={"batch_size": 2, "num_workers": 0},
+        val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+    )
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """End-to-end proof that Lightning's real save path invokes our
+    ``_save_checkpoint`` override, that ``SRCheckpoint``/``SRWeightsCheckpoint``
+    coexist in one ``dirpath`` without deleting each other's files, and that the
+    bare ``.pt`` payload is exactly what the spec requires: no optimizer state,
+    no ``model.``-prefixed keys, and the state_dict loads strict into a fresh
+    bare model.
+
+    This is the loud-failure guard for the private ``_save_checkpoint`` hook: if
+    a future Lightning release stops routing saves through it, the ``.pt`` file
+    would instead contain a full Lightning checkpoint dict (``optimizer_states``,
+    ``callbacks``, ``model.``-prefixed ``state_dict``, ...) and every assertion
+    below would fail.
+    """
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4, momentum=0.9),
+    )
+    datamodule = _make_srcnn_datamodule(tiny_rgb_image_dir)
+    # A dedicated subdir, not tmp_path itself: tiny_rgb_image_dir *is* tmp_path (the
+    # fixture writes fixture PNGs directly into it), and ModelCheckpoint.setup warns
+    # (-> error, under this suite's strict filter) if dirpath is non-empty at startup.
+    ckpt_dir = tmp_path / "checkpoints"
+
+    sr_ckpt = SRCheckpoint(monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(ckpt_dir))
+    sr_weights_ckpt = SRWeightsCheckpoint(
+        monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(ckpt_dir)
+    )
+    trainer = lightning.Trainer(
+        max_epochs=-1,
+        max_steps=3,
+        val_check_interval=1,
+        check_val_every_n_epoch=None,
+        num_sanity_val_steps=0,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        callbacks=[sr_ckpt, sr_weights_ckpt],
+    )
+
+    trainer.fit(module, datamodule=datamodule)
+
+    ckpt_files = list(ckpt_dir.glob("sr-*.ckpt"))
+    pt_files = list(ckpt_dir.glob("sr-weights-*.pt"))
+    all_files = list(ckpt_dir.iterdir())
+    # save_top_k=1 on each: exactly one file per callback survives repeated
+    # val-triggered saves, and coexisting in one dirpath produced no cross-deletion.
+    assert len(ckpt_files) == 1
+    assert len(pt_files) == 1
+    assert len(all_files) == 2
+
+    full_checkpoint = torch.load(ckpt_files[0], weights_only=True)
+    assert "optimizer_states" in full_checkpoint
+    assert "sisr_meta" in full_checkpoint  # on_save_checkpoint fired here too
+    assert all(k.startswith("model.") for k in full_checkpoint["state_dict"])
+
+    bare = torch.load(pt_files[0], weights_only=True)
+    assert set(bare.keys()) == {"state_dict", "meta"}
+    assert "optimizer_states" not in bare
+    assert not any(k.startswith("model.") for k in bare["state_dict"])
+    assert bare["meta"]["format"] == "sisr-meta-v1"
+    assert bare["meta"]["training"]["monitor"] == "psnr/val/RGB"
+
+    fresh_model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    fresh_model.load_state_dict(bare["state_dict"], strict=True)  # the real proof
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1051,3 +1051,68 @@ def test_on_fit_start_noop_when_example_input_shape_unset():
     """No shape to probe with — must not raise, not fabricate an input."""
     lit = _make_compilable_lit(compile_backend="eager", example_input_shape=None)
     lit.on_fit_start()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# on_save_checkpoint — sisr_meta provenance (public Lightning hook)
+# ---------------------------------------------------------------------------
+
+
+def test_on_save_checkpoint_injects_sisr_meta(srcnn_rgb_lit: SRLightning):
+    checkpoint = {"global_step": 500, "epoch": 2, "state_dict": srcnn_rgb_lit.state_dict()}
+    srcnn_rgb_lit.on_save_checkpoint(checkpoint)
+    meta = checkpoint["sisr_meta"]
+    assert meta["format"] == "sisr-meta-v1"
+    assert meta["model"]["class_path"] == "sisr.models.srcnn.model.SRCNN"
+    assert meta["training"]["global_step"] == 500
+    assert meta["training"]["epoch"] == 2
+
+
+def test_on_save_checkpoint_leaves_monitor_unset():
+    """A full .ckpt isn't tied to any one monitored metric (zero, one, or
+    several SRCheckpoint callbacks may independently watch it), unlike
+    SRWeightsCheckpoint's per-save monitor/monitor_value."""
+    lit = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    checkpoint = {"global_step": 1, "epoch": 0}
+    lit.on_save_checkpoint(checkpoint)
+    assert checkpoint["sisr_meta"]["training"]["monitor"] is None
+    assert checkpoint["sisr_meta"]["training"]["monitor_value"] is None
+
+
+def test_on_save_checkpoint_does_not_touch_other_checkpoint_keys(srcnn_rgb_lit: SRLightning):
+    """Only adds sisr_meta — must not mutate hyper_parameters (the key
+    LightningCLI._parse_ckpt_path actually reads for --ckpt_path resumption)
+    or any other existing entry."""
+    checkpoint = {
+        "global_step": 1,
+        "epoch": 0,
+        "hyper_parameters": {"foo": "bar"},
+        "pytorch-lightning_version": "2.6.5",
+    }
+    srcnn_rgb_lit.on_save_checkpoint(checkpoint)
+    assert checkpoint["hyper_parameters"] == {"foo": "bar"}
+    assert checkpoint["pytorch-lightning_version"] == "2.6.5"
+    assert "sisr_meta" in checkpoint
+
+
+def test_on_save_checkpoint_round_trips_weights_only(tmp_path, srcnn_rgb_lit: SRLightning):
+    """The whole checkpoint, sisr_meta included, must survive
+    torch.load(..., weights_only=True) — the safe-loading contract every
+    consumer (including LightningCLI's own ckpt_path parsing) depends on."""
+    checkpoint = {
+        "global_step": 10,
+        "epoch": 0,
+        "state_dict": srcnn_rgb_lit.state_dict(),
+    }
+    srcnn_rgb_lit.on_save_checkpoint(checkpoint)
+
+    path = tmp_path / "test.ckpt"
+    torch.save(checkpoint, path)
+    loaded = torch.load(path, weights_only=True)
+
+    assert loaded["sisr_meta"] == checkpoint["sisr_meta"]
+    assert set(loaded["state_dict"].keys()) == set(srcnn_rgb_lit.state_dict().keys())

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -1,0 +1,193 @@
+import functools
+import json
+
+import torch
+
+from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig
+from sisr.models.srresnet import SRResNet, SRResNetEvalConfig, SRResNetTrainingConfig
+from sisr.processors import RGBSignedOutputProcessor, YChannelProcessor
+from sisr.training import SRLightning, SRTrainingConfig
+from sisr.training.metadata import build_metadata
+
+
+def _make_srcnn_lit() -> SRLightning:
+    model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(5, 1, 3), padding=0)
+    return SRLightning(
+        model=model,
+        processor=YChannelProcessor(),
+        training_config=SRCNNTrainingConfig(),
+        eval_config=SRCNNEvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def _make_srresnet_lit(*, scale: int = 4) -> SRLightning:
+    model = SRResNet(scale=scale, hidden_channel=8, num_residual_blocks=1)
+    return SRLightning(
+        model=model,
+        processor=RGBSignedOutputProcessor(),
+        training_config=SRResNetTrainingConfig(),
+        eval_config=SRResNetEvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def test_build_metadata_top_level_shape():
+    lit = _make_srcnn_lit()
+    meta = build_metadata(lit)
+    assert set(meta.keys()) == {
+        "format",
+        "created",
+        "versions",
+        "model",
+        "processor",
+        "io",
+        "eval_config",
+        "training",
+    }
+    assert meta["format"] == "sisr-meta-v1"
+
+
+def test_build_metadata_versions_are_plain_strings():
+    meta = build_metadata(_make_srcnn_lit())
+    for value in meta["versions"].values():
+        assert type(value) is str  # not e.g. torch's TorchVersion (a str subclass)
+
+
+def test_build_metadata_model_class_path_and_init_args():
+    meta = build_metadata(_make_srcnn_lit())
+    assert meta["model"]["class_path"] == "sisr.models.srcnn.model.SRCNN"
+    assert meta["model"]["init_args"] == {
+        "num_channels": 1,
+        "num_filters": [8, 4],
+        "kernel_sizes": [5, 1, 3],
+        "padding": 0,
+    }
+
+
+def test_build_metadata_model_init_args_has_no_tuples():
+    """SRCNN/SRResNet hparams store tuples (num_filters, kernel_sizes); the
+    metadata dict must convert them to lists — JSON-safe and unambiguous
+    under torch.load(weights_only=True) (which pickles tuple/list differently)."""
+    meta = build_metadata(_make_srresnet_lit())
+    init_args = meta["model"]["init_args"]
+    assert isinstance(init_args["kernel_sizes"], list)
+    assert not isinstance(init_args["kernel_sizes"], tuple)
+
+
+def test_build_metadata_processor_class_path():
+    meta = build_metadata(_make_srresnet_lit())
+    assert meta["processor"]["class_path"] == "sisr.processors.rgb.RGBSignedOutputProcessor"
+
+
+def test_build_metadata_io_reflects_model_input_contract_and_processor():
+    srcnn_meta = build_metadata(_make_srcnn_lit())
+    assert srcnn_meta["io"]["input"] == "pre_upsampled"
+    assert srcnn_meta["io"]["input_channels"] == 1  # YChannelProcessor.model_channels
+    assert srcnn_meta["io"]["output_range"] == [0.0, 1.0]
+
+    srresnet_meta = build_metadata(_make_srresnet_lit())
+    assert srresnet_meta["io"]["input"] == "native_lr"
+    assert srresnet_meta["io"]["input_channels"] == 3  # RGBSignedOutputProcessor.model_channels
+    assert srresnet_meta["io"]["output_range"] == [-1.0, 1.0]  # the asymmetric paper range
+
+
+def test_build_metadata_scale_prefers_training_config_scale():
+    """SRResNetTrainingConfig defaults scale=4, matching the model's own scale
+    hparam (SRLightning.__init__ validates the two agree)."""
+    lit = _make_srresnet_lit(scale=4)
+    assert lit.training_config.scale == 4
+    meta = build_metadata(lit)
+    assert meta["io"]["scale"] == 4
+
+
+def test_build_metadata_scale_falls_back_to_model_hparams():
+    """The generic SRTrainingConfig defaults scale=None -> falls back to the
+    model's own 'scale' hparam instead of leaving it unrecorded."""
+    model = SRResNet(scale=2, hidden_channel=8, num_residual_blocks=1)
+    lit = SRLightning(
+        model=model,
+        processor=RGBSignedOutputProcessor(),
+        training_config=SRTrainingConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    assert lit.training_config.scale is None
+    meta = build_metadata(lit)
+    assert meta["io"]["scale"] == 2
+
+
+def test_build_metadata_scale_is_none_when_neither_source_has_it():
+    """SRCNN has no 'scale' hparam and training_config.scale is unset -> None,
+    not a guessed value."""
+    meta = build_metadata(_make_srcnn_lit())
+    assert meta["io"]["scale"] is None
+
+
+def test_build_metadata_eval_config_matches_dataclass_asdict():
+    import dataclasses
+
+    lit = _make_srcnn_lit()
+    meta = build_metadata(lit)
+    assert meta["eval_config"] == dataclasses.asdict(lit.eval_config)
+
+
+def test_build_metadata_training_fields_default_to_none():
+    meta = build_metadata(_make_srcnn_lit())
+    assert meta["training"] == {
+        "global_step": None,
+        "epoch": None,
+        "monitor": None,
+        "monitor_value": None,
+    }
+
+
+def test_build_metadata_training_fields_forwarded():
+    meta = build_metadata(
+        _make_srcnn_lit(),
+        global_step=1000,
+        epoch=5,
+        monitor="psnr/val/RGB",
+        monitor_value=30.5,
+    )
+    assert meta["training"] == {
+        "global_step": 1000,
+        "epoch": 5,
+        "monitor": "psnr/val/RGB",
+        "monitor_value": 30.5,
+    }
+
+
+def test_build_metadata_omits_dataset_paths():
+    """Deliberate: no dataset directory/path ever appears in the metadata tree,
+    unlike e.g. Ultralytics' train_args (which leaks local filesystem layout)."""
+    meta = build_metadata(_make_srcnn_lit())
+    dumped = json.dumps(meta)
+    for leaky_token in ("img_dir", "cache_dir", "data/", "C:\\", "/home/"):
+        assert leaky_token not in dumped
+
+
+def test_build_metadata_is_weights_only_safe(tmp_path):
+    """The whole tree must round-trip through torch.save/load(weights_only=True) —
+    the contract every checkpoint sink depends on."""
+    meta = build_metadata(
+        _make_srresnet_lit(),
+        global_step=42,
+        epoch=1,
+        monitor="ssim/val/RGB",
+        monitor_value=0.87,
+    )
+    path = tmp_path / "meta.pt"
+    torch.save({"meta": meta}, path)
+    loaded = torch.load(path, weights_only=True)
+    assert loaded["meta"] == meta
+
+
+def test_build_metadata_every_field_json_encodable_individually():
+    """Mirrors sisr.export's per-field ONNX metadata_props encoding: every
+    top-level value must either be a str already, or survive json.dumps."""
+    meta = build_metadata(_make_srresnet_lit(), global_step=1, epoch=0)
+    for value in meta.values():
+        encoded = value if isinstance(value, str) else json.dumps(value)
+        assert isinstance(encoded, str)
+        if not isinstance(value, str):
+            assert json.loads(encoded) == value


### PR DESCRIPTION
## Summary

- One `build_metadata()` function (`sisr/training/metadata.py`) produces a single provenance dict — model `class_path`/`init_args`, processor identity, IO contract (scale, input contract, channels, output range), eval config, training state — consumed by all three sinks below, so they cannot drift apart.
- `SRLightning.on_save_checkpoint` injects a `sisr_meta` key into every saved `.ckpt` via the public Lightning hook. `LightningCLI._parse_ckpt_path` only reads `hyper_parameters`, so this is inert for `--ckpt_path` resumption.
- New `SRWeightsCheckpoint` (`sisr/training/callbacks.py`), a `ModelCheckpoint` sibling to `SRCheckpoint`, overrides the private `_save_checkpoint` hook to write a bare `.pt` — `pl_module.model.state_dict()` (no `model.` prefix) + `meta` — instead of a full training checkpoint. Distinct `FILE_EXTENSION`/`filename_prefix` so it coexists with `SRCheckpoint` in one `dirpath` without cross-deleting files. Wired into both templates, enabled by default.
- `sisr/export.py` now stamps the same metadata onto exported ONNX graphs as per-field `metadata_props` (JSON-encoded per field, so Netron renders a readable table), carrying a source checkpoint's own provenance forward when `ckpt_path` is given.

**Measured size reduction:** a real SRResNet checkpoint (1,549,462 params, Adam) — `.ckpt` 18.83 MB vs `.pt` 6.31 MB, **~3x smaller**, matching the ~18.8 MB / 3x figures in the task description.

`processor` (class_path) and `io.output_range` are what make a bare `.pt` safe to hand out on its own: `RGBSignedOutputProcessor` trains in `[-1, 1]` HR/output range while `RGBProcessor` uses `[0, 1]` — applying the wrong reconstruction to a bare state_dict produces silently wrong images with no error, so recording it in the metadata means a downstream consumer never has to guess.

## Test plan
- [x] `PYTHONPATH="$PWD" python -m pytest -q` → **404 passed, 1 skipped** (base was 375 passed + 1 skipped; +29 new tests)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] Both templates resolve via `--print_config`, with `SRWeightsCheckpoint` visible alongside `SRCheckpoint`
- [x] Dedicated end-to-end `Trainer.fit` test proves: the private `_save_checkpoint` hook is actually invoked (loud-failure guard), the `.pt` has no optimizer state / no `model.`-prefixed keys, the state_dict loads `strict=True` into a fresh bare model, and `SRCheckpoint`/`SRWeightsCheckpoint` don't delete each other's files sharing one `dirpath`
- [x] ONNX `metadata_props` test asserts the fields are present and parse back to expected values; skips cleanly without the `[export]` extra

🤖 Generated with [Claude Code](https://claude.com/claude-code)