### PR TITLE
Extract shared HR-cache wiring into a dataset base class

### DIFF
--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -6,14 +6,24 @@ glob + empty-directory guard), the RGB image load, the ``uint8`` HWC →
 ``float32`` CHW ``[0, 1]`` tensor adapter, and declares the ``.img_paths``
 filename contract that :class:`~sisr.training.SRDataModule` and
 :class:`~sisr.training.callbacks.BenchmarkImageLogger` rely on.
+
+:class:`HRCachedTrainDataset` also centralises the raw-HR LMDB wiring shared
+verbatim by SRCNN's and SRResNet's train datasets — it lives here, not in the
+torch-free :mod:`~sisr.datasets.hr_cache`, because it subclasses
+:class:`torch.utils.data.Dataset`.
 """
 
 import abc
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import numpy as np
 import torch
 from PIL import Image
+
+from ..cache import LMDBCache, LMDBCacheBuildContext
+from .hr_cache import CACHE_NAME, FORMAT_TAG, HEADER, compute_checksum, estimate_map_size
 
 
 class SRDataset(torch.utils.data.Dataset, abc.ABC):
@@ -91,3 +101,119 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
     @abc.abstractmethod
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
         """Return the ``(lr_tensor, hr_tensor)`` pair at ``idx``."""
+
+
+class HRCachedTrainDataset(SRDataset):
+    """Shared base for train datasets backed by the raw-HR LMDB cache.
+
+    Owns the file-manifest checksum, per-image size probe, and
+    :class:`~sisr.cache.LMDBCache` construction/build that SRCNN's and
+    SRResNet's train datasets need identically — so the two cannot drift on
+    it (e.g. two different build progress-bar labels for what is, by design,
+    one shared cache). A subclass supplies only its indexing scheme (grid vs
+    random crop, via :attr:`_img_sizes`) and its read-time degradation, built
+    on :meth:`_read_hr`.
+
+    Args:
+        img_dir: Directory of HR images.
+        use_tqdm: Whether to display a progress bar during the LMDB build.
+        cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
+        build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
+            1, num_images)``; ``<= 1`` effective workers runs an inline,
+            no-subprocess build. Only affects cache construction, not data
+            loading.
+
+    Raises:
+        ValueError: If no image files are found in ``img_dir``.
+    """
+
+    def __init__(
+        self,
+        img_dir: str | Path,
+        use_tqdm: bool = False,
+        cache_dir: str | Path | None = None,
+        build_num_workers: int | None = None,
+    ):
+        super().__init__()
+
+        self._index_images(img_dir)
+        self.build_num_workers = build_num_workers
+        self._img_sizes = self._collect_sizes()
+
+        cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
+        self._cache = LMDBCache(
+            cache_dir=cache_dir,
+            name=CACHE_NAME,
+            checksum=self._compute_checksum(),
+            length=len(self.img_paths),
+            map_size=estimate_map_size(self._img_sizes),
+            metadata={"format": FORMAT_TAG},
+            build_fn=self._build,
+            use_tqdm=use_tqdm,
+        )
+
+    def _compute_checksum(self) -> str:
+        """Computes a SHA-256 checksum over the file manifest only.
+
+        None of a subclass's crop/grid/scale parameters enter the hash — the
+        cache stores whole raw images, unaffected by anything derived from
+        them at read time. Delegates to
+        :func:`~sisr.datasets.hr_cache.compute_checksum`.
+
+        Returns:
+            A hex-encoded SHA-256 digest string.
+        """
+        return compute_checksum(self.img_paths)
+
+    def _collect_sizes(self) -> list[tuple[int, int]]:
+        """Reads each image's ``(h, w)`` from its file header, without decoding pixels.
+
+        Returns:
+            Each source image's ``(height, width)``, in :attr:`img_paths` order.
+        """
+        sizes = []
+        for path in self.img_paths:
+            img = Image.open(path)
+            w, h = img.size
+            img.close()
+            sizes.append((h, w))
+        return sizes
+
+    def _parallel_build_hr(self, ctx: LMDBCacheBuildContext, process_fn) -> None:
+        """Runs the shared HR-decode build over :attr:`img_paths`.
+
+        *process_fn* is passed in rather than imported here so each
+        architecture module keeps its own patchable module-level
+        ``process_hr_image`` reference for its tests.
+        """
+        ctx.parallel_build(
+            items=self.img_paths,
+            process_fn=process_fn,
+            process_args=[(i,) for i in range(len(self.img_paths))],
+            num_workers=self.build_num_workers,
+            desc="Building HR cache",
+        )
+
+    @abc.abstractmethod
+    def _build(self, ctx: LMDBCacheBuildContext) -> None:
+        """Populates the LMDB cache; subclasses delegate to :meth:`_parallel_build_hr`."""
+
+    @contextmanager
+    def _read_hr(self, img_idx: int) -> Iterator[np.ndarray]:
+        """Yields the cached HR image at ``img_idx`` as an ``(H, W, 3)`` uint8 view.
+
+        A zero-copy :meth:`~sisr.cache.LMDBCache.get_buffer` view, valid only
+        inside this ``with`` block — slice and ``.copy()`` out whatever is
+        needed before it exits. ``(h, w)`` come from this image's own header,
+        never a fixed constant, so non-square and varied-size images are safe.
+
+        Raises:
+            KeyError: If the backing LMDB entry is missing (a corrupt or
+                incomplete cache).
+        """
+        key = f"hr_{img_idx:08d}"
+        with self._cache.get_buffer(key) as buf:
+            if buf is None:
+                raise KeyError(key)
+            h, w = HEADER.unpack_from(buf, 0)
+            yield np.frombuffer(buf, dtype=np.uint8, offset=HEADER.size).reshape(h, w, 3)

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -24,12 +24,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from PIL import Image
 
-from ..cache import LMDBCache, LMDBCacheBuildContext
+from ..cache import LMDBCacheBuildContext
 from ..imresize import resize
-from .base import SRDataset
-from .hr_cache import CACHE_NAME, FORMAT_TAG, HEADER, compute_checksum, estimate_map_size
+from .base import HRCachedTrainDataset, SRDataset
 from .hr_cache import process_hr_image as _process_hr_image
 
 
@@ -81,24 +79,23 @@ def _degrade(hr_arr: np.ndarray, scale: int) -> np.ndarray:
     return resize(down, (h, w))
 
 
-class TrainDataset(SRDataset):
+class TrainDataset(HRCachedTrainDataset):
     """Dataset serving deterministic LR/HR sub-image pairs, HR held in an LMDB cache.
 
     On first instantiation with a given set of files, every HR image is
