### PR TITLE
Raise torch floor past the weights_only bypass and harden workflow tokens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
 
 permissions:
   contents: read
+  # An explicit permissions block zeroes unlisted scopes; actions: write keeps
+  # Actions-cache saves working (setup-uv enable-cache / setup-python cache: pip).
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 
 permissions:
   contents: read
+  # An explicit permissions block zeroes unlisted scopes; actions: write keeps
+  # Actions-cache saves working (setup-uv enable-cache / setup-python cache: pip).
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -73,7 +76,7 @@ jobs:
         run: pytest -n 2 --dist=loadscope --cov=sisr --cov-report=xml --cov-report=term --cov-fail-under=90
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch>=2.4",
-    "torchvision>=0.19",
+    # 2.6 excludes the torch.load(weights_only=True) unpickler bypass fixed in
+    # 2.6.0 (GHSA-53q9-r3pm-6pq6 / CVE-2025-32434) — that flag is this project's
+    # entire load-time safety contract for third-party .ckpt/.pt files.
+    "torch>=2.6",
+    "torchvision>=0.21",
     "lightning>=2.4",
     "torchmetrics>=1.4",
     "jsonargparse[signatures]>=4.27",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -16,3 +16,23 @@ def test_pyyaml_declared_in_dev_extra():
     assert any(re.match(r"pyyaml(\[|[<>=!~ ]|$)", spec.strip(), re.IGNORECASE) for spec in dev), (
         f"PyYAML missing from the dev extra: {dev}"
     )
+
+
+def _floor(deps: list[str], name: str) -> tuple[int, ...]:
+    for spec in deps:
+        match = re.match(rf"{name}\s*>=\s*([0-9.]+)", spec.strip(), re.IGNORECASE)
+        if match:
+            return tuple(int(part) for part in match.group(1).split("."))
+    raise AssertionError(f"{name} not found with a >= floor in: {deps}")
+
+
+def test_torch_floor_excludes_weights_only_bypass():
+    """torch.load(weights_only=True) is this project's entire load-time safety
+    contract (sisr/cli.py, sisr/export.py). GHSA-53q9-r3pm-6pq6 / CVE-2025-32434
+    lets that check be bypassed for arbitrary code execution on torch <= 2.5.1,
+    fixed in 2.6.0 — so the floor must exclude the vulnerable range, not just
+    exist."""
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    deps = pyproject["project"]["dependencies"]
+    assert _floor(deps, "torch") >= (2, 6), f"torch floor must be >= 2.6: {deps}"
+    assert _floor(deps, "torchvision") >= (0, 21), f"torchvision floor must be >= 0.21: {deps}"


### PR DESCRIPTION
## What

Two related hardening concerns, three commits:

1. **`torch>=2.6`, `torchvision>=0.21`** — `torch.load(..., weights_only=True)` is this project's entire load-time safety contract (`sisr/cli.py`, `sisr/export.py`, `sisr/training/lightning_module.py`), and the project deliberately ships distributable `.pt`/`.ckpt` files. GHSA-53q9-r3pm-6pq6 / CVE-2025-32434 makes that flag bypassable for arbitrary code execution on torch ≤ 2.5.1 (fixed in 2.6.0), and a floor-only spec never upgrades a pre-existing environment — so the floor itself must exclude the vulnerable range. A new `tests/test_packaging.py` invariant (tomllib parse, never imports `sisr`) guards both floors.
2. **Workflow token hardening** — explicit `permissions:` blocks in both workflows (`contents: read`, plus `actions: write` with an inline comment: an explicit block zeroes unlisted scopes, and Actions-cache *saves* need `actions: write` — without it the setup-uv/setup-python caches silently stop saving). `codecov/codecov-action` repinned from the mutable `@v7` tag to the resolved commit SHA (verified to be the genuine `v7.0.0`). `astral-sh/setup-uv@v9.0.0` left as-is — already deliberately patch-pinned.

## Evidence (test proven RED → GREEN)

RED, before the floor bump:
```
tests/test_packaging.py::test_torch_floor_excludes_weights_only_bypass FAILED
E   AssertionError: torch floor must be >= 2.6: ['torch>=2.4', 'torchvision>=0.19', ...]
E   assert (2, 4) >= (2, 6)
```
GREEN, after:
```
tests/test_packaging.py::test_torch_floor_excludes_weights_only_bypass PASSED
```

Full suite from the branch: **424 passed, 2 skipped** (the two data-dependent imresize byte-equality tests, which skip without local reference data by design); `ruff check` + `ruff format --check` clean. Both workflow files re-validated with `yaml.safe_load` after each change.

Adversarially reviewed (spec compliance ✅ / quality approved), including independent re-verification that the CVE is real and fixed in 2.6.0, that the pinned SHA resolves to the genuine `codecov-action` v7.0.0, and that the packaging test's version comparison is tuple-based (no lexicographic-string trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)