### PR TITLE
Add opt-in full-step CUDA-graph capture for training

### DIFF
--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -130,16 +130,17 @@ class SRTrainingConfig:
             ``optimizer.step()`` stays eager, so LR schedulers, gradient
             clipping and ``global_step`` accounting are unaffected. Requires a
             CUDA device, ``precision='32-true'``, a single process, and
-            ``accumulate_grad_batches=1``; ``SRLightning.on_fit_start`` refuses
-            the rest rather than silently mistraining. Mutually exclusive with
-            ``compile_backend`` (see :meth:`__post_init__`). Validation, test
-            and predict always stay eager — their image sizes vary, and graphs
-            need static shapes. Measured on one RTX 5060 Laptop (SRCNN, batch
-            64, 33x33 Y patches, 60 W cap): **2.81x steps/s**, 6.21 -> 2.21
-            ms/step, bit-identical losses. The win is proportional to how
-            launch-bound the architecture is, so it is far smaller for
-            SRResNet, whose GPU floor is real compute — hence opt-in, per
-            config, defaulting off.
+            ``accumulate_grad_batches=1``; ``SRLightning.on_fit_start`` and
+            ``on_train_epoch_start`` refuse the rest rather than silently
+            mistraining. Mutually exclusive with ``compile_backend`` (see
+            :meth:`__post_init__`). Validation, test and predict always stay
+            eager — their image sizes vary, and graphs need static shapes.
+            Measured ~2.6x steps/s on one RTX 5060 Laptop with bit-identical
+            losses; the figures live in
+            ``templates/config.srcnn.template.yaml`` so there is one place to
+            keep current. The win is proportional to how launch-bound the
+            architecture is, so it is far smaller for SRResNet, whose GPU floor
+            is real compute — hence opt-in, per config, defaulting off.
     """
 
     layer_lrs: list[float] | None = None

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -122,6 +122,24 @@ class SRTrainingConfig:
             captured. ``'inductor'`` fails outright there (no upstream
             Windows Triton wheel). Defaults to ``None`` so this mostly-
             unproven-on-this-project path never ships on by default.
+
+        cuda_graph: Capture the training step's
+            ``{zero_grad, forward, loss, backward}`` into a CUDA graph and
+            replay it per step, instead of relaunching every kernel
+            (:class:`~sisr.training.cuda_graph.CUDAGraphStep`).
+            ``optimizer.step()`` stays eager, so LR schedulers, gradient
+            clipping and ``global_step`` accounting are unaffected. Requires a
+            CUDA device, ``precision='32-true'``, a single process, and
+            ``accumulate_grad_batches=1``; ``SRLightning.on_fit_start`` refuses
+            the rest rather than silently mistraining. Mutually exclusive with
+            ``compile_backend`` (see :meth:`__post_init__`). Validation, test
+            and predict always stay eager — their image sizes vary, and graphs
+            need static shapes. Measured on one RTX 5060 Laptop (SRCNN, batch
+            64, 33x33 Y patches, 60 W cap): **2.81x steps/s**, 6.21 -> 2.21
+            ms/step, bit-identical losses. The win is proportional to how
+            launch-bound the architecture is, so it is far smaller for
+            SRResNet, whose GPU floor is real compute — hence opt-in, per
+            config, defaulting off.
     """
 
     layer_lrs: list[float] | None = None
@@ -131,6 +149,23 @@ class SRTrainingConfig:
     init_std: float = 0.01
     scale: int | None = None
     compile_backend: str | None = None
+    cuda_graph: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject field combinations that cannot both be honoured.
+
+        Raises:
+            ValueError: If ``cuda_graph`` and ``compile_backend`` are both set.
+        """
+        if self.cuda_graph and self.compile_backend is not None:
+            raise ValueError(
+                f"training_config.cuda_graph=True is incompatible with "
+                f"compile_backend={self.compile_backend!r}: both take over the "
+                f"training-mode forward, and each needs its own warm-up before it is "
+                f"usable, so layering them means capturing a graph around a partially "
+                f"warmed compiled callable. Pick one — set compile_backend=null to keep "
+                f"cuda_graph, or cuda_graph=false to keep compile_backend."
+            )
 
     def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
         """Validate this config against the model/processor it will pair with.

--- a/sisr/training/cuda_graph.py
+++ b/sisr/training/cuda_graph.py
@@ -2,10 +2,11 @@
 
 An SRCNN training step is kernel-launch-bound, not compute-bound: measured 78
 ``cudaLaunchKernel`` calls per step, with the CPU's launch time equal to the
-step's wall time (3.8 ms of each) and the GPU at 27% utilisation. Replaying one
-captured graph runs the identical kernels as a single ``cudaGraphLaunch`` at 99%
-utilisation, cutting device-side time 1.93 -> 0.90 ms and the whole Lightning
-step 6.21 -> 2.21 ms (b64, 33x33, 60 W cap, RTX 5060 Laptop).
+step's wall time and the GPU at under 30% utilisation. Replaying one captured
+graph runs the identical kernels as a single ``cudaGraphLaunch`` at near-full
+utilisation, cutting device-side time roughly in half and the whole Lightning
+step by ~2.6x — see the measured figures in ``templates/config.srcnn.template.yaml``,
+which is the one place they are quoted and kept current.
 
 Only ``{zero_grad, forward, loss, backward}`` is captured — ``optimizer.step()``
 stays eager and stays Lightning's. Capturing it too saves a further 0.07 ms/step
@@ -17,6 +18,7 @@ parameter to opt out of that. 0.07 ms is not worth a silent-corruption class.
 from collections.abc import Callable, Sequence
 
 import torch
+from lightning.pytorch.utilities import rank_zero_info, rank_zero_warn
 
 
 class CUDAGraphStep:
@@ -27,40 +29,77 @@ class CUDAGraphStep:
     whose shapes differ (the partial last batch of an epoch) are rejected with
     ``None`` so the caller can fall back to an eager step.
 
-    The warm-up deliberately omits ``optimizer.step()``: nothing in the captured
-    region writes to a parameter, so capture leaves the model bit-identical to
-    how it arrived and no weight/momentum snapshot-and-rewind is needed. It does
-    run ``backward``, which is what allocates the ``.grad`` tensors the graph
-    then bakes addresses for, and what lets ``cudnn.benchmark`` finish
-    autotuning this shape before anything is recorded.
+    The warm-up deliberately omits ``optimizer.step()``, so no parameter and no
+    optimizer state is written and none has to be snapshotted. What the warm-up
+    *does* mutate is buffers — ``BatchNorm``'s ``running_mean`` /
+    ``running_var`` / ``num_batches_tracked`` advance once per forward, and
+    SRResNet's residual blocks have BatchNorm — so every buffer is snapshotted
+    and copied back in place once capture finishes. Together those two facts
+    make capture observationally inert: the module is left exactly as it
+    arrived. The warm-up still runs ``backward``, which is what allocates the
+    ``.grad`` tensors the graph bakes addresses for and what lets
+    ``cudnn.benchmark`` finish autotuning this shape before anything is recorded.
 
     Args:
         loss_fn: Maps a batch to the scalar loss to backpropagate. Called with
             the internal static buffers, never the caller's batch.
+        module: The module whose buffers the warm-up would otherwise advance.
+            Only ``named_buffers`` is used; parameters are untouched.
         optimizer: Optimizer whose ``zero_grad`` is captured. Its ``step`` is
             never called here.
         warmup_iters: Warm-up iterations run on a side stream before capture.
             Three is the CUDA-graph documented minimum for the caching
             allocator to settle.
+        fallback_warn_after: Warn once after this many consecutive shape
+            rejections. A run that never matches would otherwise silently pay
+            eager cost with the flag on and look like a 0% speedup.
     """
 
     def __init__(
         self,
         loss_fn: Callable[[Sequence[torch.Tensor]], torch.Tensor],
+        module: torch.nn.Module,
         optimizer: torch.optim.Optimizer,
         warmup_iters: int = 3,
+        fallback_warn_after: int = 10,
     ):
         self._loss_fn = loss_fn
+        self._module = module
         self._optimizer = optimizer
         self._warmup_iters = warmup_iters
+        self._fallback_warn_after = fallback_warn_after
         self._graph: torch.cuda.CUDAGraph | None = None
         self._static_batch: tuple[torch.Tensor, ...] | None = None
         self._static_loss: torch.Tensor | None = None
+        self._consecutive_fallbacks = 0
+        self._fallback_warned = False
 
     @property
     def captured(self) -> bool:
         """Whether a graph has been captured yet."""
         return self._graph is not None
+
+    def _buffer_snapshot(self) -> dict[str, torch.Tensor]:
+        """Clone every module buffer, so the warm-up's forwards can be undone.
+
+        Returns:
+            Buffer name -> detached clone. Empty for buffer-free architectures
+            like SRCNN, making the restore a no-op there.
+        """
+        return {name: buf.detach().clone() for name, buf in self._module.named_buffers()}
+
+    def _restore_buffers(self, snapshot: dict[str, torch.Tensor]) -> None:
+        """Copy snapshotted buffer values back, in place.
+
+        In place is required, not incidental: the captured graph holds the
+        buffers' addresses, so rebinding them would invalidate every replay.
+
+        Args:
+            snapshot: Output of :meth:`_buffer_snapshot`.
+        """
+        with torch.no_grad():
+            for name, buf in self._module.named_buffers():
+                buf.copy_(snapshot[name])
 
     def capture(self, batch: Sequence[torch.Tensor]) -> None:
         """Warm up on a side stream, then capture the step for ``batch``'s shapes.