-    decoded once and stored whole (uint8, RGB) in an LMDB database — see the
-    module docstring for why. Each ``__getitem__`` maps its flat index to a
-    source image and a deterministic ``(top, left)`` grid position in O(1)
-    (via :func:`_grid_dims`), reads that image's cached bytes through a
-    zero-copy :meth:`~sisr.cache.LMDBCache.get_buffer` view, slices out the
-    ``subimg_size`` square HR sub-image, and degrades it to LR with
-    :func:`_degrade`. The sliding-window grid itself — which sub-images exist
-    and in what order — is unaffected by this change: it is still derived
-    from exactly one place (:func:`_grid_dims`), so indices can never
-    silently misalign.
+    decoded once and stored whole (uint8, RGB) in an LMDB database — see
+    :mod:`~sisr.datasets.base`/:mod:`~sisr.datasets.hr_cache` for why. Each
+    ``__getitem__`` maps its flat index to a source image and a deterministic
+    ``(top, left)`` grid position in O(1) (via :func:`_grid_dims`), reads that
+    image's cached bytes through :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`,
+    slices out the ``subimg_size`` square HR sub-image, and degrades it to LR
+    with :func:`_degrade`. The sliding-window grid itself — which sub-images
+    exist and in what order — is derived from exactly one place
+    (:func:`_grid_dims`), so indices can never silently misalign.
 
     A SHA-256 checksum over the file manifest (plus a format tag) is stored
     inside the LMDB so subsequent runs over the same files skip the build
-    entirely — the checksum no longer depends on
+    entirely — the checksum does not depend on
     ``subimg_size``/``stride``/``scale``, since none of them affect the raw
     bytes written.
 
