### PR TITLE
Make the LMDB cache build lock unable to destroy live data

### DIFF
--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -14,8 +14,11 @@ build path never calls. ``tests/test_cache.py`` asserts the module stays
 torch-free; colorspace math lives in :mod:`sisr.colorspace` for this reason.
 """
 
+import logging
 import os
 import shutil
+import sys
+import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
@@ -25,6 +28,56 @@ from typing import Any
 
 import lmdb
 from tqdm.auto import tqdm
+
+_logger = logging.getLogger(__name__)
+
+# Only these mean the LMDB directory itself is broken (bad header, wrong
+# on-disk version, ...) and safe to delete. Everything else -- notably the
+# bare lmdb.Error raised for "environment already open in this process", or
+# lmdb.LockError/DiskError -- is environmental and must not delete anything.
+_CORRUPTION_ERRORS = (lmdb.CorruptedError, lmdb.InvalidError, lmdb.VersionMismatchError)
+
+_HEARTBEAT_MIN_INTERVAL = 0.01
+_HEARTBEAT_MAX_INTERVAL = 30.0
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort, portable check for whether *pid* names a running process.
+
+    ``os.kill(pid, 0)`` is the standard POSIX liveness idiom, but on Windows
+    CPython's ``os.kill`` maps arbitrary signal numbers (including 0) onto
+    ``TerminateProcess`` -- calling it here could actually kill a live
+    builder rather than merely check it. So on that platform this queries
+    the process table via ``ctypes``/``OpenProcess`` instead.
+
+    Args:
+        pid: Process id to check.
+
+    Returns:
+        ``True`` if a process with this pid is currently running.
+    """
+    if sys.platform == "win32":
+        import ctypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            if not ctypes.windll.kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            return exit_code.value == STILL_ACTIVE
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just not ours to signal
+    return True
 
 
 class LMDBCacheBuildContext:
@@ -147,10 +200,15 @@ class LMDBCache:
     never mistaken for a complete one. An advisory file lock (see
     :meth:`_acquire_lock`) exists only to *avoid duplicate work*, not to
     provide correctness: a losing process polls for the winner's result and
