### PR TITLE
Skip training-path reconstruct and correct the templates' loader settings

### DIFF
--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -486,8 +486,10 @@ class SRLightning(lightning.LightningModule):
         """
         return self.model(x)
 
-    def _forward_lr(self, lr_img: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """LR-only core of the forward pipeline: extract → model → reconstruct.
+    def _forward_lr(
+        self, lr_img: torch.Tensor, need_sr_rgb: bool = True
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """LR-only core of the forward pipeline: extract → model → (reconstruct).
 
         Factored out of :meth:`_forward_sr` so :meth:`predict_step` can share
         the exact colorspace pipeline instead of forking it — HR is only ever
@@ -503,14 +505,27 @@ class SRLightning(lightning.LightningModule):
         Args:
             lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
                 ``(B, 3, H, W)``.
+            need_sr_rgb: Whether to run ``processor.reconstruct`` at all.
+                ``training_step`` (via :meth:`_step`) is the only caller that
+                passes ``False``: it discards ``sr_rgb`` entirely
+                (``loss, *_ = self._step(...)``), yet reconstruct still costs
+                real per-step time (measured: ~11.5% of a data-free SRCNN
+                step for ``YChannelProcessor``'s bicubic Cb/Cr interpolate;
+                ~0 for SRResNet's identity/elementwise processors). Every
+                other caller — validation, test, predict, and direct calls
+                like these from tests — keeps the default ``True`` and gets
+                exactly the reconstruction this project has always produced.
 
         Returns:
             ``(sr_model_out, sr_rgb)`` — the raw model output in the model IO
-            colorspace, and the reconstructed SR RGB clamped to ``[0, 1]``.
+            colorspace, and the reconstructed SR RGB clamped to ``[0, 1]``;
+            ``sr_rgb`` is ``None`` iff ``need_sr_rgb`` is ``False``.
         """
         model_input = self.processor.extract(lr_img)
         model_fn = self._compiled if self.training and self._compiled is not None else self.model
         sr_model_out = model_fn(model_input)
+        if not need_sr_rgb:
+            return sr_model_out, None
         sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
         # Clamp display-space output only, here, once — every reconstruct()
         # consumer (_forward_sr's callers, predict_step) reads through this
@@ -524,9 +539,9 @@ class SRLightning(lightning.LightningModule):
         return sr_model_out, sr_rgb
 
     def _forward_sr(
-        self, lr_img: torch.Tensor, hr_img: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Canonical SR forward: extract → model → reconstruct → crop HR.
+        self, lr_img: torch.Tensor, hr_img: torch.Tensor, need_sr_rgb: bool = True
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+        """Canonical SR forward: extract → model → (reconstruct) → crop HR.
 
         The single source of truth for the forward pipeline. Shared by
         :meth:`_step` (which also needs the model-space output for the loss),
@@ -539,28 +554,32 @@ class SRLightning(lightning.LightningModule):
             lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
                 ``(B, 3, H, W)``.
             hr_img: HR batch, RGB ``float32`` in ``[0, 1]``.
+            need_sr_rgb: Forwarded to :meth:`_forward_lr` — see there. The
+                HR crop uses ``sr_model_out.shape[-2:]`` regardless, since
+                every shipped ``SRProcessor.reconstruct`` preserves H/W, so
+                it always agrees with what ``sr_rgb.shape[-2:]`` would be.
 
         Returns:
             ``(sr_model_out, sr_rgb, hr_cropped)`` — the raw (unclamped)
             model output in the model IO colorspace, the reconstructed SR RGB
-            clamped to ``[0, 1]``, and HR center-cropped to the SR spatial
-            size.
+            clamped to ``[0, 1]`` (``None`` iff ``need_sr_rgb`` is ``False``),
+            and HR center-cropped to the SR spatial size.
 
         Raises:
-            ValueError: If ``hr_img`` is spatially smaller than ``sr_rgb`` in
-                either dimension — ``center_crop`` would zero-pad instead of
-                cropping, silently corrupting the loss/metrics that follow.
-                :meth:`setup` catches the common cause (a model/dataset
-                ``input_contract`` mismatch) earlier and louder; this is the
-                last-resort guard for callers that bypass it (e.g. direct
-                ``_forward_sr``/``_step`` calls in tests, or a datamodule with
-                no ``trainer`` attached).
+            ValueError: If ``hr_img`` is spatially smaller than the model
+                output in either dimension — ``center_crop`` would zero-pad
+                instead of cropping, silently corrupting the loss/metrics
+                that follow. :meth:`setup` catches the common cause (a
+                model/dataset ``input_contract`` mismatch) earlier and
+                louder; this is the last-resort guard for callers that
+                bypass it (e.g. direct ``_forward_sr``/``_step`` calls in
+                tests, or a datamodule with no ``trainer`` attached).
         """
-        sr_model_out, sr_rgb = self._forward_lr(lr_img)
-        hr_hw, sr_hw = hr_img.shape[-2:], sr_rgb.shape[-2:]
+        sr_model_out, sr_rgb = self._forward_lr(lr_img, need_sr_rgb=need_sr_rgb)
+        hr_hw, sr_hw = hr_img.shape[-2:], sr_model_out.shape[-2:]
         if hr_hw[0] < sr_hw[0] or hr_hw[1] < sr_hw[1]:
             raise ValueError(
-                f"hr_img spatial size {tuple(hr_hw)} is smaller than sr_rgb "
+                f"hr_img spatial size {tuple(hr_hw)} is smaller than the model output "
                 f"{tuple(sr_hw)} — torchvision.transforms.functional.center_crop "
                 f"would zero-pad instead of cropping, silently corrupting the loss "
                 f"and every metric downstream. This usually means the dataset's "
@@ -568,7 +587,7 @@ class SRLightning(lightning.LightningModule):
                 f"input_contract={self.model.input_contract!r} — check "
                 f"data.train_dataset/val_dataset/test_datasets in your config."
             )
-        hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_rgb.shape[-2:])
+        hr_cropped = torchvision.transforms.functional.center_crop(hr_img, sr_hw)
         return sr_model_out, sr_rgb, hr_cropped
 
     def predict_rgb(
@@ -596,8 +615,8 @@ class SRLightning(lightning.LightningModule):
         return sr_rgb, hr_cropped
 
     def _step(
-        self, batch: tuple[torch.Tensor, torch.Tensor]
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        self, batch: tuple[torch.Tensor, torch.Tensor], need_sr_rgb: bool = True
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
         """Shared forward + loss for training and validation steps.
 
         The processor handles all colorspace conversion; loss is computed in
@@ -605,21 +624,26 @@ class SRLightning(lightning.LightningModule):
         ``processor.extract_target``, which defaults to ``processor.extract``
         and differs only where a model's input and output ranges differ).
         Metrics downstream consume ``sr_rgb`` / ``hr_cropped`` (both full
-        RGB, spatially aligned).
+        RGB, spatially aligned) — unavailable (``None``) when the caller
+        passed ``need_sr_rgb=False``, which is only correct for callers (like
+        ``training_step``) that never look at ``sr_rgb``.
 
         Args:
             batch: ``(lr_img, hr_img)`` tuple from a loader. Both RGB,
                 ``float32`` in ``[0, 1]``.
+            need_sr_rgb: Forwarded to :meth:`_forward_sr` — see there.
+                ``training_step`` passes ``False``.
 
         Returns:
             ``(loss, lr_img, hr_img, sr_rgb, hr_cropped)``. ``loss`` is a
             scalar tensor computed on the unclamped model output; ``sr_rgb``
-            (clamped to ``[0, 1]``) and ``hr_cropped`` are RGB tensors with
-            matching spatial size.
+            (clamped to ``[0, 1]``, or ``None`` iff ``need_sr_rgb`` is
+            ``False``) and ``hr_cropped`` are RGB tensors with matching
+            spatial size.
         """
         lr_img, hr_img = batch
 
-        sr_model_out, sr_rgb, hr_cropped = self._forward_sr(lr_img, hr_img)
+        sr_model_out, sr_rgb, hr_cropped = self._forward_sr(lr_img, hr_img, need_sr_rgb=need_sr_rgb)
         hr_for_loss = self.processor.extract_target(hr_cropped)
         loss = self.criterion(sr_model_out, hr_for_loss)
 
@@ -632,6 +656,9 @@ class SRLightning(lightning.LightningModule):
 
         Delegates the forward + colorspace + loss pipeline to :meth:`_step`
         and logs ``loss/train`` on every step for the progress bar.
+        ``need_sr_rgb=False``: this method never looks at ``sr_rgb``, so
+        skips ``processor.reconstruct`` — real per-step time (see
+        :meth:`_forward_lr`) for a value that would only be discarded.
 
         Args:
             batch: ``(lr_img, hr_img)`` tuple as produced by the
@@ -642,7 +669,7 @@ class SRLightning(lightning.LightningModule):
         Returns:
             Scalar loss tensor for the optimizer.
         """
-        loss, *_ = self._step(batch)
+        loss, *_ = self._step(batch, need_sr_rgb=False)
         self.log("loss/train", loss, prog_bar=True, on_step=True)
         return loss
 

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -65,9 +65,13 @@ data:
         scale: *scale
   train_dataloader_kwargs:
     batch_size: 64             # not specified by the paper; this project's choice
-    num_workers: 16
+    # num_workers: 0 measured FASTER than 16 workers in steady-state per-step time
+    # (6.64 vs 11.70 ms/step on this dev machine) as well as dropping the ~2-minute
+    # one-time cost of spawning 16 processes that each cold-import torch. persistent_workers
+    # dropped (errors at num_workers=0); pin_memory stays, still real work at w0.
+    # Windows-measured -- revisit if you're on Linux/fork or a much weaker CPU.
+    num_workers: 0
     pin_memory: true
-    persistent_workers: true
   val_dataloader_kwargs:
     batch_size: 1
     num_workers: 2
@@ -90,9 +94,10 @@ trainer:
   # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
   # above, hence it lives here rather than as a custom key.
   benchmark: true
-  # bf16-mixed is a bigger throughput lever, but this is a paper-reproduction repo:
-  # the shipped default trains in full fp32 so results stay comparable. Uncomment for
-  # your own runs on bf16-capable hardware.
+  # bf16-mixed measured as a REGRESSION on this project's other architecture
+  # (0.72x SRResNet b16, full power) -- autocast's cast-churn doesn't saturate
+  # the SMs at these batch sizes. Crossover measured at b32 (bf16+fused wins) --
+  # revisit only if batch_size rises well past this template's 64.
   # precision: bf16-mixed
   accelerator: cuda
   devices: [0]

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -65,13 +65,13 @@ data:
         scale: *scale
   train_dataloader_kwargs:
     batch_size: 64             # not specified by the paper; this project's choice
-    # num_workers: 0 measured FASTER than 16 workers in steady-state per-step time
-    # (6.64 vs 11.70 ms/step on this dev machine) as well as dropping the ~2-minute
-    # one-time cost of spawning 16 processes that each cold-import torch. persistent_workers
-    # dropped (errors at num_workers=0); pin_memory stays, still real work at w0.
-    # Windows-measured -- revisit if you're on Linux/fork or a much weaker CPU.
-    num_workers: 0
+    # Workers are load-bearing on real data: per-sample LR derivation measured
+    # ~1.1 ms, so batch 64 is a ~69 ms hard serial floor at num_workers=0 (real
+    # DIV2K steady-state: 79.3 ms/step at w0 vs 14.9 ms/step at w16 -- 0.19x).
+    # The ~2-minute one-time spawn cost amortizes to nothing over a full run.
+    num_workers: 16
     pin_memory: true
+    persistent_workers: true
   val_dataloader_kwargs:
     batch_size: 1
     num_workers: 2

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -68,9 +68,14 @@ data:
         scale: *scale
   train_dataloader_kwargs:
     batch_size: 16
-    num_workers: 16
+    # num_workers: 0 measured equal to 16 workers in steady-state per-step time
+    # (31.25 vs 31.95 ms/step on this dev machine) while dropping the ~2-minute
+    # one-time cost of spawning 16 processes that each cold-import torch --
+    # workers buy nothing here once that spawn cost is excluded. persistent_workers
+    # dropped (errors at num_workers=0); pin_memory stays, still real work at w0.
+    # Windows-measured -- revisit if you're on Linux/fork or a much weaker CPU.
+    num_workers: 0
     pin_memory: true
-    persistent_workers: true
   val_dataloader_kwargs:
     batch_size: 1
     num_workers: 2
@@ -88,9 +93,10 @@ trainer:
   # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
   # above, hence it lives here rather than as a custom key.
   benchmark: true
-  # bf16-mixed is a bigger throughput lever, but this is a paper-reproduction repo:
-  # the shipped default trains in full fp32 so results stay comparable. Uncomment for
-  # your own runs on bf16-capable hardware.
+  # bf16-mixed measured as a REGRESSION at this batch size (0.72x SRResNet b16,
+  # full power) -- autocast's cast-churn doesn't saturate the SMs at b16, so this
+  # is not just "stay in fp32 for paper comparability", it is currently slower.
+  # Crossover measured at b32 (bf16+fused wins) -- revisit only if batch_size rises.
   # precision: bf16-mixed
   accelerator: cuda
   devices: [0]

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -68,14 +68,13 @@ data:
         scale: *scale
   train_dataloader_kwargs:
     batch_size: 16
-    # num_workers: 0 measured equal to 16 workers in steady-state per-step time
-    # (31.25 vs 31.95 ms/step on this dev machine) while dropping the ~2-minute
-    # one-time cost of spawning 16 processes that each cold-import torch --
-    # workers buy nothing here once that spawn cost is excluded. persistent_workers
-    # dropped (errors at num_workers=0); pin_memory stays, still real work at w0.
-    # Windows-measured -- revisit if you're on Linux/fork or a much weaker CPU.
-    num_workers: 0
+    # Workers are load-bearing on real data: per-sample LR derivation is a real
+    # cost, and num_workers=0 hits a hard serial floor (real DIV2K steady-state:
+    # 56.0 ms/step at w0 vs 40.1 ms/step at w16 -- 0.72x). The ~2-minute one-time
+    # spawn cost amortizes to nothing over a full run.
+    num_workers: 16
     pin_memory: true
+    persistent_workers: true
   val_dataloader_kwargs:
     batch_size: 1
     num_workers: 2

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -148,6 +148,40 @@ def test_fast_dev_run_raises_on_cross_wired_model_and_dataset_through_real_train
         trainer.fit(module, datamodule=datamodule)
 
 
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_fast_dev_run_reconstruct_never_runs_mid_training_step(tiny_rgb_image_dir: Path):
+    """training_step passes need_sr_rgb=False (see SRLightning._forward_lr), so
+    processor.reconstruct must never fire while the module is in train mode —
+    only validation_step (self.training False) may call it. A real Trainer
+    loop, not a direct _step() call, is the only way to prove training_step
+    itself (not just _step) actually requests the skip."""
+    module = _make_srcnn_module()
+    datamodule = _make_datamodule(tiny_rgb_image_dir)
+
+    call_training_flags = []
+    real_reconstruct = module.processor.reconstruct
+
+    def _spy(*args, **kwargs):
+        call_training_flags.append(module.training)
+        return real_reconstruct(*args, **kwargs)
+
+    module.processor.reconstruct = _spy
+
+    trainer = lightning.Trainer(
+        fast_dev_run=True,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+    trainer.fit(module, datamodule=datamodule)
+
+    assert call_training_flags, "expected at least one reconstruct call, from validation_step"
+    assert not any(call_training_flags), "reconstruct must never run while self.training is True"
+
+
 # ---------------------------------------------------------------------------
 # cli predict end-to-end — LR-only inference path, both architectures
 # ---------------------------------------------------------------------------

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -130,6 +130,67 @@ def test_step_ycbcr_path():
 
 
 # ---------------------------------------------------------------------------
+# need_sr_rgb=False — training_step's reconstruct skip (measured: reconstruct
+# costs ~11.5% of a data-free SRCNN step for YChannelProcessor, ~0 for
+# SRResNet's identity/elementwise processors; training_step never consumes
+# sr_rgb, so paying for it there was pure waste).
+# ---------------------------------------------------------------------------
+
+
+def test_step_need_sr_rgb_false_skips_reconstruct(srcnn_y_lit: SRLightning, rgb_lr_hr_batch):
+    """The exact call training_step makes: reconstruct must not run, and
+    sr_rgb must come back None rather than a silently-wrong placeholder."""
+    lr, hr = rgb_lr_hr_batch
+    spy = MagicMock(wraps=srcnn_y_lit.processor.reconstruct)
+    srcnn_y_lit.processor.reconstruct = spy
+
+    loss, _, _, sr_rgb, hr_cropped = srcnn_y_lit._step((lr, hr), need_sr_rgb=False)
+
+    spy.assert_not_called()
+    assert sr_rgb is None
+    assert hr_cropped.shape == (2, 3, 21, 21)
+    assert torch.isfinite(loss)
+
+
+def test_step_default_still_reconstructs(srcnn_y_lit: SRLightning, rgb_lr_hr_batch):
+    """need_sr_rgb defaults to True — validation/predict/direct callers must
+    keep getting the exact reconstruction this project has always produced."""
+    lr, hr = rgb_lr_hr_batch
+    spy = MagicMock(wraps=srcnn_y_lit.processor.reconstruct)
+    srcnn_y_lit.processor.reconstruct = spy
+
+    loss, _, _, sr_rgb, hr_cropped = srcnn_y_lit._step((lr, hr))
+
+    spy.assert_called_once()
+    assert sr_rgb is not None
+    assert sr_rgb.shape == (2, 3, 21, 21)
+
+
+def test_step_loss_bit_identical_with_and_without_reconstruct_skip(
+    srcnn_y_lit: SRLightning, rgb_lr_hr_batch
+):
+    """The loss is computed from sr_model_out/hr_cropped alone — never sr_rgb
+    — so skipping reconstruct must not move it by even a rounding error."""
+    lr, hr = rgb_lr_hr_batch
+
+    loss_with, *_ = srcnn_y_lit._step((lr, hr))
+    loss_without, *_ = srcnn_y_lit._step((lr, hr), need_sr_rgb=False)
+
+    assert torch.equal(loss_with, loss_without)
+
+
+def test_forward_sr_need_sr_rgb_false_hr_crop_matches_sr_model_out_size(
+    srcnn_rgb_lit: SRLightning, rgb_lr_hr_batch
+):
+    """hr_cropped must still land at the correct spatial size (derived from
+    sr_model_out, not sr_rgb, when reconstruct is skipped)."""
+    lr, hr = rgb_lr_hr_batch
+    sr_model_out, sr_rgb, hr_cropped = srcnn_rgb_lit._forward_sr(lr, hr, need_sr_rgb=False)
+    assert sr_rgb is None
+    assert hr_cropped.shape[-2:] == sr_model_out.shape[-2:] == (21, 21)
+
+
+# ---------------------------------------------------------------------------
 # configure_optimizers
 # ---------------------------------------------------------------------------
 
@@ -625,6 +686,19 @@ def test_predict_rgb_returns_sr_and_hr_pair(srcnn_rgb_lit: SRLightning, rgb_lr_h
     # SRCNN with valid padding: 33 -> 21; HR center-cropped to match.
     assert sr_rgb.shape == (2, 3, 21, 21)
     assert hr_cropped.shape == (2, 3, 21, 21)
+
+
+def test_predict_rgb_always_reconstructs_regardless_of_need_sr_rgb_default(
+    srcnn_rgb_lit: SRLightning, rgb_lr_hr_batch
+):
+    """predict_rgb (the BenchmarkImageLogger/scoring seam) never passes
+    need_sr_rgb=False — its whole contract is returning a real sr_rgb."""
+    lr, hr = rgb_lr_hr_batch
+    spy = MagicMock(wraps=srcnn_rgb_lit.processor.reconstruct)
+    srcnn_rgb_lit.processor.reconstruct = spy
+    sr_rgb, _ = srcnn_rgb_lit.predict_rgb(lr, hr)
+    spy.assert_called_once()
+    assert sr_rgb is not None
 
 
 def test_predict_rgb_matches_step_forward_path(srcnn_rgb_lit: SRLightning, rgb_lr_hr_batch):


### PR DESCRIPTION
## What

Stacked on #70 (merge that first, then retarget this to `main`). Two things survived rigorous measurement; one thing was shipped, refuted by better measurement, and reverted *within this PR* — the history is kept honest below.

1. **`reconstruct` is no longer computed on the training path.** `training_step` always discarded it (`loss, *_`), yet every step paid for it — measured at +0.92 ± 0.26 ms/step on SRCNN and ~0 on SRResNet. Threaded as an explicit `need_sr_rgb` parameter (deliberately not `self.training`, which would break direct `predict_rgb` calls on un-`.eval()`'d modules); validation/test/predict/benchmark paths provably keep the full pipeline (call-site audit, spy tests on the real processor method, real-`Trainer` integration test). The crop target derives from the model output — all four shipped processors preserve H/W (independently re-verified).
2. **Templates: honest comments.** The bf16 comment no longer calls bf16-mixed "a bigger throughput lever" — measured, it is a 0.72× *regression* at the paper's batch 16 (crossover exists at b32). The `num_workers` comment now documents the real measured basis (below).

## The reverted middle commit (kept for honest history)

`af15524` shipped `num_workers: 0` based on steady-state figures that later proved to be a **synthetic-vs-real apples-to-oranges comparison** (the w0 side was measured in a worktree with no `data/`). The batch's serial benchmark pass on real DIV2K at Best-performance power showed w0 is a severe regression — SRCNN **79.3 ms/step vs 14.9** at w16 (batch 64 × ~1.08 ms/sample of real LR-derivation is a hard serial floor), SRResNet 56.0 vs 40.1 — and `43b138b` restores `num_workers: 16` / `persistent_workers: true` with the corrected comment. The ~2-minute one-time worker-spawn cost w0 saves would have traded against ~+179 hours on SRCNN's full training budget.

## Evidence

- Reconstruct skip: spy tests both directions, loss bit-identity, full-`Trainer` integration spy; branch code measured **neutral at w16** on real data (1.006×/0.972× vs main) — this commit's value is enabling the CUDA-graphs win in #74 (captured region is the skip-path shape).
- Templates parse via `--print_config` (re-verified after the revert); suite **463 passed, 2 skipped**; ruff clean.
- Reviewed: task review Approved (0 findings); the num_workers revert follows the controller's serial real-data benchmark (provenance-asserted per run, power state verified 115 W).

## Also evaluated and not shipped

A threaded in-process prefetch loader passed a bit-exact determinism gate but measured slower than stock in steady state; it is archived unpushed with a full writeup (its comparison numbers carry the same synthetic-data caveat, recorded for any future reopen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)