@@ -132,90 +129,40 @@ class TrainDataset(SRDataset):
         cache_dir: str | Path | None = None,
         build_num_workers: int | None = None,
     ):
-        super().__init__()
-
-        self._index_images(img_dir)
         self.sub_img_size = subimg_size
         self.stride = stride
         self.scale = scale
-        self.build_num_workers = build_num_workers
-
-        cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
-        checksum = self._compute_checksum()
-        self._img_sizes, self._img_offsets, self._img_n_cols, self._total_patches = (
-            self._compute_grid()
+        super().__init__(
+            img_dir, use_tqdm=use_tqdm, cache_dir=cache_dir, build_num_workers=build_num_workers
         )
+        self._img_offsets, self._img_n_cols, self._total_patches = self._compute_grid()
 
-        self._cache = LMDBCache(
-            cache_dir=cache_dir,
-            name=CACHE_NAME,
-            checksum=checksum,
-            length=len(self.img_paths),
-            map_size=estimate_map_size(self._img_sizes),
-            metadata={"format": FORMAT_TAG},
-            build_fn=self._build,
-            use_tqdm=use_tqdm,
-        )
-
-    def _compute_checksum(self) -> str:
-        """Computes a SHA-256 checksum over the file manifest only.
-
-        The cache stores whole raw HR images, so — unlike the LR-patch cache
-        this replaced — none of ``subimg_size``/``stride``/``scale`` enter the
-        hash: they only affect what gets sliced and degraded at read time,
-        never what is written to LMDB. Delegates to
-        :func:`~sisr.datasets.hr_cache.compute_checksum`, shared verbatim with
-        :mod:`sisr.datasets.srresnet` so the same file set hashes identically
-        regardless of which architecture asks first.
-
-        Returns:
-            A hex-encoded SHA-256 digest string.
-        """
-        return compute_checksum(self.img_paths)
-
-    def _compute_grid(self) -> tuple[list[tuple[int, int]], list[int], list[int], int]:
-        """Computes the deterministic sub-image grid from image dimensions alone.
+    def _compute_grid(self) -> tuple[list[int], list[int], int]:
+        """Computes the deterministic sub-image grid from :attr:`_img_sizes`.
 
         Single source of truth for the patch grid: :meth:`__len__` and
         :meth:`__getitem__`'s O(1) index -> ``(top, left)`` lookup both derive
         from the values this returns, so they can never disagree.
 
         Returns:
-            ``(sizes, offsets, n_cols, total)`` where *sizes* is each image's
-            ``(h, w)``, *offsets* is the cumulative starting patch index per
-            image, *n_cols* is each image's column count (needed to invert a
-            flat patch index back to a grid position), and *total* is the
-            grand total of patches.
+            ``(offsets, n_cols, total)`` where *offsets* is the cumulative
+            starting patch index per image, *n_cols* is each image's column
+            count (needed to invert a flat patch index back to a grid
+            position), and *total* is the grand total of patches.
         """
-        sizes: list[tuple[int, int]] = []
         offsets: list[int] = []
         n_cols_list: list[int] = []
         offset = 0
-        for path in self.img_paths:
-            img = Image.open(path)
-            w, h = img.size
-            img.close()
+        for h, w in self._img_sizes:
             n_rows, n_cols = _grid_dims(h, w, self.scale, self.sub_img_size, self.stride)
-            sizes.append((h, w))
             n_cols_list.append(n_cols)
             offsets.append(offset)
             offset += n_rows * n_cols
-        return sizes, offsets, n_cols_list, offset
+        return offsets, n_cols_list, offset
 
     def _build(self, ctx: LMDBCacheBuildContext) -> None:
-        """Populates the LMDB cache by decoding each HR image once, in parallel.
-
-        Args:
-            ctx (LMDBCacheBuildContext): Build context provided by
-                :class:`LMDBCache`.
-        """
-        ctx.parallel_build(
-            items=self.img_paths,
-            process_fn=_process_hr_image,
-            process_args=[(i,) for i in range(len(self.img_paths))],
-            num_workers=self.build_num_workers,
-            desc="Building LMDB cache",
-        )
+        """Populates the LMDB cache by decoding each HR image once, in parallel."""
+        self._parallel_build_hr(ctx, _process_hr_image)
 
     def __len__(self) -> int:
         return self._total_patches
@@ -225,11 +172,10 @@ class TrainDataset(SRDataset):
 
         Locates *idx*'s source image and grid position in O(1) via
         :attr:`_img_offsets`/:attr:`_img_n_cols`, slices the HR sub-image out
-        of that image's cached raw bytes (a zero-copy
-        :meth:`~sisr.cache.LMDBCache.get_buffer` view, copied out before the
-        transaction closes), and derives LR from it with :func:`_degrade` —
-        numerically identical to computing both at build time, just performed
-        at load time instead.
+        of that image's cached raw bytes (via
+        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`), and
+        derives LR from it with :func:`_degrade` — numerically identical to
+        computing both at build time, just performed at load time instead.
 
         Args:
             idx (int): Zero-based sub-image index.
@@ -250,17 +196,8 @@ class TrainDataset(SRDataset):
         local_idx = idx - self._img_offsets[img_idx]
         row, col = divmod(local_idx, self._img_n_cols[img_idx])
         top, left = row * self.stride, col * self.stride
-        h, w = self._img_sizes[img_idx]
 
-        key = f"hr_{img_idx:08d}"
-        with self._cache.get_buffer(key) as buf:
-            if buf is None:
-                raise KeyError(key)
-            # Read-only view into the LMDB transaction's mmap page — sliced and
-            # copied out below, before the `with` block ends and the view dies.
-            # (h, w) come from _compute_grid (the source file), not the header:
-            # only its byte offset matters here, consistent with SRResNet's read.
-            arr = np.frombuffer(buf, dtype=np.uint8, offset=HEADER.size).reshape(h, w, 3)
+        with self._read_hr(img_idx) as arr:
             hr_subimg = arr[
                 top : top + self.sub_img_size, left : left + self.sub_img_size, :
             ].copy()

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -20,29 +20,27 @@ LR is derived via MATLAB-compatible antialiased bicubic resizing (see
 import random
 from pathlib import Path
 
-import numpy as np
 import torch
-from PIL import Image
 
-from ..cache import LMDBCache, LMDBCacheBuildContext
+from ..cache import LMDBCacheBuildContext
 from ..imresize import resize
-from .base import SRDataset
-from .hr_cache import CACHE_NAME, FORMAT_TAG, HEADER, compute_checksum, estimate_map_size
+from .base import HRCachedTrainDataset, SRDataset
 from .hr_cache import process_hr_image as _process_hr_image
 
 
-class TrainDataset(SRDataset):
+class TrainDataset(HRCachedTrainDataset):
     """Random-crop HR/LR pairs for SRResNet-style training, HR held in an LMDB cache.
 
     On first instantiation with a given set of parameters, every HR image is
     decoded once and stored whole (uint8, RGB, with its own ``(H, W)`` header)
