### PR TITLE
Remove internal tracker identifiers from tracked files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# github-actions only (INIT.6): a PEP 621 pyproject with `>=` lower bounds and no
+# github-actions only: a PEP 621 pyproject with `>=` lower bounds and no
 # lock file gives the pip updater almost nothing to do, and enabling it would need
 # an `ignore` entry for albumentationsx (capped at <=2.1.0 for a documented Windows
 # import failure, see pyproject.toml) that a later PR is about to make obsolete anyway.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Smoke import
         run: python -c "import sisr; from sisr.cli import main; print('sisr', sisr.__version__, '- main:', main)"
       # Ports the old tests/test_cli.py::test_cli_help_lists_subcommands subprocess
-      # smoke here (P5.11): it cost ~10s of the pytest suite re-importing torch +
+      # smoke here: it cost ~10s of the pytest suite re-importing torch +
       # lightning just to print --help, and this job already installs the wheel and
       # smoke-imports it, so it's the natural home for a packaging-level check.
       - name: CLI entry point lists subcommands

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           path: coverage.xml
           retention-days: 14
 
-  # Numeric-parity check for the opt-in ONNX export (INIT.7): torch eager vs.
+  # Numeric-parity check for the opt-in ONNX export: torch eager vs.
   # onnxruntime CPU (GitHub runners have no GPU), both architectures. Single
   # OS/Python leg — a correctness check on one code path, not a compatibility
   # matrix. Installs the `export` extra explicitly since test-matrix's `.[dev]`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
     "pyyaml>=6",
     "ruff>=0.9",
 ]
-# Opt-in (INIT.7): sisr/export.py gates the actual `import onnx` inside to_onnx(),
+# Opt-in: sisr/export.py gates the actual `import onnx` inside to_onnx(),
 # so plain `pip install .` stays onnx-free. onnxruntime is the CI numeric-parity
 # check's target (CPU build — GitHub runners have no GPU); it also lets users
 # verify an export locally without a separate inference framework. Deliberately
@@ -106,7 +106,7 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-# Ruff owns lint + format for this project (INIT.1). line-length 100 matches the
+# Ruff owns lint + format for this project. line-length 100 matches the
 # code as written: 88 would reflow ~157 lines across every file, 100 only ~53
 # (mostly docstrings the formatter can't wrap). It governs both E501 and the
 # formatter's wrap width. target-version pins syntax so UP never rewrites below
@@ -124,7 +124,7 @@ line-length = 100
 # is nothing to suppress. Do not add it to `ignore`: ruff warns "rules have been
 # removed and ignoring them has no effect" on every run, which is noise in a required
 # check. The isinstance(x, A | B) style it enforced is now convention, not lint.
-# D: pydocstyle (P4.15) — makes "Google-style docstrings on public API" (a stated
+# D: pydocstyle — makes "Google-style docstrings on public API" (a stated
 # project non-negotiable) enforceable instead of review-only. D105 (undocumented
 # magic method) is ignored because dunder semantics are defined by the language,
 # not by us. D107 (undocumented __init__) is ignored because Google style documents

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -20,7 +20,7 @@ Top-level ``matmul_precision:`` (``'highest' | 'high' | 'medium'``) calls
 :func:`torch.set_float32_matmul_precision` once at startup. Set to ``'high'``
 on Ampere+ GPUs to enable TF32 matmul kernels.
 
-``sisr export`` (INIT.7) is a thin CLI wrapper around
+``sisr export`` is a thin CLI wrapper around
 :func:`sisr.export.to_onnx` — see that module for what gets exported and its
 SRCNN limitation. It requires the optional ``export`` extra
 (``pip install '.[export]'``).

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -178,7 +178,7 @@ class TrainDataset(SRDataset):
 
         Single source of truth for the patch grid: :meth:`__len__` and
         :meth:`__getitem__`'s O(1) index -> ``(top, left)`` lookup both derive
-        from the values this returns, so they can never disagree (P2.5).
+        from the values this returns, so they can never disagree.
 
         Returns:
             ``(sizes, offsets, n_cols, total)`` where *sizes* is each image's