@@ -70,6 +109,7 @@ class CUDAGraphStep:
                 every later :meth:`run` copies into.
         """
         self._static_batch = tuple(t.detach().clone() for t in batch)
+        buffers = self._buffer_snapshot()
 
         stream = torch.cuda.Stream()
         stream.wait_stream(torch.cuda.current_stream())
@@ -92,6 +132,12 @@ class CUDAGraphStep:
         # hits them on the default stream and warns about the mismatch. Replay
         # needs only the value buffer, which detach shares.
         self._graph, self._static_loss = graph, loss.detach()
+        self._restore_buffers(buffers)
+        rank_zero_info(
+            f"CUDA graph captured for batch shapes "
+            f"{[tuple(t.shape) for t in self._static_batch]} — the training step now "
+            f"replays as one graph launch."
+        )
 
     def run(self, batch: Sequence[torch.Tensor]) -> torch.Tensor | None:
         """Replay the captured step for ``batch``, capturing on the first call.
@@ -109,11 +155,40 @@ class CUDAGraphStep:
         """
         if self._graph is None:
             self.capture(batch)
-        if len(batch) != len(self._static_batch):
+        if not self._matches(batch):
+            self._note_fallback(batch)
             return None
-        if any(t.shape != s.shape for t, s in zip(batch, self._static_batch, strict=True)):
-            return None
+        self._consecutive_fallbacks = 0
         for static, incoming in zip(self._static_batch, batch, strict=True):
             static.copy_(incoming, non_blocking=True)
         self._graph.replay()
         return self._static_loss.clone()
+
+    def _matches(self, batch: Sequence[torch.Tensor]) -> bool:
+        """Whether ``batch``'s arity and shapes are the captured ones."""
+        if len(batch) != len(self._static_batch):
+            return False
+        return all(t.shape == s.shape for t, s in zip(batch, self._static_batch, strict=True))
+
+    def _note_fallback(self, batch: Sequence[torch.Tensor]) -> None:
+        """Count a rejected batch, warning once if they stop being occasional.
+
+        One rejection per epoch is normal and expected — that is the partial
+        last batch. A *run* of them means the captured shape never recurs, so
+        the flag is on and buying nothing, which is otherwise invisible.
+
+        Args:
+            batch: The rejected batch, for the warning's shape report.
+        """
+        self._consecutive_fallbacks += 1
+        if self._fallback_warned or self._consecutive_fallbacks < self._fallback_warn_after:
+            return
+        self._fallback_warned = True
+        rank_zero_warn(
+            f"training_config.cuda_graph is on, but the last {self._consecutive_fallbacks} "
+            f"batches all fell back to an eager step: shapes "
+            f"{[tuple(t.shape) for t in batch]} do not match the captured "
+            f"{[tuple(t.shape) for t in self._static_batch]}. The graph is buying nothing. "
+            f"Give the train loader a constant batch shape (e.g. drop_last=True) or set "
+            f"cuda_graph to false."
+        )

--- a/sisr/training/cuda_graph.py
+++ b/sisr/training/cuda_graph.py
@@ -1,0 +1,119 @@
+"""CUDA-graph capture of the training step — :class:`CUDAGraphStep`.
+
+An SRCNN training step is kernel-launch-bound, not compute-bound: measured 78
+``cudaLaunchKernel`` calls per step, with the CPU's launch time equal to the
+step's wall time (3.8 ms of each) and the GPU at 27% utilisation. Replaying one
+captured graph runs the identical kernels as a single ``cudaGraphLaunch`` at 99%
+utilisation, cutting device-side time 1.93 -> 0.90 ms and the whole Lightning
+step 6.21 -> 2.21 ms (b64, 33x33, 60 W cap, RTX 5060 Laptop).
+
+Only ``{zero_grad, forward, loss, backward}`` is captured — ``optimizer.step()``
+stays eager and stays Lightning's. Capturing it too saves a further 0.07 ms/step
+(measured) but would bake the learning rate in as a graph constant, silently
+no-opping every LR scheduler: ``torch.optim.SGD`` has no ``capturable``
+parameter to opt out of that. 0.07 ms is not worth a silent-corruption class.
+"""
+
+from collections.abc import Callable, Sequence
+
+import torch
+
+
+class CUDAGraphStep:
+    """One captured ``{zero_grad, forward, loss, backward}`` for a fixed batch shape.
+
+    Capture is lazy — the first :meth:`run` call warms up and captures using
+    that batch's shapes, so the caller never has to predict them. Later batches
+    whose shapes differ (the partial last batch of an epoch) are rejected with
+    ``None`` so the caller can fall back to an eager step.
+
+    The warm-up deliberately omits ``optimizer.step()``: nothing in the captured
+    region writes to a parameter, so capture leaves the model bit-identical to
+    how it arrived and no weight/momentum snapshot-and-rewind is needed. It does
+    run ``backward``, which is what allocates the ``.grad`` tensors the graph
+    then bakes addresses for, and what lets ``cudnn.benchmark`` finish
+    autotuning this shape before anything is recorded.
+
+    Args:
+        loss_fn: Maps a batch to the scalar loss to backpropagate. Called with
+            the internal static buffers, never the caller's batch.
+        optimizer: Optimizer whose ``zero_grad`` is captured. Its ``step`` is
+            never called here.
+        warmup_iters: Warm-up iterations run on a side stream before capture.
+            Three is the CUDA-graph documented minimum for the caching
+            allocator to settle.
+    """
+
+    def __init__(
+        self,
+        loss_fn: Callable[[Sequence[torch.Tensor]], torch.Tensor],
+        optimizer: torch.optim.Optimizer,
+        warmup_iters: int = 3,
+    ):
+        self._loss_fn = loss_fn
+        self._optimizer = optimizer
+        self._warmup_iters = warmup_iters
+        self._graph: torch.cuda.CUDAGraph | None = None
+        self._static_batch: tuple[torch.Tensor, ...] | None = None
+        self._static_loss: torch.Tensor | None = None
+
+    @property
+    def captured(self) -> bool:
+        """Whether a graph has been captured yet."""
+        return self._graph is not None
+
+    def capture(self, batch: Sequence[torch.Tensor]) -> None:
+        """Warm up on a side stream, then capture the step for ``batch``'s shapes.
+
+        Args:
+            batch: Sequence of device tensors. Cloned into the static buffers
+                every later :meth:`run` copies into.
+        """
+        self._static_batch = tuple(t.detach().clone() for t in batch)
+
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(self._warmup_iters):
+                self._optimizer.zero_grad(set_to_none=False)
+                # Not kept: a live reference to a previous iteration's autograd
+                # graph keeps its AccumulateGrad nodes alive and breaks capture.
+                self._loss_fn(self._static_batch).backward()
+        torch.cuda.current_stream().wait_stream(stream)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            self._optimizer.zero_grad(set_to_none=False)
+            loss = self._loss_fn(self._static_batch)
+            loss.backward()
+        # Detached: keeping the graph-built loss itself alive keeps its whole
+        # autograd graph alive, including AccumulateGrad nodes bound to the
+        # capture stream. A later eager backward on the same parameters then
+        # hits them on the default stream and warns about the mismatch. Replay
+        # needs only the value buffer, which detach shares.
+        self._graph, self._static_loss = graph, loss.detach()
+
+    def run(self, batch: Sequence[torch.Tensor]) -> torch.Tensor | None:
+        """Replay the captured step for ``batch``, capturing on the first call.
+
+        Args:
+            batch: Sequence of device tensors, same arity and shapes as the
+                batch that was captured.
+
+        Returns:
+            A clone of the loss — the static buffer itself is overwritten in
+            place by the next replay, so anything retaining it (Lightning's
+            progress-bar metric cache) would silently report a later step's
+            value. ``None`` if ``batch`` doesn't match the captured shapes,
+            meaning the caller must run an eager step instead.
+        """
+        if self._graph is None:
+            self.capture(batch)
+        if len(batch) != len(self._static_batch):
+            return None
+        if any(t.shape != s.shape for t, s in zip(batch, self._static_batch, strict=True)):
+            return None
+        for static, incoming in zip(self._static_batch, batch, strict=True):
+            static.copy_(incoming, non_blocking=True)
+        self._graph.replay()
+        return self._static_loss.clone()

--- a/sisr/training/cuda_graph.py
+++ b/sisr/training/cuda_graph.py
@@ -15,10 +15,17 @@ no-opping every LR scheduler: ``torch.optim.SGD`` has no ``capturable``
 parameter to opt out of that. 0.07 ms is not worth a silent-corruption class.
 """
 
+import time
 from collections.abc import Callable, Sequence
 
 import torch
 from lightning.pytorch.utilities import rank_zero_info, rank_zero_warn
+
+#: Pauses before each capture retry. Capture is invalidated by concurrent implicit
+#: device syncs (a DataLoader's pin-memory thread growing its host-block cache is
+#: the one that bit us), and that activity is a startup burst, so backing off
+#: past it is what makes the retry worth having. Only ever paid on a failure.
+_RETRY_DELAYS: tuple[float, ...] = (0.1, 0.5, 2.0)
 
 
 class CUDAGraphStep:
@@ -53,6 +60,9 @@ class CUDAGraphStep:
         fallback_warn_after: Warn once after this many consecutive shape
             rejections. A run that never matches would otherwise silently pay
             eager cost with the flag on and look like a 0% speedup.
+        retry_delays: Pauses before each capture retry; defaults to
+            :data:`_RETRY_DELAYS`. One more attempt is made than there are
+            entries, and only then is graphing disabled.
     """
 
     def __init__(
@@ -62,22 +72,45 @@ class CUDAGraphStep:
         optimizer: torch.optim.Optimizer,
         warmup_iters: int = 3,
         fallback_warn_after: int = 10,
+        retry_delays: tuple[float, ...] = _RETRY_DELAYS,
     ):
         self._loss_fn = loss_fn
         self._module = module
         self._optimizer = optimizer
         self._warmup_iters = warmup_iters
         self._fallback_warn_after = fallback_warn_after
+        self._retry_delays = retry_delays
         self._graph: torch.cuda.CUDAGraph | None = None
         self._static_batch: tuple[torch.Tensor, ...] | None = None
         self._static_loss: torch.Tensor | None = None
         self._consecutive_fallbacks = 0
         self._fallback_warned = False
+        self._disabled = False
 
     @property
     def captured(self) -> bool:
         """Whether a graph has been captured yet."""
         return self._graph is not None
