### PR TITLE
Keep graph gradients attached across mid-training validation

### DIFF
--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -801,6 +801,24 @@ class SRLightning(lightning.LightningModule):
             live = self._cuda_graph is not None and self._cuda_graph.captured
             optimizer.zero_grad(set_to_none=not live)
 
+    def on_validation_model_zero_grad(self) -> None:
+        """Skip Lightning's pre-validation gradient release while a graph is live.
+
+        Before each mid-training validation run Lightning frees gradient memory
+        with ``zero_grad(set_to_none=True)``. The replay fills the exact
+        ``.grad`` tensors allocated at capture and never re-binds the
+        parameters' ``.grad`` attributes, so one release severs the link
+        permanently: every later ``optimizer.step()`` sees ``None`` grads and
+        skips every parameter — training silently freezes at the first
+        validation while the logged loss keeps moving with the incoming
+        batches. There is also nothing to free: the tensors live in the
+        graph's private memory pool for the rest of the run either way. Eager
+        runs keep Lightning's release.
+        """
+        live = self._cuda_graph is not None and self._cuda_graph.captured
+        if not live:
+            super().on_validation_model_zero_grad()
+
     def validation_step(
         self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int, dataloader_idx: int = 0
     ) -> None:

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1746,6 +1746,34 @@ def test_zero_grad_unchanged_when_cuda_graph_off(rgb_lr_hr_batch):
     assert lit.model.recon.weight.grad is None
 
 
+def test_cuda_graph_val_boundary_grad_release_skipped_while_graph_live(rgb_lr_hr_batch):
+    """Before every mid-training validation Lightning releases gradient memory
+    via on_validation_model_zero_grad -> zero_grad(set_to_none=True). With a live
+    graph, optimizer.step() reads the static .grad tensors the replay fills, and
+    the replay never re-binds the parameters' .grad attributes — so one such
+    release detaches every parameter permanently: step() skips them all and the
+    weights freeze at the first validation while the logged loss keeps moving.
+    Caught on a real run: parameters bit-identical from step 50k to step 400k."""
+    lit = _graph_lit()
+    lit._step(rgb_lr_hr_batch, need_sr_rgb=False)[0].backward()
+    lit._cuda_graph = SimpleNamespace(captured=True)  # a live graph owns the buffers
+
+    lit.on_validation_model_zero_grad()
+
+    assert lit.model.recon.weight.grad is not None
+
+
+def test_val_boundary_grad_release_intact_without_live_graph(rgb_lr_hr_batch):
+    """Eager runs (flag off, capture disabled, or not yet captured) must keep
+    Lightning's pre-validation memory release."""
+    lit = _graph_lit(cuda_graph=False)
+    lit._step(rgb_lr_hr_batch, need_sr_rgb=False)[0].backward()
+
+    lit.on_validation_model_zero_grad()
+
+    assert lit.model.recon.weight.grad is None
+
+
 def test_cuda_graph_refuses_mixed_precision():
     """A GradScaler scales the loss in the precision plugin's pre_backward hook,
     which a captured backward never runs — gradients would be silently unscaled."""


### PR DESCRIPTION
## Bug

With `training_config.cuda_graph: true`, **training silently freezes at the first mid-training validation** while the logged train loss keeps moving.

Lightning's `on_validation_model_zero_grad` hook runs before every mid-training validation and defaults to `zero_grad(set_to_none=True)` (lightning `training_epoch_loop.py:404` → `hooks.py:161`). On a graphed run the optimizer reads the static `.grad` tensors the replay fills, and a replay never re-binds the parameters' `.grad` attributes — so that one release severs every parameter from its gradients permanently. From then on `optimizer.step()` sees `None` grads and skips every parameter. The replay keeps running forward/backward on the frozen weights, so `loss/train` still fluctuates plausibly batch-to-batch and nothing looks wrong.

## Evidence (real 1M-step SRResNet golden-config run)

- Train loss matched the eager reference run **to 4 decimal places** through step 40k (same seed), then diverged progressively after the first val at 50k — frozen weights evaluated on the reference run's batch sequence.
- Val PSNR-RGB pinned at 28.41 for ten consecutive validation cycles (50k → 500k), jitter ≤ 0.005 dB.
- Learnable parameters **bit-identical** between the step-50k and step-300k weight checkpoints (159/159 tensors); only BatchNorm running stats (updated in-graph) advanced.

## Fix

Override `on_validation_model_zero_grad` in `SRLightning`: no-op while a captured graph is live (there is nothing to free — the grad tensors live in the graph's private memory pool for the rest of the run), defer to Lightning's release otherwise.

## Tests

RED→GREEN: `test_cuda_graph_val_boundary_grad_release_skipped_while_graph_live` fails on `main` (grad severed to `None`) and passes with the fix; `test_val_boundary_grad_release_intact_without_live_graph` pins Lightning's default for eager runs. Full suite: **536 passed / 1 skipped** (the dormant MATLAB-upscale reference check), ruff clean.

Why existing coverage missed it: the bit-exactness verification ran 300 steps without ever crossing a validation boundary, and the smoke run's single val cycle left nothing to compare against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)