--- a/sisr/export.py
+++ b/sisr/export.py
@@ -1,4 +1,4 @@
-"""Bare-model ONNX export (INIT.7).
+"""Bare-model ONNX export.
 
 Exports ``module.model`` — the wrapped :class:`~sisr.models.base.SRModel`,
 *without* the :class:`~sisr.processors.SRProcessor` — so the graph matches

--- a/sisr/imresize.py
+++ b/sisr/imresize.py
@@ -1,4 +1,4 @@
-"""MATLAB-compatible bicubic image resizing (INIT.10 / INIT.11).
+"""MATLAB-compatible bicubic image resizing.
 
 Vendored -- not a dependency -- from ``fatheral/matlab_imresize``
 (https://github.com/fatheral/matlab_imresize/blob/master/imresize.py), MIT

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -287,9 +287,9 @@ class BenchmarkImageLogger(Callback):
             if n > 0:
                 sr_4d = sr_4d[..., n:-n, n:-n]
                 hr_4d = hr_4d[..., n:-n, n:-n]
-            # Still a private reach (P5.9): the colorspace split has no public
-            # seam, and duplicating it here would recreate the divergence P2.1
-            # removed. Keys now come from eval_config, so this is a value
+            # Still a private reach: the colorspace split has no public
+            # seam, and duplicating it here would recreate a divergence
+            # this design removed. Keys now come from eval_config, so this is a value
             # lookup only — the callback no longer decides *which* keys exist.
             metric_tensors = pl_module._build_metric_tensors(sr_4d, hr_4d)
             psnr_dict = {

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -265,7 +265,7 @@ class SRLightning(lightning.LightningModule):
         # Clamp display-space output only, here, once — every reconstruct()
         # consumer (_forward_sr's callers, predict_step) reads through this
         # one line, so PSNR/SSIM never diverge from what an 8-bit image would
-        # score (P4.14). sr_model_out (the loss target) is untouched: clamping
+        # score. sr_model_out (the loss target) is untouched: clamping
         # it would kill gradients on saturated pixels. Idempotent where
         # reconstruct() already clamps (YCbCrProcessor/YChannelProcessor's
         # ycbcr_to_rgb) — don't move this into forward() or a processor, or

--- a/tests/datasets/test_base.py
+++ b/tests/datasets/test_base.py
@@ -49,7 +49,7 @@ def test_index_images_populates_img_paths_as_paths(tmp_path: Path):
 
 
 def test_index_images_skips_non_image_and_extensionless_files(tmp_path: Path):
-    """P5.4: the allowlist keeps only real image extensions — a .txt file and
+    """The allowlist keeps only real image extensions — a .txt file and
     an extensionless file are excluded (the old glob('*.*') matched the .txt
     and dropped the extensionless one silently)."""
     _write_png(tmp_path / "img_00.png")

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -215,7 +215,7 @@ def test_grid_index_mapping_matches_iteration_order(tiny_rgb_image_dir: Path):
     divmod over _img_offsets/_img_n_cols) must agree, position-for-position,
     with _iter_patch_origins' explicit enumeration across every image in a
     multi-image dataset -- so an index can never silently point at the wrong
-    sub-image (the single-source-of-truth guarantee P2.5 established)."""
+    sub-image (the single-source-of-truth guarantee this design established)."""
     import bisect
 
     from sisr.datasets.srcnn import _iter_patch_origins
@@ -321,7 +321,7 @@ def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):
 
 
 # ---------------------------------------------------------------------------
-# SRDataset contract (P3.6 / P5.4)
+# SRDataset contract
 # ---------------------------------------------------------------------------
 
 

--- a/tests/datasets/test_srresnet.py
+++ b/tests/datasets/test_srresnet.py
@@ -96,7 +96,7 @@ def test_train_dataset_random_crop_varies_across_calls(tiny_rgb_image_dir: Path)
 
 
 # ---------------------------------------------------------------------------
-# TrainDataset LMDB HR cache (INIT.13)
+# TrainDataset LMDB HR cache
 # ---------------------------------------------------------------------------
 
 
@@ -309,7 +309,7 @@ def test_validation_dataset_is_deterministic(tiny_rgb_image_dir: Path):
 
 
 # ---------------------------------------------------------------------------
-# SRDataset contract (P3.6 / P5.4)
+# SRDataset contract
 # ---------------------------------------------------------------------------
 
 

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -16,7 +16,7 @@ def test_srcnn_training_config_paper_defaults():
 
 
 def test_srcnn_eval_config_paper_defaults():
-    """Regression (P2.9): defaults must report the paper's own Y-channel
+    """Regression: defaults must report the paper's own Y-channel
     metric, not the YCbCr 3-channel aggregate (which reads optimistically
     high since chroma planes are far smoother than luma)."""
     cfg = SRCNNEvalConfig()
@@ -63,7 +63,7 @@ def test_srcnn_training_config_init_defaults():
 
 
 # ---------------------------------------------------------------------------
-# validate_against (INIT.16) — SRCNN-specific num_channels/processor check
+# validate_against — SRCNN-specific num_channels/processor check
 # ---------------------------------------------------------------------------
 
 

--- a/tests/models/srresnet/test_config.py
+++ b/tests/models/srresnet/test_config.py
@@ -22,7 +22,7 @@ def test_srresnet_training_config_paper_defaults():
 def test_srresnet_eval_config_paper_defaults():
     """SRResNet paper defaults: x4 border crop; RGB+Y PSNR.
 
-    Regression (P2.9): defaults must report the paper's own Y-channel
+    Regression: defaults must report the paper's own Y-channel
     metric, not the YCbCr 3-channel aggregate (which reads optimistically
     high since chroma planes are far smoother than luma)."""
     cfg = SRResNetEvalConfig()
@@ -50,7 +50,7 @@ def test_srresnet_eval_config_psnr_channels_independent_per_instance():
 
 
 # ---------------------------------------------------------------------------
-# validate_against (INIT.16) — SRResNet-specific in_out_channels/processor check
+# validate_against — SRResNet-specific in_out_channels/processor check
 # ---------------------------------------------------------------------------
 
 

--- a/tests/models/srresnet/test_model.py
+++ b/tests/models/srresnet/test_model.py
@@ -80,14 +80,14 @@ def test_check_scale_non_int_raises():
 
 
 def test_check_architecture_wrong_kernel_sizes_length_raises():
-    """P5.6: a kernel_sizes tuple that isn't length-3 must raise a clear
+    """A kernel_sizes tuple that isn't length-3 must raise a clear
     ValueError at construction, not an IndexError deep in layer wiring."""
     with pytest.raises(ValueError, match="kernel_sizes"):
         SRResNet(scale=2, kernel_sizes=(9, 3))
 
 
 def test_check_architecture_nonpositive_num_residual_blocks_raises():
-    """P5.6: num_residual_blocks <= 0 must raise a clear ValueError instead of
+    """num_residual_blocks <= 0 must raise a clear ValueError instead of
     silently building an empty residual Sequential."""
     with pytest.raises(ValueError, match="num_residual_blocks"):
         SRResNet(scale=2, num_residual_blocks=0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,7 +99,7 @@ def test_srresnet_config_resolves_in_process():
     cli = _resolve("--config", str(SRRESNET_TEMPLATE))
     m = cli.model
     assert isinstance(m.model, SRResNet)
-    # P2.10: the template ships the paper's [-1, 1] HR/target range.
+    # The template ships the paper's [-1, 1] HR/target range.
     assert isinstance(m.processor, RGBSignedOutputProcessor)
     assert isinstance(m.training_config, SRResNetTrainingConfig)
     assert isinstance(m.eval_config, SRResNetEvalConfig)
@@ -140,7 +140,7 @@ def test_test_subcommand_help_exposes_ckpt_path_in_process(capsys, monkeypatch):
 
 
 def test_export_subcommand_help_exposes_its_args_in_process(capsys, monkeypatch):
-    """`export --help` documents --output_path, --ckpt_path, --opset_version (INIT.7).
+    """`export --help` documents --output_path, --ckpt_path, --opset_version.
 
     trainer_class is left at SRLightningCLI's default (_ExportTrainer) —
     building this parser never calls sisr.export.to_onnx's body (only inspects

--- a/tests/test_colorspace.py
+++ b/tests/test_colorspace.py
@@ -70,7 +70,7 @@ def test_round_trip_within_coefficient_precision():
 
 
 # ---------------------------------------------------------------------------
-# rgb_to_ycbcr_studio (P2.8) — BT.601 studio range, metric-only
+# rgb_to_ycbcr_studio — BT.601 studio range, metric-only
 # ---------------------------------------------------------------------------
 
 
@@ -113,13 +113,13 @@ def _psnr(a: torch.Tensor, b: torch.Tensor, data_range: float = 1.0) -> torch.Te
 
 
 def test_y_channel_studio_psnr_offset_matches_algebraic_identity():
-    """The decisive test (P2.8): studio-range Y is an affine rescale of
+    """The decisive test: studio-range Y is an affine rescale of
     full-range Y by a constant factor (219/255, offset 16/255) — the diff
     (and hence MSE) scales by (219/255)**2 regardless of the actual image
     content, so PSNR_studio - PSNR_full is the *exact* constant
     20*log10(255/219) for any pair of images with nonzero error. This is the
-    algebraic fact the empirical Set5/Set14 corroboration in triage P2.8
-    (30.56 raw + 1.3219 ~= 31.88 vs. the paper's 32.05) depends on.
+    algebraic fact the empirical Set5/Set14 measurement (30.56 raw + 1.3219
+    ~= 31.88 vs. the paper's 32.05) depends on.
     """
     expected_delta = 20 * math.log10(255 / 219)
     g = torch.Generator().manual_seed(0)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,4 @@
-"""Tests for sisr.export.to_onnx (INIT.7).
+"""Tests for sisr.export.to_onnx.
 
 Skips cleanly when the optional `onnx` / `onnxruntime` extra is absent, so the
 suite stays green for contributors who don't install `.[export]`. The CI

--- a/tests/test_imresize.py
+++ b/tests/test_imresize.py
@@ -1,4 +1,4 @@
-"""Tests for the vendored MATLAB-compatible :mod:`sisr.imresize` (INIT.11).
+"""Tests for the vendored MATLAB-compatible :mod:`sisr.imresize`.
 
 Two layers of evidence:
 

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -190,7 +190,7 @@ def test_grad_norm_logger_handles_none_grads():
 
 
 def test_grad_norm_logger_uses_grad_detach_not_grad_data():
-    """P5.3: gradient-norm accumulation must read gradients via
+    """Gradient-norm accumulation must read gradients via
     ``p.grad.detach()``, not the legacy ``p.grad.data`` attribute — and must
     still compute the correct L2 norm. The source check gives the red->green
     signal (``.grad.data`` does not raise a Python warning on the pinned torch,
@@ -261,14 +261,14 @@ def test_srcheckpoint_custom_filename_prefix():
 
 
 def test_srcheckpoint_default_filename_prefix_is_neutral_sr():
-    """P5.5: the generic checkpoint's default prefix must be arch-neutral 'sr',
+    """The generic checkpoint's default prefix must be arch-neutral 'sr',
     not the SRCNN-specific 'srcnn'."""
     ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath="/tmp/x")
     assert ckpt.filename.startswith("sr-")
 
 
 def test_srcheckpoint_disables_auto_insert_metric_name():
-    """INIT.8 prerequisite: auto_insert_metric_name must be off, since it is the
+    """auto_insert_metric_name must be off, since it is the
     mechanism that would otherwise splice the raw (possibly `/`-bearing) metric
     name into the filename as literal text."""
     ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath="/tmp/x")
@@ -276,7 +276,7 @@ def test_srcheckpoint_disables_auto_insert_metric_name():
 
 
 def test_srcheckpoint_slash_monitor_renders_flat_filename(tmp_path: Path):
-    """INIT.8 prerequisite: a `/`-bearing monitor_metric (e.g. a future
+    """A `/`-bearing monitor_metric (e.g. a future
     `psnr/val/RGB` TensorBoard-hierarchy tag) must render to a flat basename
     with no path separator. Lightning's `_format_checkpoint_name` does no
     sanitisation of its own — with the default `auto_insert_metric_name=True`
@@ -340,7 +340,7 @@ def test_srcheckpoint_setup_accepts_val_ssim_monitor(tmp_path: Path):
 
 @_ignore_gpu_warning
 def test_srcheckpoint_setup_rejects_monitor_not_in_psnr_keys(tmp_path: Path):
-    """P5.9/INIT.8: monitoring a PSNR key eval_config never requests (here 'Y',
+    """Monitoring a PSNR key eval_config never requests (here 'Y',
     since psnr_channels=['RGB'] and separate_psnr=False) must raise
     MisconfigurationException at setup() time — startup, not 20k steps into
     training once Lightning's own val_loop._has_run-gated check would fire."""
@@ -978,7 +978,7 @@ def test_benchmark_collect_batch_routes_through_processor():
 
 
 def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_false():
-    """P2.7 regression: a real run's metrics.csv contained 8 PSNR keys
+    """Regression: a real run's metrics.csv contained 8 PSNR keys
     (RGB/R/G/B/YCbCr/Y/Cb/Cr) for a config requesting only ['RGB', 'YCbCr']
     with separate_psnr=False — because _collect_batch iterated every tensor
     `_build_psnr_tensors` populates for the colorspace *family*, not the
@@ -1043,7 +1043,7 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_true
 
 
 # ---------------------------------------------------------------------------
-# BenchmarkImageLogger consumes the public predict_rgb seam + SRDataset (P2.1)
+# BenchmarkImageLogger consumes the public predict_rgb seam + SRDataset
 # ---------------------------------------------------------------------------
 
 

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -65,7 +65,7 @@ def test_sr_eval_config_field_names():
 
 
 def test_eval_config_rejects_unknown_psnr_channel():
-    """Regression (P2.3): a colorspace outside {RGB, YCbCr} fails fast at
+    """Regression: a colorspace outside {RGB, YCbCr} fails fast at
     construction with an actionable message — not an opaque KeyError deep in
     SRLightning."""
     SREvalConfig(psnr_channels=["RGB", "YCbCr"])  # valid — must not raise
@@ -74,7 +74,7 @@ def test_eval_config_rejects_unknown_psnr_channel():
 
 
 def test_eval_config_rejects_unknown_psnr_channel_still_raises_alongside_bare_y():
-    """Regression (P2.9): adding bare single-channel entries to the allowlist
+    """Regression: adding bare single-channel entries to the allowlist
     must not widen it into accepting arbitrary strings — 'HSV' stays invalid
     even though 'Y' is now first-class."""
     SREvalConfig(psnr_channels=["RGB", "Y"])  # valid — must not raise
@@ -83,7 +83,7 @@ def test_eval_config_rejects_unknown_psnr_channel_still_raises_alongside_bare_y(
 
 
 def test_eval_config_rejects_unknown_ssim_channel():
-    """(P3.8): ssim_channels reuses the same allowlist as psnr_channels, and
+    """ssim_channels reuses the same allowlist as psnr_channels, and
     the error names the offending field so it's actionable."""
     SREvalConfig(ssim_channels=["RGB", "Y", "YCbCr"])  # valid — must not raise
     with pytest.raises(ValueError, match="ssim_channels"):
@@ -100,7 +100,7 @@ def test_eval_config_rejects_unknown_channel_in_either_field_independently():
 
 
 # ---------------------------------------------------------------------------
-# psnr_keys (INIT.16) — the public seam B1/C1 depend on
+# psnr_keys — the public seam SRLightning and BenchmarkImageLogger depend on
 # ---------------------------------------------------------------------------
 
 
@@ -123,7 +123,7 @@ def test_psnr_keys_matches_legacy_loop_derivation(psnr_channels, separate_psnr):
     """psnr_keys must reproduce exactly the loop SRLightning.__init__ used to
     inline (self._psnr_keys) before this property existed. Downstream PRs
     (benchmark PSNR-key selection, TensorBoard tag rename) depend on this
-    exact ordering. Bare single-channel entries (P2.9) map to () — nothing to
+    exact ordering. Bare single-channel entries map to () — nothing to
     expand — so they always contribute exactly one key."""
     channel_names = {
         "RGB": ("R", "G", "B"),
@@ -146,7 +146,7 @@ def test_psnr_keys_matches_legacy_loop_derivation(psnr_channels, separate_psnr):
 
 
 def test_psnr_keys_bare_y_entry_yields_exactly_one_key():
-    """Regression (P2.9): a bare 'Y' entry must not decompose into anything
+    """Regression: a bare 'Y' entry must not decompose into anything
     else — it is already a single channel, unlike 'YCbCr'."""
     cfg = SREvalConfig(psnr_channels=["RGB", "Y"])
     assert cfg.psnr_keys == ["RGB", "Y"]
@@ -160,7 +160,7 @@ def test_psnr_keys_is_not_a_dataclass_field():
 
 
 # ---------------------------------------------------------------------------
-# ssim_keys (P3.8) — mirrors psnr_keys, minus the separate_psnr expansion
+# ssim_keys — mirrors psnr_keys, minus the separate_psnr expansion
 # ---------------------------------------------------------------------------
 
 
@@ -187,7 +187,7 @@ def test_ssim_keys_is_not_a_dataclass_field():
 
 
 # ---------------------------------------------------------------------------
-# SRTrainingConfig.validate_against (INIT.16) — the construction-time seam
+# SRTrainingConfig.validate_against — the construction-time seam
 # ---------------------------------------------------------------------------
 
 

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -1,4 +1,4 @@
-"""End-to-end Trainer integration for the SR training stack (P3.1).
+"""End-to-end Trainer integration for the SR training stack.
 
 A single ``Trainer(fast_dev_run=True)`` fit+test over the tiny fixture images
 exercises the wiring the per-method unit tests in ``test_lightning_module.py``
@@ -7,7 +7,7 @@ cannot reach: ``training_step`` / ``validation_step`` under a real loop,
 the metric names actually logged, and the module -> datamodule ->
 ``BenchmarkImageLogger`` integration (the callback auto-discovers ``Set5`` from
 ``datamodule.test_names``). It is also the suite's canary for the lightning
-``LeafSpec`` pytree ``FutureWarning`` (P4.8): only a real Trainer loop emits it,
+``LeafSpec`` pytree ``FutureWarning``: only a real Trainer loop emits it,
 and the strict ``filterwarnings=error`` config turns it into a failure unless
 the scoped ignore in ``pyproject.toml`` is in place.
 """
@@ -112,7 +112,7 @@ def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
 
 
 # ---------------------------------------------------------------------------
-# cli predict end-to-end (P3.7) — LR-only inference path, both architectures
+# cli predict end-to-end — LR-only inference path, both architectures
 # ---------------------------------------------------------------------------
 
 

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -242,7 +242,7 @@ def test_build_metric_tensors_rgb_only_when_neither_metric_requests_y():
 
 
 def test_build_metric_tensors_union_of_psnr_and_ssim_keys():
-    """Regression (P3.8): a colorspace requested only by ssim_channels (not
+    """Regression: a colorspace requested only by ssim_channels (not
     psnr_channels) must still get a tensor entry — the tensor map is built
     from the *union* of psnr_keys and ssim_keys, not psnr_keys alone, so
     SSIM-only keys aren't silently missing."""
@@ -295,7 +295,7 @@ def test_build_metric_tensors_ycbcr_does_conversion():
 
 
 def test_build_metric_tensors_ycbcr_uses_studio_range_not_full_range():
-    """Regression (P2.8): the metric-side YCbCr conversion must be BT.601
+    """Regression: the metric-side YCbCr conversion must be BT.601
     studio range, not the full-range conversion SRProcessor subclasses train
     in — locked by comparing against sisr.colorspace directly."""
     from sisr.colorspace import rgb_to_ycbcr, rgb_to_ycbcr_studio
@@ -465,7 +465,7 @@ def test_srlightning_rejects_non_srprocessor():
 
 
 def test_srlightning_construction_rejects_mismatched_num_channels():
-    """Regression (INIT.16): SRCNNTrainingConfig.validate_against catches a
+    """Regression: SRCNNTrainingConfig.validate_against catches a
     num_channels/processor mismatch at construction, not silently at train time."""
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     with pytest.raises(ValueError, match="num_channels"):
@@ -614,7 +614,7 @@ def test_saved_tb_hparams_contain_processor_name():
 
 
 # ---------------------------------------------------------------------------
-# predict_rgb public inference seam (P2.1)
+# predict_rgb public inference seam
 # ---------------------------------------------------------------------------
 
 
@@ -648,14 +648,14 @@ def test_predict_rgb_matches_step_forward_path_y_channel(srcnn_y_lit: SRLightnin
 
 
 # ---------------------------------------------------------------------------
-# P4.14 — metric-path clamp to [0, 1], applied once in _forward_lr
+# Metric-path clamp to [0, 1], applied once in _forward_lr
 # ---------------------------------------------------------------------------
 
 
 def _overshooting_rgb_lit() -> SRLightning:
     """SRCNN + RGBProcessor (identity reconstruct) with the tail conv biased
     hugely positive, so sr_rgb genuinely overshoots [0, 1] on any input — the
-    scenario the P4.14 clamp exists for."""
+    scenario the metric-path clamp exists for."""
     model = SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same")
     torch.nn.init.constant_(model.recon.bias, 5.0)
     return SRLightning(
@@ -668,7 +668,7 @@ def _overshooting_rgb_lit() -> SRLightning:
 
 
 def test_step_clamps_sr_rgb_but_not_the_loss_target():
-    """Regression (P4.14): sr_rgb returned by _step is clamped to [0, 1] even
+    """Regression: sr_rgb returned by _step is clamped to [0, 1] even
     though the model genuinely overshoots, while the loss — read from
     sr_model_out, never sr_rgb — is exactly the unclamped MSE. A clamp that
     leaked into the loss would kill gradients on saturated pixels (constraint
@@ -694,7 +694,7 @@ def test_step_clamps_sr_rgb_but_not_the_loss_target():
 
 
 def test_step_psnr_matches_hand_clamped_reference_not_raw_output():
-    """Regression (P4.14): PSNR scored on the validation_step path must equal
+    """Regression: PSNR scored on the validation_step path must equal
     a hand-clamped reference computed from the raw model output, not the PSNR
     the unclamped output would give — proving overshoot is being penalised
     away rather than silently scored."""
@@ -714,7 +714,7 @@ def test_step_psnr_matches_hand_clamped_reference_not_raw_output():
 
 
 def test_predict_rgb_clamps_for_benchmark_logger_consumer():
-    """Regression (P4.14): predict_rgb — the seam BenchmarkImageLogger reads
+    """Regression: predict_rgb — the seam BenchmarkImageLogger reads
     for benchmark/test-set metrics — must return the same clamped sr_rgb as
     the validation_step path, not a re-implemented, unclamped forward."""
     lit = _overshooting_rgb_lit()
@@ -738,12 +738,12 @@ def test_predict_step_output_also_clamped_via_shared_forward_lr():
 
 
 # ---------------------------------------------------------------------------
-# P2.2 — no dead stateful metric accumulator
+# No dead stateful metric accumulator
 # ---------------------------------------------------------------------------
 
 
 def test_val_metrics_hold_no_stateful_accumulators(srcnn_y_lit: SRLightning):
-    """Regression (P2.2): PSNR/SSIM are computed via torchmetrics.functional,
+    """Regression: PSNR/SSIM are computed via torchmetrics.functional,
     so SRLightning registers no stateful torchmetrics.Metric accumulators that
     would grow unread and unreset across a validation run."""
     stateful = [m for m in srcnn_y_lit.modules() if isinstance(m, torchmetrics.Metric)]
@@ -753,12 +753,12 @@ def test_val_metrics_hold_no_stateful_accumulators(srcnn_y_lit: SRLightning):
 
 
 # ---------------------------------------------------------------------------
-# P2.4 — nested config dataclasses expand into HParams columns
+# Nested config dataclasses expand into HParams columns
 # ---------------------------------------------------------------------------
 
 
 def test_tb_hparams_expand_nested_config_fields():
-    """Regression (P2.4): training_config/eval_config dataclasses expand into
+    """Regression: training_config/eval_config dataclasses expand into
     individual HParams columns (via dataclasses.asdict) using the '/' separator,
     instead of a single stringified blob under the bare key — in the TB-only
     flattened view, since self.hparams itself must stay nested (see below)."""
@@ -804,12 +804,12 @@ def test_hparams_stay_nested_plain_dicts_for_checkpoint_reload():
 
 
 # ---------------------------------------------------------------------------
-# P2.6 — val PSNR is the per-image mean, invariant to batch size
+# val PSNR is the per-image mean, invariant to batch size
 # ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
-# predict_step — LR-only inference seam (P3.7)
+# predict_step — LR-only inference seam
 # ---------------------------------------------------------------------------
 
 
@@ -864,7 +864,7 @@ def test_predict_step_dataloader_idx_default_is_ignored(srcnn_rgb_lit: SRLightni
 
 
 def test_val_psnr_is_per_image_mean_not_batch_pooled():
-    """Regression (P2.6): PSNR for a batch equals the mean of the per-image
+    """Regression: PSNR for a batch equals the mean of the per-image
     PSNRs (SR-standard reduction, invariant to val batch_size), not the
     batch-pooled PSNR that a default-dim PeakSignalNoiseRatio would give."""
     from torchmetrics.functional.image import peak_signal_noise_ratio as psnr_fn


### PR DESCRIPTION
## Summary

- Removed 69 internal tracker-identifier occurrences (`INIT.xx`, `Px.y`, and the word "triage") across 24 tracked files — private notes-directory vocabulary that means nothing to a public reader. PR numbers like `#53` were left untouched; they resolve on GitHub.
- The surrounding rationale was preserved in every case — only the bracketed/inline codes were deleted, never the explanatory sentence.
- Three spots needed a rewrite rather than a deletion: `tests/test_colorspace.py` (dropped the "triage P2.8" internal-document reference, rewrote the sentence to stand on its own), `tests/training/test_config.py` (replaced the delivery-wave label `B1/C1` with the actual consumers, `SRLightning` and `BenchmarkImageLogger`), and `.gitignore:8` was intentionally left alone (already agreed to keep as-is).

## Verification

Both required greps come back empty (or with only the expected exception):

```
$ git ls-files | xargs grep -nE "\b(INIT\.[0-9]+|[Pp][1-5]\.[0-9]+)\b"
(no output)

$ git ls-files | xargs grep -nEi "triage|wave [a-z]\b|\bB1/C1\b"
.gitignore:8:# Claude's local working notes (codebase index, triage, session history)
```

No-behavior-change proof: parsed every touched `.py` file (20 files) at both `main` and this branch, stripped docstring nodes, and compared `ast.dump()` — all 20 matched exactly.

- Full suite: `423 passed, 2 skipped in 34.66s` (matches the `main`-worktree baseline; the 2 skips are the reference-data-absent imresize checks, expected in a worktree with no `data/`).
- `ruff check .` → All checks passed. `ruff format --check .` → 61 files already formatted.
- Both templates resolve: `sisr.cli fit --config templates/config.srcnn.template.yaml --print_config` and the srresnet equivalent both exit 0.

## Test plan

- [x] `git ls-files | xargs grep -nE "\b(INIT\.[0-9]+|[Pp][1-5]\.[0-9]+)\b"` empty
- [x] `git ls-files | xargs grep -nEi "triage|wave [a-z]\b|\bB1/C1\b"` only `.gitignore:8`
- [x] AST-equivalence (docstrings stripped) across all 20 changed `.py` files
- [x] `pytest -q` → 423 passed, 2 skipped
- [x] `ruff check .` / `ruff format --check .` clean
- [x] Both templates' `--print_config` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)