### PR TITLE
Enforce the model-dataset contract and make config mistakes fail loudly

### DIFF
--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -30,13 +30,14 @@ already assigns ``torch.backends.cudnn.benchmark``, and it coordinates with
 ``trainer.deterministic``. A separate top-level key would silently bypass that.
 """
 
+import re
 import sys
 from pathlib import Path
 from typing import Any, Literal
 
 import torch
 from lightning.pytorch import Trainer
-from lightning.pytorch.cli import LightningCLI
+from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCLI
 
 from .export import to_onnx
 from .training import SRDataModule, SRLightning
@@ -47,6 +48,57 @@ from .training import SRDataModule, SRLightning
 # 'model/*'/'processor'/'criterion' entries that were never part of the loadable
 # contract. _reconstruct_ckpt_hparams rebuilds exactly what current SRLightning saves.
 _CKPT_HPARAM_KEYS = ("training_config", "eval_config")
+
+# Matches a --data.<dataset field> flag, with an optional trailing .init_args,
+# and (for the --flag=value form) captures the value. SRDataModule's dataset
+# fields (train_dataset, val_dataset, predict_dataset, each test_datasets.<name>
+# entry) are all typed dict[str, Any] for lazy per-stage instantiation — see
+# _find_whole_dict_dataset_override's docstring for why that makes a whole-JSON
+# CLI override crash inside jsonargparse instead of raising cleanly.
+_DATASET_FIELD_FLAG = re.compile(
+    r"^--data\.(train_dataset|val_dataset|predict_dataset|test_datasets\.[^.=]+)"
+    r"(\.init_args)?(?:=(.*))?$",
+    re.DOTALL,
+)
+
+
+def _find_whole_dict_dataset_override(args: list[str]) -> str | None:
+    """Return the offending ``--data.*_dataset`` flag if ``args`` has a whole dict/JSON override.
+
+    jsonargparse crashes with an unactionable ``AttributeError`` (raised deep
+    inside its own ``_typehints.py``, from code that assumes the field's
+    previous value is a ``Namespace`` with an ``.init_args`` attribute) when a
+    CLI override's value looks like a subclass spec (starts with ``{``) and
+    gets merged against an already-parsed value that is a plain ``dict`` —
+    exactly what every ``data.*_dataset`` field on :class:`~sisr.training.SRDataModule`
+    is, since each is typed ``dict[str, Any]`` rather than the real dataset
+    class (so datasets can be instantiated lazily, only for the stages that
+    need them). Both ``--data.train_dataset='{...}'`` (whole spec) and
+    ``--data.train_dataset.init_args='{...}'`` (whole ``init_args``) hit this.
+
+    Scanning here lets :meth:`SRLightningCLI.parse_arguments` raise an
+    actionable error *before* handing off to jsonargparse's own parser,
+    instead of letting the bare ``AttributeError`` surface.
+
+    Args:
+        args: Raw CLI argument tokens (as passed to ``LightningCLI(args=...)``,
+            or ``sys.argv[1:]``). Handles both the ``--flag=value`` and the
+            ``--flag value`` (separate token) forms.
+
+    Returns:
+        The matched flag (e.g. ``'--data.train_dataset.init_args'``), or
+        ``None`` if no argument matches the crashing shape.
+    """
+    for i, arg in enumerate(args):
+        match = _DATASET_FIELD_FLAG.match(arg)
+        if match is None:
+            continue
+        value = match.group(3)
+        if value is None:  # split "--flag value" form: value is the next token
+            value = args[i + 1] if i + 1 < len(args) else None
+        if value is not None and value.strip().startswith("{"):
+            return arg.split("=", 1)[0]
+    return None
 
 
 def _reconstruct_ckpt_hparams(hparams: dict[str, Any], sep: str = "/") -> dict[str, Any]:
@@ -168,6 +220,40 @@ class SRLightningCLI(LightningCLI):
                 f"an `export` method with the same signature."
             )
         super().__init__(*args, trainer_class=trainer_class, **kwargs)
+
+    def parse_arguments(self, parser: LightningArgumentParser, args: ArgsType) -> None:
+        """Parse CLI arguments, turning a known jsonargparse crash into an actionable error.
+
+        ``LightningCLI.__init__`` calls this before ``before_instantiate_classes``/
+        ``instantiate_classes`` even run, so it is the earliest seam available —
+        the crash :func:`_find_whole_dict_dataset_override` guards against
+        happens *during* ``parser.parse_args``, deep inside jsonargparse
+        itself, not at class-instantiation time.
+
+        Args:
+            parser: The top-level parser (unchanged, passed through).
+            args: CLI arguments as given to ``LightningCLI(args=...)`` — a
+                list of tokens, a dict/``Namespace`` (structured config, not
+                scanned here since it never takes the crashing ``parse_args``
+                code path), or ``None`` (read from ``sys.argv[1:]``).
+
+        Raises:
+            SystemExit: If ``args`` contains a whole-dict/JSON override of a
+                ``data.*_dataset`` field.
+        """
+        arg_list = args if isinstance(args, list) else (sys.argv[1:] if args is None else None)
+        if arg_list is not None:
+            offending = _find_whole_dict_dataset_override(arg_list)
+            if offending is not None:
+                raise SystemExit(
+                    f"{offending} passes a whole JSON/dict value. jsonargparse cannot "
+                    f"merge that into the class_path/init_args shape of this "
+                    f"dict[str, Any]-typed field — it fails with an internal "
+                    f"AttributeError instead of a clean error. Edit data.train_dataset / "
+                    f"data.val_dataset / data.test_datasets.<name> / data.predict_dataset "
+                    f"directly in your YAML config instead of overriding it from the CLI."
+                )
+        super().parse_arguments(parser, args)
 
     def add_arguments_to_parser(self, parser):
         """Wire top-level ``optimizer:`` / ``lr_scheduler:`` / ``matmul_precision:`` keys.

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -30,7 +30,6 @@ already assigns ``torch.backends.cudnn.benchmark``, and it coordinates with
 ``trainer.deterministic``. A separate top-level key would silently bypass that.
 """
 
-import re
 import sys
 from pathlib import Path
 from typing import Any, Literal
@@ -49,56 +48,9 @@ from .training import SRDataModule, SRLightning
 # contract. _reconstruct_ckpt_hparams rebuilds exactly what current SRLightning saves.
 _CKPT_HPARAM_KEYS = ("training_config", "eval_config")
 
-# Matches a --data.<dataset field> flag, with an optional trailing .init_args,
-# and (for the --flag=value form) captures the value. SRDataModule's dataset
-# fields (train_dataset, val_dataset, predict_dataset, each test_datasets.<name>
-# entry) are all typed dict[str, Any] for lazy per-stage instantiation — see
-# _find_whole_dict_dataset_override's docstring for why that makes a whole-JSON
-# CLI override crash inside jsonargparse instead of raising cleanly.
-_DATASET_FIELD_FLAG = re.compile(
-    r"^--data\.(train_dataset|val_dataset|predict_dataset|test_datasets\.[^.=]+)"
-    r"(\.init_args)?(?:=(.*))?$",
-    re.DOTALL,
-)
-
-
-def _find_whole_dict_dataset_override(args: list[str]) -> str | None:
-    """Return the offending ``--data.*_dataset`` flag if ``args`` has a whole dict/JSON override.
-
-    jsonargparse crashes with an unactionable ``AttributeError`` (raised deep
-    inside its own ``_typehints.py``, from code that assumes the field's
-    previous value is a ``Namespace`` with an ``.init_args`` attribute) when a
-    CLI override's value looks like a subclass spec (starts with ``{``) and
-    gets merged against an already-parsed value that is a plain ``dict`` —
-    exactly what every ``data.*_dataset`` field on :class:`~sisr.training.SRDataModule`
-    is, since each is typed ``dict[str, Any]`` rather than the real dataset
-    class (so datasets can be instantiated lazily, only for the stages that
-    need them). Both ``--data.train_dataset='{...}'`` (whole spec) and
-    ``--data.train_dataset.init_args='{...}'`` (whole ``init_args``) hit this.
-
-    Scanning here lets :meth:`SRLightningCLI.parse_arguments` raise an
-    actionable error *before* handing off to jsonargparse's own parser,
-    instead of letting the bare ``AttributeError`` surface.
-
-    Args:
-        args: Raw CLI argument tokens (as passed to ``LightningCLI(args=...)``,
-            or ``sys.argv[1:]``). Handles both the ``--flag=value`` and the
-            ``--flag value`` (separate token) forms.
-
-    Returns:
-        The matched flag (e.g. ``'--data.train_dataset.init_args'``), or
-        ``None`` if no argument matches the crashing shape.
-    """
-    for i, arg in enumerate(args):
-        match = _DATASET_FIELD_FLAG.match(arg)
-        if match is None:
-            continue
-        value = match.group(3)
-        if value is None:  # split "--flag value" form: value is the next token
-            value = args[i + 1] if i + 1 < len(args) else None
-        if value is not None and value.strip().startswith("{"):
-            return arg.split("=", 1)[0]
-    return None
+# jsonargparse's own crash (see SRLightningCLI.parse_arguments) when a whole-dict
+# CLI override collides with an already-set class_path/init_args value.
+_JSONARGPARSE_INIT_ARGS_CRASH = "'dict' object has no attribute 'init_args'"
 
 
 def _reconstruct_ckpt_hparams(hparams: dict[str, Any], sep: str = "/") -> dict[str, Any]:
@@ -224,36 +176,49 @@ class SRLightningCLI(LightningCLI):
     def parse_arguments(self, parser: LightningArgumentParser, args: ArgsType) -> None:
         """Parse CLI arguments, turning a known jsonargparse crash into an actionable error.
 