-    joins it, but if the winner never finishes (e.g. it crashed while
-    holding the lock) the loser builds anyway once *lock_timeout* elapses.
-    Waiting forever on a stale lock is the one failure mode this must never
-    have; rebuilding a cache that already exists is merely wasted time.
+    joins it. The lock's holder is never preempted while it is provably
+    alive (its pid running, corroborated by a heartbeat that refreshes the
+    sentinel's mtime during the build) — a losing process instead keeps
+    waiting past *lock_timeout*, logging once, rather than racing a slow but
+    healthy build. Only a holder whose pid has died *and* whose sentinel has
+    gone stale for longer than *lock_timeout* is treated as abandoned and
+    taken over. Waiting forever on a genuinely stale lock is the one failure
+    mode this must never have; rebuilding a cache that already exists is
+    merely wasted time.
 
     Args:
         cache_dir: Parent directory for the LMDB database.
@@ -166,7 +224,9 @@ class LMDBCache:
         use_tqdm: Whether to display a progress bar during the build.
         lock_poll_interval: Seconds between checks for a concurrent
             builder's result while waiting on its lock.
-        lock_timeout: Seconds to wait on a held lock before building anyway.
+        lock_timeout: Seconds to wait on a held lock, past which a *dead*
+            holder's lock is considered abandoned. A live holder is never
+            preempted regardless of this value.
     """
 
     def __init__(
@@ -188,6 +248,9 @@ class LMDBCache:
         self._length = length
         self._metadata = metadata or {}
         self._env: lmdb.Environment | None = None
+        self._owns_lock = False
+        self._heartbeat_thread: threading.Thread | None = None
+        self._heartbeat_stop: threading.Event | None = None
 
         if not self._try_load(checksum):
             if build_fn is None:
@@ -195,12 +258,14 @@ class LMDBCache:
                     f"No valid LMDB cache found at {self._lmdb_path} and no build_fn was provided."
                 )
             if self._acquire_lock(checksum, lock_poll_interval, lock_timeout):
+                self._start_heartbeat(lock_timeout)
                 try:
                     # Re-check: a concurrent builder may have finished (and released
                     # its lock) between our first _try_load and winning this one.
                     if not self._try_load(checksum):
                         self._build(checksum, length, map_size, build_fn, use_tqdm)
                 finally:
+                    self._stop_heartbeat()
                     self._release_lock()
 
     @property
@@ -286,24 +351,34 @@ class LMDBCache:
     def _try_load(self, checksum: str) -> bool:
         """Validates an existing LMDB against *checksum*; ``True`` if ready to use.
 
-        Failing to even *open* the environment is presumed genuine corruption
-        (bad format, truncated files) and the directory is dropped so a later
-        call can rebuild it. A failure *after* a successful open — reading the
-        transaction — is treated as merely not-ready-yet, without deleting
-        anything: opened with ``lock=False``, this read can raise on Windows
-        while a concurrent writer *in another process* is still active (the
-        exact scenario :meth:`_acquire_lock` exists for), even though nothing
-        is actually corrupt. Deleting the directory there would destroy that
+        Only a corruption-specific failure to *open* the environment (bad
+        file header, wrong on-disk version — see :data:`_CORRUPTION_ERRORS`)
+        is presumed genuine corruption, dropping the directory so a later
+        call can rebuild it. Every other failure, opening or reading, is
+        treated as merely not-ready-yet without deleting anything: opened
+        with ``lock=False``, this can raise a bare ``lmdb.Error`` ("already
+        open in this process") when this same process holds another handle
+        on the same path, or fail on Windows while a concurrent writer *in
+        another process* is still active (the exact scenario
+        :meth:`_acquire_lock` exists for) — in neither case is anything
+        actually corrupt. Deleting the directory there would destroy that
         other process's in-progress or just-finished build instead of merely
-        costing this call a retry.
+        costing this call a retry. Even the corruption-cleanup rmtree itself
+        is guarded: a failure there (e.g. a lingering open handle) must not
+        escape as an unhandled exception either.
         """
         if not self._lmdb_path.exists():
             return False
         try:
             env = lmdb.open(str(self._lmdb_path), readonly=True, lock=False)
+        except _CORRUPTION_ERRORS:
+            try:
+                if self._lmdb_path.exists():
+                    shutil.rmtree(self._lmdb_path)
+            except OSError:
+                pass
+            return False
         except (lmdb.Error, OSError):
-            if self._lmdb_path.exists():
-                shutil.rmtree(self._lmdb_path)
             return False
 
         try:
@@ -311,7 +386,13 @@ class LMDBCache:
                 stored = txn.get(b"__checksum__")
                 if stored is None or stored.decode() != checksum:
                     return False
-                self._length = int(txn.get(b"__length__").decode())
+                length_raw = txn.get(b"__length__")
+                if length_raw is None:
+                    return False
+                try:
+                    self._length = int(length_raw.decode())
+                except ValueError:
+                    return False
             return True
         except (lmdb.Error, OSError):
             return False
@@ -322,41 +403,150 @@ class LMDBCache:
         """Sentinel path for the advisory build lock, scoped to this checksum."""
         return self._lmdb_path.with_name(self._lmdb_path.name + ".build.lock")
 
+    def _claim_sentinel(self) -> bool:
+        """Creates this process's lock sentinel; ``True`` on success.
+
+        ``False`` means the sentinel already exists (someone else holds, or
+        just won, the race).
+        """
+        try:
+            fd = os.open(str(self._lock_path()), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            return False
+        os.write(fd, str(os.getpid()).encode())
+        os.close(fd)
+        self._owns_lock = True
+        return True
+
+    def _read_lock_pid(self) -> int | None:
+        """Returns the pid recorded in the lock sentinel, or ``None`` if unreadable."""
+        try:
+            raw = self._lock_path().read_text()
+        except OSError:
+            return None
+        try:
+            return int(raw.strip())
+        except ValueError:
+            return None
+
+    def _lock_is_stale(self, timeout: float) -> bool:
+        """``True`` if the sentinel's mtime hasn't been refreshed within *timeout*."""
+        try:
+            mtime = self._lock_path().stat().st_mtime
+        except OSError:
+            return True  # sentinel vanished entirely -- nothing left to hold onto
+        return (time.time() - mtime) > timeout
+
     def _acquire_lock(self, checksum: str, poll_interval: float, timeout: float) -> bool:
         """Becomes the sole builder for *checksum*, or waits on whoever already is.
 
+        A live holder — its pid still running — is never preempted: this
+        waits past *timeout*, logging once, rather than racing a slow but
+        healthy build. Takeover only happens once the holder's pid is
+        confirmed dead *and* its sentinel's mtime (refreshed by the
+        holder's heartbeat while it builds, see :meth:`_start_heartbeat`)
+        has gone stale for longer than *timeout* — i.e. it crashed without
+        releasing the lock.
+
         Returns:
             ``True`` if the caller should proceed to build — either it won
-            the lock outright, or it waited out *timeout* without seeing a
-            valid cache appear (a stale/crashed lock holder must not deadlock
-            every later run, so this falls through to a duplicate build
-            rather than waiting forever). ``False`` if a concurrent builder
-            produced a valid cache while waiting — :meth:`_try_load` has
-            already refreshed :attr:`_length` in that case.
+            the lock outright, or it took over one abandoned by a dead
+            holder. ``False`` if a concurrent builder produced a valid cache
+            while waiting — :meth:`_try_load` has already refreshed
+            :attr:`_length` in that case.
         """
-        lock_path = self._lock_path()
-        try:
-            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-        except FileExistsError:
-            pass
-        else:
-            os.write(fd, str(os.getpid()).encode())
-            os.close(fd)
+        if self._claim_sentinel():
             return True
 
+        warned_waiting = warned_stale = False
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
+        while True:
             if self._try_load(checksum):
                 return False
-            time.sleep(poll_interval)
-        return True
+
+            holder_pid = self._read_lock_pid()
+            if holder_pid is not None and _pid_alive(holder_pid):
+                if not warned_waiting and time.monotonic() > deadline:
+                    _logger.warning(
+                        "Build lock %s held by live pid %d past the %.1fs timeout; "
+                        "waiting rather than taking over.",
+                        self._lock_path(),
+                        holder_pid,
+                        timeout,
+                    )
+                    warned_waiting = True
+                time.sleep(poll_interval)
+                continue
+
+            if not self._lock_is_stale(timeout):
+                time.sleep(poll_interval)
+                continue
+
+            if not warned_stale:
+                _logger.warning(
+                    "Build lock %s has no live holder and is stale; taking over.",
+                    self._lock_path(),
+                )
+                warned_stale = True
+            try:
+                self._lock_path().unlink()
+            except FileNotFoundError:
+                pass
+            if self._claim_sentinel():
+                return True
+            # Another process reclaimed it first -- reassess from the top.
+
+    def _start_heartbeat(self, timeout: float) -> None:
+        """Starts a daemon thread that periodically refreshes the sentinel's mtime.
+
+        A waiter treats a holder's sentinel as possibly abandoned once its
+        mtime goes stale (see :meth:`_lock_is_stale`); refreshing it while
+        genuinely building proves this process is still alive even in the
+        pid-alive check's absence (e.g. a very short-lived poll window).
+
+        Args:
+            timeout: The caller's ``lock_timeout``; the refresh interval is
+                a small fraction of it, bounded to a sane range.
+        """
+        interval = max(_HEARTBEAT_MIN_INTERVAL, min(timeout / 4, _HEARTBEAT_MAX_INTERVAL))
+        lock_path = self._lock_path()
+        stop = threading.Event()
+
+        def _beat() -> None:
+            while not stop.wait(interval):
+                try:
+                    os.utime(lock_path, None)
+                except OSError:
+                    return
+
+        self._heartbeat_stop = stop
+        self._heartbeat_thread = threading.Thread(target=_beat, daemon=True)
+        self._heartbeat_thread.start()
+
+    def _stop_heartbeat(self) -> None:
+        """Stops the heartbeat thread started by :meth:`_start_heartbeat`, if any."""
+        if self._heartbeat_stop is None:
+            return
+        self._heartbeat_stop.set()
+        self._heartbeat_thread.join(timeout=1.0)
+        self._heartbeat_stop = None
+        self._heartbeat_thread = None
 
     def _release_lock(self) -> None:
-        """Removes the lock sentinel this process created in :meth:`_acquire_lock`."""
+        """Removes the sentinel this process created in :meth:`_acquire_lock`.
+
+        A no-op unless this instance actually created (or took over) the
+        sentinel: releasing one this process never owned would let a third
+        process immediately win a fresh race into a directory whose real
+        (still-live or just-finished) builder never asked to release it.
+        """
+        if not self._owns_lock:
+            return
         try:
             self._lock_path().unlink()
         except FileNotFoundError:
             pass
+        self._owns_lock = False
 
     def _build(
         self,
@@ -366,22 +556,67 @@ class LMDBCache:
         build_fn: Callable[[LMDBCacheBuildContext], None],
         use_tqdm: bool,
     ) -> None:
-        """Creates a fresh LMDB; *build_fn* must populate it with exactly *length* entries."""
-        if self._lmdb_path.exists():
-            shutil.rmtree(self._lmdb_path)
+        """Builds into a temp sibling directory, then atomically publishes it.
 
-        env = lmdb.open(str(self._lmdb_path), map_size=map_size)
+        *build_fn* must populate it with exactly *length* entries.
+        :attr:`_lmdb_path` itself is never opened for writing until the new
+        database is fully populated and closed, so a build that fails here
+        never touches (or half-deletes) whatever was already at that path —
+        reaching this method at all already means :meth:`_acquire_lock`
+        verified no other process can still be live-writing there.
+        """
+        tmp_path = self._lmdb_path.with_name(f"{self._lmdb_path.name}.build.{os.getpid()}.tmp")
+        if tmp_path.exists():
+            shutil.rmtree(tmp_path)  # leftover of an earlier crashed attempt, same pid: ours
 
-        ctx = LMDBCacheBuildContext(env=env, use_tqdm=use_tqdm)
-        build_fn(ctx)
+        env = lmdb.open(str(tmp_path), map_size=map_size)
+        try:
+            ctx = LMDBCacheBuildContext(env=env, use_tqdm=use_tqdm)
+            build_fn(ctx)
 
-        # __checksum__ written last so an interrupted build reads as stale, not complete.
-        txn = env.begin(write=True)
-        txn.put(b"__length__", str(length).encode())
-        for k, v in self._metadata.items():
-            txn.put(f"__{k}__".encode(), str(v).encode())
-        txn.put(b"__checksum__", checksum.encode())
-        txn.commit()
-        env.close()
+            # __checksum__ written last so an interrupted build reads as stale, not complete.
+            txn = env.begin(write=True)
+            txn.put(b"__length__", str(length).encode())
+            for k, v in self._metadata.items():
+                txn.put(f"__{k}__".encode(), str(v).encode())
+            txn.put(b"__checksum__", checksum.encode())
+            txn.commit()
+        finally:
+            env.close()
 
+        self._publish(tmp_path)
         self._length = length
+
+    def _publish(self, tmp_path: Path) -> None:
+        """Atomically moves a finished build from *tmp_path* into :attr:`_lmdb_path`.
+
+        Reaching here means :meth:`_acquire_lock` gave this process the
+        exclusive, live-verified build lock, so any pre-existing directory
+        at :attr:`_lmdb_path` is provably not another process's in-progress
+        build — only a genuinely stale (failed-checksum or corrupt)
+        leftover can land here. If clearing or replacing it fails anyway
+        (e.g. a lingering open handle on Windows), that is raised as a
+        clear error instead of silently discarding the build just finished.
+
+        Args:
+            tmp_path: The completed build's temporary directory.
+
+        Raises:
+            RuntimeError: If the stale target could not be cleared, or the
+                finished build could not be moved into place.
+        """
+        if self._lmdb_path.exists():
+            try:
+                shutil.rmtree(self._lmdb_path)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Cannot replace stale cache at {self._lmdb_path}: still in use "
+                    "elsewhere. Not deleting it -- remove it manually once nothing "
+                    "holds it open, then retry."
+                ) from exc
+        try:
+            os.replace(tmp_path, self._lmdb_path)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Built cache at {tmp_path} but could not move it to {self._lmdb_path}."
+            ) from exc

--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -14,6 +14,7 @@ build path never calls. ``tests/test_cache.py`` asserts the module stays
 torch-free; colorspace math lives in :mod:`sisr.colorspace` for this reason.
 """
 
+import ctypes
 import logging
 import os
 import shutil
@@ -40,6 +41,49 @@ _CORRUPTION_ERRORS = (lmdb.CorruptedError, lmdb.InvalidError, lmdb.VersionMismat
 _HEARTBEAT_MIN_INTERVAL = 0.01
 _HEARTBEAT_MAX_INTERVAL = 30.0
 
+# How many multiples of lock_timeout to wait on a confirmed-live holder
+# before giving up and raising -- bounds an otherwise-unbounded wait.
+_LIVE_HOLDER_WAIT_MULTIPLE = 3
+
+# Windows liveness check: OpenProcess's failure mode must be inspected via
+# GetLastError, which ctypes only tracks reliably through a use_last_error=True
+# handle (the default cached ctypes.windll.kernel32 does not guarantee the
+# value survives ctypes' own bookkeeping between the call and the check).
+_kernel32 = ctypes.WinDLL("kernel32", use_last_error=True) if sys.platform == "win32" else None
+
+
+def _pid_alive_windows(pid: int) -> bool:
+    """Windows liveness check for :func:`_pid_alive`, split out for testing.
+
+    ``OpenProcess`` failing does not always mean "no such process": a
+    builder running under another user account or session is a real,
+    live process this one simply lacks permission to query
+    (``ERROR_ACCESS_DENIED``) and must not be treated as dead. Only an
+    actually-missing pid reports something else (``ERROR_INVALID_PARAMETER``
+    in practice).
+
+    Args:
+        pid: Process id to check.
+
+    Returns:
+        ``True`` if *pid* is a running process, or one this process is
+        merely not permitted to query.
+    """
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+    ERROR_ACCESS_DENIED = 5
+
+    handle = _kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        exit_code = ctypes.c_ulong()
+        if not _kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == STILL_ACTIVE
+    finally:
+        _kernel32.CloseHandle(handle)
+
 
 def _pid_alive(pid: int) -> bool:
     """Best-effort, portable check for whether *pid* names a running process.
@@ -48,7 +92,7 @@ def _pid_alive(pid: int) -> bool:
     CPython's ``os.kill`` maps arbitrary signal numbers (including 0) onto
     ``TerminateProcess`` -- calling it here could actually kill a live
     builder rather than merely check it. So on that platform this queries
-    the process table via ``ctypes``/``OpenProcess`` instead.
+    the process table via :func:`_pid_alive_windows` instead.
 
     Args:
         pid: Process id to check.
@@ -57,20 +101,7 @@ def _pid_alive(pid: int) -> bool:
         ``True`` if a process with this pid is currently running.
     """
     if sys.platform == "win32":
-        import ctypes
-
-        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-        STILL_ACTIVE = 259
-        handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-        if not handle:
-            return False
-        try:
-            exit_code = ctypes.c_ulong()
-            if not ctypes.windll.kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-                return False
-            return exit_code.value == STILL_ACTIVE
-        finally:
-            ctypes.windll.kernel32.CloseHandle(handle)
+        return _pid_alive_windows(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -201,14 +232,19 @@ class LMDBCache:
     :meth:`_acquire_lock`) exists only to *avoid duplicate work*, not to
     provide correctness: a losing process polls for the winner's result and
     joins it. The lock's holder is never preempted while it is provably
-    alive (its pid running, corroborated by a heartbeat that refreshes the
-    sentinel's mtime during the build) — a losing process instead keeps
-    waiting past *lock_timeout*, logging once, rather than racing a slow but
-    healthy build. Only a holder whose pid has died *and* whose sentinel has
-    gone stale for longer than *lock_timeout* is treated as abandoned and
-    taken over. Waiting forever on a genuinely stale lock is the one failure
-    mode this must never have; rebuilding a cache that already exists is
-    merely wasted time.
+    alive (its pid running — and not merely this waiting process's own pid,
+    which a crashed holder's can be recycled to — corroborated by a
+    heartbeat that refreshes the sentinel's mtime during the build) — a
+    losing process instead keeps waiting past *lock_timeout*, re-logging
+    periodically, rather than racing a slow but healthy build. Only a
+    holder whose pid has died (or is our own) *and* whose sentinel has gone
+    stale for longer than *lock_timeout* is treated as abandoned and taken
+    over. Waiting on a *live* holder is itself capped: past
+    ``3 * lock_timeout`` this raises ``TimeoutError`` naming the sentinel
+    and the manual remedy, rather than blocking forever with no way for an
+    operator to notice. Waiting forever on a genuinely stale lock is the
+    other failure mode this must never have; rebuilding a cache that
+    already exists is merely wasted time.
 
     Args:
         cache_dir: Parent directory for the LMDB database.
@@ -252,17 +288,20 @@ class LMDBCache:
         self._heartbeat_thread: threading.Thread | None = None
         self._heartbeat_stop: threading.Event | None = None
 
-        if not self._try_load(checksum):
+        if not self._try_load(checksum, strict=True):
             if build_fn is None:
                 raise RuntimeError(
                     f"No valid LMDB cache found at {self._lmdb_path} and no build_fn was provided."
                 )
             if self._acquire_lock(checksum, lock_poll_interval, lock_timeout):
-                self._start_heartbeat(lock_timeout)
                 try:
+                    # _start_heartbeat lives inside this try too: if starting the
+                    # thread itself fails, the sentinel must still be released in
+                    # the finally below rather than leaked until it goes stale.
+                    self._start_heartbeat(lock_timeout)
                     # Re-check: a concurrent builder may have finished (and released
                     # its lock) between our first _try_load and winning this one.
-                    if not self._try_load(checksum):
+                    if not self._try_load(checksum, strict=True):
                         self._build(checksum, length, map_size, build_fn, use_tqdm)
                 finally:
                     self._stop_heartbeat()
@@ -348,37 +387,59 @@ class LMDBCache:
                 results.append(bytes(buf) if buf is not None else None)
         return results
 
-    def _try_load(self, checksum: str) -> bool:
+    def _try_load(self, checksum: str, strict: bool = False) -> bool:
         """Validates an existing LMDB against *checksum*; ``True`` if ready to use.
 
         Only a corruption-specific failure to *open* the environment (bad
         file header, wrong on-disk version — see :data:`_CORRUPTION_ERRORS`)
         is presumed genuine corruption, dropping the directory so a later
-        call can rebuild it. Every other failure, opening or reading, is
-        treated as merely not-ready-yet without deleting anything: opened
-        with ``lock=False``, this can raise a bare ``lmdb.Error`` ("already
-        open in this process") when this same process holds another handle
-        on the same path, or fail on Windows while a concurrent writer *in
-        another process* is still active (the exact scenario
-        :meth:`_acquire_lock` exists for) — in neither case is anything
-        actually corrupt. Deleting the directory there would destroy that
-        other process's in-progress or just-finished build instead of merely
-        costing this call a retry. Even the corruption-cleanup rmtree itself
-        is guarded: a failure there (e.g. a lingering open handle) must not
-        escape as an unhandled exception either.
+        call can rebuild it. Every other failure to open is environmental --
+        notably the bare ``lmdb.Error`` ("already open in this process")
+        raised when this same process holds another handle on the same path,
+        or a Windows failure while a concurrent writer *in another process*
+        is still active -- and never means the directory is corrupt.
+
+        Args:
+            checksum: Hex digest the stored ``__checksum__`` must match.
+            strict: When ``True``, an environmental open failure raises
+                instead of returning ``False``. Used at the two call sites
+                where this process is about to become the builder: silently
+                treating "another handle is already open" as "rebuild me"
+                previously caused a full, destructive rebuild of a perfectly
+                valid cache. Left ``False`` (the default) while merely
+                polling on someone else's lock, where the identical failure
+                is often a transient, self-resolving artifact of a
+                concurrent writer in another process.
+
+        Returns:
+            ``True`` if the cache is present, checksum-matched, and ready.
+
+        Raises:
+            RuntimeError: If *strict* and the environment could not be
+                opened for a non-corruption reason.
         """
         if not self._lmdb_path.exists():
             return False
         try:
             env = lmdb.open(str(self._lmdb_path), readonly=True, lock=False)
         except _CORRUPTION_ERRORS:
+            # Even this cleanup is guarded: a failure here (e.g. a lingering
+            # open handle) must not escape as an unhandled exception either.
             try:
                 if self._lmdb_path.exists():
                     shutil.rmtree(self._lmdb_path)
             except OSError:
                 pass
             return False
-        except (lmdb.Error, OSError):
+        except (lmdb.Error, OSError) as exc:
+            if strict:
+                raise RuntimeError(
+                    f"Cannot open the existing cache at {self._lmdb_path}: {exc}. This is "
+                    "not corruption: most likely another handle to this cache is already "
+                    "open in this process (close it first) and a rebuild would only race "
+                    "and destroy it, or the OS-level conflict needs investigating. Refusing "
+                    "to silently rebuild."
+                ) from exc
             return False
 
         try:
@@ -413,8 +474,10 @@ class LMDBCache:
             fd = os.open(str(self._lock_path()), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
         except FileExistsError:
             return False
-        os.write(fd, str(os.getpid()).encode())
-        os.close(fd)
+        try:
+            os.write(fd, str(os.getpid()).encode())
+        finally:
+            os.close(fd)  # always close, even if the write itself failed
         self._owns_lock = True
         return True
 
@@ -440,13 +503,30 @@ class LMDBCache:
     def _acquire_lock(self, checksum: str, poll_interval: float, timeout: float) -> bool:
         """Becomes the sole builder for *checksum*, or waits on whoever already is.
 
-        A live holder — its pid still running — is never preempted: this
-        waits past *timeout*, logging once, rather than racing a slow but
-        healthy build. Takeover only happens once the holder's pid is
-        confirmed dead *and* its sentinel's mtime (refreshed by the
-        holder's heartbeat while it builds, see :meth:`_start_heartbeat`)
-        has gone stale for longer than *timeout* — i.e. it crashed without
-        releasing the lock.
+        A live holder — its pid still running, and *not this process's own
+        pid* (a crashed builder's pid can be recycled to this very process;
+        Windows in particular reuses pids in small multiples, making
+        crash-then-restart-with-the-same-pid a real scenario, not a
+        theoretical one) — is never preempted: this waits past *timeout*,
+        re-logging periodically so a long wait stays diagnosable, rather
+        than racing a slow but healthy build. Takeover only happens once the
+        holder's pid is confirmed dead (or is our own) *and* its sentinel's
+        mtime (refreshed by the holder's heartbeat while it builds, see
+        :meth:`_start_heartbeat`) has gone stale for longer than *timeout*
+        — i.e. it crashed without releasing the lock. Waiting on a
+        confirmed-*live* holder is itself capped at
+        ``_LIVE_HOLDER_WAIT_MULTIPLE * timeout``: past that this raises
+        rather than blocking forever, so a genuinely stuck wait surfaces
+        instead of hanging silently.
+
+        Note on filesystem assumptions: staleness is judged by the
+        sentinel's mtime against wall-clock ``time.time()``, so it assumes
+        all racing processes share a consistent clock and a filesystem with
+        working mtimes (true for a local disk; a clock-skewed network
+        filesystem, or an NTP step during the wait, could misjudge
+        staleness in either direction). This lock is advisory and best-effort
+        by design (see the class docstring) — that assumption is accepted,
+        not solved, here.
 
         Returns:
             ``True`` if the caller should proceed to build — either it won
@@ -454,27 +534,42 @@ class LMDBCache:
             holder. ``False`` if a concurrent builder produced a valid cache
             while waiting — :meth:`_try_load` has already refreshed
             :attr:`_length` in that case.
+
+        Raises:
+            TimeoutError: If a confirmed-live holder still has not finished
+                after ``_LIVE_HOLDER_WAIT_MULTIPLE * timeout`` seconds.
         """
         if self._claim_sentinel():
             return True
 
-        warned_waiting = warned_stale = False
-        deadline = time.monotonic() + timeout
+        own_pid = os.getpid()
+        start = time.monotonic()
+        next_log_at = start + timeout
+        hard_deadline = start + timeout * _LIVE_HOLDER_WAIT_MULTIPLE
         while True:
             if self._try_load(checksum):
                 return False
 
             holder_pid = self._read_lock_pid()
-            if holder_pid is not None and _pid_alive(holder_pid):
-                if not warned_waiting and time.monotonic() > deadline:
+            if holder_pid is not None and holder_pid != own_pid and _pid_alive(holder_pid):
+                now = time.monotonic()
+                if now > hard_deadline:
+                    raise TimeoutError(
+                        f"Build lock {self._lock_path()} has been held by live pid "
+                        f"{holder_pid} for over {timeout * _LIVE_HOLDER_WAIT_MULTIPLE:.1f}s "
+                        f"({_LIVE_HOLDER_WAIT_MULTIPLE}x lock_timeout). Refusing to wait "
+                        f"indefinitely. If that process is confirmed gone, remove "
+                        f"{self._lock_path()} manually and retry."
+                    )
+                if now >= next_log_at:
                     _logger.warning(
-                        "Build lock %s held by live pid %d past the %.1fs timeout; "
-                        "waiting rather than taking over.",
+                        "Build lock %s still held by live pid %d after %.1fs; waiting "
+                        "rather than taking over.",
                         self._lock_path(),
                         holder_pid,
-                        timeout,
+                        now - start,
                     )
-                    warned_waiting = True
+                    next_log_at += timeout
                 time.sleep(poll_interval)
                 continue
 
@@ -482,12 +577,16 @@ class LMDBCache:
                 time.sleep(poll_interval)
                 continue
 
-            if not warned_stale:
-                _logger.warning(
-                    "Build lock %s has no live holder and is stale; taking over.",
-                    self._lock_path(),
-                )
-                warned_stale = True
+            # holder_pid is dead, unreadable, or (pid recycling) our own, and
+            # the sentinel is stale. TOCTOU guard: re-read immediately before
+            # unlinking -- another waiter may have already reclaimed a fresh,
+            # live sentinel in the interim; unlinking that would kill it.
+            if self._read_lock_pid() != holder_pid:
+                continue
+            _logger.warning(
+                "Build lock %s has no live holder and is stale; taking over.",
+                self._lock_path(),
+            )
             try:
                 self._lock_path().unlink()
             except FileNotFoundError:
@@ -501,8 +600,9 @@ class LMDBCache:
 
         A waiter treats a holder's sentinel as possibly abandoned once its
         mtime goes stale (see :meth:`_lock_is_stale`); refreshing it while
-        genuinely building proves this process is still alive even in the
-        pid-alive check's absence (e.g. a very short-lived poll window).
+        genuinely building corroborates :func:`_pid_alive`, covering that
+        check's own false negatives (e.g. a pid query blocked or denied for
+        a transient reason) with an independent liveness signal.
 
         Args:
             timeout: The caller's ``lock_timeout``; the refresh interval is
@@ -516,8 +616,10 @@ class LMDBCache:
             while not stop.wait(interval):
                 try:
                     os.utime(lock_path, None)
+                except FileNotFoundError:
+                    return  # sentinel is gone -- released or taken over, nothing left to refresh
                 except OSError:
-                    return
+                    pass  # transient (e.g. a momentary sharing violation) -- keep trying
 
         self._heartbeat_stop = stop
         self._heartbeat_thread = threading.Thread(target=_beat, daemon=True)
@@ -539,14 +641,52 @@ class LMDBCache:
         sentinel: releasing one this process never owned would let a third
         process immediately win a fresh race into a directory whose real
         (still-live or just-finished) builder never asked to release it.
+        The ownership flag alone is not trusted for the unlink itself: the
+        sentinel's *content* is re-checked to still be this process's own
+        pid first, since a takeover elsewhere (see :meth:`_acquire_lock`'s
+        TOCTOU guard) could in principle have replaced it in between --
+        unlinking unconditionally here would then delete a third party's
+        live sentinel instead of this process's own.
         """
         if not self._owns_lock:
             return
-        try:
-            self._lock_path().unlink()
-        except FileNotFoundError:
-            pass
+        if self._read_lock_pid() == os.getpid():
+            try:
+                self._lock_path().unlink()
+            except FileNotFoundError:
+                pass
         self._owns_lock = False
+
+    @staticmethod
+    def _pid_from_sibling_name(name: str) -> int | None:
+        """Extracts the embedded pid from a ``<...>.<kind>.<pid>.tmp`` sibling name."""
+        stem = name.removesuffix(".tmp")
+        try:
+            return int(stem.rsplit(".", 1)[-1])
+        except ValueError:
+            return None
+
+    def _sweep_stale_siblings(self) -> None:
+        """Removes leftover build/trash temp siblings whose owning pid has died.
+
+        Both :meth:`_build`'s ``.build.<pid>.tmp`` and :meth:`_publish`'s
+        ``.trash.<pid>.tmp`` are full, ``map_size``-presized LMDB directories
+        (several GB for a real dataset) — a crash before cleanup otherwise
+        leaks that disk space forever. Only called while holding the
+        exclusive build lock (from :meth:`_build`), so a sibling whose pid
+        is still alive belongs to a build genuinely in progress elsewhere
+        and must be left untouched.
+        """
+        prefix = self._lmdb_path.name
+        for pattern in (f"{prefix}.build.*.tmp", f"{prefix}.trash.*.tmp"):
+            for candidate in self._cache_dir.glob(pattern):
+                pid = self._pid_from_sibling_name(candidate.name)
+                if pid is None or pid == os.getpid() or _pid_alive(pid):
+                    continue
+                try:
+                    shutil.rmtree(candidate)
+                except OSError:
+                    pass  # best-effort; retried by the next build that reaches here
 
     def _build(
         self,
@@ -565,6 +705,8 @@ class LMDBCache:
         reaching this method at all already means :meth:`_acquire_lock`
         verified no other process can still be live-writing there.
         """
+        self._sweep_stale_siblings()
+
         tmp_path = self._lmdb_path.with_name(f"{self._lmdb_path.name}.build.{os.getpid()}.tmp")
         if tmp_path.exists():
             shutil.rmtree(tmp_path)  # leftover of an earlier crashed attempt, same pid: ours
@@ -590,29 +732,46 @@ class LMDBCache:
     def _publish(self, tmp_path: Path) -> None:
         """Atomically moves a finished build from *tmp_path* into :attr:`_lmdb_path`.
 
+        Never ``rmtree``s :attr:`_lmdb_path` in place: a pre-existing
+        directory there is moved *aside* to a pid-suffixed trash sibling via
+        ``os.replace`` (a rename, not a delete -- safe even against a
+        reader/mapper still holding files inside it open, unlike unlinking
+        them directly), the finished build is renamed into the now-vacant
+        real path, and only then is the trash sibling opportunistically
+        removed. This leaves no window where anything is unlinked out from
+        under an open handle, at the cost of transiently roughly doubling
+        peak disk usage (old + new both present) until that last cleanup
+        runs -- or indefinitely, if it can never win the race against a
+        lingering reader; see :meth:`_sweep_stale_siblings` for the backstop.
+
         Reaching here means :meth:`_acquire_lock` gave this process the
         exclusive, live-verified build lock, so any pre-existing directory
         at :attr:`_lmdb_path` is provably not another process's in-progress
         build — only a genuinely stale (failed-checksum or corrupt)
-        leftover can land here. If clearing or replacing it fails anyway
-        (e.g. a lingering open handle on Windows), that is raised as a
-        clear error instead of silently discarding the build just finished.
+        leftover can land here. If moving it aside or moving the new build
+        into place fails anyway (e.g. a lingering open handle on Windows),
+        that is raised as a clear error instead of silently discarding the
+        build just finished.
 
         Args:
             tmp_path: The completed build's temporary directory.
 
         Raises:
-            RuntimeError: If the stale target could not be cleared, or the
-                finished build could not be moved into place.
+            RuntimeError: If the stale target could not be moved aside, or
+                the finished build could not be moved into place.
         """
+        trash_path = None
         if self._lmdb_path.exists():
+            trash_path = self._lmdb_path.with_name(
+                f"{self._lmdb_path.name}.trash.{os.getpid()}.tmp"
+            )
             try:
-                shutil.rmtree(self._lmdb_path)
+                os.replace(self._lmdb_path, trash_path)
             except OSError as exc:
                 raise RuntimeError(
-                    f"Cannot replace stale cache at {self._lmdb_path}: still in use "
-                    "elsewhere. Not deleting it -- remove it manually once nothing "
-                    "holds it open, then retry."
+                    f"Cannot move the stale cache at {self._lmdb_path} aside to publish a "
+                    "fresh build; leaving both in place. Investigate and remove it manually, "
+                    "then retry."
                 ) from exc
         try:
             os.replace(tmp_path, self._lmdb_path)
@@ -620,3 +779,8 @@ class LMDBCache:
             raise RuntimeError(
                 f"Built cache at {tmp_path} but could not move it to {self._lmdb_path}."
             ) from exc
+        if trash_path is not None:
+            try:
+                shutil.rmtree(trash_path)
+            except OSError:
+                pass  # best-effort: a lingering reader may still hold it open

--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -626,11 +626,24 @@ class LMDBCache:
         self._heartbeat_thread.start()
 
     def _stop_heartbeat(self) -> None:
-        """Stops the heartbeat thread started by :meth:`_start_heartbeat`, if any."""
+        """Stops the heartbeat thread started by :meth:`_start_heartbeat`, if any.
+
+        Guards ``join()`` against a thread object that was constructed but
+        never actually started -- if ``Thread.start()`` itself raised (e.g.
+        the OS refused a new thread), ``_heartbeat_thread`` is still set, and
+        an unguarded ``join()`` would raise "cannot join thread before it is
+        started". That would mask the original ``start()`` error *and* skip
+        :meth:`_release_lock` on the next line (this runs inside a
+        ``finally``), leaving a live-pid sentinel that stalls every other
+        waiter for up to ``_LIVE_HOLDER_WAIT_MULTIPLE * lock_timeout``.
+        """
         if self._heartbeat_stop is None:
             return
         self._heartbeat_stop.set()
-        self._heartbeat_thread.join(timeout=1.0)
+        try:
+            self._heartbeat_thread.join(timeout=1.0)
+        except RuntimeError:
+            pass  # Thread.start() itself never succeeded -- nothing to join
         self._heartbeat_stop = None
         self._heartbeat_thread = None
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,9 +1,10 @@
 import os
+import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import lmdb
 import pytest
@@ -389,6 +390,53 @@ def test_lmdb_try_load_propagates_unexpected_error(tmp_path: Path):
             cache._try_load("abc")
 
 
+def test_construction_raises_instead_of_silently_rebuilding_on_same_process_conflict(
+    tmp_path: Path,
+):
+    """Constructing a *second* LMDBCache at an existing, valid path while a
+    first instance's env is still open in this process must not silently
+    treat the resulting 'already open' error as 'rebuild me'.
+
+    Previously: environmental open failure -> _try_load returns False ->
+    __init__ proceeds as if nothing were there -> the sentinel is free -> a
+    full, destructive rebuild runs (potentially minutes for a real dataset)
+    of a perfectly valid cache, ending in _build/_publish trying to touch a
+    directory this same process still has mapped. It must instead raise
+    immediately, chaining the original lmdb error, and touch neither the
+    lock nor the existing cache at all.
+    """
+    call_count = [0]
+
+    def counting_build(ctx: LMDBCacheBuildContext) -> None:
+        call_count[0] += 1
+        ctx.write_batch([("key_0", b"v0")])
+
+    first = LMDBCache(
+        cache_dir=tmp_path,
+        name="shared",
+        checksum="c1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=counting_build,
+    )
+    first.get_env()  # holds this process's only allowed handle open at this path
+
+    with pytest.raises(RuntimeError, match="already open"):
+        LMDBCache(
+            cache_dir=tmp_path,
+            name="shared",
+            checksum="c1",
+            length=1,
+            map_size=_MAP_SIZE,
+            build_fn=counting_build,
+        )
+
+    assert call_count[0] == 1, (
+        "must not silently rebuild a valid cache blocked by a same-process handle"
+    )
+    assert first.get("key_0") == b"v0", "the first instance's cache must remain untouched and valid"
+
+
 # ---------------------------------------------------------------------------
 # LMDBCacheBuildContext.parallel_build
 # ---------------------------------------------------------------------------
@@ -500,7 +548,7 @@ def test_release_lock_removes_sentinel_and_is_idempotent(tmp_path: Path):
 
     cache._release_lock()
     assert not cache._lock_path().exists()
-    cache._release_lock()  # must not raise when there is nothing to remove
+    cache._release_lock()  # _owns_lock is already False here -- a no-op, not a re-check
 
 
 def test_release_lock_does_not_remove_a_sentinel_it_never_created(tmp_path: Path):
@@ -588,13 +636,15 @@ import sys, time
 from sisr.cache import LMDBCache
 
 def build(ctx):
-    time.sleep(float(sys.argv[3]))
+    with open(sys.argv[3], "a") as f:
+        f.write("build\\n")
+    time.sleep(float(sys.argv[4]))
     ctx.write_batch([("key_0", b"v0")])
 
 cache = LMDBCache(
     cache_dir=sys.argv[1], name="live", checksum="livecs", length=1,
     map_size=16 * 1024 * 1024, build_fn=build,
-    lock_poll_interval=0.02, lock_timeout=float(sys.argv[4]),
+    lock_poll_interval=0.02, lock_timeout=float(sys.argv[5]),
 )
 with open(sys.argv[2], "w") as f:
     f.write((cache.get("key_0") or b"").decode())
@@ -608,24 +658,43 @@ def test_live_builder_past_lock_timeout_is_never_preempted(tmp_path: Path):
     rebuild -- the old fall-through-on-timeout behaviour instead had B call
     _build, which opened by shutil.rmtree-ing A's live, memory-mapped LMDB
     directory (a PermissionError crash on Windows, silent lost writes on
-    Linux). Both processes must finish cleanly and agree on the one real
-    result.
+    Linux).
+
+    The build-log assertion is the platform-independent half of this test:
+    on POSIX, the old buggy code's in-place rmtree of a live, open directory
+    often *succeeds* (unlike Windows' PermissionError), so B would silently
+    rebuild -- every process-exit-code/content assertion could pass even
+    though build_fn ran twice and A's own write was lost to an orphaned,
+    unlinked inode, because B's redundant rebuild happens to reconstruct the
+    identical value. A shared log line only the executing build_fn appends
+    to catches that regardless of platform: it must show exactly one build.
     """
     result_a, result_b = tmp_path / "result_a.txt", tmp_path / "result_b.txt"
+    build_log = tmp_path / "build_log.txt"
     script = tmp_path / "live_worker.py"
     script.write_text(_LIVE_BUILDER_WORKER_SCRIPT)
     cache_path = tmp_path / "live_livecs"
+    lock_path = tmp_path / "live_livecs.build.lock"
 
     # A: wins the lock immediately, then sleeps 1.5s inside build_fn --
     # comfortably longer than B's lock_timeout below.
     proc_a = subprocess.Popen(
-        [sys.executable, str(script), str(tmp_path), str(result_a), "1.5", "30"]
+        [sys.executable, str(script), str(tmp_path), str(result_a), str(build_log), "1.5", "30"]
     )
-    time.sleep(0.2)  # let A win the O_EXCL race and enter build_fn's sleep
+    # A's cold interpreter + import (torch-free, but tqdm's asyncio import
+    # chain alone measures ~0.4s) must finish and claim the sentinel before
+    # this check -- 1.0s gives comfortable margin over that.
+    time.sleep(1.0)
+    assert lock_path.exists(), "A must have claimed the sentinel before B ever starts"
+    assert lock_path.read_text() == str(proc_a.pid), (
+        "A must be the one holding the lock -- otherwise this test isn't exercising "
+        "the timeout-while-holder-alive path at all"
+    )
+
     # B: loses the race, and its own lock_timeout (0.2s) elapses long before
     # A's build_fn returns.
     proc_b = subprocess.Popen(
-        [sys.executable, str(script), str(tmp_path), str(result_b), "0", "0.2"]
+        [sys.executable, str(script), str(tmp_path), str(result_b), str(build_log), "0", "0.2"]
     )
 
     assert proc_a.wait(timeout=15) == 0, "A's build must complete without a crash from B"
@@ -633,6 +702,9 @@ def test_live_builder_past_lock_timeout_is_never_preempted(tmp_path: Path):
         "B must not crash trying to destroy A's live cache after its lock_timeout elapses"
     )
     assert cache_path.exists(), "A's cache directory must survive B's timed-out wait"
+    assert build_log.read_text().splitlines() == ["build"], (
+        "build_fn must run exactly once -- B must never rebuild A's live cache, on any platform"
+    )
     assert result_a.read_text() == "v0"
     assert result_b.read_text() == "v0"
 
@@ -702,3 +774,323 @@ def test_acquire_lock_polling_returns_false_once_try_load_succeeds(tmp_path: Pat
 
     assert acquired is False
     assert calls == ["pc1", "pc1", "pc1"]
+
+
+def test_acquire_lock_treats_own_recycled_pid_as_dead_not_alive(tmp_path: Path):
+    """A sentinel recording THIS process's own pid must not be treated as a
+    live holder -- it can only mean a crashed builder's pid got recycled to
+    this very process (Windows in particular reuses pids in small
+    multiples, so crash-then-restart-with-the-same-pid is realistic, not
+    theoretical). Otherwise this process would wait on "itself" forever.
+    Once stale, it must be treated as abandoned and taken over instead."""
+    name, checksum = "selfpid", "sp1"
+    lock_path = tmp_path / f"{name}_{checksum[:16]}.build.lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.write(fd, str(os.getpid()).encode())  # "our own" pid, as if recycled from a crashed run
+    os.close(fd)
+    stale_mtime = time.time() - 10
+    os.utime(lock_path, (stale_mtime, stale_mtime))
+
+    call_count = []
+
+    def build(ctx: LMDBCacheBuildContext) -> None:
+        call_count.append(1)
+        ctx.write_batch([("key_0", b"v0")])
+
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name=name,
+        checksum=checksum,
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=build,
+        lock_poll_interval=0.02,
+        lock_timeout=0.1,
+    )
+    assert call_count == [1], "a sentinel bearing this process's own pid must not block it forever"
+    assert cache.get("key_0") == b"v0"
+
+
+def test_acquire_lock_raises_timeout_error_on_confirmed_live_holder_past_hard_cap(tmp_path: Path):
+    """Waiting on a confirmed-*alive* holder must still be bounded: past
+    3x lock_timeout with no sign of it finishing, this must raise
+    TimeoutError instead of waiting forever -- an operator needs a way to
+    notice and intervene."""
+    name, checksum = "hardcap", "hc1"
+    lock_path = tmp_path / f"{name}_{checksum[:16]}.build.lock"
+    other_pid = os.getppid()  # genuinely alive, and guaranteed not to equal our own pid
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.write(fd, str(other_pid).encode())
+    os.close(fd)
+
+    with pytest.raises(TimeoutError, match="Refusing to wait indefinitely"):
+        LMDBCache(
+            cache_dir=tmp_path,
+            name=name,
+            checksum=checksum,
+            length=1,
+            map_size=_MAP_SIZE,
+            build_fn=_make_build_fn(1),
+            lock_poll_interval=0.02,
+            lock_timeout=0.05,
+        )
+
+
+def test_acquire_lock_toctou_reread_skips_unlink_if_pid_changed(tmp_path: Path):
+    """Immediately before unlinking a dead+stale sentinel to take over, the
+    pid is re-read; if it changed (another waiter already reclaimed a fresh
+    sentinel in the interim), the stale sentinel must be left alone rather
+    than deleting what might now be a live claim."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="toctou",
+        checksum="tc1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    lock_path = cache._lock_path()
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.write(fd, b"999999")  # a dead pid
+    os.close(fd)
+    stale_mtime = time.time() - 100
+    os.utime(lock_path, (stale_mtime, stale_mtime))
+
+    read_calls = []
+
+    def fake_read_lock_pid():
+        read_calls.append(1)
+        # 1st call (the outer holder_pid read): the dead pid above. 2nd call
+        # (the TOCTOU re-read right before unlinking): a DIFFERENT pid, as
+        # if another waiter had just reclaimed the sentinel in between.
+        return 999999 if len(read_calls) == 1 else 888888
+
+    try_load_calls = []
+
+    def fake_try_load(checksum):
+        try_load_calls.append(1)
+        return len(try_load_calls) >= 2  # succeed on the 2nd poll, ending the loop cleanly
+
+    with (
+        patch.object(cache, "_read_lock_pid", side_effect=fake_read_lock_pid),
+        patch.object(cache, "_try_load", side_effect=fake_try_load),
+    ):
+        acquired = cache._acquire_lock("tc1", poll_interval=0.01, timeout=0.05)
+
+    assert acquired is False, "must report no build needed once _try_load succeeds"
+    assert lock_path.read_text() == "999999", (
+        "the original sentinel must survive a mismatched TOCTOU re-read -- it must never be "
+        "unlinked when the pid changed between the two reads"
+    )
+
+
+def test_release_lock_does_not_remove_sentinel_if_content_was_replaced(tmp_path: Path):
+    """If the on-disk sentinel no longer records this process's own pid --
+    e.g. the rare TOCTOU window _acquire_lock's takeover narrows but cannot
+    fully close -- _release_lock must not delete it even though this
+    instance's _owns_lock flag is still True from when it originally
+    claimed the lock. The ownership flag alone is not sufficient; the
+    content is re-checked too."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="clobber",
+        checksum="cl1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    cache._acquire_lock("cl1", poll_interval=0.01, timeout=0.05)
+    assert cache._owns_lock is True
+    # Simulate another process's takeover clobbering our sentinel's content
+    # in between.
+    cache._lock_path().write_text("999999")
+
+    cache._release_lock()
+
+    assert cache._lock_path().read_text() == "999999", (
+        "must not delete a sentinel whose content no longer matches this process's own pid"
+    )
+
+
+def test_heartbeat_survives_transient_os_error_and_keeps_refreshing(tmp_path: Path):
+    """The heartbeat thread must not give up after the first transient
+    OSError touching the sentinel (e.g. a momentary Windows sharing
+    violation) -- only a FileNotFoundError (the sentinel is genuinely gone)
+    should stop it. Simulate one transient failure, then let real os.utime
+    calls through, and confirm the thread kept retrying rather than exiting
+    silently on the first hiccup."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="hb",
+        checksum="h1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    cache._acquire_lock("h1", poll_interval=0.01, timeout=0.05)
+
+    real_utime = os.utime
+    calls = []
+
+    def flaky_utime(path, times):
+        calls.append(1)
+        if len(calls) == 1:
+            raise PermissionError("transient")
+        real_utime(path, times)
+
+    with patch("sisr.cache.os.utime", side_effect=flaky_utime):
+        cache._start_heartbeat(timeout=0.05)  # interval clamps to _HEARTBEAT_MIN_INTERVAL (0.01s)
+        time.sleep(0.3)
+        cache._stop_heartbeat()
+
+    assert len(calls) >= 3, "the heartbeat must keep retrying past the first transient failure"
+
+
+# ---------------------------------------------------------------------------
+# Windows pid liveness (ACCESS_DENIED vs INVALID_PARAMETER)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific liveness path")
+def test_pid_alive_windows_access_denied_means_alive():
+    """OpenProcess failing with ERROR_ACCESS_DENIED means the process exists
+    (e.g. owned by another user/session) -- it must be treated as alive, or
+    a live builder running under a different account could be preempted."""
+    from sisr.cache import _pid_alive_windows  # local: doesn't exist pre-fix
+
+    fake_kernel32 = MagicMock()
+    fake_kernel32.OpenProcess.return_value = 0
+    with (
+        patch("sisr.cache._kernel32", fake_kernel32),
+        patch("sisr.cache.ctypes.get_last_error", return_value=5),  # ERROR_ACCESS_DENIED
+    ):
+        assert _pid_alive_windows(4242) is True
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific liveness path")
+def test_pid_alive_windows_invalid_parameter_means_dead():
+    """OpenProcess failing with ERROR_INVALID_PARAMETER (empirically what a
+    genuinely nonexistent pid produces) means no such process."""
+    from sisr.cache import _pid_alive_windows  # local: doesn't exist pre-fix
+
+    fake_kernel32 = MagicMock()
+    fake_kernel32.OpenProcess.return_value = 0
+    with (
+        patch("sisr.cache._kernel32", fake_kernel32),
+        patch("sisr.cache.ctypes.get_last_error", return_value=87),  # ERROR_INVALID_PARAMETER
+    ):
+        assert _pid_alive_windows(4242) is False
+
+
+# ---------------------------------------------------------------------------
+# Publish (temp-sibling build + atomic rename) and crash-safety sweep
+# ---------------------------------------------------------------------------
+
+
+def test_publish_does_not_destroy_a_still_open_target_directory(tmp_path: Path):
+    """_publish must move a pre-existing target aside via ``os.replace`` (a
+    rename) rather than ``rmtree``-ing it in place: a single rename is
+    atomic and can never leave the directory half-deleted, unlike an
+    interrupted ``rmtree`` that might remove some files before hitting one
+    it can't (e.g. still memory-mapped by a reader in another process on
+    Windows -- verified empirically: even a *rename* of such a directory can
+    itself fail there, which is exactly why this must never be an unlink).
+    The only ``rmtree`` this method may still perform is the final,
+    best-effort cleanup of the *renamed-away* trash sibling -- never of the
+    live target itself.
+    """
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="pub",
+        checksum="old",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1, value_prefix=b"old"),
+    )
+    live_target = cache.path
+
+    # Build a replacement directly, bypassing __init__ (which would now
+    # raise on a same-process handle if one were open) -- this isolates
+    # _publish's own move-aside mechanism.
+    tmp_build_dir = cache.path.with_name(f"{cache.path.name}.build.{os.getpid()}.tmp")
+    tmp_env = lmdb.open(str(tmp_build_dir), map_size=_MAP_SIZE)
+    with tmp_env.begin(write=True) as txn:
+        txn.put(b"key_0", b"new0")
+        txn.put(b"__checksum__", b"old")
+        txn.put(b"__length__", b"1")
+    tmp_env.close()
+
+    with patch("sisr.cache.shutil.rmtree") as mock_rmtree:
+        cache._publish(tmp_build_dir)
+
+    assert mock_rmtree.call_count == 1, (
+        "the only rmtree call must be the trash sibling's final cleanup"
+    )
+    (swept_path,), _ = mock_rmtree.call_args
+    assert swept_path != live_target, (
+        "the live target itself must never be rmtree'd, only renamed aside"
+    )
+
+    fresh_env = lmdb.open(str(cache.path), readonly=True, lock=False)
+    with fresh_env.begin() as txn:
+        assert bytes(txn.get(b"key_0")) == b"new0", (
+            "the new build must now be live at the target path"
+        )
+    fresh_env.close()
+
+
+def test_sweep_stale_siblings_removes_only_dead_pid_temp_dirs(tmp_path: Path):
+    """A leftover .build.<pid>.tmp or .trash.<pid>.tmp from a crashed build
+    whose pid is no longer alive must be swept -- these are full,
+    map_size-presized LMDB directories (several GB for a real dataset), so a
+    crash before cleanup otherwise leaks that disk space forever. A sibling
+    belonging to this process's own (obviously alive) pid must survive."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="sweep",
+        checksum="sw1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+
+    dead_build_leftover = cache.path.with_name(f"{cache.path.name}.build.999999.tmp")
+    dead_build_leftover.mkdir()
+    dead_trash_leftover = cache.path.with_name(f"{cache.path.name}.trash.999998.tmp")
+    dead_trash_leftover.mkdir()
+    own_leftover = cache.path.with_name(f"{cache.path.name}.build.{os.getpid()}.tmp")
+    own_leftover.mkdir()
+
+    cache._sweep_stale_siblings()
+
+    assert not dead_build_leftover.exists(), "a dead pid's leftover build temp must be swept"
+    assert not dead_trash_leftover.exists(), "a dead pid's leftover trash temp must be swept"
+    assert own_leftover.exists(), "this process's own pid must never be swept as 'dead'"
+
+
+def test_build_invokes_sibling_sweep_automatically(tmp_path: Path):
+    """_build must call the sweep itself as part of a real rebuild, not just
+    have it available for manual use -- a leftover from a previous crash
+    must be gone after the very next build that touches this cache."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="autosweep",
+        checksum="v1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    leftover = cache.path.with_name(f"{cache.path.name}.build.999999.tmp")
+    leftover.mkdir()
+    shutil.rmtree(cache.path)  # force a genuine rebuild at the identical (name, checksum) path
+
+    LMDBCache(
+        cache_dir=tmp_path,
+        name="autosweep",
+        checksum="v1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+
+    assert not leftover.exists()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -259,9 +259,11 @@ def test_lmdb_missing_dir_with_no_build_fn_raises(tmp_path: Path):
         )
 
 
-def test_lmdb_try_load_swallows_lmdb_error_and_drops_cache(tmp_path: Path):
-    """An unreadable cache (lmdb.Error) is treated as stale: _try_load returns
-    False and removes the directory so it can be rebuilt."""
+def test_lmdb_try_load_drops_cache_on_genuine_corruption(tmp_path: Path):
+    """A corruption-specific exception (bad file header, wrong LMDB version)
+    means the directory itself is broken: _try_load returns False and removes
+    it so it can be rebuilt. Nothing else can be legitimately using data that
+    is genuinely corrupt."""
     cache = LMDBCache(
         cache_dir=tmp_path,
         name="test",
@@ -271,9 +273,104 @@ def test_lmdb_try_load_swallows_lmdb_error_and_drops_cache(tmp_path: Path):
         build_fn=_make_build_fn(1),
     )
     assert cache.path.exists()
-    with patch("sisr.cache.lmdb.open", side_effect=lmdb.Error("corrupt")):
+    with patch("sisr.cache.lmdb.open", side_effect=lmdb.CorruptedError("corrupt")):
         assert cache._try_load("abc") is False
     assert not cache.path.exists()
+
+
+def test_lmdb_try_load_does_not_raise_when_rmtree_fails_on_corruption(tmp_path: Path):
+    """Even genuine corruption must not let a failed cleanup (e.g. a file
+    still locked by another handle on Windows) escape as an unhandled
+    exception -- _try_load must still just report not-ready."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    with (
+        patch("sisr.cache.lmdb.open", side_effect=lmdb.CorruptedError("corrupt")),
+        patch("sisr.cache.shutil.rmtree", side_effect=PermissionError("locked")),
+    ):
+        assert cache._try_load("abc") is False
+
+
+def test_lmdb_try_load_does_not_delete_cache_on_same_process_reopen_error(tmp_path: Path):
+    """A second lmdb.open of an already-open environment in the same process
+    raises a bare lmdb.Error ('environment already open in this process'),
+    not a corruption-specific subclass -- empirically hit when two datasets
+    in one process both open caches with lock=False. This is environmental,
+    not corruption: the directory must survive and _try_load must just
+    report not-ready so a later retry can succeed."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    cache.get_env()  # holds an open Environment at cache.path in this process
+
+    assert cache._try_load("abc") is False
+    assert cache.path.exists(), "a same-process reopen conflict is not corruption"
+
+
+def test_lmdb_try_load_does_not_delete_cache_on_permission_error(tmp_path: Path):
+    """A PermissionError opening the environment (e.g. Windows denying access
+    to a file another process still has mapped) is environmental too, not
+    corruption -- must not delete the directory."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    with patch("sisr.cache.lmdb.open", side_effect=PermissionError("denied")):
+        assert cache._try_load("abc") is False
+    assert cache.path.exists()
+
+
+def test_lmdb_try_load_does_not_delete_cache_on_non_corruption_lmdb_error(tmp_path: Path):
+    """Only the specific corruption subclasses (CorruptedError, InvalidError,
+    VersionMismatchError) justify deleting the directory. Other lmdb.Error
+    subclasses (e.g. a full lock table) are environmental and must not delete."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    with patch("sisr.cache.lmdb.open", side_effect=lmdb.LockError("lock table full")):
+        assert cache._try_load("abc") is False
+    assert cache.path.exists()
+
+
+def test_lmdb_try_load_treats_missing_length_as_stale_not_crash(tmp_path: Path):
+    """A cache whose __checksum__ matches but __length__ is absent (e.g. a
+    hand-built or foreign-layout cache) must be treated as incomplete/stale,
+    not crash with AttributeError from int(None.decode())."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="test",
+        checksum="abc",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    env = lmdb.open(str(cache.path), map_size=_MAP_SIZE)
+    with env.begin(write=True) as txn:
+        txn.delete(b"__length__")
+    env.close()
+
+    assert cache._try_load("abc") is False
+    assert cache.path.exists(), "an incomplete cache is stale, not corrupt -- must not be deleted"
 
 
 def test_lmdb_try_load_propagates_unexpected_error(tmp_path: Path):
@@ -406,6 +503,31 @@ def test_release_lock_removes_sentinel_and_is_idempotent(tmp_path: Path):
     cache._release_lock()  # must not raise when there is nothing to remove
 
 
+def test_release_lock_does_not_remove_a_sentinel_it_never_created(tmp_path: Path):
+    """_release_lock must be a no-op for an instance that never won (or
+    stole) the build lock -- otherwise any call to it (e.g. a defensive
+    double-call, or reuse of a cache object across a retry) could delete a
+    live builder's sentinel out from under it, letting a third process
+    immediately win a fresh race into the same directory."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="own",
+        checksum="c",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    # cache already built + released its own lock inside __init__ above.
+    lock_path = cache._lock_path()
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.write(fd, b"424242")  # simulates another (live) process's sentinel
+    os.close(fd)
+
+    cache._release_lock()
+
+    assert lock_path.exists(), "must not delete a sentinel this instance never created"
+
+
 _RACE_WORKER_SCRIPT = """
 import sys, time
 from sisr.cache import LMDBCache
@@ -459,6 +581,60 @@ def test_lmdb_cache_builds_exactly_once_across_two_racing_processes(tmp_path: Pa
     )
     assert result_1.read_text() == "v0"
     assert result_2.read_text() == "v0"
+
+
+_LIVE_BUILDER_WORKER_SCRIPT = """
+import sys, time
+from sisr.cache import LMDBCache
+
+def build(ctx):
+    time.sleep(float(sys.argv[3]))
+    ctx.write_batch([("key_0", b"v0")])
+
+cache = LMDBCache(
+    cache_dir=sys.argv[1], name="live", checksum="livecs", length=1,
+    map_size=16 * 1024 * 1024, build_fn=build,
+    lock_poll_interval=0.02, lock_timeout=float(sys.argv[4]),
+)
+with open(sys.argv[2], "w") as f:
+    f.write((cache.get("key_0") or b"").decode())
+"""
+
+
+def test_live_builder_past_lock_timeout_is_never_preempted(tmp_path: Path):
+    """Process A wins the lock and is still inside a slow build_fn when
+    process B's much shorter lock_timeout elapses. B must not treat that as
+    an abandoned lock: A's pid is still alive, so B must wait rather than
+    rebuild -- the old fall-through-on-timeout behaviour instead had B call
+    _build, which opened by shutil.rmtree-ing A's live, memory-mapped LMDB
+    directory (a PermissionError crash on Windows, silent lost writes on
+    Linux). Both processes must finish cleanly and agree on the one real
+    result.
+    """
+    result_a, result_b = tmp_path / "result_a.txt", tmp_path / "result_b.txt"
+    script = tmp_path / "live_worker.py"
+    script.write_text(_LIVE_BUILDER_WORKER_SCRIPT)
+    cache_path = tmp_path / "live_livecs"
+
+    # A: wins the lock immediately, then sleeps 1.5s inside build_fn --
+    # comfortably longer than B's lock_timeout below.
+    proc_a = subprocess.Popen(
+        [sys.executable, str(script), str(tmp_path), str(result_a), "1.5", "30"]
+    )
+    time.sleep(0.2)  # let A win the O_EXCL race and enter build_fn's sleep
+    # B: loses the race, and its own lock_timeout (0.2s) elapses long before
+    # A's build_fn returns.
+    proc_b = subprocess.Popen(
+        [sys.executable, str(script), str(tmp_path), str(result_b), "0", "0.2"]
+    )
+
+    assert proc_a.wait(timeout=15) == 0, "A's build must complete without a crash from B"
+    assert proc_b.wait(timeout=15) == 0, (
+        "B must not crash trying to destroy A's live cache after its lock_timeout elapses"
+    )
+    assert cache_path.exists(), "A's cache directory must survive B's timed-out wait"
+    assert result_a.read_text() == "v0"
+    assert result_b.read_text() == "v0"
 
 
 def test_acquire_lock_times_out_and_builds_anyway_on_stale_lock(tmp_path: Path):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -691,10 +691,14 @@ def test_live_builder_past_lock_timeout_is_never_preempted(tmp_path: Path):
         "the timeout-while-holder-alive path at all"
     )
 
-    # B: loses the race, and its own lock_timeout (0.2s) elapses long before
-    # A's build_fn returns.
+    # B: loses the race, and its own lock_timeout elapses long before A's
+    # build_fn returns. 1.0s (not e.g. 0.2s) keeps its 3x-lock_timeout hard
+    # cap at 3.0s -- 0.2s left only ~0.6s of margin for B to observe A's
+    # publish, which cold-vs-warm interpreter start asymmetry (A pays a
+    # cold import, B's is warmer) plus tens of ms of Windows publish time
+    # could burn through, flaking B into a TimeoutError on a loaded CI box.
     proc_b = subprocess.Popen(
-        [sys.executable, str(script), str(tmp_path), str(result_b), str(build_log), "0", "0.2"]
+        [sys.executable, str(script), str(tmp_path), str(result_b), str(build_log), "0", "1.0"]
     )
 
     assert proc_a.wait(timeout=15) == 0, "A's build must complete without a crash from B"
@@ -944,6 +948,34 @@ def test_heartbeat_survives_transient_os_error_and_keeps_refreshing(tmp_path: Pa
         cache._stop_heartbeat()
 
     assert len(calls) >= 3, "the heartbeat must keep retrying past the first transient failure"
+
+
+def test_construction_releases_lock_when_heartbeat_thread_fails_to_start(tmp_path: Path):
+    """If Thread.start() itself raises (e.g. the OS refuses a new thread),
+    _stop_heartbeat's join() must not blow up on a thread that was
+    constructed but never started -- that would mask the original start()
+    error and skip _release_lock on the next line (both run inside the same
+    finally), leaving a live-pid sentinel that stalls every other waiter for
+    up to 3x lock_timeout. The original error must still surface, and the
+    sentinel must still be released."""
+    with patch(
+        "sisr.cache.threading.Thread.start",
+        side_effect=RuntimeError("can't start new thread"),
+    ):
+        with pytest.raises(RuntimeError, match="can't start new thread"):
+            LMDBCache(
+                cache_dir=tmp_path,
+                name="hbfail",
+                checksum="hf1",
+                length=1,
+                map_size=_MAP_SIZE,
+                build_fn=_make_build_fn(1),
+            )
+
+    lock_path = tmp_path / "hbfail_hf1.build.lock"
+    assert not lock_path.exists(), (
+        "the sentinel must be released even though the heartbeat thread never started"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The cache build lock had a destructive fall-through: past `lock_timeout` (600 s — exceedable by a real DIV2K build on a slow disk), a second process would `rmtree` the live builder's memory-mapped LMDB (crash on Windows; on Linux the deletion *succeeds silently* and the builder spends the rest of its run writing to deleted inodes), then unlink a sentinel it never created, inviting a third process into the same race. Separately, `_try_load` treated *any* open failure as corruption and deleted the cache — including `lmdb.Error: environment already open in this process`, which is reachable through shipped code.

The fix, two commits:

- **Builds are atomic and never destructive.** Build into a pid-suffixed temp sibling; publish via rename-aside (`os.replace` to a trash sibling) + `os.replace` into place — no partial-deletion window exists at all. A target blocked by a reader's open handle produces a clear chained error with both directories intact, never a deletion.
- **Environmental failures raise; only genuine corruption rebuilds.** Deletion is now reserved for `lmdb.CorruptedError`/`InvalidError`/`VersionMismatchError`; bare `lmdb.Error`, `LockError`, `DiskError`, and `OSError`/`PermissionError` return "not ready" without touching disk, and builder-side open failures raise an actionable chained error instead of silently rebuilding for minutes. Missing metadata keys classify as stale instead of crashing.
- **A live builder is never preempted.** The sentinel carries pid + an mtime heartbeat (which retries transient errors); takeover requires dead-pid *and* staleness, with the pid re-read immediately before unlink; a sentinel recording our own pid is treated as dead (Windows pid recycling); waiting is bounded (3× `lock_timeout` → `TimeoutError` naming the sentinel and remedy, with periodic re-logging); release verifies the sentinel still records our pid. Windows pid-probing avoids `os.kill(pid, 0)` (which would *terminate* the probed process) and distinguishes access-denied (alive) from invalid-parameter (dead).
- **No disk leaks:** cache-sized orphan temp/trash siblings from crashed builds are swept under the lock once their pid is dead.

## Evidence (all RED on the pre-fix code)

- Live-builder-past-timeout race (two real processes): the loser neither deletes the live DB nor removes the winner's sentinel, and a shared build log asserts the build ran **exactly once** — platform-independent (the original failure was masked on POSIX, where the deletion succeeds silently; only a Windows `PermissionError` ever made it visible).
- Same-process double-open: construction now raises an actionable error instead of a silent full rebuild ending in deletion under a live reader.
- Ownership: a process that never acquired the sentinel provably leaves a foreign sentinel intact.
- The pre-existing test that *encoded* the bug (generic `lmdb.Error` ⇒ assert deleted) is tightened to genuine corruption.
- Suite: **441 passed, 2 skipped**; ruff clean; `sisr/cache.py` remains torch-free (guard test intact).

Adversarially reviewed twice (Opus, interleaving-level analysis both rounds): round 1 found six Important gaps including the POSIX-silent deletion and an unbounded self-pid wait — all verified closed in round 2; six non-blocking minors recorded for the batch's final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)