### PR TITLE
Speed up the imresize hot path and benchmark-callback metrics

### DIFF
--- a/sisr/imresize.py
+++ b/sisr/imresize.py
@@ -60,6 +60,7 @@ SOFTWARE.
 ------------------------------------------------------------------------------
 """
 
+import functools
 from math import ceil
 
 import numpy as np
@@ -84,6 +85,7 @@ def _round_half_away_from_zero(x: np.ndarray) -> np.ndarray:
     return np.sign(x) * np.floor(np.abs(x) + 0.5)
 
 
+@functools.lru_cache(maxsize=32)
 def _contributions(in_length: int, out_length: int, scale: float) -> tuple[np.ndarray, np.ndarray]:
     """Per-output-pixel interpolation weights and source indices for one axis.
 
@@ -93,15 +95,22 @@ def _contributions(in_length: int, out_length: int, scale: float) -> tuple[np.nd
     indices are folded back via symmetric (mirror) padding, matching
     MATLAB's boundary handling.
 
+    A pure function of its arguments and constant for any one configured
+    dataset (fixed crop/scale), so it is memoized -- measured 2.21x/1.41x
+    (SRCNN/SRResNet) per-sample speedups with byte-identical output. The
+    returned arrays are marked read-only (``setflags(write=False)``) since
+    they are shared, not copied, across every call with the same arguments;
+    a caller mutating them would corrupt every other cache consumer.
+
     Args:
         in_length: Input size along this axis.
         out_length: Output size along this axis.
         scale: ``out_length / in_length``.
 
     Returns:
-        A ``(weights, indices)`` pair, each ``(out_length, num_taps)``:
-        row *i* lists the source-pixel weights/indices contributing to
-        output pixel *i*.
+        A ``(weights, indices)`` pair, each ``(out_length, num_taps)``,
+        both read-only: row *i* lists the source-pixel weights/indices
+        contributing to output pixel *i*.
     """
     if scale < 1.0:
         kernel_width = _KERNEL_WIDTH / scale
@@ -125,13 +134,23 @@ def _contributions(in_length: int, out_length: int, scale: float) -> tuple[np.nd
     indices = mirror[np.mod(indices.astype(np.int64), mirror.size)]
 
     keep = np.any(weights != 0.0, axis=0)
-    return weights[:, keep], indices[:, keep]
+    weights, indices = weights[:, keep], indices[:, keep]
+    weights.setflags(write=False)
+    indices.setflags(write=False)
+    return weights, indices
 
 
 def _resize_axis(
     image: np.ndarray, axis: int, weights: np.ndarray, indices: np.ndarray
 ) -> np.ndarray:
     """One 1-D weighted-interpolation pass along *axis*, re-quantized to uint8.
+
+    The weights/gathered-taps contraction runs through a single
+    ``np.einsum`` call rather than broadcasting ``weights * gathered`` into a
+    second full-size float64 temporary before ``np.sum`` -- on a ~1356x2040x3
+    DIV2K image that temporary was >530 MB transient per call; einsum fuses
+    the multiply and reduction, measured 1.77x per axis pass with
+    bit-identical output.
 
     Args:
         image: uint8 array, ``(H, W, C)``.
@@ -144,10 +163,10 @@ def _resize_axis(
     """
     if axis == 0:
         gathered = image[indices].astype(np.float64)  # (out_h, num_taps, W, C)
-        out = np.sum(weights[:, :, None, None] * gathered, axis=1)
+        out = np.einsum("ij,ijkl->ikl", weights, gathered, optimize=True)
     else:
         gathered = image[:, indices].astype(np.float64)  # (H, out_w, num_taps, C)
-        out = np.sum(weights[None, :, :, None] * gathered, axis=2)
+        out = np.einsum("jk,ijkl->ijl", weights, gathered, optimize=True)
     return _round_half_away_from_zero(np.clip(out, 0.0, 255.0)).astype(np.uint8)
 
 

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -33,6 +33,11 @@ class BenchmarkSample(NamedTuple):
     Fields are accessed by name at every read site — a bare positional
     tuple here previously made ``_flush_buffer``'s mean computation
     (``s[4]``/``s[5]``) unreadable at the call site.
+
+    Attributes:
+        filename: Stem of the source image path, used as the TensorBoard tag suffix.
+        psnr: PSNR value per configured key (``eval_config.psnr_keys``).
+        ssim: SSIM value per configured key (``eval_config.ssim_keys``).
     """
 
     filename: str

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -13,7 +13,7 @@ output to disk as PNGs.
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from weakref import proxy
 
 import lightning
@@ -25,6 +25,19 @@ from lightning.pytorch.callbacks import BasePredictionWriter, Callback, ModelChe
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 from .metadata import build_metadata
+
+
+class BenchmarkSample(NamedTuple):
+    """One buffered per-image result: PSNR/SSIM only, no image tensors.
+
+    Fields are accessed by name at every read site — a bare positional
+    tuple here previously made ``_flush_buffer``'s mean computation
+    (``s[4]``/``s[5]``) unreadable at the call site.
+    """
+
+    filename: str
+    psnr: dict[str, float]
+    ssim: dict[str, float]
 
 
 class BenchmarkImageLogger(Callback):
@@ -56,6 +69,17 @@ class BenchmarkImageLogger(Callback):
 
     Border cropping is sourced from ``pl_module.eval_config.crop_border`` at
     the use site; this avoids dual-knob configuration drift.
+
+    Metrics are computed directly on the on-device SR/HR slices (mirroring
+    the primary-val-loader path in ``SRLightning.validation_step``) and both
+    the per-image scalars and the image strip are emitted immediately, per
+    image, from :meth:`_collect_batch` — nothing image-shaped is buffered.
+    Buffering full-resolution LR/SR/HR CPU tensors for every image across
+    every test set until epoch end cost ~0.5 GB per validation cycle purely
+    to defer ``add_image``; only a :class:`BenchmarkSample` (filename +
+    PSNR/SSIM dicts) is buffered now, for the per-set mean computed in
+    :meth:`_flush_buffer`. The TensorBoard experiment is resolved once, in
+    :meth:`setup`, rather than re-searched on every batch/epoch-end.
 
     Args:
         dataset_names: Ordered list of test set names (e.g.
@@ -96,7 +120,12 @@ class BenchmarkImageLogger(Callback):
 
         self._val_run_count = 0
 
-        self._buffer: dict[str, list[tuple]] = {}
+        self._buffer: dict[str, list[BenchmarkSample]] = {}
+
+        # Resolved once in setup() rather than re-searched every batch/epoch-end;
+        # None when no TensorBoard logger is attached (image/scalar emission is
+        # then silently skipped, same as the previous per-flush behaviour).
+        self._tb_experiment: Any = None
 
     def setup(
         self,
@@ -104,7 +133,7 @@ class BenchmarkImageLogger(Callback):
         pl_module: lightning.LightningModule,
         stage: str,
     ):
-        """Resolve ``dataset_names`` and build both dataloader_idx mappings.
+        """Resolve ``dataset_names``, both dataloader_idx mappings, and the TB experiment.
 
         Auto-discovers ``dataset_names`` from ``trainer.datamodule.test_names``
         when not supplied at construction time.
@@ -120,6 +149,16 @@ class BenchmarkImageLogger(Callback):
             self.dataset_names = list(names or [])
         self._val_mapping = {i + 1: name for i, name in enumerate(self.dataset_names)}
         self._test_mapping = {i: name for i, name in enumerate(self.dataset_names)}
+
+        tb_logger = next(
+            (
+                logger
+                for logger in getattr(trainer, "loggers", None) or []
+                if isinstance(logger, lightning.pytorch.loggers.TensorBoardLogger)
+            ),
+            None,
+        )
+        self._tb_experiment = tb_logger.experiment if tb_logger is not None else None
 
     def on_validation_epoch_start(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
@@ -173,17 +212,17 @@ class BenchmarkImageLogger(Callback):
     def on_validation_epoch_end(
         self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
     ):
-        """Log per-set means every val epoch; image strips every N val runs.
+        """Log per-set mean PSNR/SSIM for the val epoch.
+
+        Image strips and per-image scalars were already streamed to
+        TensorBoard per-image in :meth:`_collect_batch`; only the means
+        remain to compute here.
 
         Args:
-            trainer: The active trainer.
+            trainer: Unused.
             pl_module: The model being evaluated.
         """
-        self._flush_buffer(
-            trainer=trainer,
-            pl_module=pl_module,
-            should_log_images=self._on_image_log_interval(),
-        )
+        self._flush_buffer(pl_module=pl_module)
 
     def on_test_epoch_start(self, trainer: lightning.Trainer, pl_module: lightning.LightningModule):
         """Clear buffers ahead of a test run.
@@ -231,17 +270,17 @@ class BenchmarkImageLogger(Callback):
         )
 
     def on_test_epoch_end(self, trainer: lightning.Trainer, pl_module: lightning.LightningModule):
-        """Log per-set means and image strips at the end of ``cli test``.
+        """Log per-set mean PSNR/SSIM at the end of ``cli test``.
+
+        Image strips and per-image scalars were already streamed to
+        TensorBoard per-image in :meth:`_collect_batch`; only the means
+        remain to compute here.
 
         Args:
-            trainer: The active trainer.
+            trainer: Unused.
             pl_module: The model being evaluated.
         """
-        self._flush_buffer(
-            trainer=trainer,
-            pl_module=pl_module,
-            should_log_images=True,
-        )
+        self._flush_buffer(pl_module=pl_module)
 
     def _on_image_log_interval(self) -> bool:
         """Return True when this val run should also log image strips."""
@@ -258,15 +297,24 @@ class BenchmarkImageLogger(Callback):
         dataloader_idx: int,
         should_log_images: bool,
     ):
-        """Forward one batch, compute per-image metrics, and buffer the results.
+        """Forward one batch, compute per-image metrics on-device, and stream image strips.
 
         Shared between :meth:`on_validation_batch_end` and
         :meth:`on_test_batch_end`. Border cropping is sourced from
         ``pl_module.eval_config.crop_border`` at the use site.
         *source_dataloaders* recovers the underlying dataset for filename
-        resolution. When *should_log_images*, LR/SR/HR tensors are cached for
-        image-strip emission in :meth:`_flush_buffer`; otherwise only scalar
-        metrics are buffered.
+        resolution.
+
+        PSNR/SSIM are computed from the on-device ``sr``/``hr_cropped``
+        slices — mirroring the primary-val-loader path in
+        ``SRLightning.validation_step`` — so only the scalar ``.item()``
+        results ever leave the GPU. When *should_log_images* (or
+        ``self.log_per_image_metrics``), exactly one host transfer per image
+        (``lr_img[i]``/``sr[i]``/``hr_img[i]`` each ``.cpu()`` at most once)
+        composes the bicubic|SR|HR strip and/or the per-image scalars, and
+        both are emitted to TensorBoard immediately — nothing image-shaped is
+        buffered. Only ``BenchmarkSample(filename, psnr_dict, ssim_dict)`` is
+        appended to ``self._buffer``, for :meth:`_flush_buffer`'s per-set mean.
         """
         lr_img, hr_img = batch
 
@@ -276,22 +324,22 @@ class BenchmarkImageLogger(Callback):
         # Resolve filenames from the underlying dataset for use as TB tags.
         dataset = source_dataloaders[dataloader_idx].dataset
         batch_size = lr_img.size(0)
+        n = pl_module.eval_config.crop_border
 
         for i in range(batch_size):
             global_idx = batch_idx * batch_size + i
             filename = dataset.img_paths[global_idx].stem
 
-            sr_4d = sr[i].unsqueeze(0).cpu()
-            hr_4d = hr_cropped[i].unsqueeze(0).cpu()
-            n = pl_module.eval_config.crop_border
+            sr_metric = sr[i : i + 1]
+            hr_metric = hr_cropped[i : i + 1]
             if n > 0:
-                sr_4d = sr_4d[..., n:-n, n:-n]
-                hr_4d = hr_4d[..., n:-n, n:-n]
+                sr_metric = sr_metric[..., n:-n, n:-n]
+                hr_metric = hr_metric[..., n:-n, n:-n]
             # Still a private reach: the colorspace split has no public
             # seam, and duplicating it here would recreate a divergence
             # this design removed. Keys now come from eval_config, so this is a value
             # lookup only — the callback no longer decides *which* keys exist.
-            metric_tensors = pl_module._build_metric_tensors(sr_4d, hr_4d)
+            metric_tensors = pl_module._build_metric_tensors(sr_metric, hr_metric)
             psnr_dict = {
                 key: torchmetrics.functional.image.peak_signal_noise_ratio(
                     *metric_tensors[key], data_range=1.0
@@ -304,96 +352,69 @@ class BenchmarkImageLogger(Callback):
                 ).item()
                 for key in pl_module.eval_config.ssim_keys
             }
-            self._buffer[dataset_name].append(
-                (
-                    filename,
-                    lr_img[i].cpu() if should_log_images else None,
-                    sr[i].cpu() if should_log_images else None,
-                    hr_img[i].cpu() if should_log_images else None,
-                    psnr_dict,
-                    ssim_dict,
-                )
+            self._buffer[dataset_name].append(BenchmarkSample(filename, psnr_dict, ssim_dict))
+
+            if self._tb_experiment is None:
+                continue
+
+            if self.log_per_image_metrics:
+                step = trainer.global_step
+                for key, psnr_val in psnr_dict.items():
+                    tag = f"per_image/{dataset_name}/psnr/{key}/{filename}"
+                    self._tb_experiment.add_scalar(tag, psnr_val, global_step=step)
+                for key, ssim_val in ssim_dict.items():
+                    tag = f"per_image/{dataset_name}/ssim/{key}/{filename}"
+                    self._tb_experiment.add_scalar(tag, ssim_val, global_step=step)
+
+            if not should_log_images:
+                continue
+
+            # One host transfer per image, only on cycles that log strips.
+            lr_cpu = lr_img[i].cpu()
+            sr_cpu = sr[i].cpu()
+            hr_cpu = hr_img[i].cpu()
+
+            # Triptych: bicubic | SR | HR, all at HR size.
+            # The bicubic panel is the LR upsampled to HR via bicubic
+            # interpolation — the standard SR baseline.  For SRCNN the
+            # LR is already at HR size (pre-upsampled in the dataset),
+            # so this resamples at 1:1 and is near-identity.  For
+            # SRResNet (LR < HR) it upscales to HR for direct visual
+            # comparison against SR.  SR is center-padded only when
+            # smaller than HR (SRCNN with padding='valid') to preserve
+            # full HR context on the right.
+            target_hw = hr_cpu.shape[-2:]
+            bicubic = self._bicubic_to(lr_cpu, target_hw)
+            sr_padded = self._pad_to_match(sr_cpu, target_hw)
+            strip = torchvision.utils.make_grid(
+                [bicubic, sr_padded, hr_cpu], nrow=3, padding=2, pad_value=0.5
+            )
+            self._tb_experiment.add_image(
+                f"{dataset_name}/{filename}", strip, global_step=trainer.global_step
             )
 
-    def _flush_buffer(
-        self,
-        trainer: lightning.Trainer,
-        pl_module: lightning.LightningModule,
-        should_log_images: bool,
-    ):
-        """Log per-set means and (optionally) per-image scalars/image strips.
+    def _flush_buffer(self, pl_module: lightning.LightningModule):
+        """Log per-set mean PSNR/SSIM from the buffered samples.
 
         Shared between :meth:`on_validation_epoch_end` and
-        :meth:`on_test_epoch_end`. Looks up the TensorBoard logger from
-        ``trainer.loggers``; silently skips per-image/image emission for
-        sets whose logger is missing. Per-image scalar emission is gated by
-        ``self.log_per_image_metrics``, independent of *should_log_images*
-        (which gates only the image strips) — the two concerns cost
-        differently (tag count vs. bytes) and are configured separately.
+        :meth:`on_test_epoch_end`. Per-image scalars and image strips were
+        already streamed to TensorBoard from :meth:`_collect_batch`; this
+        only reduces the buffered ``BenchmarkSample.psnr``/``.ssim`` dicts to
+        a mean per dataset/key.
         """
-        step = trainer.global_step
-
         for dataset_name, samples in self._buffer.items():
             if not samples:
                 continue
 
-            psnr_keys = samples[0][4].keys()
-            ssim_keys = samples[0][5].keys()
+            psnr_keys = samples[0].psnr.keys()
+            ssim_keys = samples[0].ssim.keys()
 
             for key in psnr_keys:
-                mean_psnr = sum(s[4][key] for s in samples) / len(samples)
+                mean_psnr = sum(s.psnr[key] for s in samples) / len(samples)
                 pl_module.log(f"psnr/{dataset_name}/{key}", mean_psnr, add_dataloader_idx=False)
             for key in ssim_keys:
-                mean_ssim = sum(s[5][key] for s in samples) / len(samples)
+                mean_ssim = sum(s.ssim[key] for s in samples) / len(samples)
                 pl_module.log(f"ssim/{dataset_name}/{key}", mean_ssim, add_dataloader_idx=False)
-
-            if should_log_images or self.log_per_image_metrics:
-                tb_logger = next(
-                    (
-                        logger
-                        for logger in trainer.loggers
-                        if isinstance(logger, lightning.pytorch.loggers.TensorBoardLogger)
-                    ),
-                    None,
-                )
-                if tb_logger is None:
-                    continue
-
-                experiment = tb_logger.experiment
-                for filename, lr, sr, hr, psnr_dict, ssim_dict in samples:
-                    if self.log_per_image_metrics:
-                        for key, psnr_val in psnr_dict.items():
-                            experiment.add_scalar(
-                                f"per_image/{dataset_name}/psnr/{key}/{filename}",
-                                psnr_val,
-                                global_step=step,
-                            )
-                        for key, ssim_val in ssim_dict.items():
-                            experiment.add_scalar(
-                                f"per_image/{dataset_name}/ssim/{key}/{filename}",
-                                ssim_val,
-                                global_step=step,
-                            )
-
-                    if not should_log_images:
-                        continue
-
-                    # Triptych: bicubic | SR | HR, all at HR size.
-                    # The bicubic panel is the LR upsampled to HR via bicubic
-                    # interpolation — the standard SR baseline.  For SRCNN the
-                    # LR is already at HR size (pre-upsampled in the dataset),
-                    # so this resamples at 1:1 and is near-identity.  For
-                    # SRResNet (LR < HR) it upscales to HR for direct visual
-                    # comparison against SR.  SR is center-padded only when
-                    # smaller than HR (SRCNN with padding='valid') to preserve
-                    # full HR context on the right.
-                    target_hw = hr.shape[-2:]
-                    bicubic = self._bicubic_to(lr, target_hw)
-                    sr_padded = self._pad_to_match(sr, target_hw)
-                    strip = torchvision.utils.make_grid(
-                        [bicubic, sr_padded, hr], nrow=3, padding=2, pad_value=0.5
-                    )
-                    experiment.add_image(f"{dataset_name}/{filename}", strip, global_step=step)
 
         self._buffer.clear()
 

--- a/tests/test_imresize.py
+++ b/tests/test_imresize.py
@@ -71,6 +71,7 @@ from PIL import Image
 from sisr.imresize import (
     _contributions,
     _cubic,
+    _resize_axis,
     _round_half_away_from_zero,
     matlab_imresize,
     resize,
@@ -120,6 +121,117 @@ def test_contributions_folds_out_of_range_indices_symmetrically():
     # Mirror padding revisits near-edge source pixels rather than saturating
     # at a single edge value -- i.e. more than one distinct low index is used.
     assert len(set(indices[0].tolist())) > 1
+
+
+##########################################################################
+# _contributions memoization (functools.lru_cache)
+##########################################################################
+
+
+def test_contributions_repeat_call_returns_identical_cached_arrays():
+    """Same args must return the exact same (cached) array objects, not
+    merely equal ones -- proves the lru_cache is actually hit, not just
+    present and bypassed."""
+    weights1, indices1 = _contributions(50, 20, 0.4)
+    weights2, indices2 = _contributions(50, 20, 0.4)
+    assert weights1 is weights2
+    assert indices1 is indices2
+
+
+def test_contributions_cached_arrays_are_read_only():
+    """Cached arrays are shared across every call with the same args; a
+    mutating caller would corrupt every other consumer, so both arrays must
+    refuse in-place writes."""
+    weights, indices = _contributions(50, 20, 0.4)
+    assert weights.flags.writeable is False
+    assert indices.flags.writeable is False
+    with pytest.raises(ValueError):
+        weights[0, 0] = 999.0
+    with pytest.raises(ValueError):
+        indices[0, 0] = 999
+
+
+def test_contributions_cache_matches_uncached_computation():
+    """The memoized wrapper must compute the exact same weights/indices as
+    the undecorated function -- reached via __wrapped__, lru_cache's
+    standard escape hatch to the raw callable, so this holds regardless of
+    what else has populated the cache."""
+    for in_length, out_length, scale in [(100, 25, 0.25), (25, 100, 4.0), (24, 8, 1 / 3)]:
+        cached_weights, cached_indices = _contributions(in_length, out_length, scale)
+        raw_weights, raw_indices = _contributions.__wrapped__(in_length, out_length, scale)
+        assert np.array_equal(cached_weights, raw_weights)
+        assert np.array_equal(cached_indices, raw_indices)
+
+
+def test_matlab_imresize_output_unchanged_by_contributions_cache():
+    """End-to-end resize output must be byte-identical whether _contributions
+    is served from cache or recomputed via __wrapped__ -- the strongest
+    available proof that memoizing it didn't change matlab_imresize's
+    numerics."""
+    rng = np.random.default_rng(3)
+    img = rng.integers(0, 256, size=(24, 24, 3), dtype=np.uint8)
+    out_shape = (8, 8)
+
+    cached_out = matlab_imresize(img, out_shape)
+
+    in_h, in_w = img.shape[:2]
+    out_h, out_w = out_shape
+    scale = out_h / in_h  # square image, square target -> one scale for both axes
+    weights_h, indices_h = _contributions.__wrapped__(in_h, out_h, scale)
+    weights_w, indices_w = _contributions.__wrapped__(in_w, out_w, scale)
+    arr = _resize_axis(img, 0, weights_h, indices_h)
+    arr = _resize_axis(arr, 1, weights_w, indices_w)
+
+    assert np.array_equal(cached_out, arr)
+
+
+##########################################################################
+# _resize_axis single-pass einsum contraction
+##########################################################################
+
+
+def _naive_resize_axis(image: np.ndarray, axis: int, weights: np.ndarray, indices: np.ndarray):
+    """Pre-optimization reference: materializes the full weights*gathered
+    temporary before np.sum -- the exact computation _resize_axis's einsum
+    now replaces. Kept local to this test so the einsum path has an
+    independent, un-optimized oracle to compare against."""
+    if axis == 0:
+        gathered = image[indices].astype(np.float64)
+        out = np.sum(weights[:, :, None, None] * gathered, axis=1)
+    else:
+        gathered = image[:, indices].astype(np.float64)
+        out = np.sum(weights[None, :, :, None] * gathered, axis=2)
+    return _round_half_away_from_zero(np.clip(out, 0.0, 255.0)).astype(np.uint8)
+
+
+@pytest.mark.parametrize(
+    "in_h,in_w,out_h,out_w,channels",
+    [
+        (30, 45, 10, 15, 3),  # downscale, non-square
+        (10, 15, 30, 45, 3),  # upscale, non-square
+        (17, 23, 9, 8, 1),  # downscale, 1-channel, odd sizes
+        (9, 8, 17, 23, 1),  # upscale, 1-channel
+        (24, 24, 24, 24, 3),  # identity scale
+    ],
+)
+def test_resize_axis_einsum_matches_naive_multiply_then_sum(in_h, in_w, out_h, out_w, channels):
+    """The einsum contraction in _resize_axis must be bit-identical to the
+    multiply-then-np.sum it replaces, for both axis passes, non-square
+    shapes, 1- and 3-channel images, and both up- and down-scaling."""
+    rng = np.random.default_rng(hash((in_h, in_w, out_h, out_w, channels)) % (2**32))
+    img = rng.integers(0, 256, size=(in_h, in_w, channels), dtype=np.uint8)
+
+    weights_h, indices_h = _contributions(in_h, out_h, out_h / in_h)
+    weights_w, indices_w = _contributions(in_w, out_w, out_w / in_w)
+
+    assert np.array_equal(
+        _resize_axis(img, 0, weights_h, indices_h),
+        _naive_resize_axis(img, 0, weights_h, indices_h),
+    )
+    assert np.array_equal(
+        _resize_axis(img, 1, weights_w, indices_w),
+        _naive_resize_axis(img, 1, weights_w, indices_w),
+    )
 
 
 def test_matlab_imresize_constant_image_is_invariant():

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import lightning
 import pytest
 import torch
+import torchmetrics.functional
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
@@ -617,6 +618,81 @@ def test_benchmark_collect_batch_buffers_no_image_tensors():
     assert isinstance(sample, BenchmarkSample)
     for value in sample:
         assert not isinstance(value, torch.Tensor)
+
+
+def test_collect_batch_metric_values_match_pre_change_host_copy_first_ordering():
+    """D3 equivalence proof: the pre-change code moved each image to CPU
+    FIRST (``sr[i].unsqueeze(0).cpu()``), THEN cropped, THEN built metric
+    tensors + PSNR/SSIM; the shipped _collect_batch crops the (on-device)
+    per-image slice directly and computes PSNR/SSIM on it without any
+    intervening host copy. Both orderings must agree exactly on every
+    configured metric key. CPU-only (no GPU dependency), so this runs on CI.
+    """
+    torch.manual_seed(0)
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    pl_module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(
+            crop_border=3,
+            psnr_channels=["RGB", "YCbCr"],
+            separate_psnr=True,
+            ssim_channels=["RGB", "Y"],
+        ),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    lr_img = torch.rand(4, 3, 20, 20)
+    hr_img = torch.rand(4, 3, 20, 20)
+    with torch.no_grad():
+        sr, hr_cropped = pl_module.predict_rgb(lr_img, hr_img)
+
+    n = pl_module.eval_config.crop_border
+    psnr_keys = pl_module.eval_config.psnr_keys
+    ssim_keys = pl_module.eval_config.ssim_keys
+    assert n > 0 and len(psnr_keys) > 1 and len(ssim_keys) > 1  # actually exercises both
+
+    for i in range(lr_img.size(0)):
+        # Pre-change ordering: host-copy the per-image slice FIRST, then crop.
+        sr_old = sr[i].unsqueeze(0).cpu()
+        hr_old = hr_cropped[i].unsqueeze(0).cpu()
+        sr_old = sr_old[..., n:-n, n:-n]
+        hr_old = hr_old[..., n:-n, n:-n]
+        metric_tensors_old = pl_module._build_metric_tensors(sr_old, hr_old)
+        psnr_old = {
+            key: torchmetrics.functional.image.peak_signal_noise_ratio(
+                *metric_tensors_old[key], data_range=1.0
+            ).item()
+            for key in psnr_keys
+        }
+        ssim_old = {
+            key: torchmetrics.functional.image.structural_similarity_index_measure(
+                *metric_tensors_old[key], data_range=1.0
+            ).item()
+            for key in ssim_keys
+        }
+
+        # Shipped ordering: crop the per-image slice directly, no intervening copy.
+        sr_new = sr[i : i + 1][..., n:-n, n:-n]
+        hr_new = hr_cropped[i : i + 1][..., n:-n, n:-n]
+        metric_tensors_new = pl_module._build_metric_tensors(sr_new, hr_new)
+        psnr_new = {
+            key: torchmetrics.functional.image.peak_signal_noise_ratio(
+                *metric_tensors_new[key], data_range=1.0
+            ).item()
+            for key in psnr_keys
+        }
+        ssim_new = {
+            key: torchmetrics.functional.image.structural_similarity_index_measure(
+                *metric_tensors_new[key], data_range=1.0
+            ).item()
+            for key in ssim_keys
+        }
+
+        for key in psnr_keys:
+            assert psnr_new[key] == pytest.approx(psnr_old[key], abs=1e-6), f"psnr[{key}]"
+        for key in ssim_keys:
+            assert ssim_new[key] == pytest.approx(ssim_old[key], abs=1e-6), f"ssim[{key}]"
 
 
 def test_benchmark_validation_epoch_end_logs_means():

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -22,6 +22,7 @@ from sisr.training import (
     SRWeightsCheckpoint,
     WeightHistogramLogger,
 )
+from sisr.training.callbacks import BenchmarkSample
 
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
@@ -562,8 +563,7 @@ def test_benchmark_validation_batch_end_skips_primary_loader():
 
 
 def test_benchmark_validation_batch_end_collects_for_test_loader():
-    """dataloader_idx >= 1 populates the buffer with metrics + (since
-    log_every_n_val_runs=1) cached LR/SR/HR tensors."""
+    """dataloader_idx >= 1 populates the buffer with a BenchmarkSample per image."""
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = _make_real_pl_module()
@@ -586,13 +586,37 @@ def test_benchmark_validation_batch_end_collects_for_test_loader():
         dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 2
-    # Each entry: (filename, lr|None, sr|None, hr|None, psnr_dict, ssim_dict).
-    fname, lr, sr, hr, psnr, ssim = cb._buffer["Set5"][0]
-    assert fname == "Set5_000"
-    assert lr is not None and sr is not None and hr is not None
-    assert "RGB" in psnr
-    assert "RGB" in ssim and "Y" in ssim  # eval_config.ssim_channels default
-    assert isinstance(ssim["RGB"], float)
+    sample = cb._buffer["Set5"][0]
+    assert sample.filename == "Set5_000"
+    assert "RGB" in sample.psnr
+    assert "RGB" in sample.ssim and "Y" in sample.ssim  # eval_config.ssim_channels default
+    assert isinstance(sample.ssim["RGB"], float)
+
+
+def test_benchmark_collect_batch_buffers_no_image_tensors():
+    """The buffer must hold BenchmarkSample(filename, psnr, ssim) only -- no
+    LR/SR/HR tensors -- even when should_log_images is True, since image
+    strips are now streamed directly from _collect_batch instead of being
+    deferred to epoch end."""
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    pl_module = _make_real_pl_module()
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer = SimpleNamespace(val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)])
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
+    )
+    sample = cb._buffer["Set5"][0]
+    assert isinstance(sample, BenchmarkSample)
+    for value in sample:
+        assert not isinstance(value, torch.Tensor)
 
 
 def test_benchmark_validation_epoch_end_logs_means():
@@ -602,14 +626,11 @@ def test_benchmark_validation_epoch_end_logs_means():
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    # Hand-populate buffer with two entries; image tensors set None so the
-    # image-strip branch is skipped (covered by the next test).
     cb._buffer["Set5"] = [
-        ("img_0", None, None, None, {"RGB": 30.0}, {"RGB": 0.9}),
-        ("img_1", None, None, None, {"RGB": 32.0}, {"RGB": 0.85}),
+        BenchmarkSample("img_0", {"RGB": 30.0}, {"RGB": 0.9}),
+        BenchmarkSample("img_1", {"RGB": 32.0}, {"RGB": 0.85}),
     ]
-    trainer = SimpleNamespace(global_step=42, loggers=[])
-    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    cb.on_validation_epoch_end(trainer=SimpleNamespace(), pl_module=pl_module)
     # Two log calls per dataset: psnr + ssim.
     log_keys = [call.args[0] for call in pl_module.log.call_args_list]
     assert "psnr/Set5/RGB" in log_keys
@@ -622,30 +643,13 @@ def test_benchmark_validation_epoch_end_logs_means():
     assert ssim_call.args[1] == pytest.approx(0.875)
 
 
-def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path: Path, monkeypatch):
-    """With log_per_image_metrics=True and on the log interval, _flush_buffer
-    must actually call experiment.add_image once (the bicubic|SR|HR strip) and
-    experiment.add_scalar for the per-image psnr + ssim. The old test only
-    checked it didn't raise, so a silently-skipped emit would have passed."""
+def test_benchmark_collect_batch_emits_add_image_and_add_scalar(tmp_path: Path, monkeypatch):
+    """With log_per_image_metrics=True and on the log interval, _collect_batch
+    must call experiment.add_image once (the bicubic|SR|HR strip) and
+    experiment.add_scalar for the per-image psnr + ssim -- streamed immediately
+    from the batch hook rather than deferred to epoch end."""
     import lightning.pytorch.loggers as pl_loggers
 
-    cb = BenchmarkImageLogger(
-        dataset_names=["Set5"], log_every_n_val_runs=1, log_per_image_metrics=True
-    )
-    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
-    pl_module = MagicMock()
-    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    # SRCNN-style: LR already at HR size (4x4). One image, one psnr key.
-    cb._buffer["Set5"] = [
-        (
-            "img_0",
-            torch.rand(3, 4, 4),
-            torch.rand(3, 4, 4),
-            torch.rand(3, 4, 4),
-            {"RGB": 30.0},
-            {"RGB": 0.9},
-        ),
-    ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     experiment = tb_logger.experiment  # materialize the SummaryWriter before wrapping
     add_image = MagicMock(wraps=experiment.add_image)
@@ -653,40 +657,48 @@ def test_benchmark_validation_epoch_end_emits_add_image_and_add_scalar(tmp_path:
     monkeypatch.setattr(experiment, "add_image", add_image)
     monkeypatch.setattr(experiment, "add_scalar", add_scalar)
 
-    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
-    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    cb = BenchmarkImageLogger(
+        dataset_names=["Set5"], log_every_n_val_runs=1, log_per_image_metrics=True
+    )
+    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    cb.setup(trainer, pl_module=None, stage="fit")
+    pl_module = _make_real_pl_module()  # SRCNN + RGBProcessor: LR/SR/HR all 16x16
+    cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
+
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer.val_dataloaders = [_stub_dataloader(None), _stub_dataloader(ds)]
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
+    )
     tb_logger.finalize("success")
 
     add_image.assert_called_once()
     tag, strip = add_image.call_args.args[0], add_image.call_args.args[1]
-    assert tag == "Set5/img_0"
+    assert tag == "Set5/Set5_000"
     assert strip.ndim == 3 and strip.shape[0] == 3  # (C, H, W) triptych
-    # One psnr scalar (RGB) + one ssim scalar for the single buffered image.
+    # psnr_channels default ['RGB'] + ssim_channels default ['RGB', 'Y'].
     scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
-    assert scalar_tags == ["per_image/Set5/psnr/RGB/img_0", "per_image/Set5/ssim/RGB/img_0"]
+    assert scalar_tags == [
+        "per_image/Set5/psnr/RGB/Set5_000",
+        "per_image/Set5/ssim/RGB/Set5_000",
+        "per_image/Set5/ssim/Y/Set5_000",
+    ]
 
 
-def test_benchmark_default_omits_per_image_scalars_but_keeps_set_means(tmp_path: Path, monkeypatch):
-    """log_per_image_metrics defaults to False: image strips still log (gated
-    only by should_log_images), but no per_image/... scalar is emitted. Per-set
-    mean psnr/ssim (via pl_module.log) are unaffected by this flag entirely."""
+def test_benchmark_collect_batch_default_omits_per_image_scalars_but_keeps_images(
+    tmp_path: Path, monkeypatch
+):
+    """log_per_image_metrics defaults to False: image strips still stream
+    (gated only by should_log_images), but no per_image/... scalar is
+    emitted."""
     import lightning.pytorch.loggers as pl_loggers
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
-    assert cb.log_per_image_metrics is False
-    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
-    pl_module = MagicMock()
-    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    cb._buffer["Set5"] = [
-        (
-            "img_0",
-            torch.rand(3, 4, 4),
-            torch.rand(3, 4, 4),
-            torch.rand(3, 4, 4),
-            {"RGB": 30.0},
-            {"RGB": 0.9},
-        ),
-    ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     experiment = tb_logger.experiment
     add_image = MagicMock(wraps=experiment.add_image)
@@ -694,33 +706,38 @@ def test_benchmark_default_omits_per_image_scalars_but_keeps_set_means(tmp_path:
     monkeypatch.setattr(experiment, "add_image", add_image)
     monkeypatch.setattr(experiment, "add_scalar", add_scalar)
 
-    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
-    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    assert cb.log_per_image_metrics is False
+    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    cb.setup(trainer, pl_module=None, stage="fit")
+    pl_module = _make_real_pl_module()
+    cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
+
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer.val_dataloaders = [_stub_dataloader(None), _stub_dataloader(ds)]
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
+    )
     tb_logger.finalize("success")
 
     add_image.assert_called_once()  # image strip unaffected by the flag
     add_scalar.assert_not_called()  # no per_image/... scalar emitted
-    log_keys = [call.args[0] for call in pl_module.log.call_args_list]
-    assert "psnr/Set5/RGB" in log_keys
-    assert "ssim/Set5/RGB" in log_keys
 
 
-def test_benchmark_log_per_image_metrics_decoupled_from_image_strips(tmp_path: Path, monkeypatch):
+def test_benchmark_collect_batch_log_per_image_metrics_decoupled_from_image_strips(
+    tmp_path: Path, monkeypatch
+):
     """log_per_image_metrics=True must emit per-image scalars even on a val run
     where should_log_images is False (log_every_n_val_runs throttles images,
     not per-image metrics) — proving the two concerns are independently gated."""
     import lightning.pytorch.loggers as pl_loggers
 
-    cb = BenchmarkImageLogger(
-        dataset_names=["Set5"], log_every_n_val_runs=99, log_per_image_metrics=True
-    )
-    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
-    pl_module = MagicMock()
-    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    assert cb._on_image_log_interval() is False  # confirms should_log_images will be False
-    cb._buffer["Set5"] = [
-        ("img_0", None, None, None, {"RGB": 30.0}, {"RGB": 0.9}),
-    ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     experiment = tb_logger.experiment
     add_image = MagicMock(wraps=experiment.add_image)
@@ -728,16 +745,40 @@ def test_benchmark_log_per_image_metrics_decoupled_from_image_strips(tmp_path: P
     monkeypatch.setattr(experiment, "add_image", add_image)
     monkeypatch.setattr(experiment, "add_scalar", add_scalar)
 
-    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
-    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    cb = BenchmarkImageLogger(
+        dataset_names=["Set5"], log_every_n_val_runs=99, log_per_image_metrics=True
+    )
+    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    cb.setup(trainer, pl_module=None, stage="fit")
+    pl_module = _make_real_pl_module()
+    cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
+    assert cb._on_image_log_interval() is False  # confirms should_log_images will be False
+
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer.val_dataloaders = [_stub_dataloader(None), _stub_dataloader(ds)]
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
+    )
     tb_logger.finalize("success")
 
     add_image.assert_not_called()  # images still throttled
     scalar_tags = [c.args[0] for c in add_scalar.call_args_list]
-    assert scalar_tags == ["per_image/Set5/psnr/RGB/img_0", "per_image/Set5/ssim/RGB/img_0"]
+    assert scalar_tags == [
+        "per_image/Set5/psnr/RGB/Set5_000",
+        "per_image/Set5/ssim/RGB/Set5_000",
+        "per_image/Set5/ssim/Y/Set5_000",
+    ]
 
 
-def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path, monkeypatch):
+def test_benchmark_collect_batch_image_strip_first_panel_is_bicubic_at_hr_size(
+    tmp_path: Path, monkeypatch
+):
     """The first triptych panel must be the bicubic-upsampled LR at HR size,
     not the original LR or a zero-padded LR. Locks the Bicubic|SR|HR layout."""
     import lightning.pytorch.loggers as pl_loggers
@@ -752,58 +793,81 @@ def test_benchmark_image_strip_first_panel_is_bicubic_at_hr_size(tmp_path: Path,
 
     monkeypatch.setattr(torchvision.utils, "make_grid", spy_make_grid)
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
-    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
-    pl_module = MagicMock()
-    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    lr = torch.rand(3, 4, 4)
-    sr = torch.rand(3, 16, 16)
-    hr = torch.rand(3, 16, 16)
-    cb._buffer["Set5"] = [("img_0", lr, sr, hr, {"RGB": 30.0}, {"RGB": 0.9})]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
-    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
-    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    cb.setup(trainer, pl_module=None, stage="fit")
+
+    pl_module = _make_real_pl_module()
+    # Fix predict_rgb's output so the SR/HR panel content is known exactly,
+    # independent of the (untrained) model's actual forward pass.
+    sr_fixed = torch.rand(1, 3, 16, 16)
+    hr_cropped_fixed = torch.rand(1, 3, 16, 16)
+    monkeypatch.setattr(
+        pl_module, "predict_rgb", MagicMock(return_value=(sr_fixed, hr_cropped_fixed))
+    )
+    cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
+
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer.val_dataloaders = [_stub_dataloader(None), _stub_dataloader(ds)]
+    lr_batch = torch.rand(1, 3, 4, 4)
+    hr_batch = torch.rand(1, 3, 16, 16)
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=(lr_batch, hr_batch),
+        batch_idx=0,
+        dataloader_idx=1,
+    )
     tb_logger.finalize("success")
 
     assert len(captured) == 1
     panels = captured[0]
     assert len(panels) == 3
-    expected_bicubic = BenchmarkImageLogger._bicubic_to(lr, hr.shape[-2:])
+    expected_bicubic = BenchmarkImageLogger._bicubic_to(lr_batch[0], hr_batch[0].shape[-2:])
     torch.testing.assert_close(panels[0], expected_bicubic)
-    # SR is already HR-sized so _pad_to_match is a no-op; HR is untouched.
-    torch.testing.assert_close(panels[1], sr)
-    torch.testing.assert_close(panels[2], hr)
+    # SR is already HR-sized so _pad_to_match is a no-op; HR panel is the
+    # original (uncropped) batch HR, not predict_rgb's cropped hr_cropped.
+    torch.testing.assert_close(panels[1], sr_fixed[0])
+    torch.testing.assert_close(panels[2], hr_batch[0])
 
 
-def test_benchmark_image_strips_upsample_lr_to_hr_size(tmp_path: Path, monkeypatch):
+def test_benchmark_collect_batch_image_strip_upsamples_lr_to_hr_size(tmp_path: Path, monkeypatch):
     """For an upscaling model (SRResNet) LR (4x4) is smaller than SR/HR (16x16);
     the strip must bicubic-upsample LR to HR size, so add_image is called once
-    with a panel taller than the LR (not crash make_grid on a size mismatch, and
-    not log at LR size). The old test only asserted it didn't raise."""
+    with a panel taller than the LR (not crash make_grid on a size mismatch)."""
     import lightning.pytorch.loggers as pl_loggers
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
-    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
-    pl_module = MagicMock()
-    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    # LR 4x4, SR and HR 16x16 (x4 model).
-    cb._buffer["Set5"] = [
-        (
-            "img_0",
-            torch.rand(3, 4, 4),
-            torch.rand(3, 16, 16),
-            torch.rand(3, 16, 16),
-            {"RGB": 30.0},
-            {"RGB": 0.9},
-        ),
-    ]
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     experiment = tb_logger.experiment
     add_image = MagicMock(wraps=experiment.add_image)
     monkeypatch.setattr(experiment, "add_image", add_image)
 
-    trainer = SimpleNamespace(global_step=42, loggers=[tb_logger])
-    cb.on_validation_epoch_end(trainer=trainer, pl_module=pl_module)  # must not raise
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    cb.setup(trainer, pl_module=None, stage="fit")
+
+    pl_module = _make_real_pl_module()
+    sr_fixed = torch.rand(1, 3, 16, 16)
+    hr_cropped_fixed = torch.rand(1, 3, 16, 16)
+    monkeypatch.setattr(
+        pl_module, "predict_rgb", MagicMock(return_value=(sr_fixed, hr_cropped_fixed))
+    )
+    cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
+
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer.val_dataloaders = [_stub_dataloader(None), _stub_dataloader(ds)]
+    lr_batch = torch.rand(1, 3, 4, 4)  # LR 4x4, SR/HR (mocked) 16x16 -- x4 model
+    hr_batch = torch.rand(1, 3, 16, 16)
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=(lr_batch, hr_batch),
+        batch_idx=0,
+        dataloader_idx=1,
+    )  # must not raise
     tb_logger.finalize("success")
 
     add_image.assert_called_once()
@@ -842,11 +906,8 @@ def test_benchmark_test_epoch_end_logs_means():
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="test")
     pl_module = MagicMock()
     cb.on_test_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    cb._buffer["Set5"] = [
-        ("img_0", None, None, None, {"RGB": 28.0}, {"RGB": 0.7}),
-    ]
-    trainer = SimpleNamespace(global_step=0, loggers=[])
-    cb.on_test_epoch_end(trainer=trainer, pl_module=pl_module)
+    cb._buffer["Set5"] = [BenchmarkSample("img_0", {"RGB": 28.0}, {"RGB": 0.7})]
+    cb.on_test_epoch_end(trainer=SimpleNamespace(), pl_module=pl_module)
     log_keys = [call.args[0] for call in pl_module.log.call_args_list]
     assert "psnr/Set5/RGB" in log_keys
     assert "ssim/Set5/RGB" in log_keys
@@ -929,16 +990,17 @@ def test_benchmark_collect_batch_crops_per_eval_config():
         dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 1
-    _, _, _, _, psnr_dict, ssim_dict = cb._buffer["Set5"][0]
-    assert "RGB" in psnr_dict
-    assert "RGB" in ssim_dict
-    assert isinstance(ssim_dict["RGB"], float)
+    sample = cb._buffer["Set5"][0]
+    assert "RGB" in sample.psnr
+    assert "RGB" in sample.ssim
+    assert isinstance(sample.ssim["RGB"], float)
 
 
 def test_benchmark_collect_batch_routes_through_processor():
     """SRCNN+YChannelProcessor: _collect_batch must extract Y from RGB LR before the
     model forward, then reconstruct SR back to RGB. Bypassing the processor would
-    feed 3-channel RGB to a 1-channel Conv2d and crash with a shape mismatch."""
+    feed 3-channel RGB to a 1-channel Conv2d and crash with a shape mismatch (proven
+    here by the forward completing and yielding the expected metric key sets)."""
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     # 1-channel SRCNN paired with YChannelProcessor — production SRCNN template shape.
@@ -966,15 +1028,11 @@ def test_benchmark_collect_batch_routes_through_processor():
         dataloader_idx=1,
     )
     assert len(cb._buffer["Set5"]) == 1
-    _, lr_cached, sr_cached, hr_cached, psnr_dict, ssim_dict = cb._buffer["Set5"][0]
-    # All cached tensors are full RGB (reconstruct stitched SR-Y with bicubic Cb/Cr).
-    assert lr_cached.shape == (3, 16, 16)
-    assert sr_cached.shape == (3, 16, 16)
-    assert hr_cached.shape == (3, 16, 16)
-    assert "RGB" in psnr_dict
-    assert "YCbCr" in psnr_dict
-    assert "RGB" in ssim_dict and "Y" in ssim_dict  # eval_config.ssim_channels default
-    assert isinstance(ssim_dict["RGB"], float)
+    sample = cb._buffer["Set5"][0]
+    assert "RGB" in sample.psnr
+    assert "YCbCr" in sample.psnr
+    assert "RGB" in sample.ssim and "Y" in sample.ssim  # eval_config.ssim_channels default
+    assert isinstance(sample.ssim["RGB"], float)
 
 
 def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_false():
@@ -1008,8 +1066,8 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_fals
         batch_idx=0,
         dataloader_idx=1,
     )
-    _, _, _, _, psnr_dict, _ = cb._buffer["Set5"][0]
-    assert set(psnr_dict.keys()) == set(pl_module.eval_config.psnr_keys) == {"RGB", "YCbCr"}
+    sample = cb._buffer["Set5"][0]
+    assert set(sample.psnr.keys()) == set(pl_module.eval_config.psnr_keys) == {"RGB", "YCbCr"}
 
 
 def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_true():
@@ -1038,8 +1096,8 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_true
         batch_idx=0,
         dataloader_idx=1,
     )
-    _, _, _, _, psnr_dict, _ = cb._buffer["Set5"][0]
-    assert set(psnr_dict.keys()) == set(pl_module.eval_config.psnr_keys) == {"R", "G", "B", "RGB"}
+    sample = cb._buffer["Set5"][0]
+    assert set(sample.psnr.keys()) == set(pl_module.eval_config.psnr_keys) == {"R", "G", "B", "RGB"}
 
 
 # ---------------------------------------------------------------------------
@@ -1048,15 +1106,10 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_true
 
 
 def test_benchmark_collect_batch_routes_through_predict_rgb():
-    """_collect_batch must call the public pl_module.predict_rgb, and the
-    buffered SR/HR must equal its output — proving no re-implemented, divergent
-    forward path remains in the callback."""
-    from unittest.mock import MagicMock
-
+    """_collect_batch must call the public pl_module.predict_rgb -- proving no
+    re-implemented, divergent forward path remains in the callback."""
     pl_module = _make_real_pl_module()  # SRCNN + RGBProcessor, crop_border=0
     batch = (torch.rand(2, 3, 16, 16), torch.rand(2, 3, 16, 16))
-    with torch.no_grad():
-        ref_sr, ref_hr = pl_module.predict_rgb(*batch)
 
     spy = MagicMock(wraps=pl_module.predict_rgb)
     pl_module.predict_rgb = spy
@@ -1081,10 +1134,7 @@ def test_benchmark_collect_batch_routes_through_predict_rgb():
     call_args, _ = spy.call_args
     torch.testing.assert_close(call_args[0], batch[0])
     torch.testing.assert_close(call_args[1], batch[1])
-    # Buffered SR/HR (uncropped, crop_border=0) match the public forward output.
-    _, _, sr0, hr0, _, _ = cb._buffer["Set5"][0]
-    torch.testing.assert_close(sr0, ref_sr[0].cpu())
-    torch.testing.assert_close(hr0, ref_hr[0].cpu())
+    assert len(cb._buffer["Set5"]) == 2
 
 
 def test_prediction_writer_creates_output_dir(tmp_path: Path):


### PR DESCRIPTION
## What

Three measured performance fixes from the four-dimension audit, byte-exactness preserved and proven:

1. **`_contributions` memoized** (`functools.lru_cache`, arrays frozen read-only) — it is a pure function of `(in_length, out_length, scale)` and constant per configured dataset, yet was recomputed on every resize call (measured at 48% of SRCNN's per-sample degrade, 20% of SRResNet's resize).
2. **`_resize_axis` single-pass `einsum` contraction** — the old multiply-then-`np.sum` materialized a second full float64 temporary (~265 MB per axis on a DIV2K validation image; >530 MB transient per call).
3. **Benchmark callback**: PSNR/SSIM now computed from the on-device slices *before* any host copy (mirroring what the primary val path already did), exactly one host transfer per image and only on image-logging cycles, image strips emitted immediately instead of buffering ~0.5 GB of full-res tensors per validation cycle, and the buffer is a `BenchmarkSample` NamedTuple (killing the positional `s[4]`/`s[5]` reads).

## Evidence

- **Byte-exactness (the non-negotiable):** the full **357-case MATLAB reference corpus passes against this exact head**, verified independently from the main checkout with this branch's code injected (`-P` + `PYTHONPATH`, module resolution asserted). Unit-level equivalence tests: einsum vs a naive multiply-sum oracle byte-identical across non-square/1-channel/3-channel shapes; cached vs `__wrapped__` output identical; read-only enforcement tested by actual mutation attempt.
- **Metric-value equivalence:** a dedicated test reconstructs the pre-change ordering (host-copy → crop → metrics) against the shipped ordering on the same tensors — every PSNR/SSIM key equal at `abs=1e-6`, CPU-only (CI-safe).
- **TensorBoard tags byte-identical** (verified string-by-string in review), per-set means unchanged.
- **Micro-benchmarks (this machine; directional — shared hardware):** SRCNN per-sample degrade path 572 → 319 µs/call (**1.79×**); SRResNet resize path 1545 → 837 µs/call (**1.85×**); callback metric computation **6.09× / 3.54×** faster by avoiding the pre-metric host copy. Audit-time baselines measured the same shapes at 2.21×/1.41×/10.6× on quiet hardware; final serial numbers land with the batch close-out.
- Suite: **434 passed, 2 skipped** (data-dependent imresize tests skip in a worktree by design); ruff clean.

Adversarially reviewed twice (initial review verified the einsum subscripts by re-derivation and re-ran the affected test files; verdict Approved after the equivalence-test fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)