### PR TITLE
Correct every audit-verified false docstring claim

### DIFF
--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -42,7 +42,7 @@ class TrainDataset(HRCachedTrainDataset):
     never the crop), and bicubic-downsamples it by ``scale`` (via
     :func:`sisr.imresize.resize`) to form the LR input. Unlike
     :class:`sisr.datasets.srcnn.TrainDataset` there is **no
-    blur+downsample+upsample round-trip** and the LR is *not* upsampled back —
+    downsample+upsample round-trip** and the LR is *not* upsampled back —
     the model is responsible for the ×``scale`` upsampling, so the LR tensor is
     ``hr_crop_size // scale`` on a side.
 

--- a/sisr/export.py
+++ b/sisr/export.py
@@ -70,9 +70,11 @@ def to_onnx(
     Traces the wrapped model alone — see the module docstring for why the
     processor is excluded and what that means for SRCNN consumers. The
     exported graph accepts arbitrary spatial dimensions (``dynamic_axes`` on
-    height/width): a fixed-shape export would be useless on real images,
-    since ``training_config.example_input_shape`` is only a TensorBoard-graph
-    dummy size, not a training or inference constraint.
+    height/width) because real images vary in H/W independently of
+    ``training_config.example_input_shape``: that field is a representative
+    dummy shared by several fixed-shape uses (TensorBoard graph, ModelSummary
+    FLOPs, the compile warm-up, and this function's own default
+    ``input_sample``), none of which constrain inference spatial dims.
 
     Args:
         module: An :class:`~sisr.training.SRLightning` instance (e.g. built

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -137,7 +137,10 @@ class SRCNN(SRModel):
             clamp_minmax: Min/max values for clamping the output.
 
         Returns:
-            Output tensor, same shape as *x*.
+            Output tensor. Same shape as *x* only when ``padding='same'``;
+            with the default ``'valid'`` (or an explicit int), each conv
+            layer shrinks H/W by ``kernel_size - 1 - 2*padding``, e.g. -12 px
+            total for the shipped ``(9, 1, 5)`` kernels at padding 0.
         """
         x = self.feat(x)
         x = self.mapping(x)

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -472,17 +472,26 @@ class SRLightning(lightning.LightningModule):
         """Run the wrapped SR model on ``x`` and return its raw output.
 
         Pure inference path — no colorspace conversion, no metrics, no
-        cropping. Used by ``trainer.predict`` and direct ``module(x)``
-        calls. The training / validation paths go through :meth:`_step`,
-        which adds the colorspace pipeline.
+        cropping. Used by TensorBoard graph logging (tracing
+        ``example_input_array``) and direct ``module(x)`` calls — NOT the
+        ``trainer.predict`` path, which :meth:`predict_step` overrides,
+        calling :meth:`_forward_lr` (extract → model → reconstruct)
+        instead. Training and validation likewise bypass this method,
+        going through :meth:`_step`, which adds the same colorspace
+        pipeline.
 
         Args:
-            x: LR input tensor of shape ``(B, C, H, W)``.
+            x: Input tensor of shape ``(B, C, H, W)``, already in the
+                model's own IO colorspace (e.g. Y for SRCNN, RGB for
+                SRResNet).
 
         Returns:
-            SR tensor as produced by the wrapped model. Shape depends on
-            the architecture (same as ``x`` for SRCNN; ``(B, C, H*scale,
-            W*scale)`` for SRResNet).
+            SR tensor as produced by the wrapped model. SRResNet upscales
+            spatially to ``(B, C, H*scale, W*scale)``; SRCNN preserves
+            H/W only when ``padding='same'`` — the default ``'valid'``
+            (or an explicit int) shrinks each dim by
+            ``kernel_size - 1 - 2*padding`` per conv layer instead (see
+            :meth:`~sisr.models.srcnn.model.SRCNN.forward`).
         """
         return self.model(x)
 
@@ -836,8 +845,11 @@ class SRLightning(lightning.LightningModule):
 
         Returns:
             SR RGB tensor, ``float32`` in ``[0, 1]``, shape
-            ``(B, 3, H', W')`` — same size as the input for SRCNN,
-            ``H'=H*scale``/``W'=W*scale`` for SRResNet.
+            ``(B, 3, H', W')`` — ``H'=H*scale``/``W'=W*scale`` for
+            SRResNet; for SRCNN, same size as the input only when
+            ``padding='same'``, since the default ``'valid'`` (or an
+            explicit int) shrinks H/W per conv layer (see
+            :meth:`~sisr.models.srcnn.model.SRCNN.forward`).
         """
         _, sr_rgb = self._forward_lr(batch)
         return sr_rgb


### PR DESCRIPTION
## What

Doc-only commit fixing the four documentation claims that this batch's adversarial audit proved false against the code (stacked on #72 → #70; merge those first, then retarget this to `main`):

1. **SRCNN output-shape claim, three sites** — `SRCNN.forward`, `SRLightning.forward`, and `predict_rgb` all claimed output "same shape as *x*" while the shipped config (`kernel_sizes: [9,1,5]`, `padding: 0`) shrinks 33×33 → 21×21; the codebase's own crop/pad logic exists *because* the claim was false. Now stated padding-conditionally with the per-conv arithmetic, cross-referenced so the three sites can't drift apart again.
2. **`SRLightning.forward` claimed to be the `trainer.predict` path with no colorspace conversion** — it is bypassed entirely (`predict_step → _forward_lr` runs the full pipeline). Now names its real callers (TensorBoard `log_graph` tracing `example_input_array`, direct `module(x)`) and the actual routing — verified accurate against this stack's newest code (reconstruct skip, setup probe).
3. **Stale "blur" reference** in `sisr/datasets/srresnet.py` — the contrasted SRCNN degradation has no blur step (imresize's kernel widening *is* the low-pass); the repo-wide sweep confirmed this was the only stale remnant.
4. **`to_onnx` called `example_input_shape` "only a TensorBoard-graph dummy size"** — contradicted by its own function's default trace input 40 lines below, plus ModelSummary FLOPs and the compile warm-up. Now enumerates the real consumers accurately.

## Evidence

Each item was adversarially verified twice: once by the audit (verdict + exact wording), once by this PR's reviewer re-deriving every claim against the current branch (padding arithmetic, call-graph traces, config values). Diff is strictly docstring/comment prose — zero executable hunks. Suite independently re-run by the reviewer: **463 passed, 2 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)