-        ``LightningCLI.__init__`` calls this before ``before_instantiate_classes``/
-        ``instantiate_classes`` even run, so it is the earliest seam available —
-        the crash :func:`_find_whole_dict_dataset_override` guards against
-        happens *during* ``parser.parse_args``, deep inside jsonargparse
-        itself, not at class-instantiation time.
+        A whole-dict/JSON CLI override of a ``data.*_dataset`` field (e.g.
+        ``--data.train_dataset='{...}'`` or
+        ``--data.train_dataset.init_args='{...}'``) only crashes when it
+        collides with an *existing* ``class_path``/``init_args`` value for
+        that field — typically one set by ``--config`` (both shipped
+        templates set ``train_dataset``/``val_dataset``/``test_datasets``,
+        so overriding those this way always collides). jsonargparse's merge
+        logic then reaches for ``prev_val.init_args`` assuming ``prev_val``
+        is a ``Namespace``, but every ``data.*_dataset`` field on
+        :class:`~sisr.training.SRDataModule` is typed ``dict[str, Any]``
+        (not the real dataset class, so datasets can be instantiated lazily —
+        see that module's docstring), so ``prev_val`` is a plain ``dict`` and
+        the attribute access raises. When there is no prior value (e.g.
+        ``predict_dataset``, which neither template sets — the documented
+        ``sisr predict`` workflow overrides it this exact way), the same
+        whole-dict override parses fine.
+
+        A prior version of this guard pre-scanned the raw CLI tokens and
+        rejected *any* whole-dict override of these fields, which broke that
+        working ``predict_dataset`` case. Catching the actual jsonargparse
+        failure here instead only intercepts the forms that really crash.
 
         Args:
             parser: The top-level parser (unchanged, passed through).
-            args: CLI arguments as given to ``LightningCLI(args=...)`` — a
-                list of tokens, a dict/``Namespace`` (structured config, not
-                scanned here since it never takes the crashing ``parse_args``
-                code path), or ``None`` (read from ``sys.argv[1:]``).
+            args: CLI arguments as given to ``LightningCLI(args=...)``.
 
         Raises:
-            SystemExit: If ``args`` contains a whole-dict/JSON override of a
-                ``data.*_dataset`` field.
+            SystemExit: If parsing hits jsonargparse's
+                ``prev_val.init_args`` crash on an already-``dict`` value.
         """
-        arg_list = args if isinstance(args, list) else (sys.argv[1:] if args is None else None)
-        if arg_list is not None:
-            offending = _find_whole_dict_dataset_override(arg_list)
-            if offending is not None:
-                raise SystemExit(
-                    f"{offending} passes a whole JSON/dict value. jsonargparse cannot "
-                    f"merge that into the class_path/init_args shape of this "
-                    f"dict[str, Any]-typed field — it fails with an internal "
-                    f"AttributeError instead of a clean error. Edit data.train_dataset / "
-                    f"data.val_dataset / data.test_datasets.<name> / data.predict_dataset "
-                    f"directly in your YAML config instead of overriding it from the CLI."
-                )
-        super().parse_arguments(parser, args)
+        try:
+            super().parse_arguments(parser, args)
+        except AttributeError as e:
+            if _JSONARGPARSE_INIT_ARGS_CRASH not in str(e):
+                raise
+            raise SystemExit(
+                "A CLI override passed a whole JSON/dict value for a data.*_dataset "
+                "field that already has a class_path/init_args value (typically set by "
+                "--config). jsonargparse cannot merge a whole dict into this "
+                "dict[str, Any]-typed field in that case and fails with an internal "
+                "AttributeError instead of a clean one. Edit the dataset spec directly "
+                "in your YAML config instead of overriding an existing one from the CLI."
+            ) from e
 
     def add_arguments_to_parser(self, parser):
         """Wire top-level ``optimizer:`` / ``lr_scheduler:`` / ``matmul_precision:`` keys.

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -99,6 +99,26 @@ class SRDataModule(lightning.LightningDataModule):
         """
         return list(self._test_specs.keys())
 
+    @property
+    def train_dataset(self) -> Dataset | None:
+        """The instantiated train dataset, or ``None`` before ``setup('fit')`` runs.
+
+        Public read accessor — lets consumers outside this module (e.g.
+        :meth:`~sisr.training.SRLightning.setup`'s input-contract probe)
+        inspect the real dataset without reaching into private state.
+        """
+        return self._train_ds
+
+    @property
+    def val_dataset(self) -> Dataset | None:
+        """The instantiated primary val dataset, or ``None`` before setup runs."""
+        return self._val_ds
+
+    @property
+    def test_datasets(self) -> dict[str, Dataset]:
+        """Instantiated test datasets by name — empty before setup runs (or if none configured)."""
+        return dict(self._test_ds)
+
     def setup(self, stage: str | None = None) -> None:
         """Instantiate datasets lazily based on the trainer stage.
 

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -13,6 +13,48 @@ import lightning
 from lightning.pytorch.cli import instantiate_class
 from torch.utils.data import DataLoader, Dataset
 
+_SPEC_KEYS = frozenset({"class_path", "init_args"})
+
+
+def _validate_spec(field_name: str, spec: dict[str, Any]) -> None:
+    """Raise if ``spec`` isn't a well-formed ``{class_path, init_args}`` mapping.
+
+    Every dataset field on this module is typed ``dict[str, Any]`` (not the
+    real dataset class) so :meth:`SRDataModule.setup` can instantiate it
+    lazily, only for the stages that need it (see the module docstring). That
+    laziness has a cost: jsonargparse treats the field as an opaque dict, so a
+    dotted CLI override like ``--data.train_dataset.init_args.crops_per_image=8``
+    cannot reach the nested ``init_args`` key — it lands as a stray sibling
+    key next to ``class_path``/``init_args`` instead, invisible to
+    :func:`~lightning.pytorch.cli.instantiate_class`, which silently keeps
+    building the dataset with its old, unoverridden value. This check turns
+    that silent no-op into an immediate, actionable error.
+
+    Args:
+        field_name: Dotted config path for the error message, e.g.
+            ``'data.train_dataset'`` or ``'data.test_datasets.Set14'``.
+        spec: The value to validate.
+
+    Raises:
+        ValueError: If ``spec`` isn't a dict, has no ``class_path``, has any
+            key besides ``class_path``/``init_args``, or has a non-dict
+            ``init_args``.
+    """
+    if not isinstance(spec, dict) or "class_path" not in spec:
+        raise ValueError(f"{field_name} must be a {{class_path, init_args}} mapping; got {spec!r}.")
+    extra = sorted(set(spec) - _SPEC_KEYS)
+    if extra:
+        raise ValueError(
+            f"{field_name} has unexpected key(s) {extra} alongside class_path/init_args: "
+            f"{spec!r}. This usually means a CLI override like "
+            f"--{field_name}.init_args.<key>=<value> landed as a sibling key instead of "
+            f"inside init_args — jsonargparse cannot merge a dotted override into this "
+            f"dict[str, Any]-typed field. Edit the YAML directly instead."
+        )
+    init_args = spec.get("init_args", {})
+    if not isinstance(init_args, dict):
+        raise ValueError(f"{field_name}.init_args must be a mapping; got {init_args!r}.")
+
 
 class SRDataModule(lightning.LightningDataModule):
     """Generic LightningDataModule for single-image super-resolution.
@@ -75,6 +117,13 @@ class SRDataModule(lightning.LightningDataModule):
         predict_dataloader_kwargs: dict[str, Any] | None = None,
     ):
         super().__init__()
+        _validate_spec("data.train_dataset", train_dataset)
+        _validate_spec("data.val_dataset", val_dataset)
+        for name, spec in (test_datasets or {}).items():
+            _validate_spec(f"data.test_datasets.{name}", spec)
+        if predict_dataset is not None:
+            _validate_spec("data.predict_dataset", predict_dataset)
+
         self._train_spec = train_dataset
         self._val_spec = val_dataset
         self._test_specs = test_datasets or {}

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -9,6 +9,7 @@ itself. Optimizer / LR scheduler are wired in from top-level YAML keys by
 """
 
 import dataclasses
+import random
 from typing import Any
 
 import lightning
@@ -166,9 +167,20 @@ class SRLightning(lightning.LightningModule):
         set, its spatial dims are checked against the real train LR patch —
         train-only, since validation/test images vary in size.
 
-        No-op when no ``Trainer`` is attached (direct/unit-test construction)
-        or when ``trainer.datamodule`` has nothing instantiated yet for this
-        stage.
+        No-op when no ``Trainer`` is attached (direct/unit-test construction),
+        when ``trainer.datamodule`` has nothing instantiated yet for this
+        stage, or when ``trainer.datamodule`` is some foreign object that
+        doesn't expose the ``train_dataset``/``val_dataset``/``test_datasets``
+        read accessors (degrades to a skip rather than ``AttributeError``).
+
+        The probe's own dataset reads are isolated from the global
+        :mod:`random` state: :class:`~sisr.datasets.srresnet.TrainDataset`
+        draws its random crop via ``random.randint`` in ``__getitem__``, so an
+        unguarded probe call would consume draws from the same sequence the
+        real training loop uses, shifting every seeded crop after it — a real
+        change in a paper-reproduction repo, not just a probe side effect.
+        ``random.getstate()``/``setstate()`` around the whole probe make it
+        transparent regardless of what a dataset's ``__getitem__`` consumes.
 
         Args:
             stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
@@ -184,16 +196,24 @@ class SRLightning(lightning.LightningModule):
         if dm is None:
             return
 
-        probe = self._first_probe_dataset(dm)
-        if probe is not None:
-            source, dataset = probe
-            lr, hr = dataset[0]
-            self._check_input_contract(lr, hr, source, dataset)
+        rng_state = random.getstate()
+        try:
+            probe = self._first_probe_dataset(dm)
+            train_lr = None
+            if probe is not None:
+                source, dataset = probe
+                lr, hr = dataset[0]
+                self._check_input_contract(lr, hr, source, dataset)
+                if source == "train_dataset":
+                    train_lr = lr  # reuse below instead of re-sampling index 0
 
-        train_ds = dm.train_dataset
-        if train_ds is not None and self.training_config.example_input_shape is not None:
-            lr, _ = train_ds[0]
-            self._check_example_input_shape(lr, train_ds)
+            train_ds = getattr(dm, "train_dataset", None)
+            if train_ds is not None and self.training_config.example_input_shape is not None:
+                if train_lr is None:
+                    train_lr, _ = train_ds[0]
+                self._check_example_input_shape(train_lr, train_ds)
+        finally:
+            random.setstate(rng_state)
 
     @staticmethod
     def _first_probe_dataset(dm: Any) -> tuple[str, Any] | None:
@@ -204,19 +224,23 @@ class SRLightning(lightning.LightningModule):
         is never considered: its samples have no HR to pair-check against.
 
         Args:
-            dm: The attached ``SRDataModule`` (or any object exposing the
-                same ``train_dataset``/``val_dataset``/``test_datasets``
-                read accessors).
+            dm: The attached datamodule. Normally an ``SRDataModule``, but
+                accessed via ``getattr(..., None)`` throughout so a foreign
+                datamodule missing these read accessors degrades to "nothing
+                to probe" instead of raising ``AttributeError``.
 
         Returns:
             ``(source_name, dataset)`` for the first available dataset, or
-            ``None`` if train/val/test are all unset (e.g. a predict-only run).
+            ``None`` if train/val/test are all unset (e.g. a predict-only run,
+            or a datamodule that isn't an ``SRDataModule`` at all).
         """
-        if dm.train_dataset is not None:
-            return "train_dataset", dm.train_dataset
-        if dm.val_dataset is not None:
-            return "val_dataset", dm.val_dataset
-        test_datasets = dm.test_datasets
+        train_ds = getattr(dm, "train_dataset", None)
+        if train_ds is not None:
+            return "train_dataset", train_ds
+        val_ds = getattr(dm, "val_dataset", None)
+        if val_ds is not None:
+            return "val_dataset", val_ds
+        test_datasets = getattr(dm, "test_datasets", None) or {}
         if test_datasets:
             name, dataset = next(iter(test_datasets.items()))
             return f"test_datasets.{name}", dataset
@@ -235,7 +259,8 @@ class SRLightning(lightning.LightningModule):
             dataset: The dataset instance, for its class name in the error.
 
         Raises:
-            ValueError: See :meth:`setup`.
+            ValueError: See :meth:`setup`, or if ``model.input_contract`` is
+                neither ``'pre_upsampled'`` nor ``'native_lr'``.
         """
         contract = self.model.input_contract
         lr_hw, hr_hw = tuple(lr.shape[-2:]), tuple(hr.shape[-2:])
@@ -254,10 +279,20 @@ class SRLightning(lightning.LightningModule):
                 f"or switch to a native_lr model."
             )
 
-        # native_lr: skip when training_config.scale is unset — nothing to check
-        # against (mirrors SRTrainingConfig.scale's own "absent skips silently"
-        # rule; the shipped SRResNetTrainingConfig always sets it).
+        if contract != "native_lr":
+            raise ValueError(
+                f"{type(self.model).__name__}.input_contract={contract!r} is not a "
+                f"recognised contract — expected 'pre_upsampled' or 'native_lr'. Fix "
+                f"{type(self.model).__name__}.input_contract."
+            )
+
+        # Fall back to the model's own 'scale' hparam when training_config.scale
+        # is unset (e.g. a bare SRTrainingConfig()) — only skip the check when
+        # BOTH are absent. Falling back keeps this from silently no-opping for
+        # exactly the native_lr construction several existing tests use.
         scale = self.training_config.scale
+        if scale is None:
+            scale = self.model.hparams.get("scale")
         if scale is None:
             return
         expected_hw = (lr_hw[0] * scale, lr_hw[1] * scale)

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -142,6 +142,161 @@ class SRLightning(lightning.LightningModule):
         if self.training_config.example_input_shape is not None:
             self.example_input_array = torch.zeros(1, *self.training_config.example_input_shape)
 
+    def setup(self, stage: str | None = None) -> None:
+        """Probe one real sample against ``model.input_contract`` / ``example_input_shape``.
+
+        Lightning always runs ``DataModule.setup(stage)`` before
+        ``LightningModule.setup(stage)`` (``Trainer._call_setup_hook``), so
+        ``trainer.datamodule``'s stage-relevant datasets are already
+        instantiated by the time this runs. Cross-wiring a model and dataset
+        with mismatched ``input_contract`` (e.g. SRResNet's ``native_lr``
+        trained on SRCNN's ``pre_upsampled`` dataset, or the mirror) produces
+        no error downstream otherwise — :meth:`_forward_sr`'s ``center_crop``
+        silently zero-pads instead, and every loss/PSNR number that follows is
+        meaningless. Checking one real sample here is cheap and fires before
+        the first step.
+
+        Picks the first dataset ``trainer.datamodule`` has actually
+        instantiated for this stage — train, else the primary val set, else
+        the first test set — so the check runs for ``fit`` as well as a
+        bare ``validate``/``test`` invocation, not only ``fit``.
+        ``PredictDataset`` (bare LR tensor, no HR) is never in that list, so
+        a predict-only datamodule has nothing to check. Separately, when a
+        train dataset exists and ``training_config.example_input_shape`` is
+        set, its spatial dims are checked against the real train LR patch —
+        train-only, since validation/test images vary in size.
+
+        No-op when no ``Trainer`` is attached (direct/unit-test construction)
+        or when ``trainer.datamodule`` has nothing instantiated yet for this
+        stage.
+
+        Args:
+            stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
+                ``'test'``, or ``'predict'``.
+
+        Raises:
+            ValueError: If the sampled LR/HR pair disagrees with
+                ``self.model.input_contract``, or (train stage only) if
+                ``training_config.example_input_shape``'s spatial dims don't
+                match the real train LR sample.
+        """
+        dm = self._trainer.datamodule if self._trainer is not None else None
+        if dm is None:
+            return
+
+        probe = self._first_probe_dataset(dm)
+        if probe is not None:
+            source, dataset = probe
+            lr, hr = dataset[0]
+            self._check_input_contract(lr, hr, source, dataset)
+
+        train_ds = dm.train_dataset
+        if train_ds is not None and self.training_config.example_input_shape is not None:
+            lr, _ = train_ds[0]
+            self._check_example_input_shape(lr, train_ds)
+
+    @staticmethod
+    def _first_probe_dataset(dm: Any) -> tuple[str, Any] | None:
+        """First stage-instantiated (source_name, dataset) pair, or ``None``.
+
+        Priority train > primary val > first test set — whichever loader
+        would actually run first for the live stage. ``predict_dataset``
+        is never considered: its samples have no HR to pair-check against.
+
+        Args:
+            dm: The attached ``SRDataModule`` (or any object exposing the
+                same ``train_dataset``/``val_dataset``/``test_datasets``
+                read accessors).
+
+        Returns:
+            ``(source_name, dataset)`` for the first available dataset, or
+            ``None`` if train/val/test are all unset (e.g. a predict-only run).
+        """
+        if dm.train_dataset is not None:
+            return "train_dataset", dm.train_dataset
+        if dm.val_dataset is not None:
+            return "val_dataset", dm.val_dataset
+        test_datasets = dm.test_datasets
+        if test_datasets:
+            name, dataset = next(iter(test_datasets.items()))
+            return f"test_datasets.{name}", dataset
+        return None
+
+    def _check_input_contract(
+        self, lr: torch.Tensor, hr: torch.Tensor, source: str, dataset: Any
+    ) -> None:
+        """Raise if the sampled ``(lr, hr)`` pair disagrees with ``model.input_contract``.
+
+        Args:
+            lr: LR sample tensor, shape ``(C, H, W)``.
+            hr: HR sample tensor, shape ``(C, H, W)``.
+            source: Config path of the dataset the sample came from (e.g.
+                ``'train_dataset'``), for the error message.
+            dataset: The dataset instance, for its class name in the error.
+
+        Raises:
+            ValueError: See :meth:`setup`.
+        """
+        contract = self.model.input_contract
+        lr_hw, hr_hw = tuple(lr.shape[-2:]), tuple(hr.shape[-2:])
+        ds_name = type(dataset).__name__
+
+        if contract == "pre_upsampled":
+            if lr_hw == hr_hw:
+                return
+            raise ValueError(
+                f"{type(self.model).__name__}.input_contract='pre_upsampled' requires "
+                f"LR and HR to share spatial size, but data.{source} ({ds_name}) served "
+                f"lr {lr_hw} != hr {hr_hw}. A native-LR dataset (e.g. "
+                f"sisr.datasets.srresnet) paired with a pre-upsampled model silently "
+                f"zero-pads in SRLightning._forward_sr instead of raising — point "
+                f"data.{source} at a pre-upsampled dataset (e.g. sisr.datasets.srcnn), "
+                f"or switch to a native_lr model."
+            )
+
+        # native_lr: skip when training_config.scale is unset — nothing to check
+        # against (mirrors SRTrainingConfig.scale's own "absent skips silently"
+        # rule; the shipped SRResNetTrainingConfig always sets it).
+        scale = self.training_config.scale
+        if scale is None:
+            return
+        expected_hw = (lr_hw[0] * scale, lr_hw[1] * scale)
+        if hr_hw == expected_hw:
+            return
+        raise ValueError(
+            f"{type(self.model).__name__}.input_contract='native_lr' requires "
+            f"hr.shape[-2:] == lr.shape[-2:] * training_config.scale ({scale}), but "
+            f"data.{source} ({ds_name}) served lr {lr_hw}, hr {hr_hw} (expected "
+            f"{expected_hw}). A pre-upsampled dataset (e.g. sisr.datasets.srcnn) "
+            f"paired with a native-LR model silently zero-pads in "
+            f"SRLightning._forward_sr instead of raising — point data.{source} at a "
+            f"native-LR dataset (e.g. sisr.datasets.srresnet), or fix "
+            f"training_config.scale."
+        )
+
+    def _check_example_input_shape(self, lr: torch.Tensor, train_dataset: Any) -> None:
+        """Raise if ``example_input_shape``'s H/W disagrees with the real train LR patch.
+
+        Args:
+            lr: Real LR sample from the train dataset, shape ``(C, H, W)``.
+            train_dataset: The train dataset instance, for its class name in
+                the error.
+
+        Raises:
+            ValueError: If ``example_input_shape[1:] != lr.shape[-2:]``.
+        """
+        expected_hw = tuple(self.training_config.example_input_shape[1:])
+        actual_hw = tuple(lr.shape[-2:])
+        if expected_hw == actual_hw:
+            return
+        raise ValueError(
+            f"training_config.example_input_shape has spatial dims {expected_hw}, but "
+            f"data.train_dataset ({type(train_dataset).__name__}) serves LR patches of "
+            f"{actual_hw}. example_input_shape drives the compile warm-up shape and "
+            f"FLOPs reporting — set it to match the true train patch (hr_crop_size // "
+            f"scale for SRResNet-style datasets, subimg_size for SRCNN-style)."
+        )
+
     @staticmethod
     def _flatten_hparams(hparams: dict[str, Any], sep: str = "/") -> dict:
         """Recursively flatten nested hparams dicts/lists for clean TensorBoard HParams columns.
@@ -295,8 +450,29 @@ class SRLightning(lightning.LightningModule):
             model output in the model IO colorspace, the reconstructed SR RGB
             clamped to ``[0, 1]``, and HR center-cropped to the SR spatial
             size.
+
+        Raises:
+            ValueError: If ``hr_img`` is spatially smaller than ``sr_rgb`` in
+                either dimension — ``center_crop`` would zero-pad instead of
+                cropping, silently corrupting the loss/metrics that follow.
+                :meth:`setup` catches the common cause (a model/dataset
+                ``input_contract`` mismatch) earlier and louder; this is the
+                last-resort guard for callers that bypass it (e.g. direct
+                ``_forward_sr``/``_step`` calls in tests, or a datamodule with
+                no ``trainer`` attached).
         """
         sr_model_out, sr_rgb = self._forward_lr(lr_img)
+        hr_hw, sr_hw = hr_img.shape[-2:], sr_rgb.shape[-2:]
+        if hr_hw[0] < sr_hw[0] or hr_hw[1] < sr_hw[1]:
+            raise ValueError(
+                f"hr_img spatial size {tuple(hr_hw)} is smaller than sr_rgb "
+                f"{tuple(sr_hw)} — torchvision.transforms.functional.center_crop "
+                f"would zero-pad instead of cropping, silently corrupting the loss "
+                f"and every metric downstream. This usually means the dataset's "
+                f"LR/HR pairing doesn't match {type(self.model).__name__}."
+                f"input_contract={self.model.input_contract!r} — check "
+                f"data.train_dataset/val_dataset/test_datasets in your config."
+            )
         hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_rgb.shape[-2:])
         return sr_model_out, sr_rgb, hr_cropped
 

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -9,6 +9,7 @@ itself. Optimizer / LR scheduler are wired in from top-level YAML keys by
 """
 
 import dataclasses
+import pickle
 import random
 from typing import Any
 
@@ -182,6 +183,19 @@ class SRLightning(lightning.LightningModule):
         ``random.getstate()``/``setstate()`` around the whole probe make it
         transparent regardless of what a dataset's ``__getitem__`` consumes.
 
+        Every sample is read via :meth:`_sample_zero`, never
+        ``dataset[0]`` directly on the live object: the LMDB-backed train
+        datasets (SRCNN/SRResNet) open their ``lmdb.Environment`` lazily on
+        first read and cache it on the instance, and an open
+        ``lmdb.Environment`` cannot be pickled. Reading straight from
+        ``trainer.datamodule``'s own (still-pristine) dataset would poison
+        that exact instance for any later ``num_workers > 0`` ``DataLoader``
+        — ``spawn`` (the only start method on Windows) must pickle the
+        dataset to hand it to worker processes, and would then crash inside
+        torch/Lightning long after this probe ran. :meth:`_sample_zero`
+        samples a disposable pickle clone instead, leaving the original
+        untouched, so this probe can never be what first poisons it.
+
         Args:
             stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
                 ``'test'``, or ``'predict'``.
@@ -202,7 +216,7 @@ class SRLightning(lightning.LightningModule):
             train_lr = None
             if probe is not None:
                 source, dataset = probe
-                lr, hr = dataset[0]
+                lr, hr = self._sample_zero(dataset)
                 self._check_input_contract(lr, hr, source, dataset)
                 if source == "train_dataset":
                     train_lr = lr  # reuse below instead of re-sampling index 0
@@ -210,10 +224,56 @@ class SRLightning(lightning.LightningModule):
             train_ds = getattr(dm, "train_dataset", None)
             if train_ds is not None and self.training_config.example_input_shape is not None:
                 if train_lr is None:
-                    train_lr, _ = train_ds[0]
+                    train_lr, _ = self._sample_zero(train_ds)
                 self._check_example_input_shape(train_lr, train_ds)
         finally:
             random.setstate(rng_state)
+
+    @staticmethod
+    def _sample_zero(dataset: Any) -> Any:
+        """Reads index 0 from a disposable pickle clone of ``dataset`` when possible.
+
+        LMDB-backed datasets (:class:`~sisr.datasets.srcnn.TrainDataset` /
+        :class:`~sisr.datasets.srresnet.TrainDataset`) open their
+        ``lmdb.Environment`` lazily on first read and cache it on the
+        instance (``LMDBCache._env``); an open ``lmdb.Environment`` is not
+        picklable. Sampling the live dataset object handed to the
+        ``DataLoader`` would open its environment and poison that exact,
+        still-pristine instance for any later ``num_workers > 0`` loader,
+        since ``spawn`` (unconditional on Windows) must pickle every dataset
+        to send it to worker processes. Cloning first means the
+        eventually-opened environment belongs to the throwaway clone, which
+        is discarded right after — the original ``dataset`` is never touched
+        by this call and stays exactly as picklable as it was before.
+
+        Falls back to reading ``dataset`` directly if it can't currently be
+        pickled — e.g. a prior ``num_workers=0`` in-process read (real
+        training, not this probe) already opened its environment for real,
+        which is harmless on its own (a ``num_workers=0`` loader never
+        pickles anything) but would make *this* call's own pickle attempt
+        fail on a re-probe (e.g. ``fit`` followed by ``test`` in the same
+        process). Reading the live object further at that point adds no new
+        harm: something other than this probe already made it what it is.
+        This method only *prevents* being the first thing to open a
+        pristine dataset's environment — it does not guarantee a dataset
+        stays picklable forever regardless of what real training does to it
+        afterwards.
+
+        Args:
+            dataset: The live dataset instance to sample from. Mutated only
+                in the fallback case, and only exactly as a real
+                ``num_workers=0`` read already would.
+
+        Returns:
+            ``dataset[0]`` (via the clone when picklable) — an ``(lr, hr)``
+            tuple for every paired dataset, or a bare LR tensor for
+            :class:`~sisr.datasets.predict.PredictDataset`.
+        """
+        try:
+            clone = pickle.loads(pickle.dumps(dataset))
+        except (pickle.PickleError, TypeError, AttributeError):
+            return dataset[0]
+        return clone[0]
 
     @staticmethod
     def _first_probe_dataset(dm: Any) -> tuple[str, Any] | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,6 +211,25 @@ def test_optimizer_lr_override_in_process():
     assert cli.config.optimizer.init_args.lr == pytest.approx(0.005)
 
 
+def test_dataset_cli_override_fails_loudly_instead_of_silently_ignored():
+    """--data.train_dataset.init_args.crops_per_image=8 must not silently no-op.
+
+    jsonargparse treats `data.train_dataset` as an opaque `dict[str, Any]`, so a
+    dotted CLI override targeting a nested `init_args` key lands as a stray
+    sibling key next to `class_path`/`init_args` instead — `instantiate_class`
+    never sees it, and the constructed dataset silently keeps
+    crops_per_image=1. SRDataModule must reject the malformed spec loudly at
+    construction (during `instantiate_classes()`, i.e. CLI resolution here)
+    instead of quietly building the wrong dataset.
+    """
+    with pytest.raises(ValueError, match="crops_per_image"):
+        _resolve(
+            "--config",
+            str(SRRESNET_TEMPLATE),
+            "--data.train_dataset.init_args.crops_per_image=8",
+        )
+
+
 def test_matmul_precision_accepted_in_process():
     """--matmul_precision=medium overrides the template's shipped 'high' default."""
     cli = _resolve("--config", str(TEMPLATE), "--matmul_precision=medium")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,6 +230,36 @@ def test_dataset_cli_override_fails_loudly_instead_of_silently_ignored():
         )
 
 