-    in an LMDB database — see module docstring for why. Each ``__getitem__``
-    then reads that image's cached bytes via a zero-copy
-    :meth:`~sisr.cache.LMDBCache.get_buffer` view, takes a fresh random
-    ``hr_crop_size`` square crop (plain numpy slicing — crop randomness must
-    survive the cache, so only the *decode* is memoized, never the crop), and
-    bicubic-downsamples it by ``scale`` (via :func:`sisr.imresize.resize`) to
-    form the LR input. Unlike
+    in an LMDB database — see :mod:`~sisr.datasets.base`/
+    :mod:`~sisr.datasets.hr_cache` for why. Each ``__getitem__`` then reads
+    that image's cached bytes via
+    :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`, takes a fresh
+    random ``hr_crop_size`` square crop (plain numpy slicing — crop
+    randomness must survive the cache, so only the *decode* is memoized,
+    never the crop), and bicubic-downsamples it by ``scale`` (via
+    :func:`sisr.imresize.resize`) to form the LR input. Unlike
     :class:`sisr.datasets.srcnn.TrainDataset` there is **no
     blur+downsample+upsample round-trip** and the LR is *not* upsampled back —
     the model is responsible for the ×``scale`` upsampling, so the LR tensor is
@@ -88,74 +86,20 @@ class TrainDataset(SRDataset):
         cache_dir: str | Path | None = None,
         build_num_workers: int | None = None,
     ):
-        super().__init__()
-
         if hr_crop_size % scale != 0:
             raise ValueError(f"hr_crop_size ({hr_crop_size}) must be divisible by scale ({scale}).")
 
-        self._index_images(img_dir)
         self.scale = scale
         self.hr_crop_size = hr_crop_size
         self.crops_per_image = crops_per_image
-        self.build_num_workers = build_num_workers
         self.lr_size = hr_crop_size // scale
-
-        cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
-        checksum = self._compute_checksum()
-
-        self._cache = LMDBCache(
-            cache_dir=cache_dir,
-            name=CACHE_NAME,
-            checksum=checksum,
-            length=len(self.img_paths),
-            map_size=estimate_map_size(self._collect_sizes()),
-            metadata={"format": FORMAT_TAG},
-            build_fn=self._build,
-            use_tqdm=use_tqdm,
+        super().__init__(
+            img_dir, use_tqdm=use_tqdm, cache_dir=cache_dir, build_num_workers=build_num_workers
         )
-
-    def _compute_checksum(self) -> str:
-        """Computes a SHA-256 checksum over the file manifest only.
-
-        No crop/scale parameter enters this hash: the cache stores whole raw
-        images, so it is valid for any ``hr_crop_size``/``crops_per_image``/
-        ``scale`` combination over the same file set. Delegates to
-        :func:`~sisr.datasets.hr_cache.compute_checksum`, shared verbatim with
-        :mod:`sisr.datasets.srcnn` so the same file set hashes identically
-        regardless of which architecture asks first.
-
-        Returns:
-            A hex-encoded SHA-256 digest string.
-        """
-        return compute_checksum(self.img_paths)
-
-    def _collect_sizes(self) -> list[tuple[int, int]]:
-        """Reads each image's ``(h, w)`` from its file header, without decoding pixels.
-
-        Returns:
-            Each source image's ``(height, width)``, in :attr:`img_paths` order.
-        """
-        sizes = []
-        for path in self.img_paths:
-            img = Image.open(path)
-            w, h = img.size
-            img.close()
-            sizes.append((h, w))
-        return sizes
 
     def _build(self, ctx: LMDBCacheBuildContext) -> None:
-        """Populates the LMDB cache by decoding each HR image once in parallel.
-
-        Args:
-            ctx (LMDBCacheBuildContext): Build context provided by :class:`~sisr.cache.LMDBCache`.
-        """
-        ctx.parallel_build(
-            items=self.img_paths,
-            process_fn=_process_hr_image,
-            process_args=[(i,) for i in range(len(self.img_paths))],
-            num_workers=self.build_num_workers,
-            desc="Building SRResNet HR cache",
-        )
+        """Populates the LMDB cache by decoding each HR image once in parallel."""
+        self._parallel_build_hr(ctx, _process_hr_image)
 
     def __len__(self) -> int:
         return len(self.img_paths) * self.crops_per_image
@@ -169,20 +113,14 @@ class TrainDataset(SRDataset):
         with shape ``(3, H, W)``.
         """
         img_idx = idx % len(self.img_paths)
-        key = f"hr_{img_idx:08d}"
 
-        with self._cache.get_buffer(key) as buf:
-            if buf is None:
-                raise KeyError(key)
-            h, w = HEADER.unpack_from(buf, 0)
+        with self._read_hr(img_idx) as arr:
+            h, w = arr.shape[:2]
             if w < self.hr_crop_size or h < self.hr_crop_size:
                 raise ValueError(
                     f"Image {self.img_paths[img_idx].name} ({w}x{h}) is smaller than "
                     f"hr_crop_size {self.hr_crop_size}."
                 )
-            # Read-only view into the LMDB transaction's mmap page — sliced and
-            # copied out below, before the `with` block ends and the view dies.
-            arr = np.frombuffer(buf, dtype=np.uint8, offset=HEADER.size).reshape(h, w, 3)
             top = random.randint(0, h - self.hr_crop_size)
             left = random.randint(0, w - self.hr_crop_size)
             hr_arr = arr[top : top + self.hr_crop_size, left : left + self.hr_crop_size, :].copy()

--- a/tests/datasets/test_hr_cache.py
+++ b/tests/datasets/test_hr_cache.py
@@ -209,3 +209,51 @@ def test_shared_cache_pixel_equivalence_across_architectures(varied_size_rgb_ima
         for left in range(0, w - 16 + 1)
     )
     assert found, "SRResNet crop read through the shared cache does not match its source image"
+
+
+def test_existing_cache_reopens_without_rebuild_via_either_architecture(
+    varied_size_rgb_image_dir: Path,
+):
+    """Regression guard for the HR-cache-wiring extraction itself: a cache
+    already on disk must reopen without a rebuild afterwards, via EITHER
+    architecture's TrainDataset -- independent of the cross-arch tests above,
+    which exercise the sharing design rather than a persisted directory
+    surviving the internal restructuring of how each dataset wires it up.
+    """
+    from sisr.datasets.srcnn import TrainDataset as SRCNNTrainDataset
+    from sisr.datasets.srresnet import TrainDataset as SRResNetTrainDataset
+
+    cache_dir = varied_size_rgb_image_dir / ".lmdb_cache"
+
+    built = SRResNetTrainDataset(
+        img_dir=varied_size_rgb_image_dir,
+        scale=2,
+        hr_crop_size=16,
+        cache_dir=cache_dir,
+        build_num_workers=1,
+    )
+    built._cache.get_env().close()  # release before reopening the same path
+
+    with (
+        patch("sisr.datasets.srresnet._process_hr_image") as mock_srresnet,
+        patch("sisr.datasets.srcnn._process_hr_image") as mock_srcnn,
+    ):
+        reopened_srresnet = SRResNetTrainDataset(
+            img_dir=varied_size_rgb_image_dir,
+            scale=2,
+            hr_crop_size=16,
+            cache_dir=cache_dir,
+            build_num_workers=1,
+        )
+        reopened_srresnet._cache.get_env().close()
+        reopened_srcnn = SRCNNTrainDataset(
+            img_dir=varied_size_rgb_image_dir,
+            subimg_size=16,
+            stride=8,
+            scale=2,
+            cache_dir=cache_dir,
+            build_num_workers=1,
+        )
+    mock_srresnet.assert_not_called()
+    mock_srcnn.assert_not_called()
+    assert built._cache.path == reopened_srresnet._cache.path == reopened_srcnn._cache.path


### PR DESCRIPTION
## What

Both training datasets copy-pasted the wiring around `hr_cache.py`'s primitives — checksum delegation, the PIL size probe, the ~10-line `LMDBCache` construction, the header-decode dance in `__getitem__` — and the copies had already drifted (two different tqdm labels for the *same shared cache*). This extracts an `HRCachedTrainDataset` base in `sisr/datasets/base.py`; each architecture now contributes only its indexing scheme (grid vs random crop) and its degradation.

## Behaviour-neutrality (the acceptance criterion)

- `sisr/datasets/hr_cache.py`: **zero-line diff** — the torch-free pool-worker boundary is untouched (guard test still targets it).
- Checksum inputs, cache directory naming, `FORMAT_TAG`, stored byte format, and build parallelism: all verified unchanged (adversarial review traced each against the pre-change code).
- New regression test: an existing on-disk cache re-opens through **both** architectures against the same directory with the build path proven never invoked (`process_fn` mock asserted not called — the actual mechanism, not a timing proxy).
- Public constructor signatures and YAML `class_path`s unchanged; existing tests needed zero adaptation.
- Suite: **424 passed, 2 skipped** (data-dependent imresize tests skip in a worktree by design); `ruff check` + `ruff format --check` clean.

LOC: `srcnn.py` −63, `srresnet.py` −62, `base.py` +126 (mostly the mandatory Google-style docstrings on the new public base) — the duplication is gone even though net LOC lands flat.

Adversarially reviewed: spec ✅, quality approved, no Critical/Important findings (three minor docstring polish notes deferred to the batch's final whole-branch review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)