+
+    @property
+    def disabled(self) -> bool:
+        """Whether this run has given up on capture, by failure or up front."""
+        return self._disabled
+
+    def disable(self, reason: str) -> None:
+        """Give up on capture before ever attempting it, explaining why once.
+
+        For conditions known in advance to make capture unsafe rather than
+        merely slow — see
+        :meth:`~sisr.training.lightning_module.SRLightning._unsafe_capture_reason`.
+        Degrading to eager beats both crashing and refusing to start.
+
+        Args:
+            reason: Operator-facing explanation, including how to get the
+                speedup back.
+        """
+        self._disabled = True
+        rank_zero_warn(f"CUDA graph capture disabled: {reason}")
 
     def _buffer_snapshot(self) -> dict[str, torch.Tensor]:
         """Clone every module buffer, so the warm-up's forwards can be undone.
@@ -111,33 +144,96 @@ class CUDAGraphStep:
         self._static_batch = tuple(t.detach().clone() for t in batch)
         buffers = self._buffer_snapshot()
 
-        stream = torch.cuda.Stream()
-        stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(stream):
-            for _ in range(self._warmup_iters):
-                self._optimizer.zero_grad(set_to_none=False)
-                # Not kept: a live reference to a previous iteration's autograd
-                # graph keeps its AccumulateGrad nodes alive and breaks capture.
-                self._loss_fn(self._static_batch).backward()
-        torch.cuda.current_stream().wait_stream(stream)
+        try:
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream):
+                for _ in range(self._warmup_iters):
+                    self._optimizer.zero_grad(set_to_none=False)
+                    # Not kept: a live reference to a previous iteration's autograd
+                    # graph keeps its AccumulateGrad nodes alive and breaks capture.
+                    self._loss_fn(self._static_batch).backward()
+            torch.cuda.current_stream().wait_stream(stream)
 
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
-            self._optimizer.zero_grad(set_to_none=False)
-            loss = self._loss_fn(self._static_batch)
-            loss.backward()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                self._optimizer.zero_grad(set_to_none=False)
+                loss = self._loss_fn(self._static_batch)
+                loss.backward()
+        finally:
+            # Even a failed attempt ran the warm-up's forwards, so the buffers
+            # have moved either way.
+            self._restore_buffers(buffers)
         # Detached: keeping the graph-built loss itself alive keeps its whole
         # autograd graph alive, including AccumulateGrad nodes bound to the
         # capture stream. A later eager backward on the same parameters then
         # hits them on the default stream and warns about the mismatch. Replay
         # needs only the value buffer, which detach shares.
         self._graph, self._static_loss = graph, loss.detach()
-        self._restore_buffers(buffers)
         rank_zero_info(
             f"CUDA graph captured for batch shapes "
             f"{[tuple(t.shape) for t in self._static_batch]} — the training step now "
             f"replays as one graph launch."
         )
+
+    @staticmethod
+    def _drain_error_state() -> None:
+        """Spend the one CUDA call that re-raises an invalidated capture's error.
+
+        Measured, and reproducible for every injector tried: after
+        ``cudaErrorStreamCaptureInvalidated`` exactly one further CUDA operation
+        raises, and the context is fully usable from the next one on. Burning
+        that operation here is what makes the eager fallback survivable — the
+        caller's next real kernel launch would otherwise inherit the failure and
+        kill the run anyway, which is the whole thing this class is trying to
+        avoid. Three tries, so the accounting cannot be off by one.
+        """
+        for _ in range(3):
+            try:
+                torch.zeros(1, device="cuda").add_(1)
+                return
+            except Exception:  # noqa: S110 - draining a known-sticky error is the point
+                continue
+
+    def _try_capture(self, batch: Sequence[torch.Tensor]) -> bool:
+        """Capture, retrying a few times, and give up permanently rather than raise.
+
+        Capture is not reliably available: it is invalidated by any implicit
+        device synchronization anywhere in the process while it is open, and a
+        ``DataLoader`` with ``num_workers>0`` and ``pin_memory=True`` runs a
+        pin-memory thread that calls ``cudaHostAlloc`` — which synchronizes —
+        every time its host-block cache needs a new size. That cache is coldest
+        during the first batches, exactly when capture would otherwise happen,
+        which is why failures cluster on the first attempt and are
+        non-deterministic. Retrying after a pause is therefore likely to
+        succeed, since the window closes as the cache warms.
+
+        A crashed 10M-step run is far worse than a slower one, so exhausting the
+        retries disables graphing for the rest of the run instead of propagating.
+
+        Args:
+            batch: The batch to capture against.
+
+        Returns:
+            Whether a graph is now available.
+        """
+        for delay in (*self._retry_delays, None):
+            try:
+                self.capture(batch)
+                return True
+            except Exception as exc:
+                self._drain_error_state()
+                if delay is None:
+                    self._disabled = True
+                    rank_zero_warn(
+                        f"CUDA graph capture failed "
+                        f"{len(self._retry_delays) + 1} times and is now disabled for the "
+                        f"rest of this run; training continues eagerly, with identical "
+                        f"results and no speedup. Last error: {type(exc).__name__}: {exc}"
+                    )
+                    return False
+                time.sleep(delay)
+        return False
 
     def run(self, batch: Sequence[torch.Tensor]) -> torch.Tensor | None:
         """Replay the captured step for ``batch``, capturing on the first call.
@@ -150,11 +246,14 @@ class CUDAGraphStep:
             A clone of the loss — the static buffer itself is overwritten in
             place by the next replay, so anything retaining it (Lightning's
             progress-bar metric cache) would silently report a later step's
-            value. ``None`` if ``batch`` doesn't match the captured shapes,
-            meaning the caller must run an eager step instead.
+            value. ``None`` if ``batch`` doesn't match the captured shapes or if
+            capture is unavailable, meaning the caller must run an eager step
+            instead. Never raises on a capture failure — see :meth:`_try_capture`.
         """
-        if self._graph is None:
-            self.capture(batch)
+        if self._disabled:
+            return None
+        if self._graph is None and not self._try_capture(batch):
+            return None
         if not self._matches(batch):
             self._note_fallback(batch)
             return None

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -24,6 +24,7 @@ from ..colorspace import rgb_to_ycbcr_studio
 from ..models.base import SRModel
 from ..processors import SRProcessor
 from .config import SREvalConfig, SRTrainingConfig
+from .cuda_graph import CUDAGraphStep
 from .metadata import build_metadata
 
 
@@ -113,6 +114,13 @@ class SRLightning(lightning.LightningModule):
         # set of weights and it still moves with .to() through self.model's
         # normal registration.
         object.__setattr__(self, "_compiled", compiled)
+
+        self._cuda_graph: CUDAGraphStep | None = None
+        # Per-step, not per-run: on an eager fallback step Lightning must still
+        # run backward and zero_grad. Gating those on "a graph exists" instead
+        # makes the epoch's partial last batch step on the previous replay's
+        # gradients — a silent duplicated update, not a crash.
+        self._graphed_step = False
 
         # Save exactly this plain dict — bypasses save_hyperparameters' frame/given_hparams
         # introspection, so the checkpoint's `hyper_parameters` is identical whether this
@@ -678,9 +686,67 @@ class SRLightning(lightning.LightningModule):
         Returns:
             Scalar loss tensor for the optimizer.
         """
-        loss, *_ = self._step(batch, need_sr_rgb=False)
+        loss = self._graph_step(batch) if self.training_config.cuda_graph else None
+        if loss is None:
+            loss, *_ = self._step(batch, need_sr_rgb=False)
         self.log("loss/train", loss, prog_bar=True, on_step=True)
         return loss