+def test_dataset_whole_dict_cli_override_fails_loudly_not_with_internal_error():
+    """--data.train_dataset='{...}' must not crash with jsonargparse's raw,
+    unactionable AttributeError ('dict' object has no attribute 'init_args').
+
+    SRLightningCLI.parse_arguments must intercept this shape before handing
+    off to jsonargparse's own parser and raise a SystemExit naming the
+    offending flag instead.
+    """
+    with pytest.raises(SystemExit, match="data.train_dataset"):
+        _resolve(
+            "--config",
+            str(SRRESNET_TEMPLATE),
+            '--data.train_dataset={"class_path": "sisr.datasets.srresnet.TrainDataset", '
+            '"init_args": {"img_dir": "data/DIV2K_train_HR", "scale": 4, "hr_crop_size": 96, '
+            '"crops_per_image": 8, "use_tqdm": true, "cache_dir": ".lmdb_cache/DIV2K_train_HR"}}',
+        )
+
+
+def test_dataset_whole_init_args_cli_override_fails_loudly_not_with_internal_error():
+    """--data.train_dataset.init_args='{...}' hits the same jsonargparse crash
+    (a whole-dict CLI value merged against an already-dict prev_val) and must
+    also fail loudly with an actionable SystemExit."""
+    with pytest.raises(SystemExit, match="data.train_dataset"):
+        _resolve(
+            "--config",
+            str(SRRESNET_TEMPLATE),
+            '--data.train_dataset.init_args={"crops_per_image": 8}',
+        )
+
+
 def test_matmul_precision_accepted_in_process():
     """--matmul_precision=medium overrides the template's shipped 'high' default."""
     cli = _resolve("--config", str(TEMPLATE), "--matmul_precision=medium")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,15 +230,14 @@ def test_dataset_cli_override_fails_loudly_instead_of_silently_ignored():
         )
 
 