+
+    def _graph_step(self, batch: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor | None:
+        """Run the captured training step, building the graph on first use.
+
+        Args:
+            batch: ``(lr_img, hr_img)`` tuple, already on the device.
+
+        Returns:
+            The replayed step's loss, or ``None`` when the batch's shapes don't
+            match the captured ones (the epoch's partial last batch) and the
+            caller must run an eager step instead.
+        """
+        if self._cuda_graph is None:
+            optimizer = self.optimizers()
+            self._cuda_graph = CUDAGraphStep(
+                lambda b: self._step(b, need_sr_rgb=False)[0],
+                getattr(optimizer, "optimizer", optimizer),
+            )
+        loss = self._cuda_graph.run(batch)
+        self._graphed_step = loss is not None
+        return loss
+
+    def backward(self, loss: torch.Tensor, *args: Any, **kwargs: Any) -> None:
+        """Backpropagate ``loss``, unless the captured graph already did.
+
+        Args:
+            loss: Scalar loss returned by :meth:`training_step`.
+            *args: Forwarded to Lightning's implementation.
+            **kwargs: Forwarded to Lightning's implementation.
+        """
+        if self._graphed_step:
+            return
+        super().backward(loss, *args, **kwargs)
+
+    def optimizer_zero_grad(
+        self, epoch: int, batch_idx: int, optimizer: torch.optim.Optimizer
+    ) -> None:
+        """Zero gradients, unless the captured graph owns them.
+
+        Lightning's closure order is ``training_step -> zero_grad -> backward``,
+        so on a graphed step this must be a no-op: the replay has already
+        zeroed, filled and finished with the gradients, and zeroing again here
+        would hand the optimizer nothing but zeros. On an eager fallback step it
+        must run — but with ``set_to_none=False``, because the captured graph
+        writes into those exact ``.grad`` tensors and freeing them invalidates
+        every later replay.
+
+        Args:
+            epoch: Current epoch index.
+            batch_idx: Current batch index.
+            optimizer: The optimizer whose gradients to zero.
+        """
+        if not self.training_config.cuda_graph:
+            super().optimizer_zero_grad(epoch, batch_idx, optimizer)
+        elif not self._graphed_step:
+            optimizer.zero_grad(set_to_none=False)
 
     def validation_step(
         self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -736,7 +802,7 @@ class SRLightning(lightning.LightningModule):
             )
 
     def on_fit_start(self) -> None:
-        """Warm up the compiled training path before the training loop starts.
+        """Check the CUDA-graph prerequisites, then warm up the compiled training path.
 
         A backend name ``torch._dynamo.list_backends()`` recognizes can
         still lack its toolchain (e.g. ``'inductor'`` without Triton), which
@@ -747,15 +813,74 @@ class SRLightning(lightning.LightningModule):
         running first would not catch it, since validation always runs the
         eager path (see :meth:`_forward_lr`).
 
-        No-op when compilation is off, or when
+        The warm-up is a no-op when compilation is off, or when
         ``training_config.example_input_shape`` is unset — there is then no
         input shape to probe with (both shipped templates set it).
+
+        Raises:
+            RuntimeError: Via :meth:`_check_cuda_graph_prerequisites` when
+                ``training_config.cuda_graph`` is set on a run that cannot
+                honour it.
         """
+        if self.training_config.cuda_graph:
+            self._check_cuda_graph_prerequisites()
         if self._compiled is None or self.training_config.example_input_shape is None:
             return
         dummy = torch.zeros(1, *self.training_config.example_input_shape, device=self.device)
         with torch.no_grad():
             self._compiled(dummy)
+
+    def _check_cuda_graph_prerequisites(self) -> None:
+        """Refuse ``cuda_graph=True`` on a run whose semantics it would change.
+
+        Each of these would otherwise mistrain silently rather than crash, so
+        they are hard refusals at the start of ``fit``, not warnings. Checked in
+        config-then-environment order so a misconfiguration is reported even on
+        a machine with no GPU to run on.
+
+        Raises:
+            RuntimeError: If precision is not ``'32-true'`` (a ``GradScaler``
+                scales the loss in ``pre_backward``, which a captured backward
+                never sees, and autocast's cast churn is a measured regression
+                on this project besides); if the run is distributed (capture and
+                DDP's gradient hooks conflict — DDP stashes ``AccumulateGrad``
+                references); if ``accumulate_grad_batches > 1`` (Lightning zeroes
+                gradients only on the first micro-batch and expects the rest to
+                accumulate, but every replay zeroes them, and the loss is not
+                scaled by the accumulation factor); or if the accelerator is not
+                CUDA.
+        """
+        trainer = self.trainer
+        if trainer.precision != "32-true":
+            raise RuntimeError(
+                f"training_config.cuda_graph=True requires trainer.precision='32-true', "
+                f"got {trainer.precision!r}. Mixed precision scales the loss in the "
+                f"precision plugin's pre_backward hook, which a captured backward pass "
+                f"never runs, so gradients would be silently unscaled. Set "
+                f"trainer.precision to 32-true, or cuda_graph to false."
+            )
+        if trainer.world_size > 1:
+            raise RuntimeError(
+                f"training_config.cuda_graph=True does not support distributed training "
+                f"(trainer.world_size={trainer.world_size}). DDP stashes references to "
+                f"the autograd graph's AccumulateGrad nodes and inserts gradient "
+                f"all-reduce hooks, neither of which survives capture. Train on one "
+                f"device, or set cuda_graph to false."
+            )
+        if trainer.accumulate_grad_batches > 1:
+            raise RuntimeError(
+                f"training_config.cuda_graph=True does not support gradient accumulation "
+                f"(trainer.accumulate_grad_batches={trainer.accumulate_grad_batches}). "
+                f"Every replay zeroes the gradients, so nothing would accumulate across "
+                f"micro-batches. Raise the loader's batch_size instead, or set cuda_graph "
+                f"to false."
+            )
+        if self.device.type != "cuda":
+            raise RuntimeError(
+                f"training_config.cuda_graph=True requires a CUDA device, but this module "
+                f"is on {self.device!r}. Set trainer.accelerator='cuda', or cuda_graph to "
+                f"false."
+            )
 
     def on_train_start(self) -> None:
         """Register val metric tags with TensorBoard's HParams tab.

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -710,9 +710,52 @@ class SRLightning(lightning.LightningModule):
                 self,
                 getattr(optimizer, "optimizer", optimizer),
             )
+            reason = self._unsafe_capture_reason()
+            if reason is not None:
+                self._cuda_graph.disable(reason)
         loss = self._cuda_graph.run(batch)
         self._graphed_step = loss is not None
         return loss
+
+    def _unsafe_capture_reason(self) -> str | None:
+        """Why capture must not even be attempted on this run, or ``None``.
+
+        A ``DataLoader`` with ``num_workers > 0`` **and** ``pin_memory=True``
+        runs its pinning in a separate thread of *this* process, and that thread
+        calls ``cudaHostAlloc`` whenever its host-block cache needs a new size.
+        ``cudaHostAlloc`` implicitly synchronizes the device, which invalidates
+        any capture open at that moment. Measured on this project: 1 crash in 6
+        fits at ``num_workers=16, pin_memory=True`` versus 0 in 8 with
+        ``pin_memory=False``, all else equal.
+
+        Retrying does not make this safe. The invalidation leaves a sticky CUDA
+        error that the *next* CUDA call in the process consumes, and when that
+        call belongs to the pin-memory thread the ``DataLoader`` dies
+        ("Caught AcceleratorError in pin memory thread") no matter what this
+        process's main thread does about its own capture. Prevention is the only
+        option, so this is a warn-and-run-eager condition rather than one of
+        :meth:`_check_cuda_graph_prerequisites`'s hard refusals: those catch
+        silent mistraining, this only costs speed.
+
+        ``num_workers=0`` — what both shipped templates use — pins inline on the
+        main thread, so there is no second thread to race and ``pin_memory``
+        stays worth having there.
+
+        Returns:
+            An operator-facing reason, or ``None`` when capture is safe to try.
+        """
+        loader = getattr(self.trainer, "train_dataloader", None)
+        workers = getattr(loader, "num_workers", 0) or 0
+        if workers > 0 and getattr(loader, "pin_memory", False):
+            return (
+                f"the train DataLoader combines num_workers={workers} with "
+                f"pin_memory=True, whose pin-memory thread calls cudaHostAlloc and can "
+                f"invalidate a capture mid-flight, killing the run. Training continues "
+                f"eagerly. Set pin_memory: false to graph at this worker count, or "
+                f"num_workers: 0 (both shipped templates do) to keep pin_memory — it "
+                f"pins on the main thread there, with nothing to race."
+            )
+        return None
 
     def backward(self, loss: torch.Tensor, *args: Any, **kwargs: Any) -> None:
         """Backpropagate ``loss``, unless the captured graph already did.
@@ -741,9 +784,11 @@ class SRLightning(lightning.LightningModule):
         so on a graphed step this must be a no-op: the replay has already
         zeroed, filled and finished with the gradients, and zeroing again here
         would hand the optimizer nothing but zeros. On an eager fallback step it
-        must run — but with ``set_to_none=False``, because the captured graph
-        writes into those exact ``.grad`` tensors and freeing them invalidates
-        every later replay.
+        must run — but with ``set_to_none=False`` whenever a graph is live,
+        because the graph writes into those exact ``.grad`` tensors and freeing
+        them invalidates every later replay. With no live graph (capture
+        disabled after repeated failures) the ordinary ``set_to_none=True`` is
+        both safe and marginally faster.
 
         Args:
             epoch: Current epoch index.
@@ -753,7 +798,8 @@ class SRLightning(lightning.LightningModule):
         if not self.training_config.cuda_graph:
             super().optimizer_zero_grad(epoch, batch_idx, optimizer)
         elif not self._graphed_step:
-            optimizer.zero_grad(set_to_none=False)
+            live = self._cuda_graph is not None and self._cuda_graph.captured
+            optimizer.zero_grad(set_to_none=not live)
 
     def validation_step(
         self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int, dataloader_idx: int = 0

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -707,6 +707,7 @@ class SRLightning(lightning.LightningModule):
             optimizer = self.optimizers()
             self._cuda_graph = CUDAGraphStep(
                 lambda b: self._step(b, need_sr_rgb=False)[0],
+                self,
                 getattr(optimizer, "optimizer", optimizer),
             )
         loss = self._cuda_graph.run(batch)
@@ -715,6 +716,12 @@ class SRLightning(lightning.LightningModule):
 
     def backward(self, loss: torch.Tensor, *args: Any, **kwargs: Any) -> None:
         """Backpropagate ``loss``, unless the captured graph already did.
+
+        On an eager fallback step this writes into the same ``.grad`` tensors the
+        captured graph holds addresses for, which is only safe while
+        ``create_graph`` stays ``False`` — a double-backward pass makes ``.grad``
+        a graph-tracked tensor and can rebind it, invalidating every later replay.
+        Nothing in this project passes ``create_graph``.
 
         Args:
             loss: Scalar loss returned by :meth:`training_step`.
@@ -817,11 +824,20 @@ class SRLightning(lightning.LightningModule):
         ``training_config.example_input_shape`` is unset — there is then no
         input shape to probe with (both shipped templates set it).
 
+        Any graph captured by a previous ``fit`` on this module is dropped here,
+        unconditionally. ``Strategy.teardown`` moves the module — and its
+        ``.grad`` tensors — back to CPU at the end of a fit, which frees the
+        device blocks the graph baked addresses for; replaying it in a second
+        ``fit`` would write into freed memory. Re-capturing is cheap (three
+        warm-up iterations) and happens on the next graphed step.
+
         Raises:
             RuntimeError: Via :meth:`_check_cuda_graph_prerequisites` when
                 ``training_config.cuda_graph`` is set on a run that cannot
                 honour it.
         """
+        self._cuda_graph = None
+        self._graphed_step = False
         if self.training_config.cuda_graph:
             self._check_cuda_graph_prerequisites()
         if self._compiled is None or self.training_config.example_input_shape is None:
@@ -830,34 +846,60 @@ class SRLightning(lightning.LightningModule):
         with torch.no_grad():
             self._compiled(dummy)
 
+    def on_train_epoch_start(self) -> None:
+        """Re-assert the CUDA-graph prerequisites at the top of every epoch.
+
+        ``on_fit_start`` alone is not enough:
+        :class:`~lightning.pytorch.callbacks.GradientAccumulationScheduler`
+        *requires* ``trainer.accumulate_grad_batches`` to still be 1 when
+        training starts and only raises it from its own
+        ``on_train_epoch_start``, so a once-at-fit-start check is guaranteed to
+        read 1 and pass, and accumulation would then silently take effect from
+        the scheduled epoch. Lightning runs callback hooks before this module
+        hook, so by here the scheduler's value for this epoch is already in
+        place.
+
+        Raises:
+            RuntimeError: Via :meth:`_check_cuda_graph_prerequisites` when a
+                prerequisite stopped holding since ``fit`` began.
+        """
+        if self.training_config.cuda_graph:
+            self._check_cuda_graph_prerequisites()
+
     def _check_cuda_graph_prerequisites(self) -> None:
         """Refuse ``cuda_graph=True`` on a run whose semantics it would change.
 
         Each of these would otherwise mistrain silently rather than crash, so