-def test_dataset_whole_dict_cli_override_fails_loudly_not_with_internal_error():
-    """--data.train_dataset='{...}' must not crash with jsonargparse's raw,
-    unactionable AttributeError ('dict' object has no attribute 'init_args').
-
-    SRLightningCLI.parse_arguments must intercept this shape before handing
-    off to jsonargparse's own parser and raise a SystemExit naming the
-    offending flag instead.
+def test_dataset_whole_dict_cli_override_colliding_with_config_fails_loudly():
+    """--data.train_dataset='{...}' colliding with the template's own
+    train_dataset (--config already sets one) must not crash with
+    jsonargparse's raw, unactionable AttributeError ('dict' object has no
+    attribute 'init_args'). SRLightningCLI.parse_arguments must convert that
+    into an actionable SystemExit instead.
     """
-    with pytest.raises(SystemExit, match="data.train_dataset"):
+    with pytest.raises(SystemExit, match="already has a class_path"):
         _resolve(
             "--config",
             str(SRRESNET_TEMPLATE),
@@ -248,16 +247,36 @@ def test_dataset_whole_dict_cli_override_fails_loudly_not_with_internal_error():
         )
 
 
-def test_dataset_whole_init_args_cli_override_fails_loudly_not_with_internal_error():
+def test_dataset_whole_init_args_cli_override_colliding_with_config_fails_loudly():
     """--data.train_dataset.init_args='{...}' hits the same jsonargparse crash
-    (a whole-dict CLI value merged against an already-dict prev_val) and must
-    also fail loudly with an actionable SystemExit."""
-    with pytest.raises(SystemExit, match="data.train_dataset"):
+    (a whole-dict CLI value merged against an already-dict prev_val the
+    template set) and must also fail loudly with an actionable SystemExit."""
+    with pytest.raises(SystemExit, match="already has a class_path"):
         _resolve(
             "--config",
             str(SRRESNET_TEMPLATE),
             '--data.train_dataset.init_args={"crops_per_image": 8}',
         )
+
+
+def test_dataset_whole_dict_override_without_prior_config_value_still_works():
+    """Regression: --data.predict_dataset='{...}' must keep working when
+    neither shipped template sets predict_dataset — there is no prior dict
+    value to collide with, so jsonargparse's merge never hits the
+    prev_val.init_args crash. This is the documented `sisr predict` workflow
+    (SRDataModule.predict_dataloader's own error message tells users to set
+    data.predict_dataset exactly this way). A blanket pre-scan that rejects
+    every whole-dict dataset override regardless of a prior value would break
+    this working case — the guard must only intercept an actual collision.
+    """
+    cli = _resolve(
+        "--config",
+        str(SRRESNET_TEMPLATE),
+        '--data.predict_dataset={"class_path": "sisr.datasets.predict.PredictDataset", '
+        '"init_args": {"img_dir": "data/Set5_HR"}}',
+    )
+    assert cli.config.data.predict_dataset["class_path"] == "sisr.datasets.predict.PredictDataset"
+    assert cli.config.data.predict_dataset["init_args"]["img_dir"] == "data/Set5_HR"
 
 
 def test_matmul_precision_accepted_in_process():

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -285,6 +285,133 @@ def test_predict_dataloader_without_predict_dataset_raises(tiny_rgb_image_dir: P
         dm.predict_dataloader()
 
 
+# ---------------------------------------------------------------------------
+# Dataset spec validation — catches malformed {class_path, init_args} dicts,
+# including the shape a CLI dotted override produces when it can't reach a
+# nested init_args key on this dict[str, Any]-typed field (see test_cli.py's
+# test_dataset_cli_override_fails_loudly_instead_of_silently_ignored).
+# ---------------------------------------------------------------------------
+
+
+def test_train_dataset_spec_rejects_stray_sibling_key(tiny_rgb_image_dir: Path):
+    """A key alongside class_path/init_args — exactly what a dotted CLI
+    override produces when it can't reach nested init_args — must raise
+    instead of silently building the wrong dataset."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+        },
+        "crops_per_image": 8,  # stray — never reaches init_args
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    with pytest.raises(ValueError, match="crops_per_image"):
+        SRDataModule(train_dataset=train_spec, val_dataset=val_spec)
+
+
+def test_val_dataset_spec_rejects_stray_sibling_key(tiny_rgb_image_dir: Path):
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+        "scale": 3,
+    }
+    with pytest.raises(ValueError, match="val_dataset"):
+        SRDataModule(train_dataset=train_spec, val_dataset=val_spec)
+
+
+def test_test_datasets_spec_rejects_stray_sibling_key_names_the_entry(tiny_rgb_image_dir: Path):
+    """The error must name which test_datasets entry is malformed — 'Set14',
+    not just 'test_datasets' — since there can be several."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    bad_test_spec = {**val_spec, "scale": 4}
+    with pytest.raises(ValueError, match="Set14"):
+        SRDataModule(
+            train_dataset=train_spec,
+            val_dataset=val_spec,
+            test_datasets={"Set5": val_spec, "Set14": bad_test_spec},
+        )
+
+
+def test_predict_dataset_spec_rejects_stray_sibling_key(tiny_rgb_image_dir: Path):
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    bad_predict_spec = {
+        "class_path": "sisr.datasets.predict.PredictDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir)},
+        "extra": 1,
+    }
+    with pytest.raises(ValueError, match="predict_dataset"):
+        SRDataModule(
+            train_dataset=train_spec, val_dataset=val_spec, predict_dataset=bad_predict_spec
+        )
+
+
+def test_predict_dataset_none_skips_validation(tiny_rgb_image_dir: Path):
+    """predict_dataset=None (the default, unconfigured predict) must not be
+    validated as if it were a malformed spec."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": 2,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    SRDataModule(train_dataset=train_spec, val_dataset=val_spec)  # must not raise
+
+
+def test_dataset_spec_missing_class_path_rejected(tiny_rgb_image_dir: Path):
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    with pytest.raises(ValueError, match="class_path"):
+        SRDataModule(train_dataset={"init_args": {"scale": 2}}, val_dataset=val_spec)
+
+
 def test_train_dataset_built_from_class_path_spec(tiny_rgb_image_dir: Path):
     """train_dataset accepts {class_path, init_args} and setup() instantiates it."""
     train_spec = {

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -20,6 +20,7 @@ import pytest
 import torch
 
 from sisr.models.srcnn import SRCNN
+from sisr.models.srresnet import SRResNetTrainingConfig
 from sisr.models.srresnet.model import SRResNet
 from sisr.processors import RGBProcessor, YChannelProcessor
 from sisr.training import (
@@ -109,6 +110,42 @@ def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
     test_metrics = set(trainer.callback_metrics)
     # test_step is a no-op; these come solely from BenchmarkImageLogger.on_test_*.
     assert {"psnr/Set5/RGB", "ssim/Set5/RGB", "ssim/Set5/Y"} <= test_metrics
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_fast_dev_run_raises_on_cross_wired_model_and_dataset_through_real_trainer(
+    tiny_rgb_image_dir: Path,
+):
+    """Regression: SRLightning.setup()'s input_contract probe must actually
+    fire through a real Trainer.fit() call, not only the SimpleNamespace-
+    stubbed trainer every setup() unit test in test_lightning_module.py uses.
+    Locks Lightning's documented DataModule.setup-before-LightningModule.setup
+    hook ordering (Trainer._call_setup_hook) against a silent regression that
+    every stubbed-trainer test would stay green through.
+    """
+    model = SRResNet(scale=2, num_residual_blocks=1)
+    module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRResNetTrainingConfig(scale=2),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    # srcnn's datasets are pre_upsampled (lr.shape == hr.shape) -- mismatched
+    # against SRResNet's native_lr contract.
+    datamodule = _make_datamodule(tiny_rgb_image_dir)
+    trainer = lightning.Trainer(
+        fast_dev_run=True,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+    with pytest.raises(ValueError, match="input_contract"):
+        trainer.fit(module, datamodule=datamodule)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1387,3 +1387,128 @@ def test_forward_sr_accepts_hr_exactly_equal_to_sr():
     hr = torch.rand(1, 3, 16, 16)  # exactly lr * scale
     _, sr_rgb, hr_cropped = lit._forward_sr(lr, hr)
     assert sr_rgb.shape == hr_cropped.shape == (1, 3, 16, 16)
+
+
+# ---------------------------------------------------------------------------
+# Code-review follow-ups: model.hparams['scale'] fallback, RNG isolation,
+# foreign-datamodule degradation, unrecognised input_contract
+# ---------------------------------------------------------------------------
+
+
+def test_setup_raises_using_model_scale_fallback_when_training_config_scale_unset(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """Regression: a native_lr model paired with a bare SRTrainingConfig()
+    (scale=None — the construction several existing tests use) must still
+    catch a scale-mismatched dataset via the model's own 'scale' hparam,
+    instead of silently skipping the check just because
+    training_config.scale wasn't set. Model declares scale=2; the dataset
+    actually downsamples by 4."""
+    model = SRResNet(scale=2, num_residual_blocks=1)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),  # scale=None
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=4, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    with pytest.raises(ValueError, match="input_contract"):
+        lit.setup(stage="fit")
+
+
+def test_setup_still_skips_when_both_training_config_and_model_scale_absent(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """When neither training_config.scale nor model.hparams['scale'] is
+    set, there is genuinely nothing to check against — must not raise."""
+    model = SRResNet(scale=2, num_residual_blocks=1)
+    del model.hparams["scale"]  # simulate a native_lr model with no scale hparam at all
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),  # scale=None
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=4, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")  # must not raise
+
+
+def test_setup_samples_train_dataset_index_zero_only_once(
+    tiny_rgb_image_dir: Path, tmp_path: Path, monkeypatch
+):
+    """When train_dataset is both the input_contract probe target and the
+    example_input_shape check's source, __getitem__(0) must be read once
+    and reused — not sampled twice.
+
+    Wraps with a plain function (not a MagicMock instance) assigned onto the
+    class: CPython's implicit special-method dispatch for `dataset[0]` only
+    passes `self` through when the found `__getitem__` is a real function
+    object — a Mock instance stored there is invoked without `self`, which
+    would silently miscount (or crash) here.
+    """
+    lit = _srresnet_lit(scale=2)
+    lit.training_config.example_input_shape = (3, 12, 12)
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    ds_cls = type(dm.train_dataset)
+    original_getitem = ds_cls.__getitem__
+    calls: list[int] = []
+
+    def counting_getitem(self, idx):
+        calls.append(idx)
+        return original_getitem(self, idx)
+
+    monkeypatch.setattr(ds_cls, "__getitem__", counting_getitem)
+
+    lit.setup(stage="fit")
+
+    assert calls == [0]
+
+
+def test_setup_does_not_perturb_global_random_state(tiny_rgb_image_dir: Path, tmp_path: Path):
+    """Regression: TrainDataset.__getitem__'s random.randint crop draws must
+    not leak into the global random sequence the real training loop consumes
+    — this is a paper-reproduction repo, so an unguarded probe call would
+    silently shift every seeded crop drawn after setup()."""
+    import random
+
+    lit = _srresnet_lit(scale=2)
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    random.seed(12345)
+    state_before = random.getstate()
+    lit.setup(stage="fit")
+    assert random.getstate() == state_before
+
+
+def test_setup_skips_when_datamodule_lacks_dataset_accessors():
+    """A foreign datamodule (not an SRDataModule — exposes none of
+    train_dataset/val_dataset/test_datasets) must degrade to 'nothing to
+    probe' instead of raising AttributeError."""
+    lit = _srcnn_lit()
+    lit.trainer = SimpleNamespace(datamodule=SimpleNamespace())
+
+    lit.setup(stage="fit")  # must not raise
+
+
+def test_check_input_contract_raises_on_unrecognised_contract(srcnn_rgb_lit: SRLightning):
+    """A future/typo'd input_contract value must raise clearly, instead of
+    silently falling into the native_lr branch (the old bare if/else)."""
+    srcnn_rgb_lit.model.input_contract = "not_a_real_contract"
+    lr = torch.rand(1, 3, 8, 8)
+    hr = torch.rand(1, 3, 8, 8)
+
+    with pytest.raises(ValueError, match="not_a_real_contract"):
+        srcnn_rgb_lit._check_input_contract(lr, hr, "train_dataset", object())

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1,4 +1,5 @@
 import functools
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -18,7 +19,7 @@ from sisr.processors import (
     YCbCrProcessor,
     YChannelProcessor,
 )
-from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
+from sisr.training import SRDataModule, SREvalConfig, SRLightning, SRTrainingConfig
 
 # ---------------------------------------------------------------------------
 # fixtures
@@ -1116,3 +1117,273 @@ def test_on_save_checkpoint_round_trips_weights_only(tmp_path, srcnn_rgb_lit: SR
 
     assert loaded["sisr_meta"] == checkpoint["sisr_meta"]
     assert set(loaded["state_dict"].keys()) == set(srcnn_rgb_lit.state_dict().keys())
+
+
+# ---------------------------------------------------------------------------
+# setup() — input_contract probe + example_input_shape probe (real datasets)
+# ---------------------------------------------------------------------------
+
+
+def _srcnn_datamodule(tiny_rgb_image_dir: Path, tmp_path: Path, scale: int = 2) -> SRDataModule:
+    """SRDataModule over srcnn's pre-upsampled datasets (lr.shape == hr.shape)."""
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "subimg_size": 33,
+            "stride": 14,
+            "scale": scale,
+            "use_tqdm": False,
+            "cache_dir": str(tmp_path / ".lmdb_cache_srcnn"),
+            "build_num_workers": 1,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": scale},
+    }
+    return SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        train_dataloader_kwargs={"batch_size": 2, "num_workers": 0},
+        val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+    )
+
+
+def _srresnet_datamodule(
+    tiny_rgb_image_dir: Path, tmp_path: Path, scale: int = 2, hr_crop_size: int = 24
+) -> SRDataModule:
+    """SRDataModule over srresnet's native-LR datasets (hr.shape == lr.shape * scale)."""
+    train_spec = {
+        "class_path": "sisr.datasets.srresnet.TrainDataset",
+        "init_args": {
+            "img_dir": str(tiny_rgb_image_dir),
+            "scale": scale,
+            "hr_crop_size": hr_crop_size,
+            "use_tqdm": False,
+            "cache_dir": str(tmp_path / ".lmdb_cache_srresnet"),
+            "build_num_workers": 1,
+        },
+    }
+    val_spec = {
+        "class_path": "sisr.datasets.srresnet.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": scale},
+    }
+    return SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=val_spec,
+        train_dataloader_kwargs={"batch_size": 2, "num_workers": 0},
+        val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+    )
+
+
+def _srresnet_lit(scale: int = 2) -> SRLightning:
+    model = SRResNet(scale=scale, num_residual_blocks=1)
+    return SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRResNetTrainingConfig(scale=scale),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def _srcnn_lit() -> SRLightning:
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    return SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def test_setup_raises_on_native_lr_model_with_pre_upsampled_dataset(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """Regression: SRResNet (native_lr) wired to SRCNN's pre-upsampled dataset
+    must raise at setup(), not silently corrupt training via _forward_sr's
+    center_crop zero-padding."""
+    lit = _srresnet_lit(scale=2)
+    dm = _srcnn_datamodule(tiny_rgb_image_dir, tmp_path, scale=2)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    with pytest.raises(ValueError, match="input_contract"):
+        lit.setup(stage="fit")
+
+
+def test_setup_raises_on_pre_upsampled_model_with_native_lr_dataset(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """Mirror of the above: SRCNN (pre_upsampled) wired to SRResNet's
+    native-LR dataset must also raise."""
+    lit = _srcnn_lit()
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    with pytest.raises(ValueError, match="input_contract"):
+        lit.setup(stage="fit")
+
+
+def test_setup_accepts_correctly_paired_native_lr_model_and_dataset(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    lit = _srresnet_lit(scale=2)
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")  # must not raise
+
+
+def test_setup_accepts_correctly_paired_pre_upsampled_model_and_dataset(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    lit = _srcnn_lit()
+    dm = _srcnn_datamodule(tiny_rgb_image_dir, tmp_path, scale=2)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")  # must not raise
+
+
+def test_setup_checks_validate_stage_too_not_just_fit(tiny_rgb_image_dir: Path, tmp_path: Path):
+    """Regression: the probe must cover validate/test, not only fit — a
+    validate-only run (no train dataset instantiated at all) must still
+    catch a cross-wired model/dataset pairing via the primary val dataset."""
+    lit = _srresnet_lit(scale=2)
+    dm = _srcnn_datamodule(tiny_rgb_image_dir, tmp_path, scale=2)
+    dm.setup(stage="validate")
+    assert dm.train_dataset is None, "validate stage must not build the train dataset"
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    with pytest.raises(ValueError, match="input_contract"):
+        lit.setup(stage="validate")
+
+
+def test_setup_skips_pair_check_for_predict_only_datamodule(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """PredictDataset has no HR pair; a predict-only datamodule (train/val/test
+    all unbuilt) must not raise even for a would-be-mismatched model."""
+    lit = _srresnet_lit(scale=2)
+    train_spec = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(tiny_rgb_image_dir), "scale": 2},
+    }
+    dm = SRDataModule(
+        train_dataset=train_spec,
+        val_dataset=train_spec,
+        predict_dataset={
+            "class_path": "sisr.datasets.predict.PredictDataset",
+            "init_args": {"img_dir": str(tiny_rgb_image_dir)},
+        },
+    )
+    dm.setup(stage="predict")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="predict")  # must not raise
+
+
+def test_setup_noop_when_trainer_unattached(srcnn_rgb_lit: SRLightning):
+    """Guard: pure-module unit-test construction (no Trainer attached) must
+    not raise — self._trainer is None."""
+    srcnn_rgb_lit.setup(stage="fit")  # must not raise
+
+
+def test_setup_noop_when_datamodule_unset():
+    """Guard: a Trainer attached but with no datamodule must not raise."""
+    lit = _srcnn_lit()
+    lit.trainer = SimpleNamespace(datamodule=None)
+    lit.setup(stage="fit")  # must not raise
+
+
+def test_setup_raises_on_wrong_example_input_shape(tiny_rgb_image_dir: Path, tmp_path: Path):
+    """Regression: training_config.example_input_shape spatial dims must
+    match the real train LR patch — currently unvalidated (validate_against
+    only checks the channel count)."""
+    lit = _srresnet_lit(scale=2)
+    lit.training_config.example_input_shape = (3, 999, 999)  # wrong H/W
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    with pytest.raises(ValueError, match="example_input_shape"):
+        lit.setup(stage="fit")
+
+
+def test_setup_accepts_correct_example_input_shape(tiny_rgb_image_dir: Path, tmp_path: Path):
+    """hr_crop_size=24 // scale=2 == 12: the real train LR patch side."""
+    lit = _srresnet_lit(scale=2)
+    lit.training_config.example_input_shape = (3, 12, 12)
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")  # must not raise
+
+
+def test_setup_skips_example_input_shape_check_when_unset(tiny_rgb_image_dir: Path, tmp_path: Path):
+    lit = _srresnet_lit(scale=2)
+    assert lit.training_config.example_input_shape is None
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")  # must not raise
+
+
+def test_setup_skips_example_input_shape_check_when_no_train_dataset(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """example_input_shape is train-only — a validate run (no train dataset
+    instantiated) must not check it, even when it's set and would mismatch
+    the (variable-size) val images."""
+    lit = _srresnet_lit(scale=2)
+    lit.training_config.example_input_shape = (3, 999, 999)
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="validate")
+    assert dm.train_dataset is None
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="validate")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _forward_sr belt-and-braces: HR must not be smaller than SR (center_crop
+# would otherwise zero-pad silently instead of cropping)
+# ---------------------------------------------------------------------------
+
+
+def test_forward_sr_raises_when_hr_smaller_than_sr():
+    """A native-LR model whose SR output outgrows the HR it's paired with
+    must raise before torchvision.center_crop would zero-pad it."""
+    lit = _srresnet_lit(scale=4)
+    lr = torch.rand(1, 3, 8, 8)  # sr_rgb will be 32x32
+    hr = torch.rand(1, 3, 16, 16)  # smaller than sr_rgb in both dims
+
+    with pytest.raises(ValueError, match="center_crop|zero-pad|smaller"):
+        lit._forward_sr(lr, hr)
+
+
+def test_forward_sr_accepts_hr_larger_than_sr_srcnn_direction(srcnn_rgb_lit: SRLightning):
+    """SRCNN's legitimate direction — HR strictly larger than SR (valid-padding
+    shrinkage) — must keep working unchanged."""
+    lr = torch.rand(1, 3, 33, 33)
+    hr = torch.rand(1, 3, 33, 33)
+    _, sr_rgb, hr_cropped = srcnn_rgb_lit._forward_sr(lr, hr)
+    assert sr_rgb.shape == (1, 3, 21, 21)
+    assert hr_cropped.shape == (1, 3, 21, 21)
+
+
+def test_forward_sr_accepts_hr_exactly_equal_to_sr():
+    """HR exactly equal to SR (the common same-padding / native-LR-correct
+    case) must not raise — only strictly smaller HR is a problem."""
+    lit = _srresnet_lit(scale=2)
+    lr = torch.rand(1, 3, 8, 8)
+    hr = torch.rand(1, 3, 16, 16)  # exactly lr * scale
+    _, sr_rgb, hr_cropped = lit._forward_sr(lr, hr)
+    assert sr_rgb.shape == hr_cropped.shape == (1, 3, 16, 16)

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1512,3 +1512,56 @@ def test_check_input_contract_raises_on_unrecognised_contract(srcnn_rgb_lit: SRL
 
     with pytest.raises(ValueError, match="not_a_real_contract"):
         srcnn_rgb_lit._check_input_contract(lr, hr, "train_dataset", object())
+
+
+# ---------------------------------------------------------------------------
+# Real-world regression: the probe must not poison the live LMDB-backed train
+# dataset for pickling (num_workers > 0 DataLoaders spawn, unconditionally on
+# Windows, and must pickle the dataset to send it to worker processes).
+# ---------------------------------------------------------------------------
+
+
+def test_setup_leaves_train_dataset_picklable_for_spawned_workers(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """Regression: setup()'s probe must not call __getitem__(0) on the live
+    dm.train_dataset. Doing so lazily opens LMDBCache._env (an
+    lmdb.Environment, not picklable) on that exact instance — the same
+    instance a num_workers > 0 DataLoader later hands to spawned worker
+    processes via pickle. Before the fix, pickle.dumps(dm.train_dataset)
+    raised TypeError: cannot pickle 'Environment' object after setup() ran.
+    """
+    import pickle
+
+    lit = _srresnet_lit(scale=2)
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")
+
+    pickle.dumps(dm.train_dataset)  # must not raise
+
+
+def test_setup_gracefully_reprobes_dataset_already_opened_by_real_training(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """Regression: a second setup() call (e.g. `test` after `fit` in the same
+    process — trainer.fit() then trainer.test() on the same datamodule, a
+    real scenario test_integration.py already exercises) against a
+    train_dataset whose LMDB env real training already opened for real
+    (harmless on its own for num_workers=0 -- nothing pickles a num_workers=0
+    dataset) must not raise. The picklability guarantee _sample_zero
+    provides is "this probe never opens a still-pristine dataset first", not
+    "the dataset stays picklable forever no matter what real training does
+    to it afterwards" -- a naive implementation that hard-raises whenever
+    the pickle round trip fails would reject this legitimate re-probe."""
+    lit = _srresnet_lit(scale=2)
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")
+    dm.train_dataset[0]  # simulate a real in-process (num_workers=0) training read
+
+    lit.setup(stage="fit")  # must not raise on the re-probe


### PR DESCRIPTION
## What

Closes the one configuration cross-wire in the framework that corrupted results **without any error** — plus two adjacent validation gaps. Three concerns, six commits:

1. **`input_contract` is now enforced.** Previously its only consumer was provenance metadata: pairing SRResNet with the SRCNN dataset in YAML made `center_crop` silently zero-pad HR to 4× (93.75% of the loss target became black border — loss still decreased, PSNR still reported). A `setup()`-time probe now samples one `(lr, hr)` pair via the datamodule and validates it against the model's declared contract (`pre_upsampled` ⇒ equal spatial dims; `native_lr` ⇒ `hr == lr × scale`, falling back to the model's own `scale` hparam when the config leaves it unset), raising an actionable error naming the model, contract, dataset class, both shapes, and two remedies. A belt-and-braces guard in `_forward_sr` refuses to crop when HR is smaller than SR. Verified live: the probe **cannot false-positive on any shipped configuration** (both validation datasets guarantee exact LR/HR relationships by construction).
2. **`example_input_shape` H/W validated** against the real sampled train patch (it drives the compile warm-up shape and FLOPs; only the channel count was checked before).
3. **Dataset CLI overrides fail loudly instead of silently.** `--data.train_dataset.init_args.x=y` used to parse cleanly and do *nothing*; whole-dict JSON forms crashed with a bare jsonargparse `AttributeError`. Now: malformed specs are rejected with actionable messages at construction, and the parse-time crash is converted to an actionable error **only** when it is genuinely that collision — whole-dict overrides of fields with no prior value (the documented `sisr predict` workflow) keep working, byte-for-byte verified against the pre-change baseline.

## Evidence

- All gaps proven **RED → GREEN**: cross-wired pairing (both directions) raises at setup where it previously trained silently; wrong `example_input_shape` raises where it previously passed; each malformed CLI form now errors actionably where it previously no-op'd or crashed raw. RED outputs captured against the pre-fix tree via stash/pop.
- A real `Trainer(fast_dev_run=True)` integration test exercises the probe end-to-end (guards the Lightning hook-ordering premise).
- The probe is deterministic-safe: single sample, global RNG state snapshot/restored (seeded crop sequences unchanged), no LMDB build triggered, graceful skip on foreign datamodules.
- Suite: **455 passed, 2 skipped** (33 new tests); ruff clean; templates parse unchanged.

Adversarially reviewed across three rounds (Opus): initial review attacked the probe for false positives on shipped configs (none constructible), round 2 caught a guard over-rejection that would have regressed the predict workflow — fixed and byte-for-byte verified — and the final round approved with the remaining minors explicitly recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)