-        they are hard refusals at the start of ``fit``, not warnings. Checked in
+        they are hard refusals, not warnings. Checked in
         config-then-environment order so a misconfiguration is reported even on
-        a machine with no GPU to run on.
+        a machine with no GPU to run on. Called from ``on_fit_start`` and again
+        from :meth:`on_train_epoch_start`, since a callback can move
+        ``accumulate_grad_batches`` after ``fit`` has begun.
 
         Raises:
-            RuntimeError: If precision is not ``'32-true'`` (a ``GradScaler``
-                scales the loss in ``pre_backward``, which a captured backward
-                never sees, and autocast's cast churn is a measured regression
-                on this project besides); if the run is distributed (capture and
-                DDP's gradient hooks conflict — DDP stashes ``AccumulateGrad``
-                references); if ``accumulate_grad_batches > 1`` (Lightning zeroes
-                gradients only on the first micro-batch and expects the rest to
-                accumulate, but every replay zeroes them, and the loss is not
-                scaled by the accumulation factor); or if the accelerator is not
-                CUDA.
+            RuntimeError: If precision is not ``'32-true'``; if the run is
+                distributed (capture and DDP's gradient hooks conflict — DDP
+                stashes ``AccumulateGrad`` references); if
+                ``accumulate_grad_batches > 1`` (Lightning zeroes gradients only
+                on the first micro-batch and expects the rest to accumulate, but
+                every replay zeroes them, and the loss is not scaled by the
+                accumulation factor); or if the accelerator is not CUDA.
         """
         trainer = self.trainer
         if trainer.precision != "32-true":
+            reason = (
+                "its GradScaler scales the loss in the precision plugin's pre_backward "
+                "hook, which a captured backward pass never runs, so gradients would be "
+                "silently unscaled"
+                if trainer.precision == "16-mixed"
+                else "the captured region's dtypes and autocast state are fixed at capture "
+                "time and this path is only validated for full fp32 (bf16 is a measured "
+                "regression on this project's architectures besides)"
+            )
             raise RuntimeError(
                 f"training_config.cuda_graph=True requires trainer.precision='32-true', "
-                f"got {trainer.precision!r}. Mixed precision scales the loss in the "
-                f"precision plugin's pre_backward hook, which a captured backward pass "
-                f"never runs, so gradients would be silently unscaled. Set "
-                f"trainer.precision to 32-true, or cuda_graph to false."
+                f"got {trainer.precision!r}: {reason}. Set trainer.precision to 32-true, "
+                f"or cuda_graph to false."
             )
         if trainer.world_size > 1:
             raise RuntimeError(

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -36,6 +36,11 @@ model:
       # than mistrain quietly -- re-checked every epoch, since a callback can
       # switch accumulation on after fit starts), and the win shrinks on
       # architectures whose GPU time is real compute rather than launch overhead.
+      # Also incompatible with num_workers > 0 AND pin_memory together: the
+      # pin-memory thread's cudaHostAlloc can invalidate a capture mid-flight and
+      # kill the run (measured 1 crash in 6 fits at w16+pin, 0 in 8 without pin),
+      # so that combination logs a warning and trains eagerly instead. The
+      # num_workers: 0 below pins on the main thread, so it captures fine.
       # cuda_graph: true
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -32,9 +32,10 @@ model:
       # this template's batch 64 / 33x33 geometry, losses bit-identical to eager --
       # SRCNN's step is launch-bound, so removing the launches is nearly all of it.
       # Off by default: it requires precision 32-true, one device, no gradient
-      # accumulation and no compile_backend (SRLightning.on_fit_start refuses the
-      # rest rather than mistrain quietly), and the win shrinks on architectures
-      # whose GPU time is real compute rather than launch overhead.
+      # accumulation and no compile_backend (SRLightning refuses the rest rather
+      # than mistrain quietly -- re-checked every epoch, since a callback can
+      # switch accumulation on after fit starts), and the win shrinks on
+      # architectures whose GPU time is real compute rather than launch overhead.
       # cuda_graph: true
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -27,6 +27,15 @@ model:
       # No longer only a TensorBoard-graph dummy -- it also shapes the compile warm-up
       # (a wrong size compiles once then recompiles on step 1) and ModelSummary's FLOPs.
       example_input_shape: [1, 33, 33]
+      # Replay one captured graph of {zero_grad, forward, loss, backward} per step
+      # instead of relaunching 78 kernels. Measured 5.91 -> 2.23 ms/step (2.65x) at
+      # this template's batch 64 / 33x33 geometry, losses bit-identical to eager --
+      # SRCNN's step is launch-bound, so removing the launches is nearly all of it.
+      # Off by default: it requires precision 32-true, one device, no gradient
+      # accumulation and no compile_backend (SRLightning.on_fit_start refuses the
+      # rest rather than mistrain quietly), and the win shrinks on architectures
+      # whose GPU time is real compute rather than launch overhead.
+      # cuda_graph: true
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig
 

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -28,19 +28,20 @@ model:
       # (a wrong size compiles once then recompiles on step 1) and ModelSummary's FLOPs.
       example_input_shape: [1, 33, 33]
       # Replay one captured graph of {zero_grad, forward, loss, backward} per step
-      # instead of relaunching 78 kernels. Measured 5.91 -> 2.23 ms/step (2.65x) at
-      # this template's batch 64 / 33x33 geometry, losses bit-identical to eager --
-      # SRCNN's step is launch-bound, so removing the launches is nearly all of it.
-      # Off by default: it requires precision 32-true, one device, no gradient
+      # instead of relaunching 78 kernels. Real-DIV2K measurement at this template's
+      # geometry (num_workers 16, pin_memory false): 14.9 -> 8.3 ms/step (~1.8x; the
+      # full 1e7-step budget drops ~41 h -> ~23 h), losses bit-identical to eager.
+      # SRCNN's step is launch-bound, so removing the launches is nearly all of it;
+      # compute-bound architectures gain less but still gain (SRResNet ~1.4x).
+      # Off by default: requires precision 32-true, one device, no gradient
       # accumulation and no compile_backend (SRLightning refuses the rest rather
       # than mistrain quietly -- re-checked every epoch, since a callback can
-      # switch accumulation on after fit starts), and the win shrinks on
-      # architectures whose GPU time is real compute rather than launch overhead.
-      # Also incompatible with num_workers > 0 AND pin_memory together: the
-      # pin-memory thread's cudaHostAlloc can invalidate a capture mid-flight and
-      # kill the run (measured 1 crash in 6 fits at w16+pin, 0 in 8 without pin),
-      # so that combination logs a warning and trains eagerly instead. The
-      # num_workers: 0 below pins on the main thread, so it captures fine.
+      # switch accumulation on after fit starts).
+      # When enabling this, also set pin_memory: false below: the pin-memory
+      # thread's cudaHostAlloc can invalidate a capture mid-flight (the only
+      # measured capture crashes came from graphs + workers + pinning), so that
+      # combination is refused with a warning and trains eagerly. Dropping pinning
+      # measured neutral-to-positive here (the pin thread contends for the GIL).
       # cuda_graph: true
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -17,6 +17,7 @@ def test_sr_training_config_defaults():
     assert cfg.init_std == 0.01
     assert cfg.scale is None
     assert cfg.compile_backend is None
+    assert cfg.cuda_graph is False
 
 
 def test_sr_eval_config_defaults():
@@ -56,7 +57,22 @@ def test_sr_training_config_field_names():
         "init_std",
         "scale",
         "compile_backend",
+        "cuda_graph",
     }
+
+
+def test_training_config_rejects_cuda_graph_with_compile_backend():
+    """Both take over the training-mode forward and each needs its own warm-up,
+    so the combination would capture a graph around a half-warmed compiled
+    callable. Fails at config construction, not at the first training step."""
+    with pytest.raises(ValueError, match="incompatible with compile_backend"):
+        SRTrainingConfig(cuda_graph=True, compile_backend="eager")
+
+
+def test_training_config_allows_cuda_graph_without_compile_backend():
+    cfg = SRTrainingConfig(cuda_graph=True)
+    assert cfg.cuda_graph is True
+    assert cfg.compile_backend is None
 
 
 def test_sr_eval_config_field_names():

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import lightning
 import pytest
 import torch
+from lightning.pytorch.callbacks import GradientAccumulationScheduler
 from torch.utils.data import DataLoader, Dataset
 
 from sisr.models.srcnn import SRCNN
@@ -32,6 +33,7 @@ from sisr.training import (
     SRPredictionWriter,
     SRTrainingConfig,
 )
+from sisr.training.cuda_graph import CUDAGraphStep
 
 
 def _make_srcnn_module() -> SRLightning:
@@ -392,3 +394,102 @@ def test_cuda_graph_leaves_lr_scheduler_effective():
 
     assert graphed == eager
     assert module.optimizers().param_groups[0]["lr"] < 1e-3
+
+
+def _graph_srcnn_module() -> SRLightning:
+    """The module `_run_graph_fit` builds, for tests that need to reuse one."""
+    return SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(cuda_graph=True),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-3, momentum=0.9),
+    )
+
+
+def _graph_trainer(callbacks: list, **overrides) -> lightning.Trainer:
+    return lightning.Trainer(
+        accelerator="cuda",
+        devices=1,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        benchmark=True,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        callbacks=callbacks,
+        **overrides,
+    )
+
+
+@requires_cuda
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+@pytest.mark.filterwarnings("ignore:When using:UserWarning")
+def test_cuda_graph_refuses_accumulation_scheduled_mid_run():
+    """GradientAccumulationScheduler only raises accumulate_grad_batches from its
+    own on_train_epoch_start, so a refusal checked once at fit start is
+    guaranteed to miss it and training would silently degrade from the scheduled
+    epoch — every replay re-zeroes, leaving only the last micro-batch's
+    gradient, unscaled. Lightning merely warns about our optimizer_zero_grad
+    override here; it does not stop the run."""
+    lightning.seed_everything(7, verbose=False)
+    module = _graph_srcnn_module()
+    trainer = _graph_trainer(
+        [GradientAccumulationScheduler(scheduling={2: 2})], max_epochs=3, max_steps=-1
+    )
+    loader = DataLoader(_FixedPairs(16), batch_size=4, num_workers=0, shuffle=False)
+
+    with pytest.raises(RuntimeError, match="does not support gradient accumulation"):
+        trainer.fit(module, train_dataloaders=loader)
+
+
+@requires_cuda
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_cuda_graph_recaptures_on_a_second_fit():
+    """Strategy.teardown moves the module and its .grad tensors back to CPU at the
+    end of a fit, freeing the blocks the graph baked addresses for. A second fit
+    must capture afresh; replaying the first fit's graph writes into freed
+    memory."""
+    lightning.seed_everything(7, verbose=False)
+    module = _graph_srcnn_module()
+    loader = DataLoader(_FixedPairs(16), batch_size=4, num_workers=0, shuffle=False)
+
+    graph_ids = []
+    for _ in range(2):
+        trace = _LossTrace()
+        _graph_trainer([trace], max_steps=8).fit(module, train_dataloaders=loader)
+        assert module._cuda_graph is not None and module._cuda_graph.captured
+        graph_ids.append(id(module._cuda_graph))
+        assert all(loss == loss for loss in trace.losses)  # no NaN from freed memory
+        assert len(trace.losses) == 8
+
+    assert graph_ids[0] != graph_ids[1], "second fit reused the first fit's dead graph"
+
+
+@requires_cuda
+def test_cuda_graph_capture_leaves_batchnorm_buffers_untouched():
+    """The warm-up's forwards advance BatchNorm running stats, and SRResNet's
+    residual blocks have BatchNorm — so capture would silently perturb them
+    (decaying as 0.9^n) without the snapshot/restore. SRCNN has no buffers, so
+    no SRCNN parity test can catch this."""
+    lightning.seed_everything(7, verbose=False)
+    module = SRLightning(
+        model=SRResNet(scale=2, num_residual_blocks=1),
+        processor=RGBProcessor(),
+        training_config=SRResNetTrainingConfig(scale=2, cuda_graph=True),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-3),
+    ).to("cuda")
+    module.train()
+    before = {name: buf.detach().clone() for name, buf in module.named_buffers()}
+    assert any("running_mean" in name for name in before)
+
+    step = CUDAGraphStep(
+        lambda b: module._step(b, need_sr_rgb=False)[0], module, module.configure_optimizers()
+    )
+    step.capture((torch.rand(2, 3, 8, 8, device="cuda"), torch.rand(2, 3, 16, 16, device="cuda")))
+
+    assert step.captured
+    for name, buf in module.named_buffers():
+        assert torch.equal(buf, before[name]), name

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -455,16 +455,18 @@ def test_cuda_graph_recaptures_on_a_second_fit():
     module = _graph_srcnn_module()
     loader = DataLoader(_FixedPairs(16), batch_size=4, num_workers=0, shuffle=False)
 
-    graph_ids = []
+    # The objects, not their id()s: on_fit_start drops the first CUDAGraphStep, so
+    # comparing id()s of a freed object could pass or fail on allocator reuse.
+    graphs = []
     for _ in range(2):
         trace = _LossTrace()
         _graph_trainer([trace], max_steps=8).fit(module, train_dataloaders=loader)
         assert module._cuda_graph is not None and module._cuda_graph.captured
-        graph_ids.append(id(module._cuda_graph))
+        graphs.append(module._cuda_graph)
         assert all(loss == loss for loss in trace.losses)  # no NaN from freed memory
         assert len(trace.losses) == 8
 
-    assert graph_ids[0] != graph_ids[1], "second fit reused the first fit's dead graph"
+    assert graphs[0] is not graphs[1], "second fit reused the first fit's dead graph"
 
 
 @requires_cuda

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import lightning
 import pytest
 import torch
+from torch.utils.data import DataLoader, Dataset
 
 from sisr.models.srcnn import SRCNN
 from sisr.models.srresnet import SRResNetTrainingConfig
@@ -29,6 +30,7 @@ from sisr.training import (
     SREvalConfig,
     SRLightning,
     SRPredictionWriter,
+    SRTrainingConfig,
 )
 
 
@@ -280,3 +282,113 @@ def test_predict_end_to_end_srresnet_rgb_upsamples_by_scale(
     for name in written:
         with Image.open(out_dir / f"{name}.png") as img:
             assert img.size == (72, 72)
+
+
+# ---------------------------------------------------------------------------
+# cuda_graph — graphed training must be indistinguishable from eager
+# ---------------------------------------------------------------------------
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA graph capture needs a CUDA device"
+)
+
+
+class _FixedPairs(Dataset):
+    """Deterministic same-shape ``(lr, hr)`` RGB pairs — no decode, no randomness."""
+
+    def __init__(self, n: int):
+        g = torch.Generator().manual_seed(0)
+        self.pairs = [
+            (torch.rand(3, 16, 16, generator=g), torch.rand(3, 16, 16, generator=g))
+            for _ in range(n)
+        ]
+
+    def __len__(self) -> int:
+        return len(self.pairs)
+
+    def __getitem__(self, i: int) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.pairs[i]
+
+
+class _LossTrace(lightning.Callback):
+    """Records the per-step training loss so two runs can be compared exactly."""
+
+    def __init__(self):
+        self.losses: list[float] = []
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        self.losses.append(float(outputs["loss"]))
+
+
+def _run_graph_fit(
+    cuda_graph: bool, n_samples: int, max_steps: int, lr_scheduler=None
+) -> tuple[list[float], SRLightning]:
+    """Fit a graphed-or-eager SRCNN over ``_FixedPairs`` and return its loss trace."""
+    lightning.seed_everything(7, verbose=False)
+    module = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(cuda_graph=cuda_graph),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-3, momentum=0.9),
+        lr_scheduler=lr_scheduler,
+    )
+    trace = _LossTrace()
+    trainer = lightning.Trainer(
+        accelerator="cuda",
+        devices=1,
+        max_steps=max_steps,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        benchmark=True,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        callbacks=[trace],
+    )
+    loader = DataLoader(_FixedPairs(n_samples), batch_size=4, num_workers=0, shuffle=False)
+    trainer.fit(module, train_dataloaders=loader)
+    return trace.losses, module
+
+
+@requires_cuda
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_cuda_graph_loss_trace_is_bit_identical_to_eager():
+    """Graphed training must be numerically indistinguishable from eager, not
+    merely close: the capture warm-up runs three extra backward passes, and any
+    of them leaking into the weights (or a missed zero_grad) shifts the trace."""
+    eager, _ = _run_graph_fit(cuda_graph=False, n_samples=16, max_steps=12)
+    graphed, module = _run_graph_fit(cuda_graph=True, n_samples=16, max_steps=12)
+
+    assert module._cuda_graph is not None and module._cuda_graph.captured
+    assert len(graphed) == 12
+    assert graphed == eager
+
+
+@requires_cuda
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_cuda_graph_partial_last_batch_falls_back_without_stale_gradients():
+    """14 samples at batch 4 ends every epoch with a 2-sample batch the graph
+    cannot replay. Gating the backward/zero_grad no-ops per run instead of per
+    step makes that batch step on the previous replay's gradients — a silent
+    duplicated update this exact-equality trace catches."""
+    eager, _ = _run_graph_fit(cuda_graph=False, n_samples=14, max_steps=12)
+    graphed, _ = _run_graph_fit(cuda_graph=True, n_samples=14, max_steps=12)
+
+    assert graphed == eager
+
+
+@requires_cuda
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_cuda_graph_leaves_lr_scheduler_effective():
+    """optimizer.step() is deliberately left out of the capture, so a scheduler's
+    learning-rate changes still reach the weights. Capturing it would bake the LR
+    in as a graph constant (torch.optim.SGD has no `capturable` opt-out) and
+    every scheduler would silently no-op."""
+    scheduler = functools.partial(torch.optim.lr_scheduler.StepLR, step_size=1, gamma=0.5)
+    eager, _ = _run_graph_fit(False, n_samples=16, max_steps=12, lr_scheduler=scheduler)
+    graphed, module = _run_graph_fit(True, n_samples=16, max_steps=12, lr_scheduler=scheduler)
+
+    assert graphed == eager
+    assert module.optimizers().param_groups[0]["lr"] < 1e-3

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1639,3 +1639,142 @@ def test_setup_gracefully_reprobes_dataset_already_opened_by_real_training(
     dm.train_dataset[0]  # simulate a real in-process (num_workers=0) training read
 
     lit.setup(stage="fit")  # must not raise on the re-probe
+
+
+# ---------------------------------------------------------------------------
+# cuda_graph — full-step CUDA-graph capture of the training step
+# ---------------------------------------------------------------------------
+
+
+def _graph_lit(cuda_graph: bool = True) -> SRLightning:
+    """Small SRCNN wired for graphed training. The gating logic these tests
+    exercise is device-independent, so they run on CPU CI."""
+    model = SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same")
+    return SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(cuda_graph=cuda_graph),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def _fake_trainer(**overrides) -> SimpleNamespace:
+    """Minimal trainer stand-in exposing what the prerequisite checks read."""
+    return SimpleNamespace(
+        **{"precision": "32-true", "world_size": 1, "accumulate_grad_batches": 1, **overrides}
+    )
+
+
+def test_cuda_graph_defaults_off_and_leaves_step_state_clean():
+    lit = _graph_lit(cuda_graph=False)
+    assert lit._cuda_graph is None
+    assert lit._graphed_step is False
+
+
+def test_cuda_graph_backward_runs_when_step_was_not_graphed(rgb_lr_hr_batch):
+    """The eager fallback path must still backpropagate. A per-run gate (skip
+    backward whenever a graph exists) leaves .grad holding whatever the last
+    replay produced, so the epoch's partial last batch contributes a duplicated
+    update instead of its own."""
+    lit = _graph_lit()
+    lit._graphed_step = False
+    loss, *_ = lit._step(rgb_lr_hr_batch, need_sr_rgb=False)
+
+    lit.backward(loss)
+
+    assert lit.model.recon.weight.grad is not None
+    assert lit.model.recon.weight.grad.abs().sum() > 0
+
+
+def test_cuda_graph_backward_skipped_when_step_was_graphed(rgb_lr_hr_batch):
+    """On a graphed step the replay already ran backward; running it again here
+    would double the gradients."""
+    lit = _graph_lit()
+    loss, *_ = lit._step(rgb_lr_hr_batch, need_sr_rgb=False)
+    lit._graphed_step = True
+
+    lit.backward(loss)
+
+    assert lit.model.recon.weight.grad is None
+
+
+def test_cuda_graph_zero_grad_is_noop_on_graphed_step(rgb_lr_hr_batch):
+    """Lightning's closure order is training_step -> zero_grad -> backward, so
+    zeroing here on a graphed step would hand the optimizer nothing but zeros —
+    training would silently stop converging."""
+    lit = _graph_lit()
+    optimizer = lit.configure_optimizers()
+    lit._step(rgb_lr_hr_batch, need_sr_rgb=False)[0].backward()
+    before = lit.model.recon.weight.grad.clone()
+    lit._graphed_step = True
+
+    lit.optimizer_zero_grad(0, 0, optimizer)
+
+    assert torch.equal(lit.model.recon.weight.grad, before)
+
+
+def test_cuda_graph_zero_grad_on_fallback_step_keeps_grad_buffers_allocated(rgb_lr_hr_batch):
+    """set_to_none=True would free the exact .grad tensors the captured graph
+    writes into, invalidating every later replay — so the fallback path zeroes
+    in place instead."""
+    lit = _graph_lit()
+    optimizer = lit.configure_optimizers()
+    lit._step(rgb_lr_hr_batch, need_sr_rgb=False)[0].backward()
+    lit._graphed_step = False
+
+    lit.optimizer_zero_grad(0, 0, optimizer)
+
+    grad = lit.model.recon.weight.grad
+    assert grad is not None
+    assert torch.count_nonzero(grad) == 0
+
+
+def test_zero_grad_unchanged_when_cuda_graph_off(rgb_lr_hr_batch):
+    """Flag off must leave Lightning's own set_to_none=True behaviour intact."""
+    lit = _graph_lit(cuda_graph=False)
+    optimizer = lit.configure_optimizers()
+    lit._step(rgb_lr_hr_batch, need_sr_rgb=False)[0].backward()
+
+    lit.optimizer_zero_grad(0, 0, optimizer)
+
+    assert lit.model.recon.weight.grad is None
+
+
+def test_cuda_graph_refuses_mixed_precision():
+    """A GradScaler scales the loss in the precision plugin's pre_backward hook,
+    which a captured backward never runs — gradients would be silently unscaled."""
+    lit = _graph_lit()
+    lit.trainer = _fake_trainer(precision="16-mixed")
+    with pytest.raises(RuntimeError, match="requires trainer.precision='32-true'"):
+        lit.on_fit_start()
+
+
+def test_cuda_graph_refuses_distributed_run():
+    lit = _graph_lit()
+    lit.trainer = _fake_trainer(world_size=2)
+    with pytest.raises(RuntimeError, match="does not support distributed training"):
+        lit.on_fit_start()
+
+
+def test_cuda_graph_refuses_gradient_accumulation():
+    """Every replay zeroes the gradients, so nothing accumulates across
+    micro-batches."""
+    lit = _graph_lit()
+    lit.trainer = _fake_trainer(accumulate_grad_batches=2)
+    with pytest.raises(RuntimeError, match="does not support gradient accumulation"):
+        lit.on_fit_start()
+
+
+def test_cuda_graph_refuses_non_cuda_device():
+    lit = _graph_lit()
+    lit.trainer = _fake_trainer()
+    with pytest.raises(RuntimeError, match="requires a CUDA device"):
+        lit.on_fit_start()
+
+
+def test_cuda_graph_off_skips_prerequisite_checks():
+    """The refusals are scoped to the flag — an ordinary bf16 CPU run is untouched."""
+    lit = _graph_lit(cuda_graph=False)
+    lit.trainer = _fake_trainer(precision="bf16-mixed", world_size=4)
+    lit.on_fit_start()

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -1725,6 +1726,7 @@ def test_cuda_graph_zero_grad_on_fallback_step_keeps_grad_buffers_allocated(rgb_
     optimizer = lit.configure_optimizers()
     lit._step(rgb_lr_hr_batch, need_sr_rgb=False)[0].backward()
     lit._graphed_step = False
+    lit._cuda_graph = SimpleNamespace(captured=True)  # a live graph owns the buffers
 
     lit.optimizer_zero_grad(0, 0, optimizer)
 
@@ -1871,3 +1873,147 @@ def test_cuda_graph_step_never_calls_optimizer_step():
     source = inspect.getsource(CUDAGraphStep)
     assert "_optimizer.zero_grad" in source
     assert "_optimizer.step" not in source
+
+
+def _capture_step(module, **kwargs) -> CUDAGraphStep:
+    return CUDAGraphStep(
+        lambda b: module._step(b, need_sr_rgb=False)[0], module, MagicMock(), **kwargs
+    )
+
+
+def test_cuda_graph_fallback_warns_once_after_repeated_shape_rejections():
+    """A run whose captured shape never recurs pays eager cost with the flag on and
+    reports no speedup, with nothing in the log to say why."""
+    step = _capture_step(_graph_lit(), fallback_warn_after=3)
+    step._static_batch = (torch.zeros(4, 3, 8, 8), torch.zeros(4, 3, 8, 8))
+    rejected = (torch.zeros(2, 3, 8, 8), torch.zeros(2, 3, 8, 8))
+
+    with pytest.warns(UserWarning, match="all fell back to an eager step"):
+        for _ in range(3):
+            step._note_fallback(rejected)
+
+    with warnings.catch_warnings():  # the warning is once per run, not per batch
+        warnings.simplefilter("error")
+        for _ in range(5):
+            step._note_fallback(rejected)
+
+
+def test_cuda_graph_fallback_counter_resets_on_a_matching_batch():
+    """Only a *run* of rejections means the graph is buying nothing — one per epoch
+    is the normal partial last batch and must never warn."""
+    step = _capture_step(_graph_lit(), fallback_warn_after=3)
+    step._static_batch = (torch.zeros(4, 3, 8, 8),)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        for _ in range(10):
+            step._note_fallback((torch.zeros(2, 3, 8, 8),))
+            step._consecutive_fallbacks = 0  # what a successful replay does
+    assert step._fallback_warned is False
+
+
+def test_cuda_graph_capture_failure_falls_back_instead_of_raising():
+    """A capture-time failure must never kill the run: a crashed 10M-step run at
+    minute one is far worse than an eager one that says so. Retries are exhausted,
+    one warning names the error, and run() reports 'no graph' from then on."""
+    step = _capture_step(_graph_lit(), retry_delays=(0.0, 0.0))
+    calls = []
+
+    def boom(_batch):
+        calls.append(1)
+        raise RuntimeError("CUDA error: operation failed due to a previous error")
+
+    step.capture = boom
+    step._drain_error_state = lambda: None
+    batch = (torch.zeros(2, 3, 8, 8), torch.zeros(2, 3, 8, 8))
+
+    with pytest.warns(UserWarning, match="capture failed 3 times and is now disabled"):
+        assert step.run(batch) is None
+
+    assert len(calls) == 3, "should retry, then give up"
+    assert step.disabled and not step.captured
+
+    with warnings.catch_warnings():  # subsequent steps are silent and stop retrying
+        warnings.simplefilter("error")
+        for _ in range(5):
+            assert step.run(batch) is None
+    assert len(calls) == 3
+
+
+def test_cuda_graph_zero_grad_uses_set_to_none_once_capture_is_disabled(rgb_lr_hr_batch):
+    """With no live graph there are no static .grad buffers to protect, so the
+    fallback path should not keep paying for the graph-safe zeroing."""
+    lit = _graph_lit()
+    optimizer = lit.configure_optimizers()
+    lit._cuda_graph = _capture_step(lit)
+    lit._cuda_graph._disabled = True
+    lit._graphed_step = False
+    lit._step(rgb_lr_hr_batch, need_sr_rgb=False)[0].backward()
+
+    lit.optimizer_zero_grad(0, 0, optimizer)
+
+    assert lit.model.recon.weight.grad is None
+
+
+def test_cuda_graph_capture_retry_succeeds_without_warning():
+    """Capture is invalidated by concurrent implicit device syncs, which cluster in
+    a startup burst, so a retry a moment later is expected to work — and must not
+    leave the run permanently degraded or emit a scary warning."""
+    step = _capture_step(_graph_lit(), retry_delays=(0.0, 0.0))
+    attempts = []
+
+    def flaky(batch):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("CUDA error: operation failed due to a previous error")
+        step._graph = MagicMock()
+        step._static_loss = torch.zeros(())
+        step._static_batch = tuple(t.detach().clone() for t in batch)
+
+    step.capture = flaky
+    step._drain_error_state = lambda: None
+    batch = (torch.zeros(2, 3, 8, 8), torch.zeros(2, 3, 8, 8))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        loss = step.run(batch)
+
+    assert len(attempts) == 2
+    assert loss is not None
+    assert step.captured and not step.disabled
+
+
+@pytest.mark.parametrize(
+    ("workers", "pin", "unsafe"),
+    [(0, True, False), (0, False, False), (16, False, False), (16, True, True), (1, True, True)],
+)
+def test_cuda_graph_flags_worker_pin_memory_combination_as_unsafe(workers, pin, unsafe):
+    """num_workers>0 with pin_memory=True runs a pinning thread whose cudaHostAlloc
+    can invalidate an open capture; measured 1 crash in 6 fits at w16+pin vs 0 in 8
+    without pin. num_workers=0 pins inline, so it is safe and both templates use it."""
+    lit = _graph_lit()
+    lit.trainer = SimpleNamespace(
+        train_dataloader=SimpleNamespace(num_workers=workers, pin_memory=pin)
+    )
+    reason = lit._unsafe_capture_reason()
+    assert (reason is not None) == unsafe
+    if unsafe:
+        assert "pin_memory" in reason and "eagerly" in reason
+
+
+def test_unsafe_capture_reason_tolerates_a_missing_dataloader():
+    """on_fit_start runs before Lightning builds the train loader, so the probe has
+    to degrade to 'no reason to worry' rather than raise."""
+    lit = _graph_lit()
+    lit.trainer = SimpleNamespace()
+    assert lit._unsafe_capture_reason() is None
+
+
+def test_cuda_graph_disable_warns_once_and_sticks():
+    step = _capture_step(_graph_lit())
+    with pytest.warns(UserWarning, match="capture disabled: because"):
+        step.disable("because")
+    assert step.disabled
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert step.run((torch.zeros(1),)) is None

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -8,6 +9,7 @@ import pytest
 import torch
 import torch._dynamo
 import torchmetrics
+from lightning.pytorch.callbacks import GradientAccumulationScheduler
 
 from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
 from sisr.models.srresnet import SRResNetTrainingConfig
@@ -20,6 +22,7 @@ from sisr.processors import (
     YChannelProcessor,
 )
 from sisr.training import SRDataModule, SREvalConfig, SRLightning, SRTrainingConfig
+from sisr.training.cuda_graph import CUDAGraphStep
 
 # ---------------------------------------------------------------------------
 # fixtures
@@ -1778,3 +1781,93 @@ def test_cuda_graph_off_skips_prerequisite_checks():
     lit = _graph_lit(cuda_graph=False)
     lit.trainer = _fake_trainer(precision="bf16-mixed", world_size=4)
     lit.on_fit_start()
+
+
+def test_gradient_accumulation_scheduler_raises_accumulation_only_at_epoch_start():
+    """Pins the Lightning behaviour that makes a once-at-fit-start refusal
+    useless: GradientAccumulationScheduler requires accumulate_grad_batches to
+    still be 1 when training starts, and only raises it from its own
+    on_train_epoch_start. Breaks loudly if a future Lightning moves that."""
+    cb = GradientAccumulationScheduler(scheduling={2: 2})
+    trainer = SimpleNamespace(accumulate_grad_batches=1, current_epoch=0)
+
+    cb.on_train_epoch_start(trainer)
+    assert trainer.accumulate_grad_batches == 1
+
+    trainer.current_epoch = 2
+    cb.on_train_epoch_start(trainer)
+    assert trainer.accumulate_grad_batches == 2
+
+
+def test_cuda_graph_refuses_accumulation_turned_on_after_fit_start():
+    """The refusal has to be re-asserted per epoch: accumulation switched on by a
+    callback after on_fit_start would otherwise let every replay re-zero the
+    gradients, leaving only the last micro-batch's, unscaled."""
+    lit = _graph_lit()
+    lit.trainer = _fake_trainer(accumulate_grad_batches=2)
+    with pytest.raises(RuntimeError, match="does not support gradient accumulation"):
+        lit.on_train_epoch_start()
+
+
+def test_cuda_graph_epoch_check_silent_while_prerequisites_hold():
+    lit = _graph_lit()
+    lit.trainer = _fake_trainer(accumulate_grad_batches=1)
+    with pytest.raises(RuntimeError, match="requires a CUDA device"):
+        lit.on_train_epoch_start()  # only the device check fires on a CPU box
+
+
+def test_cuda_graph_epoch_check_skipped_when_flag_off():
+    lit = _graph_lit(cuda_graph=False)
+    lit.trainer = _fake_trainer(accumulate_grad_batches=8, precision="bf16-mixed")
+    lit.on_train_epoch_start()
+
+
+def test_new_fit_drops_a_graph_captured_by_a_previous_fit():
+    """Strategy.teardown moves the module and its .grad tensors back to CPU at
+    the end of a fit, freeing the device blocks the graph baked addresses for.
+    Replaying it in a second fit would write into freed memory."""
+    lit = _graph_lit(cuda_graph=False)
+    lit._cuda_graph = object()
+    lit._graphed_step = True
+    lit.trainer = _fake_trainer()
+
+    lit.on_fit_start()
+
+    assert lit._cuda_graph is None
+    assert lit._graphed_step is False
+
+
+def test_cuda_graph_buffer_snapshot_restores_batchnorm_running_stats():
+    """The capture warm-up runs forwards, which advance BatchNorm's running
+    stats and num_batches_tracked. SRResNet's residual blocks have BatchNorm, so
+    without the snapshot/restore capture would silently perturb them — invisible
+    to any SRCNN-only parity test, since SRCNN has no buffers at all."""
+    lit = _srresnet_lit(scale=2)
+    step = CUDAGraphStep(lambda b: lit._step(b, need_sr_rgb=False)[0], lit, MagicMock())
+    lit.train()
+    names = [n for n, _ in lit.named_buffers()]
+    assert any("running_mean" in n for n in names) and any(
+        "num_batches_tracked" in n for n in names
+    )
+
+    snapshot = step._buffer_snapshot()
+    lr = torch.rand(2, 3, 8, 8)
+    for _ in range(3):
+        lit._step((lr, torch.rand(2, 3, 16, 16)), need_sr_rgb=False)
+    assert not all(torch.equal(buf, snapshot[name]) for name, buf in lit.named_buffers()), (
+        "forwards must move the buffers, or this test proves nothing"
+    )
+
+    step._restore_buffers(snapshot)
+
+    for name, buf in lit.named_buffers():
+        assert torch.equal(buf, snapshot[name]), name
+
+
+def test_cuda_graph_step_never_calls_optimizer_step():
+    """Guards the deliberate design choice that optimizer.step() stays eager and
+    stays Lightning's: capturing it would bake the learning rate in as a graph
+    constant and silently no-op every LR scheduler."""
+    source = inspect.getsource(CUDAGraphStep)
+    assert "_optimizer.zero_grad" in source
+    assert "_optimizer.step" not in source


### PR DESCRIPTION
## What

Opt-in CUDA-graph capture of the full training step (stacked on #72 → #70; merge those first, then retarget). `SRTrainingConfig.cuda_graph` (default **off**) captures `{zero_grad, extract, model, crop, loss, backward}` into one graph — the optimizer step deliberately stays eager, which is what keeps LR schedulers, `global_step`, grad clipping, and checkpointing working untouched.

**Why:** with the loader myths dispelled, SRCNN's training step is CPU-launch-bound — 78 kernel launches per step with the GPU at 27% utilization. Graph replay collapses them to one launch: measured through the real config surface (the only change being the flag), **5.91 → 2.23 ms/step = 2.65×, with losses bit-identical to 17 digits across interleaved runs**, GPU utilization 27% → 99%. On SRCNN's 10⁷-step budget that is on the order of ten hours saved per full run.

## Safety engineering (the interesting part)

- **Partial batches**: shape-mismatched batches take a bit-exact eager fallback, gated **per step** — a naive per-run gate demonstrably steps the optimizer on stale gradients at every epoch's final partial batch (RED-proven: loss diverges at exactly the first post-partial step).
- **Hard refusals with actionable messages**: mixed/low precision, `compile_backend`, DDP, gradient accumulation — the last re-checked **every epoch**, because `GradientAccumulationScheduler` mutates the value after fit-start and is *guaranteed* to bypass a fit-start-only check (review-caught Critical, RED-proven with the real scheduler).
- **Refit-safe**: graph state resets unconditionally at fit start — a stale graph after Lightning's teardown (which reallocates params/grads on CPU) would otherwise replay into freed memory, and a stale fallback flag would silently skip backprop on a flag-off refit.
- **Warm-up leaves the model bit-identical**: all buffers (BatchNorm running stats included) snapshot/restore around the warm-up forwards — proven on SRResNet, whose BN buffers otherwise drift invisibly to SRCNN-only parity tests.
- **Diagnosable**: one-shot capture log; a warning after persistent consecutive fallbacks so a silent 0%-speedup misconfiguration is visible.
- `lr_scheduler` deliberately **not** refused: the eager optimizer re-reads `param_groups[i]['lr']` every step, so schedulers are correct under this design — verified with a StepLR parity-and-decay test that trips if anyone ever moves the optimizer into the capture.

## Evidence

- Bit-exact parity: 200-step loss traces, exact equality (GPU-gated tests; CI-safe skips — CPU-only run: 483 passed / 8 skipped).
- Suite: **489 passed, 2 skipped**; ruff clean. 26 new tests, 13+ CPU-runnable (refusals, gating, reset, buffer snapshot all guarded without a GPU).
- Reviewed by an Opus reviewer in two rounds of interleaving-level analysis (every Lightning-internals assumption verified against the installed 2.13); one Critical and two Importants found, fixed, and RED-proven; final verdict Approved.

Definitive real-data numbers at Best-performance power state land in a follow-up comment from the batch's serial benchmark pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)