### PR TITLE
Add pluggable losses: Charbonnier, total variation, and VGG16/19 perceptual

### DIFF
--- a/sisr/losses/__init__.py
+++ b/sisr/losses/__init__.py
@@ -1,6 +1,7 @@
 """Pluggable loss functions, wired via YAML ``model.criterion``."""
 
 from .base import SRLoss
+from .composite import WeightedSumLoss
 from .pixel import CharbonnierLoss, TotalVariationLoss
 from .vgg import VGG16FeatureLoss, VGG19FeatureLoss
 
@@ -10,4 +11,5 @@ __all__ = [
     "TotalVariationLoss",
     "VGG16FeatureLoss",
     "VGG19FeatureLoss",
+    "WeightedSumLoss",
 ]

--- a/sisr/losses/__init__.py
+++ b/sisr/losses/__init__.py
@@ -1,0 +1,5 @@
+"""Pluggable loss functions, wired via YAML ``model.criterion``."""
+
+from .base import SRLoss
+
+__all__ = ["SRLoss"]

--- a/sisr/losses/__init__.py
+++ b/sisr/losses/__init__.py
@@ -2,5 +2,12 @@
 
 from .base import SRLoss
 from .pixel import CharbonnierLoss, TotalVariationLoss
+from .vgg import VGG16FeatureLoss, VGG19FeatureLoss
 
-__all__ = ["SRLoss", "CharbonnierLoss", "TotalVariationLoss"]
+__all__ = [
+    "SRLoss",
+    "CharbonnierLoss",
+    "TotalVariationLoss",
+    "VGG16FeatureLoss",
+    "VGG19FeatureLoss",
+]

--- a/sisr/losses/__init__.py
+++ b/sisr/losses/__init__.py
@@ -1,5 +1,6 @@
 """Pluggable loss functions, wired via YAML ``model.criterion``."""
 
 from .base import SRLoss
+from .pixel import CharbonnierLoss, TotalVariationLoss
 
-__all__ = ["SRLoss"]
+__all__ = ["SRLoss", "CharbonnierLoss", "TotalVariationLoss"]

--- a/sisr/losses/base.py
+++ b/sisr/losses/base.py
@@ -15,6 +15,15 @@ class SRLoss(torch.nn.Module, abc.ABC):
     model. Plain :class:`torch.nn.Module` criteria (``MSELoss``, ``L1Loss``,
     :class:`~sisr.losses.pixel.CharbonnierLoss`) need no such adaptation and
     are used directly — this base exists only for the losses that do.
+
+    A loss may optionally expose ``last_terms: dict[str, torch.Tensor]``, a
+    structural protocol :class:`SRLightning` checks via ``getattr`` rather
+    than ``isinstance``, so any criterion holding one participates in
+    per-term logging as ``loss/<stage>/<name>``
+    (:class:`~sisr.losses.composite.WeightedSumLoss` is the one that does).
+    The tensors must be stable buffers written in place on every
+    :meth:`forward`, never rebound, since a CUDA-graph replay can only
+    update a tensor that already existed at capture time.
     """
 
     @abc.abstractmethod

--- a/sisr/losses/base.py
+++ b/sisr/losses/base.py
@@ -1,0 +1,49 @@
+"""Abstract base for losses that must adapt to the model's output space."""
+
+import abc
+
+import torch
+
+from ..processors import SRProcessor
+
+
+class SRLoss(torch.nn.Module, abc.ABC):
+    """A criterion that needs facts only the :class:`SRProcessor` knows.
+
+    :class:`~sisr.training.lightning_module.SRLightning` calls :meth:`bind`
+    exactly once at construction, passing the processor wired alongside the
+    model. Plain :class:`torch.nn.Module` criteria (``MSELoss``, ``L1Loss``,
+    :class:`~sisr.losses.pixel.CharbonnierLoss`) need no such adaptation and
+    are used directly — this base exists only for the losses that do.
+    """
+
+    @abc.abstractmethod
+    def bind(self, processor: SRProcessor) -> None:
+        """Adopt the model's output space, or raise if it cannot be served.
+
+        Abstract rather than defaulted to a no-op, for the same reason
+        :attr:`SRProcessor.output_range` is: a wrong inherited default is
+        exactly the failure this declaration exists to prevent. It is also
+        the one place an impossible model/loss pairing can fail loudly
+        instead of silently computing the wrong quantity.
+
+        Args:
+            processor: The processor wired alongside the model, supplying
+                ``output_range`` and ``model_channels``.
+
+        Raises:
+            ValueError: If this loss cannot operate on the processor's
+                output space.
+        """
+
+    @abc.abstractmethod
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Scalar loss between a model output and its target, both in model space."""
+
+    def describe(self) -> str:
+        """One-line recipe for the TensorBoard HParams column.
+
+        Concrete with a class-name default: this is presentation, so a new
+        loss must not be forced to implement it.
+        """
+        return type(self).__name__

--- a/sisr/losses/base.py
+++ b/sisr/losses/base.py
@@ -21,9 +21,10 @@ class SRLoss(torch.nn.Module, abc.ABC):
     than ``isinstance``, so any criterion holding one participates in
     per-term logging as ``loss/<stage>/<name>``
     (:class:`~sisr.losses.composite.WeightedSumLoss` is the one that does).
-    The tensors must be stable buffers written in place on every
-    :meth:`forward`, never rebound, since a CUDA-graph replay can only
-    update a tensor that already existed at capture time.
+    The tensors are written in place across ordinary steps and only replaced
+    when the existing buffer cannot be reused (first use, a device/dtype
+    change, or leaving :func:`torch.inference_mode`), so a CUDA-graph replay
+    keeps updating the entry it captured.
     """
 
     @abc.abstractmethod
@@ -38,7 +39,7 @@ class SRLoss(torch.nn.Module, abc.ABC):
 
         Args:
             processor: The processor wired alongside the model, supplying
-                ``output_range`` and ``model_channels``.
+                ``output_range``, ``model_channels``, and ``output_colorspace``.
 
         Raises:
             ValueError: If this loss cannot operate on the processor's

--- a/sisr/losses/composite.py
+++ b/sisr/losses/composite.py
@@ -57,7 +57,10 @@ class WeightedSumLoss(SRLoss):
 
         self.terms = torch.nn.ModuleDict(terms)
         self.weights = {name: float(weights.get(name, 1.0)) for name in terms}
-        #: Per-term weighted contributions from the most recent forward.
+        #: Per-term weighted contributions from the most recent forward, as
+        #: stable buffers written in place (see :meth:`forward`) rather than
+        #: rebound each call — a CUDA-graph replay can only update a tensor
+        #: that already existed at capture time.
         self.last_terms: dict[str, torch.Tensor] = {}
 
     def bind(self, processor: SRProcessor) -> None:
@@ -71,10 +74,16 @@ class WeightedSumLoss(SRLoss):
         total = None
         for name, term in self.terms.items():
             contribution = term(pred, target) * self.weights[name]
-            # detach().clone(): a bare detach would alias a CUDA graph's own
-            # memory and keep the whole graph alive; the clone is a scalar, and
-            # inside a capture it becomes a static buffer each replay rewrites.
-            self.last_terms[name] = contribution.detach().clone()
+            value = contribution.detach()
+            prior = self.last_terms.get(name)
+            # In place, not a fresh clone: a CUDA-graph replay re-runs only the
+            # recorded copy kernel, so the only tensor it can update is the one
+            # that existed at capture. Rebinding here would strand the tag on
+            # the last eager step's value for the rest of the run.
+            if prior is None or prior.device != value.device or prior.dtype != value.dtype:
+                self.last_terms[name] = value.clone()
+            else:
+                prior.copy_(value)
             total = contribution if total is None else total + contribution
         return total
 

--- a/sisr/losses/composite.py
+++ b/sisr/losses/composite.py
@@ -79,8 +79,19 @@ class WeightedSumLoss(SRLoss):
             # In place, not a fresh clone: a CUDA-graph replay re-runs only the
             # recorded copy kernel, so the only tensor it can update is the one
             # that existed at capture. Rebinding here would strand the tag on
-            # the last eager step's value for the rest of the run.
-            if prior is None or prior.device != value.device or prior.dtype != value.dtype:
+            # the last eager step's value for the rest of the run. A buffer
+            # captured under torch.inference_mode() (trainer.validate()/test())
+            # can never be written to again once outside it, so it must be
+            # replaced rather than reused.
+            stale_inference = (
+                prior is not None and prior.is_inference() and not torch.is_inference_mode_enabled()
+            )
+            if (
+                prior is None
+                or stale_inference
+                or prior.device != value.device
+                or prior.dtype != value.dtype
+            ):
                 self.last_terms[name] = value.clone()
             else:
                 prior.copy_(value)

--- a/sisr/losses/composite.py
+++ b/sisr/losses/composite.py
@@ -1,0 +1,83 @@
+"""Weighted-sum composition of several losses under one criterion."""
+
+import torch
+
+from ..processors import SRProcessor
+from .base import SRLoss
+
+
+class WeightedSumLoss(SRLoss):
+    """Sum of named, individually weighted loss terms.
+
+    Every post-SRGAN content loss is a weighted sum, including the one VGG
+    recipe reproducible without a discriminator — Ledig et al.'s
+    SRResNet-VGG22, which is a VGG22 term plus total variation at ``2e-8``
+    and no pixel term at all.
+
+    Terms are **named**, and the names become TensorBoard tag segments
+    (``loss/train/{name}``, ``loss/val/{name}``) via :attr:`last_terms`, so
+    a run shows which term dominates rather than one opaque total.
+
+    A multi-layer perceptual loss is two
+    :class:`~sisr.losses.vgg.VGG19FeatureLoss` terms at different layers —
+    there is deliberately no second construction path inside the VGG loss.
+
+    Args:
+        terms: Named loss modules, each called as ``term(pred, target)``.
+            Plain :class:`torch.nn.Module` losses and
+            :class:`~sisr.losses.base.SRLoss` ones may be mixed freely.
+        weights: Per-name multipliers. Names absent here default to ``1.0``;
+            a name absent from ``terms`` is an error rather than a no-op,
+            because the silent alternative is training at the wrong weight.
+            Defaults to ``None``.
+
+    Raises:
+        ValueError: If ``terms`` is empty, a term name contains ``'/'`` or
+            ``'.'``, or ``weights`` names a term that does not exist.
+    """
+
+    def __init__(
+        self,
+        terms: dict[str, torch.nn.Module],
+        weights: dict[str, float] | None = None,
+    ):
+        super().__init__()
+        if not terms:
+            raise ValueError("WeightedSumLoss needs at least one term")
+        for name in terms:
+            if "/" in name or "." in name:
+                raise ValueError(
+                    f"term name {name!r} may not contain '/' or '.' — names become "
+                    f"metric-tag segments under loss/<stage>/"
+                )
+        weights = dict(weights or {})
+        unknown = sorted(set(weights) - set(terms))
+        if unknown:
+            raise ValueError(f"weights names no such term: {unknown}; terms are {sorted(terms)}")
+
+        self.terms = torch.nn.ModuleDict(terms)
+        self.weights = {name: float(weights.get(name, 1.0)) for name in terms}
+        #: Per-term weighted contributions from the most recent forward.
+        self.last_terms: dict[str, torch.Tensor] = {}
+
+    def bind(self, processor: SRProcessor) -> None:
+        """Forward the bind to every term that is an :class:`SRLoss`."""
+        for term in self.terms.values():
+            if isinstance(term, SRLoss):
+                term.bind(processor)
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Weighted sum of every term, recording each contribution."""
+        total = None
+        for name, term in self.terms.items():
+            contribution = term(pred, target) * self.weights[name]
+            # detach().clone(): a bare detach would alias a CUDA graph's own
+            # memory and keep the whole graph alive; the clone is a scalar, and
+            # inside a capture it becomes a static buffer each replay rewrites.
+            self.last_terms[name] = contribution.detach().clone()
+            total = contribution if total is None else total + contribution
+        return total
+
+    def describe(self) -> str:
+        """e.g. ``"1*vgg22 + 2e-08*tv"``."""
+        return " + ".join(f"{self.weights[name]:g}*{name}" for name in self.terms)

--- a/sisr/losses/pixel.py
+++ b/sisr/losses/pixel.py
@@ -1,0 +1,113 @@
+"""Pixel-domain losses: Charbonnier distance and total-variation regularisation."""
+
+import torch
+
+_REDUCTIONS = ("mean", "sum", "none")
+
+
+def _reduce(loss: torch.Tensor, reduction: str) -> torch.Tensor:
+    """Apply a torch-style reduction to an elementwise loss tensor."""
+    if reduction == "mean":
+        return loss.mean()
+    if reduction == "sum":
+        return loss.sum()
+    return loss
+
+
+def _check_reduction(reduction: str) -> str:
+    """Validate a reduction name at construction, not at the first step."""
+    if reduction not in _REDUCTIONS:
+        raise ValueError(f"reduction must be one of {_REDUCTIONS}; got {reduction!r}")
+    return reduction
+
+
+class CharbonnierLoss(torch.nn.Module):
+    """Charbonnier distance ``sqrt((pred - target)^2 + eps^2)``.
+
+    A differentiable variant of L1: the ``eps`` floor gives a finite gradient
+    at ``pred == target``, which is where ``|x|`` has none. That is the whole
+    reason to prefer it — at the default ``eps`` the *value* is numerically
+    close to L1 for typical residuals, so do not expect a PSNR change from
+    swapping one for the other.
+
+    ``eps`` is **squared inside the root**, which spans both conventions in
+    circulation: LapSRN's ``sqrt(diff^2 + eps^2)`` at ``eps=1e-3`` (the
+    default here, and the paper that brought Charbonnier to SISR), and
+    BasicSR's ``sqrt(diff^2 + 1e-12)`` at ``eps=1e-6``.
+
+    Args:
+        eps: Intensity-scale floor, squared inside the root. Defaults to
+            ``1e-3``.
+        reduction: One of ``'mean'``, ``'sum'``, ``'none'``. Defaults to
+            ``'mean'``.
+
+    Raises:
+        ValueError: If ``reduction`` is not a recognised name.
+    """
+
+    def __init__(self, eps: float = 1e-3, reduction: str = "mean"):
+        super().__init__()
+        self.eps = eps
+        self.reduction = _check_reduction(reduction)
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Charbonnier distance between ``pred`` and ``target``."""
+        return _reduce(torch.sqrt((pred - target) ** 2 + self.eps**2), self.reduction)
+
+
+class TotalVariationLoss(torch.nn.Module):
+    """Total-variation regularisation, ``mean(sqrt(dx^2 + dy^2 + eps^2))``.
+
+    Ledig et al. §3.4 add this to the VGG22 content loss at weight
+    ``2e-8`` when training SRResNet-VGG22 — the one VGG variant reproducible
+    without a discriminator, so this is required for that recipe rather than
+    optional. Their ``l_TV = 1/(r^2 WH) * sum ||grad G(I_LR)||`` is a norm of
+    the gradient *vector*, i.e. the isotropic form; ``isotropic=False`` gives
+    the more common ``|dx| + |dy|`` reimplementation, which is a different
+    function (up to ``sqrt(2)`` larger on diagonal structure) and not a
+    rescaling of it.
+
+    Both difference grids are cropped to a common ``(H-1, W-1)`` so the
+    isotropic norm can combine them per pixel.
+
+    Two things worth knowing before setting a weight:
+
+    - ``target`` is **ignored**. This is a regulariser, not a distance; the
+      uniform ``(pred, target)`` signature is what lets
+      :class:`~sisr.losses.composite.WeightedSumLoss` dispatch every term
+      identically.
+    - The value **scales with the intensity range**, so the paper's ``2e-8``
+      presumes the model's ``[-1, 1]`` output range
+      (:class:`~sisr.processors.rgb.RGBSignedOutputProcessor`). Under a
+      ``[0, 1]`` processor the same image gives exactly half the TV, so the
+      effective weight differs by 2x.
+
+    Args:
+        isotropic: Use the paper's ``sqrt(dx^2 + dy^2)`` norm. ``False``
+            selects ``|dx| + |dy|``, where ``eps`` is unused. Defaults to
+            ``True``.
+        eps: Intensity-scale floor, squared inside the root. Non-zero by
+            default because ``sqrt`` is non-differentiable at zero and flat
+            regions dominate natural images. Defaults to ``1e-4``.
+        reduction: One of ``'mean'``, ``'sum'``, ``'none'``. Defaults to
+            ``'mean'``.
+
+    Raises:
+        ValueError: If ``reduction`` is not a recognised name.
+    """
+
+    def __init__(self, isotropic: bool = True, eps: float = 1e-4, reduction: str = "mean"):
+        super().__init__()
+        self.isotropic = isotropic
+        self.eps = eps
+        self.reduction = _check_reduction(reduction)
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor | None = None) -> torch.Tensor:
+        """Total variation of ``pred``. ``target`` is accepted and ignored."""
+        dy = pred[..., 1:, :-1] - pred[..., :-1, :-1]
+        dx = pred[..., :-1, 1:] - pred[..., :-1, :-1]
+        if self.isotropic:
+            tv = torch.sqrt(dx * dx + dy * dy + self.eps**2)
+        else:
+            tv = dx.abs() + dy.abs()
+        return _reduce(tv, self.reduction)

--- a/sisr/losses/pixel.py
+++ b/sisr/losses/pixel.py
@@ -56,7 +56,7 @@ class CharbonnierLoss(torch.nn.Module):
 
 
 class TotalVariationLoss(torch.nn.Module):
-    """Total-variation regularisation, ``mean(sqrt(dx^2 + dy^2 + eps^2))``.
+    """Total-variation loss: isotropic ``sqrt(dx^2 + dy^2 + eps^2)``, reduced per ``reduction``.
 
     Ledig et al. §3.4 add this to the VGG22 content loss at weight
     ``2e-8`` when training SRResNet-VGG22 — the one VGG variant reproducible

--- a/sisr/losses/vgg.py
+++ b/sisr/losses/vgg.py
@@ -1,8 +1,9 @@
 """VGG feature-space perceptual losses (Ledig et al. §3.2)."""
 
+import math
 import warnings
-from collections.abc import Sequence
-from typing import ClassVar
+from collections.abc import Callable, Sequence
+from typing import ClassVar, Self
 
 import torch
 import torchvision
@@ -164,10 +165,11 @@ class _VGGFeatureLoss(SRLoss):
         )
         self.register_buffer("_std", torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1), persistent=False)
 
-    def _apply(self, fn, recurse: bool = True):
+    def _apply(self, fn: Callable[[torch.Tensor], torch.Tensor], recurse: bool = True) -> Self:
         """Carry ``.to()`` / dtype changes to the unregistered VGG."""
         applied = super()._apply(fn, recurse)
-        self._vgg._apply(fn)
+        if recurse:
+            self._vgg._apply(fn)
         return applied
 
     def bind(self, processor: SRProcessor) -> None:
@@ -208,8 +210,26 @@ class _VGGFeatureLoss(SRLoss):
         return _DISTANCES[self.distance](pred_features, target_features)
 
     def describe(self) -> str:
-        """e.g. ``"VGG19FeatureLoss(vgg22)"``."""
-        return f"{type(self).__name__}({self.layer})"
+        """e.g. ``"VGG19FeatureLoss(vgg22)"``, or with non-default knobs appended.
+
+        ``before_activation``, ``distance``, ``feature_scale`` and
+        ``input_norm`` all change the loss materially (see the class
+        docstring), yet this string is the only record of the criterion in
+        checkpoint metadata, HParams and provenance — so any of them that
+        differs from its default is appended, e.g.
+        ``"VGG19FeatureLoss(vgg22, before_activation=True, distance=l1)"``.
+        """
+        extras = []
+        if self.before_activation:
+            extras.append(f"before_activation={self.before_activation}")
+        if self.distance != "mse":
+            extras.append(f"distance={self.distance}")
+        if not math.isclose(self.feature_scale, 1 / 12.75, rel_tol=1e-9):
+            extras.append(f"feature_scale={self.feature_scale:g}")
+        if not self.input_norm:
+            extras.append(f"input_norm={self.input_norm}")
+        suffix = "".join(f", {extra}" for extra in extras)
+        return f"{type(self).__name__}({self.layer}{suffix})"
 
 
 class VGG19FeatureLoss(_VGGFeatureLoss):

--- a/sisr/losses/vgg.py
+++ b/sisr/losses/vgg.py
@@ -1,6 +1,14 @@
 """VGG feature-space perceptual losses (Ledig et al. §3.2)."""
 
+import warnings
 from collections.abc import Sequence
+from typing import ClassVar
+
+import torch
+import torchvision
+
+from ..processors import SRProcessor
+from .base import SRLoss
 
 
 def _parse_layer(layer: str) -> tuple[int, int]:
@@ -61,3 +69,168 @@ def _resolve_slice_end(block_widths: Sequence[int], i: int, j: int, before_activ
     offset = sum(2 * w + 1 for w in block_widths[: i - 1])
     conv_index = offset + 2 * (j - 1)
     return conv_index + (1 if before_activation else 2)
+
+
+#: ImageNet statistics torchvision's VGG weights were trained under.
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+_DISTANCES = {"mse": torch.nn.functional.mse_loss, "l1": torch.nn.functional.l1_loss}
+
+
+class _VGGFeatureLoss(SRLoss):
+    """Shared implementation of a VGG feature-space loss. See the subclasses.
+
+    Args:
+        layer: Feature layer in the paper's ``phi_{i,j}`` shorthand, e.g.
+            ``"vgg22"``. Defaults to ``"vgg22"`` — valid at every depth, and
+            the layer of the reproducible SRResNet-VGG22 recipe.
+        before_activation: Take the pre-ReLU feature map (ESRGAN) instead of
+            the post-ReLU one (SRGAN). Defaults to ``False``.
+        feature_scale: Multiplies the **feature maps**, per Ledig et al.'s
+            footnote, so an MSE of them carries its square: the default
+            ``1/12.75`` yields the paper's ``0.006``. Under
+            ``distance='l1'`` the effect is linear instead, i.e. switching
+            distance changes the loss magnitude by ``12.75x``. Defaults to
+            ``1 / 12.75``.
+        input_norm: Apply ImageNet mean/std normalisation, which is what the
+            weights were trained under. Defaults to ``True``.
+        distance: ``'mse'`` (Ledig eq. 5) or ``'l1'`` (the BasicSR/ESRGAN
+            habit). Defaults to ``'mse'``.
+        grayscale_to_rgb: Replicate a 1-channel model output across RGB
+            instead of refusing it. Off by default because a Y-channel VGG
+            loss is nobody's published recipe. Defaults to ``False``.
+        weights: A torchvision weights-enum name, or ``None`` for a random
+            initialisation — which makes the loss meaningless and warns, and
+            exists so tests can stay offline. Defaults to
+            ``"IMAGENET1K_V1"``.
+
+    Raises:
+        ValueError: If ``distance`` is unknown, or ``layer`` names a
+            convolution this depth does not have.
+    """
+
+    #: Convolutions per block, which is what makes a layer name valid or not.
+    BLOCK_WIDTHS: ClassVar[tuple[int, ...]]
+    #: Name of the ``torchvision.models`` builder for this depth.
+    MODEL_NAME: ClassVar[str]
+
+    def __init__(
+        self,
+        layer: str = "vgg22",
+        before_activation: bool = False,
+        feature_scale: float = 1 / 12.75,
+        input_norm: bool = True,
+        distance: str = "mse",
+        grayscale_to_rgb: bool = False,
+        weights: str | None = "IMAGENET1K_V1",
+    ):
+        super().__init__()
+        if distance not in _DISTANCES:
+            raise ValueError(f"distance must be one of {tuple(_DISTANCES)}; got {distance!r}")
+        i, j = _parse_layer(layer)
+        slice_end = _resolve_slice_end(self.BLOCK_WIDTHS, i, j, before_activation)
+
+        if weights is None:
+            warnings.warn(
+                f"{type(self).__name__}(weights=None) builds a randomly initialised "
+                f"VGG, so the perceptual loss it computes is meaningless. This exists "
+                f"for offline tests — do not train with it.",
+                UserWarning,
+                stacklevel=2,
+            )
+        features = getattr(torchvision.models, self.MODEL_NAME)(weights=weights).features
+        vgg = torch.nn.Sequential(*list(features)[:slice_end]).eval()
+        vgg.requires_grad_(False)
+        # object.__setattr__ keeps this out of _modules: nn.Module.__setattr__
+        # would register it, putting up to 20M frozen params into every
+        # state_dict (so every .ckpt) and making a checkpoint non-loadable in
+        # strict mode against a module built with a different criterion. _apply
+        # below is what still carries .to()/dtype changes across.
+        object.__setattr__(self, "_vgg", vgg)
+
+        self.layer = layer
+        self.before_activation = before_activation
+        self.feature_scale = feature_scale
+        self.input_norm = input_norm
+        self.distance = distance
+        self.grayscale_to_rgb = grayscale_to_rgb
+        # Identity until bind(); a [0, 1] processor needs no mapping anyway.
+        self._gain, self._offset = 1.0, 0.0
+        # persistent=False: constants, and a distributable checkpoint should not
+        # carry them.
+        self.register_buffer(
+            "_mean", torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1), persistent=False
+        )
+        self.register_buffer("_std", torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1), persistent=False)
+
+    def _apply(self, fn, recurse: bool = True):
+        """Carry ``.to()`` / dtype changes to the unregistered VGG."""
+        applied = super()._apply(fn, recurse)
+        self._vgg._apply(fn)
+        return applied
+
+    def bind(self, processor: SRProcessor) -> None:
+        """Derive the affine map from the model's output range into ``[0, 1]``."""
+        channels = processor.model_channels
+        if channels != 3 and not self.grayscale_to_rgb:
+            raise ValueError(
+                f"{type(self).__name__} needs 3-channel RGB but "
+                f"{type(processor).__name__} emits {channels} channel(s). VGG "
+                f"perceptual loss is not a published Y-channel recipe. Set "
+                f"grayscale_to_rgb: true to replicate the single channel across "
+                f"RGB anyway, or pair the model with an RGB processor."
+            )
+        low, high = processor.output_range
+        if high <= low:
+            raise ValueError(
+                f"{type(processor).__name__}.output_range must be increasing; got {(low, high)}"
+            )
+        self._gain = 1.0 / (high - low)
+        self._offset = -low / (high - low)
+
+    def _features(self, x: torch.Tensor) -> torch.Tensor:
+        """Map into ``[0, 1]``, normalise, and take the truncated VGG's output."""
+        x = x * self._gain + self._offset
+        if x.shape[1] == 1:
+            x = x.expand(-1, 3, -1, -1)
+        if self.input_norm:
+            x = (x - self._mean) / self._std
+        return self._vgg(x) * self.feature_scale
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Distance between the VGG features of ``pred`` and of ``target``."""
+        pred_features = self._features(pred)
+        # The target is a constant, so its graph is pure waste. pred's is not:
+        # it is the only path a gradient has back to the generator.
+        with torch.no_grad():
+            target_features = self._features(target)
+        return _DISTANCES[self.distance](pred_features, target_features)
+
+    def describe(self) -> str:
+        """e.g. ``"VGG19FeatureLoss(vgg22)"``."""
+        return f"{type(self).__name__}({self.layer})"
+
+
+class VGG19FeatureLoss(_VGGFeatureLoss):
+    """VGG19 feature-space loss — the depth Ledig et al. specify.
+
+    ``phi_{i,j}`` is the feature map after the j-th convolution before the
+    i-th maxpool; ``"vgg22"`` and ``"vgg54"`` are the paper's two variants.
+    Constructor arguments are documented on :class:`_VGGFeatureLoss`.
+    """
+
+    BLOCK_WIDTHS: ClassVar[tuple[int, ...]] = (2, 2, 4, 4, 4)
+    MODEL_NAME: ClassVar[str] = "vgg19"
+
+
+class VGG16FeatureLoss(_VGGFeatureLoss):
+    """VGG16 feature-space loss — offered for experimentation, not fidelity.
+
+    Blocks 3-5 hold three convolutions rather than four, so the deepest layer
+    is ``"vgg53"`` and ``"vgg54"`` raises. Constructor arguments are
+    documented on :class:`_VGGFeatureLoss`.
+    """
+
+    BLOCK_WIDTHS: ClassVar[tuple[int, ...]] = (2, 2, 3, 3, 3)
+    MODEL_NAME: ClassVar[str] = "vgg16"

--- a/sisr/losses/vgg.py
+++ b/sisr/losses/vgg.py
@@ -1,0 +1,63 @@
+"""VGG feature-space perceptual losses (Ledig et al. §3.2)."""
+
+from collections.abc import Sequence
+
+
+def _parse_layer(layer: str) -> tuple[int, int]:
+    """Split a ``"vgg<i><j>"`` layer name into its block and conv indices.
+
+    Args:
+        layer: Layer name in the paper's ``phi_{i,j}`` shorthand, e.g.
+            ``"vgg22"`` for ``phi_{2,2}``.
+
+    Returns:
+        ``(i, j)`` — the 1-based block index and the 1-based conv index
+        within that block.
+
+    Raises:
+        ValueError: If ``layer`` is not ``"vgg"`` followed by exactly two
+            digits.
+    """
+    if len(layer) != 5 or not layer.startswith("vgg") or not layer[3:].isdigit():
+        raise ValueError(
+            f"layer must have the form 'vgg<i><j>' — two single digits naming "
+            f"phi_{{i,j}}, e.g. 'vgg22' or 'vgg54'; got {layer!r}"
+        )
+    return int(layer[3]), int(layer[4])
+
+
+def _resolve_slice_end(block_widths: Sequence[int], i: int, j: int, before_activation: bool) -> int:
+    """Index one past the last ``features`` layer to keep for ``phi_{i,j}``.
+
+    A torchvision VGG's ``features`` is ``(conv, ReLU) * width`` per block,
+    then one ``MaxPool2d``. Ledig et al. define ``phi_{i,j}`` as the feature
+    map after the j-th convolution (**after activation**) before the i-th
+    maxpool; ESRGAN later argued for the pre-activation map, which is one
+    layer shallower.
+
+    Args:
+        block_widths: Convolutions per block, e.g. ``(2, 2, 4, 4, 4)`` for
+            VGG19.
+        i: 1-based block index.
+        j: 1-based conv index within block ``i``.
+        before_activation: Stop at the conv instead of its ReLU.
+
+    Returns:
+        A slice end usable as ``features[:end]``.
+
+    Raises:
+        ValueError: If ``i`` is not a block, or ``j`` not a conv of block
+            ``i``.
+    """
+    if not 1 <= i <= len(block_widths):
+        raise ValueError(f"block index i must be 1..{len(block_widths)} for this depth; got {i}")
+    width = block_widths[i - 1]
+    if not 1 <= j <= width:
+        deepest = f"vgg{len(block_widths)}{block_widths[-1]}"
+        raise ValueError(
+            f"conv index j must be 1..{width} — block {i} has {width} convolutions; "
+            f"got {j}. The deepest layer at this depth is '{deepest}'."
+        )
+    offset = sum(2 * w + 1 for w in block_widths[: i - 1])
+    conv_index = offset + 2 * (j - 1)
+    return conv_index + (1 if before_activation else 2)

--- a/sisr/losses/vgg.py
+++ b/sisr/losses/vgg.py
@@ -101,6 +101,11 @@ class _VGGFeatureLoss(SRLoss):
         grayscale_to_rgb: Replicate a 1-channel model output across RGB
             instead of refusing it. Off by default because a Y-channel VGG
             loss is nobody's published recipe. Defaults to ``False``.
+        allow_non_rgb: Skip the RGB-colorspace check for a 3-channel
+            processor, so e.g. :class:`~sisr.processors.ycbcr.YCbCrProcessor`
+            can be paired with this loss anyway. Off by default because
+            feeding Y/Cb/Cr to VGG as though it were R/G/B is not a published
+            recipe. Defaults to ``False``.
         weights: A torchvision weights-enum name, or ``None`` for a random
             initialisation — which makes the loss meaningless and warns, and
             exists so tests can stay offline. Defaults to
@@ -124,6 +129,7 @@ class _VGGFeatureLoss(SRLoss):
         input_norm: bool = True,
         distance: str = "mse",
         grayscale_to_rgb: bool = False,
+        allow_non_rgb: bool = False,
         weights: str | None = "IMAGENET1K_V1",
     ):
         super().__init__()
@@ -156,6 +162,7 @@ class _VGGFeatureLoss(SRLoss):
         self.input_norm = input_norm
         self.distance = distance
         self.grayscale_to_rgb = grayscale_to_rgb
+        self.allow_non_rgb = allow_non_rgb
         # Identity until bind(); a [0, 1] processor needs no mapping anyway.
         self._gain, self._offset = 1.0, 0.0
         # persistent=False: constants, and a distributable checkpoint should not
@@ -182,6 +189,14 @@ class _VGGFeatureLoss(SRLoss):
                 f"perceptual loss is not a published Y-channel recipe. Set "
                 f"grayscale_to_rgb: true to replicate the single channel across "
                 f"RGB anyway, or pair the model with an RGB processor."
+            )
+        if channels == 3 and processor.output_colorspace != "RGB" and not self.allow_non_rgb:
+            raise ValueError(
+                f"{type(self).__name__} normalises with RGB ImageNet statistics, but "
+                f"{type(processor).__name__} emits {processor.output_colorspace} planes. "
+                f"Feeding Y/Cb/Cr to VGG as though they were R/G/B is not a published "
+                f"recipe and trains on features that mean nothing. Pair the model with "
+                f"an RGB processor, or set allow_non_rgb: true to experiment anyway."
             )
         low, high = processor.output_range
         if high <= low:

--- a/sisr/processors/base.py
+++ b/sisr/processors/base.py
@@ -1,6 +1,7 @@
 """Abstract base class for per-batch colorspace adapters."""
 
 import abc
+from typing import Literal
 
 import torch
 
@@ -70,4 +71,17 @@ class SRProcessor(abc.ABC):
         README documents for ONNX consumers of that processor. Recorded in
         checkpoint/export provenance metadata precisely so a downstream
         consumer never has to guess it.
+        """
+
+    @property
+    @abc.abstractmethod
+    def output_colorspace(self) -> Literal["RGB", "YCbCr", "Y"]:
+        """Colorspace of the model's output planes.
+
+        A fact only the processor knows (mirrors :attr:`output_range`) —
+        abstract rather than defaulted, because a consumer cannot tell Y/Cb/Cr
+        planes from R/G/B ones by shape, and one that matters
+        (:class:`~sisr.losses.vgg.VGG19FeatureLoss`, which normalises with RGB
+        ImageNet statistics) would otherwise silently compute a meaningless
+        quantity.
         """

--- a/sisr/processors/rgb.py
+++ b/sisr/processors/rgb.py
@@ -1,5 +1,7 @@
 """RGB processors — model trains and emits RGB, in one of two output ranges."""
 
+from typing import Literal
+
 import torch
 
 from .base import SRProcessor
@@ -25,6 +27,11 @@ class RGBProcessor(SRProcessor):
     def output_range(self) -> tuple[float, float]:
         """Model output range — ``(0.0, 1.0)``, unscaled RGB."""
         return (0.0, 1.0)
+
+    @property
+    def output_colorspace(self) -> Literal["RGB", "YCbCr", "Y"]:
+        """Model output colorspace — RGB."""
+        return "RGB"
 
 
 class RGBSignedOutputProcessor(SRProcessor):
@@ -68,3 +75,8 @@ class RGBSignedOutputProcessor(SRProcessor):
     def output_range(self) -> tuple[float, float]:
         """Model output range — ``(-1.0, 1.0)``, the paper's HR range. See class docstring."""
         return (-1.0, 1.0)
+
+    @property
+    def output_colorspace(self) -> Literal["RGB", "YCbCr", "Y"]:
+        """Model output colorspace — RGB; only the range differs from RGBProcessor."""
+        return "RGB"

--- a/sisr/processors/y_channel.py
+++ b/sisr/processors/y_channel.py
@@ -1,5 +1,7 @@
 """Y-channel processor: extract Y from LR, stitch SR-Y with bicubic LR Cb/Cr."""
 
+from typing import Literal
+
 import torch
 import torch.nn.functional as F
 
@@ -41,3 +43,8 @@ class YChannelProcessor(SRProcessor):
     def output_range(self) -> tuple[float, float]:
         """Model output range — ``(0.0, 1.0)``, unscaled Y."""
         return (0.0, 1.0)
+
+    @property
+    def output_colorspace(self) -> Literal["RGB", "YCbCr", "Y"]:
+        """Model output colorspace — Y."""
+        return "Y"

--- a/sisr/processors/ycbcr.py
+++ b/sisr/processors/ycbcr.py
@@ -1,5 +1,7 @@
 """Full YCbCr processor: convert LR to YCbCr in, convert SR back to RGB out."""
 
+from typing import Literal
+
 import torch
 
 from sisr.colorspace import rgb_to_ycbcr, ycbcr_to_rgb
@@ -27,3 +29,8 @@ class YCbCrProcessor(SRProcessor):
     def output_range(self) -> tuple[float, float]:
         """Model output range — ``(0.0, 1.0)``, unscaled YCbCr."""
         return (0.0, 1.0)
+
+    @property
+    def output_colorspace(self) -> Literal["RGB", "YCbCr", "Y"]:
+        """Model output colorspace — YCbCr."""
+        return "YCbCr"

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -693,7 +693,8 @@ class SRLightning(lightning.LightningModule):
         """Compute training loss for one batch and log it.
 
         Delegates the forward + colorspace + loss pipeline to :meth:`_step`
-        and logs ``loss/train`` on every step for the progress bar.
+        and logs ``loss/train`` on every step for the progress bar, plus
+        ``loss/train/{term}`` for each term of a composite criterion.
         ``need_sr_rgb=False``: this method never looks at ``sr_rgb``, so
         skips ``processor.reconstruct`` — real per-step time (see
         :meth:`_forward_lr`) for a value that would only be discarded.
@@ -711,7 +712,31 @@ class SRLightning(lightning.LightningModule):
         if loss is None:
             loss, *_ = self._step(batch, need_sr_rgb=False)
         self.log("loss/train", loss, prog_bar=True, on_step=True)
+        self._log_loss_terms("train")
         return loss
+
+    def _log_loss_terms(self, stage: str) -> None:
+        """Log a composite criterion's per-term contributions, if it has any.
+
+        Reads ``last_terms`` structurally rather than by type, so any
+        criterion exposing that mapping participates. Empty (and so a no-op)
+        for every scalar loss.
+
+        Args:
+            stage: ``"train"`` or ``"val"`` — the middle tag segment.
+        """
+        terms = getattr(self.criterion, "last_terms", None)
+        if not terms:
+            return
+        on_step = stage == "train"
+        for name, value in terms.items():
+            self.log(
+                f"loss/{stage}/{name}",
+                value,
+                on_step=on_step,
+                on_epoch=not on_step,
+                add_dataloader_idx=False,
+            )
 
     def _graph_step(self, batch: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor | None:
         """Run the captured training step, building the graph on first use.
@@ -870,6 +895,7 @@ class SRLightning(lightning.LightningModule):
         # add_dataloader_idx=False keeps metric names clean — needed because the
         # primary val loader is at idx 0 of a list that also contains test loaders.
         self.log("loss/val", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
+        self._log_loss_terms("val")
         primary_psnr = self.eval_config.psnr_channels[0]
         for key in self.eval_config.psnr_keys:
             sr_t, hr_t = metric_tensors[key]

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -21,6 +21,7 @@ from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 
 from ..colorspace import rgb_to_ycbcr_studio
+from ..losses import SRLoss
 from ..models.base import SRModel
 from ..processors import SRProcessor
 from .config import SREvalConfig, SRTrainingConfig
@@ -50,7 +51,9 @@ class SRLightning(lightning.LightningModule):
         eval_config: Per-architecture evaluation settings (crop_border,
             psnr_channels, separate_psnr, ssim_channels). Defaults to base
             :class:`SREvalConfig`.
-        criterion: Loss instance. Defaults to :class:`torch.nn.MSELoss`.
+        criterion: Loss instance. Defaults to :class:`torch.nn.MSELoss`. An
+            :class:`~sisr.losses.SRLoss` additionally gets ``bind(processor)``
+            called once here, so it can adapt to the model's output space.
         optimizer: ``OptimizerCallable`` populated from top-level YAML
             ``optimizer:``. Defaults to :class:`torch.optim.Adam`.
         lr_scheduler: ``LRSchedulerCallable`` or ``None``. Defaults to ``None``.
@@ -94,6 +97,9 @@ class SRLightning(lightning.LightningModule):
         self.lr_scheduler = lr_scheduler
 
         self.training_config.validate_against(self.model, self.processor)
+
+        if isinstance(self.criterion, SRLoss):
+            self.criterion.bind(self.processor)
 
         if self.training_config.init_strategy == "paper":
             model.reset_parameters(
@@ -145,12 +151,27 @@ class SRLightning(lightning.LightningModule):
                 **self.hparams,
                 "model": model.hparams,
                 "processor": type(processor).__name__,
-                "criterion": type(self.criterion).__name__,
+                "criterion": self.criterion_description,
             }
         )
 
         if self.training_config.example_input_shape is not None:
             self.example_input_array = torch.zeros(1, *self.training_config.example_input_shape)
+
+    @property
+    def criterion_description(self) -> str:
+        """One-line human-readable identity of the criterion.
+
+        The single derivation point for the TensorBoard HParams column and
+        for checkpoint/export provenance metadata, so the two cannot drift —
+        mirroring how ``SREvalConfig.psnr_keys`` is the one derivation for
+        its consumers.
+        """
+        return (
+            self.criterion.describe()
+            if isinstance(self.criterion, SRLoss)
+            else type(self.criterion).__name__
+        )
 
     def setup(self, stage: str | None = None) -> None:
         """Probe one real sample against ``model.input_contract`` / ``example_input_shape``.

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -6,6 +6,9 @@ distributable ``.pt``), and :func:`sisr.export.to_onnx` (the ``.onnx``'s ``metad
 call :func:`build_metadata` so the three payloads cannot drift apart — mirrors how
 ``SREvalConfig.psnr_keys`` is the single derivation point for its three consumers.
 
+Carries ``format``, ``created``, ``versions``, ``model``, ``processor``, ``criterion``, ``io``,
+``eval_config``, and ``training``.
+
 Deliberately omits dataset paths: Ultralytics' ``train_args`` leaks local filesystem layout into
 distributed files; this stays leak-free by construction. If dataset provenance is ever added,
 it must be names only, never paths.
@@ -65,9 +68,11 @@ def build_metadata(
         monitor_value: Value of ``monitor`` at save time (``None`` otherwise).
 
     Returns:
-        A dict tree containing only ``dict``/``list``/``str``/``int``/``float``/``bool``/
-        ``None`` values — safe for ``torch.save``/``torch.load(weights_only=True)`` and,
-        per top-level field, for JSON-encoding into ONNX ``metadata_props``.
+        A dict tree carrying ``format``, ``created``, ``versions``, ``model``, ``processor``,
+        ``criterion``, ``io``, ``eval_config``, and ``training``. Contains only ``dict``/
+        ``list``/``str``/``int``/``float``/``bool``/``None`` values — safe for ``torch.save``/
+        ``torch.load(weights_only=True)`` and, per top-level field, for JSON-encoding into
+        ONNX ``metadata_props``.
     """
     model = module.model
     processor = module.processor
@@ -93,6 +98,10 @@ def build_metadata(
         },
         "processor": {
             "class_path": _class_path(processor),
+        },
+        "criterion": {
+            "class_path": _class_path(module.criterion),
+            "description": module.criterion_description,
         },
         "io": {
             "scale": scale,

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -108,6 +108,7 @@ def build_metadata(
             "input": model.input_contract,
             "input_channels": processor.model_channels,
             "output_range": list(processor.output_range),
+            "output_colorspace": processor.output_colorspace,
         },
         "eval_config": _to_plain(dataclasses.asdict(module.eval_config)),
         "training": {

--- a/tests/losses/test_composite.py
+++ b/tests/losses/test_composite.py
@@ -118,6 +118,27 @@ def test_last_terms_are_stable_buffers_written_in_place():
     assert first.item() == pytest.approx(7.0), "buffer was not updated"
 
 
+def test_validate_then_fit_on_one_instance_does_not_raise():
+    """trainer.validate()/test() run under torch.inference_mode() by default,
+    so a prior last_terms buffer can be an inference tensor. Lightning
+    hard-codes inference_mode=False for the fit loop's own validation, so
+    only a validate()-then-fit() sequence on one instance hits this: writing
+    to that stale buffer outside inference mode would otherwise raise
+    RuntimeError: Inplace update to inference tensor outside InferenceMode
+    is not allowed. The buffer is deliberately replaced across this
+    transition, so unlike test_last_terms_are_stable_buffers_written_in_place
+    this does not assert identity."""
+    loss = WeightedSumLoss(terms={"a": _BindSpy(2.0)}, weights={"a": 1.0})
+
+    with torch.inference_mode():
+        loss(torch.zeros(1), torch.zeros(1))
+
+    loss.terms["a"].value = 7.0
+    loss(torch.zeros(1), torch.zeros(1))
+
+    assert loss.last_terms["a"].item() == pytest.approx(7.0)
+
+
 def test_describe_renders_the_recipe():
     loss = WeightedSumLoss(
         terms={"vgg22": _BindSpy(1.0), "tv": TotalVariationLoss()},

--- a/tests/losses/test_composite.py
+++ b/tests/losses/test_composite.py
@@ -101,6 +101,23 @@ def test_last_terms_holds_detached_weighted_contributions_that_sum_to_the_total(
     assert not any(v.requires_grad for v in loss.last_terms.values())
 
 
+def test_last_terms_are_stable_buffers_written_in_place():
+    """A CUDA-graph replay re-runs only recorded kernels, never the Python line
+    that creates a tensor — so the entry a replay updates is the one present at
+    capture. Rebinding it on an eager forward (mid-training validation, or an
+    epoch's partial last batch) would strand every per-term tag on that eager
+    value for the rest of the run, silently, while loss/train kept moving."""
+    loss = WeightedSumLoss(terms={"a": _BindSpy(2.0)}, weights={"a": 1.0})
+
+    loss(torch.zeros(1), torch.zeros(1))
+    first = loss.last_terms["a"]
+    loss.terms["a"].value = 7.0
+    loss(torch.zeros(1), torch.zeros(1))
+
+    assert loss.last_terms["a"] is first, "rebound instead of writing in place"
+    assert first.item() == pytest.approx(7.0), "buffer was not updated"
+
+
 def test_describe_renders_the_recipe():
     loss = WeightedSumLoss(
         terms={"vgg22": _BindSpy(1.0), "tv": TotalVariationLoss()},

--- a/tests/losses/test_composite.py
+++ b/tests/losses/test_composite.py
@@ -1,0 +1,149 @@
+import functools
+
+import pytest
+import torch
+
+from sisr.losses import SRLoss, TotalVariationLoss, VGG19FeatureLoss, WeightedSumLoss
+from sisr.models.srcnn import SRCNN
+from sisr.processors import RGBProcessor, RGBSignedOutputProcessor, SRProcessor
+from sisr.training import SREvalConfig, SRLightning
+
+
+class _BindSpy(SRLoss):
+    def __init__(self, value: float):
+        super().__init__()
+        self.value = value
+        self.bound: list[SRProcessor] = []
+
+    def bind(self, processor: SRProcessor) -> None:
+        self.bound.append(processor)
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        return torch.tensor(self.value, requires_grad=True)
+
+
+def test_weighted_sum_matches_the_hand_computed_total():
+    loss = WeightedSumLoss(
+        terms={"a": _BindSpy(2.0), "b": _BindSpy(5.0)}, weights={"a": 1.0, "b": 0.1}
+    )
+
+    got = loss(torch.zeros(1), torch.zeros(1))
+
+    assert got.item() == pytest.approx(2.0 * 1.0 + 5.0 * 0.1)
+
+
+def test_a_missing_weight_defaults_to_one():
+    loss = WeightedSumLoss(terms={"a": _BindSpy(2.0), "b": _BindSpy(5.0)}, weights={"b": 0.1})
+
+    assert loss(torch.zeros(1), torch.zeros(1)).item() == pytest.approx(2.5)
+
+
+def test_an_unknown_weight_key_raises_rather_than_being_ignored():
+    """A typo in a weight name would otherwise silently train at weight 1.0."""
+    with pytest.raises(ValueError, match="vgg2"):
+        WeightedSumLoss(terms={"vgg22": _BindSpy(1.0)}, weights={"vgg2": 0.5})
+
+
+def test_empty_terms_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        WeightedSumLoss(terms={})
+
+
+@pytest.mark.parametrize("name", ["a/b", "a.b"])
+def test_a_term_name_that_would_break_a_metric_tag_raises(name: str):
+    """Names become TensorBoard tag segments under loss/train/, so a '/' would
+    silently invent a nesting level. '.' is rejected by ModuleDict anyway."""
+    with pytest.raises(ValueError, match="term name"):
+        WeightedSumLoss(terms={name: _BindSpy(1.0)})
+
+
+def test_bind_reaches_nested_srloss_terms_and_skips_plain_modules():
+    spy = _BindSpy(1.0)
+    loss = WeightedSumLoss(terms={"spy": spy, "plain": torch.nn.MSELoss()})
+    processor = RGBSignedOutputProcessor()
+
+    loss.bind(processor)
+
+    assert spy.bound == [processor]
+
+
+def test_nested_vgg_loss_actually_receives_the_bound_range():
+    """Forwarding bind must take EFFECT, not merely be called. An unbound
+    VGGFeatureLoss silently assumes [0, 1], so a composite that failed to
+    forward would train on mis-normalised features with no error at all."""
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        nested = VGG19FeatureLoss(layer="vgg22", weights=None)
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        direct = VGG19FeatureLoss(layer="vgg22", weights=None)
+    direct._vgg.load_state_dict(nested._vgg.state_dict())
+
+    composite = WeightedSumLoss(terms={"vgg22": nested})
+    composite.bind(RGBSignedOutputProcessor())
+    direct.bind(RGBSignedOutputProcessor())
+    pred = torch.rand(1, 3, 32, 32) * 2 - 1
+    target = torch.rand(1, 3, 32, 32) * 2 - 1
+
+    assert composite(pred, target).item() == pytest.approx(direct(pred, target).item(), rel=1e-6)
+
+
+def test_last_terms_holds_detached_weighted_contributions_that_sum_to_the_total():
+    """Weighted, not raw: the point of the breakdown is 'which term dominates',
+    and summing to the total is the property that answers it."""
+    loss = WeightedSumLoss(
+        terms={"a": _BindSpy(2.0), "b": _BindSpy(5.0)}, weights={"a": 1.0, "b": 0.1}
+    )
+
+    total = loss(torch.zeros(1), torch.zeros(1))
+
+    assert set(loss.last_terms) == {"a", "b"}
+    assert loss.last_terms["b"].item() == pytest.approx(0.5)
+    assert sum(v.item() for v in loss.last_terms.values()) == pytest.approx(total.item())
+    assert not any(v.requires_grad for v in loss.last_terms.values())
+
+
+def test_describe_renders_the_recipe():
+    loss = WeightedSumLoss(
+        terms={"vgg22": _BindSpy(1.0), "tv": TotalVariationLoss()},
+        weights={"vgg22": 1.0, "tv": 2e-8},
+    )
+
+    assert loss.describe() == "1*vgg22 + 2e-08*tv"
+
+
+def test_the_faithful_srresnet_vgg22_recipe_binds_and_backpropagates():
+    """Ledig et al. §3.4: VGG22 content loss plus total variation at 2e-8, and
+    no MSE term. This is the recipe the composite exists for."""
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        vgg = VGG19FeatureLoss(layer="vgg22", weights=None)
+    criterion = WeightedSumLoss(
+        terms={"vgg22": vgg, "tv": TotalVariationLoss()},
+        weights={"vgg22": 1.0, "tv": 2.0e-8},
+    )
+    lit = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBSignedOutputProcessor(),
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=criterion,
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+    loss, *_ = lit._step((torch.rand(2, 3, 32, 32), torch.rand(2, 3, 32, 32)))
+    loss.backward()
+
+    assert lit.criterion_description == "1*vgg22 + 2e-08*tv"
+    assert any(p.grad is not None for p in lit.model.parameters())
+
+
+def test_composite_criterion_survives_a_module_state_dict_roundtrip():
+    """A nested VGG must not reintroduce itself into the checkpoint."""
+    with pytest.warns(UserWarning):
+        vgg = VGG19FeatureLoss(layer="vgg22", weights=None)
+    lit = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=WeightedSumLoss(terms={"vgg22": vgg, "tv": TotalVariationLoss()}),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+    assert all(k.startswith("model.") for k in lit.state_dict()), list(lit.state_dict())

--- a/tests/losses/test_pixel.py
+++ b/tests/losses/test_pixel.py
@@ -23,12 +23,15 @@ def test_charbonnier_matches_the_closed_form():
 
 def test_charbonnier_eps_is_squared_so_1e_6_reproduces_basicsr():
     """BasicSR computes sqrt(diff**2 + 1e-12). One formula, both conventions —
-    if eps stopped being squared, this silently becomes a different loss."""
-    pred, target = torch.tensor([[[[2.0]]]]), torch.tensor([[[[0.0]]]])
+    if eps stopped being squared, this must fail. float64 and a tolerance below
+    the 1.25e-7 relative effect size are both required: in float32 the two
+    variants differ by less than the dtype's own epsilon."""
+    pred = torch.tensor([[[[2.0]]]], dtype=torch.float64)
+    target = torch.zeros_like(pred)
 
     got = CharbonnierLoss(eps=1e-6)(pred, target)
 
-    assert got.item() == pytest.approx(math.sqrt(4.0 + 1e-12))
+    assert got.item() == pytest.approx(math.sqrt(4.0 + 1e-12), rel=1e-9)
 
 
 def test_charbonnier_gradient_is_finite_where_l1_is_not():

--- a/tests/losses/test_pixel.py
+++ b/tests/losses/test_pixel.py
@@ -1,0 +1,131 @@
+import math
+
+import pytest
+import torch
+
+from sisr.losses import CharbonnierLoss, TotalVariationLoss
+
+# ---------------------------------------------------------------------------
+# CharbonnierLoss
+# ---------------------------------------------------------------------------
+
+
+def test_charbonnier_matches_the_closed_form():
+    pred = torch.tensor([[[[0.0, 3.0]]]])
+    target = torch.tensor([[[[0.0, 0.0]]]])
+    eps = 0.5
+
+    got = CharbonnierLoss(eps=eps)(pred, target)
+
+    expected = (math.sqrt(0.0 + eps**2) + math.sqrt(9.0 + eps**2)) / 2
+    assert got.item() == pytest.approx(expected)
+
+
+def test_charbonnier_eps_is_squared_so_1e_6_reproduces_basicsr():
+    """BasicSR computes sqrt(diff**2 + 1e-12). One formula, both conventions —
+    if eps stopped being squared, this silently becomes a different loss."""
+    pred, target = torch.tensor([[[[2.0]]]]), torch.tensor([[[[0.0]]]])
+
+    got = CharbonnierLoss(eps=1e-6)(pred, target)
+
+    assert got.item() == pytest.approx(math.sqrt(4.0 + 1e-12))
+
+
+def test_charbonnier_gradient_is_finite_where_l1_is_not():
+    """The entire reason to prefer Charbonnier over L1: |x| has an undefined
+    derivative at 0, and a pixel-perfect prediction is the common case."""
+    pred = torch.zeros(1, 1, 4, 4, requires_grad=True)
+
+    CharbonnierLoss()(pred, torch.zeros(1, 1, 4, 4)).backward()
+
+    assert torch.isfinite(pred.grad).all()
+    assert torch.equal(pred.grad, torch.zeros_like(pred.grad))
+
+
+@pytest.mark.parametrize(
+    ("reduction", "shape"), [("mean", ()), ("sum", ()), ("none", (1, 1, 2, 2))]
+)
+def test_charbonnier_reduction_modes(reduction: str, shape: tuple[int, ...]):
+    pred, target = torch.rand(1, 1, 2, 2), torch.rand(1, 1, 2, 2)
+
+    got = CharbonnierLoss(reduction=reduction)(pred, target)
+
+    assert got.shape == shape
+
+
+def test_charbonnier_rejects_an_unknown_reduction():
+    with pytest.raises(ValueError, match="reduction"):
+        CharbonnierLoss(reduction="average")
+
+
+# ---------------------------------------------------------------------------
+# TotalVariationLoss
+# ---------------------------------------------------------------------------
+
+
+def _ramp(direction: str, n: int = 8) -> torch.Tensor:
+    """Unit-slope ramp on an n x n grid, as a (1, 1, n, n) batch."""
+    yy, xx = torch.meshgrid(torch.arange(float(n)), torch.arange(float(n)), indexing="ij")
+    field = {"x": xx, "y": yy, "diag": (xx + yy) / 2}[direction]
+    return (field / n)[None, None]
+
+
+def test_tv_isotropic_equals_anisotropic_on_an_axis_aligned_ramp():
+    """Only one derivative is nonzero, so sqrt(dx^2 + dy^2) == |dx| + |dy|."""
+    ramp = _ramp("x")
+
+    iso = TotalVariationLoss(isotropic=True)(ramp)
+    aniso = TotalVariationLoss(isotropic=False)(ramp)
+
+    assert iso.item() == pytest.approx(aniso.item(), abs=1e-6)
+
+
+def test_tv_anisotropic_is_sqrt2_times_isotropic_on_a_45_degree_ramp():
+    """The measurement that proves the two are different functions, not two
+    scalings of one: dx == dy makes |dx| + |dy| exactly sqrt(2) * ||(dx, dy)||.
+    A step edge cannot show this (one nonzero derivative per pixel)."""
+    diag = _ramp("diag")
+
+    iso = TotalVariationLoss(isotropic=True)(diag)
+    aniso = TotalVariationLoss(isotropic=False)(diag)
+
+    assert aniso.item() / iso.item() == pytest.approx(math.sqrt(2), rel=1e-4)
+
+
+def test_tv_default_eps_keeps_a_flat_patch_differentiable():
+    """sqrt(0) has an infinite derivative, and flat regions dominate natural
+    images — eps=0 NaNs on the first flat crop of a real run."""
+    flat = torch.zeros(1, 1, 8, 8, requires_grad=True)
+    TotalVariationLoss()(flat).backward()
+    assert torch.isfinite(flat.grad).all()
+
+    unguarded = torch.zeros(1, 1, 8, 8, requires_grad=True)
+    TotalVariationLoss(eps=0.0)(unguarded).backward()
+    assert not torch.isfinite(unguarded.grad).all()
+
+
+def test_tv_ignores_its_target_argument():
+    """TV is a regulariser, not a distance. The uniform (pred, target)
+    signature is what lets WeightedSumLoss dispatch every term identically."""
+    pred = torch.rand(1, 3, 8, 8)
+    tv = TotalVariationLoss()
+
+    assert tv(pred, torch.rand(1, 3, 8, 8)).item() == pytest.approx(tv(pred).item())
+
+
+def test_tv_reduces_over_a_common_grid_one_smaller_in_both_dims():
+    """The isotropic norm has to combine two differently-shaped difference
+    grids, so both are cropped to (H-1, W-1). 'none' exposes that shape."""
+    got = TotalVariationLoss(reduction="none")(torch.rand(2, 3, 8, 6))
+
+    assert got.shape == (2, 3, 7, 5)
+
+
+def test_tv_is_range_dependent_by_exactly_the_range_ratio():
+    """Documents why the paper's 2e-8 weight presumes a [-1, 1] output range:
+    the same image mapped to [-1, 1] doubles the TV value, so under
+    RGBProcessor the effective weight differs 2x."""
+    x01 = torch.rand(1, 3, 16, 16)
+    tv = TotalVariationLoss()
+
+    assert tv(x01 * 2 - 1).item() == pytest.approx(2 * tv(x01).item(), rel=1e-5)

--- a/tests/losses/test_vgg.py
+++ b/tests/losses/test_vgg.py
@@ -6,7 +6,12 @@ import torch
 from sisr.losses import VGG16FeatureLoss, VGG19FeatureLoss
 from sisr.losses.vgg import _parse_layer, _resolve_slice_end
 from sisr.models.srcnn import SRCNN
-from sisr.processors import RGBProcessor, RGBSignedOutputProcessor, YChannelProcessor
+from sisr.processors import (
+    RGBProcessor,
+    RGBSignedOutputProcessor,
+    YCbCrProcessor,
+    YChannelProcessor,
+)
 from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
 
 VGG19_WIDTHS = (2, 2, 4, 4, 4)
@@ -149,6 +154,24 @@ def test_grayscale_to_rgb_opts_in_to_the_one_channel_case():
     loss.bind(YChannelProcessor())
 
     got = loss(torch.rand(1, 1, 32, 32), torch.rand(1, 1, 32, 32))
+
+    assert got.ndim == 0 and torch.isfinite(got)
+
+
+def test_bind_rejects_a_non_rgb_three_channel_processor_and_names_the_opt_in(vgg22):
+    """YCbCrProcessor emits 3 channels — the shape check alone would accept it, but
+    its planes are not R/G/B, so ImageNet normalisation and every downstream VGG
+    feature are meaningless. Must name allow_non_rgb, the escape hatch."""
+    with pytest.raises(ValueError, match="allow_non_rgb"):
+        vgg22.bind(YCbCrProcessor())
+
+
+def test_allow_non_rgb_opts_in_to_the_ycbcr_case():
+    with pytest.warns(UserWarning):
+        loss = VGG19FeatureLoss(layer="vgg22", allow_non_rgb=True, weights=None)
+    loss.bind(YCbCrProcessor())
+
+    got = loss(torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32))
 
     assert got.ndim == 0 and torch.isfinite(got)
 

--- a/tests/losses/test_vgg.py
+++ b/tests/losses/test_vgg.py
@@ -183,10 +183,24 @@ def test_before_activation_changes_the_features(vgg22):
     """ESRGAN's variant is a real behaviour change, not a documentation note."""
     with pytest.warns(UserWarning):
         pre = VGG19FeatureLoss(layer="vgg22", before_activation=True, weights=None)
-    pre._vgg.load_state_dict(vgg22._vgg.state_dict(), strict=False)
+    pre._vgg.load_state_dict(vgg22._vgg.state_dict(), strict=True)
     x, target = torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32)
 
     assert pre(x, target).item() != pytest.approx(vgg22(x, target).item())
+
+
+def test_describe_omits_default_knobs(vgg22):
+    assert vgg22.describe() == "VGG19FeatureLoss(vgg22)"
+
+
+def test_describe_appends_non_default_knobs():
+    """before_activation and distance both change the loss materially, so a
+    non-default value must survive into the only recipe string that lands in
+    checkpoint metadata and HParams."""
+    with pytest.warns(UserWarning):
+        loss = VGG19FeatureLoss(layer="vgg22", before_activation=True, distance="l1", weights=None)
+
+    assert loss.describe() == "VGG19FeatureLoss(vgg22, before_activation=True, distance=l1)"
 
 
 def test_rejects_an_unknown_distance():
@@ -277,3 +291,18 @@ def test_to_moves_the_unregistered_vgg_with_the_module(vgg22):
     vgg22.to(torch.float64)
 
     assert next(vgg22._vgg.parameters()).dtype is torch.float64
+
+
+def test_to_empty_with_recurse_false_leaves_the_vgg_weights_untouched(vgg22):
+    """_apply must forward recurse rather than always recursing: to_empty's
+    recurse=False call is meant to touch only this module's own tensors (there
+    are none outside _vgg), and ignoring it would silently replace every VGG
+    weight with torch.empty_like's uninitialised memory."""
+    before = [p.clone() for p in vgg22._vgg.parameters()]
+
+    vgg22.to_empty(device="cpu", recurse=False)
+
+    after = list(vgg22._vgg.parameters())
+    assert len(after) == len(before)
+    for b, a in zip(before, after, strict=True):
+        assert torch.equal(b, a)

--- a/tests/losses/test_vgg.py
+++ b/tests/losses/test_vgg.py
@@ -1,0 +1,67 @@
+import pytest
+
+from sisr.losses.vgg import _parse_layer, _resolve_slice_end
+
+VGG19_WIDTHS = (2, 2, 4, 4, 4)
+VGG16_WIDTHS = (2, 2, 3, 3, 3)
+
+
+def test_parse_layer_splits_the_two_digits():
+    assert _parse_layer("vgg22") == (2, 2)
+    assert _parse_layer("vgg54") == (5, 4)
+
+
+@pytest.mark.parametrize("bad", ["vgg2", "vgg222", "conv22", "vggxy", "22", ""])
+def test_parse_layer_rejects_anything_but_vgg_plus_two_digits(bad: str):
+    with pytest.raises(ValueError, match="vgg"):
+        _parse_layer(bad)
+
+
+@pytest.mark.parametrize(
+    ("layer", "expected_conv_idx"),
+    [
+        ("vgg11", 0),
+        ("vgg12", 2),
+        ("vgg21", 5),
+        ("vgg22", 7),
+        ("vgg31", 10),
+        ("vgg34", 16),
+        ("vgg41", 19),
+        ("vgg44", 25),
+        ("vgg51", 28),
+        ("vgg54", 34),
+    ],
+)
+def test_resolve_slice_end_matches_torchvision_vgg19_indices(layer: str, expected_conv_idx: int):
+    """These indices are measured against torchvision's real vgg19.features.
+    after-activation keeps the ReLU (conv_idx + 2); before-activation stops at
+    the conv itself (conv_idx + 1)."""
+    i, j = _parse_layer(layer)
+
+    assert _resolve_slice_end(VGG19_WIDTHS, i, j, before_activation=False) == expected_conv_idx + 2
+    assert _resolve_slice_end(VGG19_WIDTHS, i, j, before_activation=True) == expected_conv_idx + 1
+
+
+def test_resolve_slice_end_matches_torchvision_vgg16_indices():
+    """VGG16's blocks 3-5 hold 3 convs, not 4, so indices diverge from VGG19
+    past block 2 — conv2_2 is 7 in both, conv5_3 is 28 in VGG16."""
+    assert _resolve_slice_end(VGG16_WIDTHS, 2, 2, before_activation=False) == 9
+    assert _resolve_slice_end(VGG16_WIDTHS, 5, 3, before_activation=False) == 30
+
+
+def test_resolve_slice_end_rejects_a_conv_the_block_does_not_have():
+    """vgg23 looks plausible and does not exist: block 2 has 2 convs."""
+    with pytest.raises(ValueError, match="block 2 has 2"):
+        _resolve_slice_end(VGG19_WIDTHS, 2, 3, before_activation=False)
+
+
+def test_resolve_slice_end_rejects_vgg54_on_vgg16_naming_the_deepest_valid_layer():
+    """The one cross-depth trap: vgg54 is SRGAN's headline layer and simply
+    does not exist on VGG16."""
+    with pytest.raises(ValueError, match="vgg53"):
+        _resolve_slice_end(VGG16_WIDTHS, 5, 4, before_activation=False)
+
+
+def test_resolve_slice_end_rejects_an_out_of_range_block():
+    with pytest.raises(ValueError, match="block index"):
+        _resolve_slice_end(VGG19_WIDTHS, 6, 1, before_activation=False)

--- a/tests/losses/test_vgg.py
+++ b/tests/losses/test_vgg.py
@@ -1,6 +1,13 @@
-import pytest
+import functools
 
+import pytest
+import torch
+
+from sisr.losses import VGG16FeatureLoss, VGG19FeatureLoss
 from sisr.losses.vgg import _parse_layer, _resolve_slice_end
+from sisr.models.srcnn import SRCNN
+from sisr.processors import RGBProcessor, RGBSignedOutputProcessor, YChannelProcessor
+from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
 
 VGG19_WIDTHS = (2, 2, 4, 4, 4)
 VGG16_WIDTHS = (2, 2, 3, 3, 3)
@@ -65,3 +72,208 @@ def test_resolve_slice_end_rejects_vgg54_on_vgg16_naming_the_deepest_valid_layer
 def test_resolve_slice_end_rejects_an_out_of_range_block():
     with pytest.raises(ValueError, match="block index"):
         _resolve_slice_end(VGG19_WIDTHS, 6, 1, before_activation=False)
+
+
+# ---------------------------------------------------------------------------
+# VGG*FeatureLoss — every construction passes weights=None to stay offline
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vgg22() -> VGG19FeatureLoss:
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        return VGG19FeatureLoss(layer="vgg22", weights=None)
+
+
+def test_weights_none_warns_that_the_loss_is_meaningless():
+    """A random-init VGG computes a perceptual loss over noise. It is the only
+    way to keep CI offline, so it must be loud rather than convenient."""
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        VGG19FeatureLoss(weights=None)
+
+
+def test_truncates_to_only_the_layers_it_evaluates():
+    """vgg22 needs 0.26M of vgg19's 20.02M feature params. Carrying the rest
+    would be 80MB of unused weights resident for the whole run."""
+    with pytest.warns(UserWarning):
+        shallow = VGG19FeatureLoss(layer="vgg22", weights=None)
+    with pytest.warns(UserWarning):
+        deep = VGG19FeatureLoss(layer="vgg54", weights=None)
+
+    n_shallow = sum(p.numel() for p in shallow._vgg.parameters())
+    n_deep = sum(p.numel() for p in deep._vgg.parameters())
+    assert n_shallow == pytest.approx(260_000, rel=0.05)
+    assert n_deep == pytest.approx(20_024_000, rel=0.05)
+
+
+def test_vgg16_rejects_vgg54_but_vgg19_accepts_it():
+    with pytest.warns(UserWarning):
+        VGG19FeatureLoss(layer="vgg54", weights=None)
+    with pytest.raises(ValueError, match="vgg53"):
+        VGG16FeatureLoss(layer="vgg54", weights=None)
+
+
+def test_default_layer_constructs_at_both_depths():
+    """Guards the one cross-depth footgun in the default arguments."""
+    with pytest.warns(UserWarning):
+        assert VGG19FeatureLoss(weights=None).layer == "vgg22"
+    with pytest.warns(UserWarning):
+        assert VGG16FeatureLoss(weights=None).layer == "vgg22"
+
+
+def test_bind_makes_the_two_rgb_ranges_produce_identical_features(vgg22):
+    """THE test for the whole bind design: a [0, 1] tensor under RGBProcessor
+    and the same image as 2x-1 under RGBSignedOutputProcessor are the same
+    picture, so they must score identically. Without bind reading
+    output_range, the signed path feeds [-1, 1] to VGG and is silently wrong."""
+    x = torch.rand(1, 3, 32, 32)
+    target = torch.rand(1, 3, 32, 32)
+
+    vgg22.bind(RGBProcessor())
+    unsigned = vgg22(x, target)
+
+    vgg22.bind(RGBSignedOutputProcessor())
+    signed = vgg22(x * 2 - 1, target * 2 - 1)
+
+    assert signed.item() == pytest.approx(unsigned.item(), rel=1e-5)
+
+
+def test_bind_rejects_a_one_channel_processor_and_names_the_opt_in(vgg22):
+    with pytest.raises(ValueError, match="grayscale_to_rgb"):
+        vgg22.bind(YChannelProcessor())
+
+
+def test_grayscale_to_rgb_opts_in_to_the_one_channel_case():
+    with pytest.warns(UserWarning):
+        loss = VGG19FeatureLoss(layer="vgg22", grayscale_to_rgb=True, weights=None)
+    loss.bind(YChannelProcessor())
+
+    got = loss(torch.rand(1, 1, 32, 32), torch.rand(1, 1, 32, 32))
+
+    assert got.ndim == 0 and torch.isfinite(got)
+
+
+def test_error_message_names_the_concrete_subclass(vgg22):
+    with pytest.raises(ValueError, match="VGG19FeatureLoss"):
+        vgg22.bind(YChannelProcessor())
+
+
+def test_feature_scale_squares_into_an_mse_and_is_linear_in_an_l1():
+    """feature_scale multiplies the feature maps (the paper's wording), so an
+    MSE of them carries its square. Switching distance changes the magnitude
+    by 12.75x, which is why the docstring has to say so."""
+    x, target = torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32)
+    for distance, power in (("mse", 2), ("l1", 1)):
+        with pytest.warns(UserWarning):
+            unscaled = VGG19FeatureLoss(
+                layer="vgg22", feature_scale=1.0, distance=distance, weights=None
+            )
+        with pytest.warns(UserWarning):
+            scaled = VGG19FeatureLoss(
+                layer="vgg22", feature_scale=0.5, distance=distance, weights=None
+            )
+        scaled._vgg.load_state_dict(unscaled._vgg.state_dict())
+
+        ratio = scaled(x, target).item() / unscaled(x, target).item()
+
+        assert ratio == pytest.approx(0.5**power, rel=1e-4), distance
+
+
+def test_before_activation_changes_the_features(vgg22):
+    """ESRGAN's variant is a real behaviour change, not a documentation note."""
+    with pytest.warns(UserWarning):
+        pre = VGG19FeatureLoss(layer="vgg22", before_activation=True, weights=None)
+    pre._vgg.load_state_dict(vgg22._vgg.state_dict(), strict=False)
+    x, target = torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32)
+
+    assert pre(x, target).item() != pytest.approx(vgg22(x, target).item())
+
+
+def test_rejects_an_unknown_distance():
+    with pytest.raises(ValueError, match="distance"):
+        VGG19FeatureLoss(distance="huber", weights=None)
+
+
+# --- the grad contract: three independent facts ---
+
+
+def test_frozen_vgg_takes_no_gradient_but_still_passes_one_through(vgg22):
+    """Frozen weights and a grad-carrying forward are independent. Wrapping the
+    SR branch in no_grad would kill all learning while the loss still moved."""
+    vgg22.bind(RGBProcessor())
+    model = torch.nn.Conv2d(3, 3, 3, padding=1)
+    pred = model(torch.rand(1, 3, 32, 32))
+
+    vgg22(pred, torch.rand(1, 3, 32, 32)).backward()
+
+    assert model.weight.grad is not None, "gradient must reach the generator"
+    assert all(p.grad is None for p in vgg22._vgg.parameters()), "VGG must not accumulate"
+    assert not any(p.requires_grad for p in vgg22._vgg.parameters())
+
+
+def test_target_branch_is_not_differentiated(vgg22):
+    """The target is a constant; building its graph is wasted memory."""
+    vgg22.bind(RGBProcessor())
+    target = torch.rand(1, 3, 32, 32, requires_grad=True)
+
+    vgg22(torch.rand(1, 3, 32, 32, requires_grad=True), target).backward()
+
+    assert target.grad is None
+
+
+def test_vgg_params_are_invisible_to_the_optimizer(vgg22):
+    """A frozen 20M-param VGG inside .parameters() is an accident waiting for
+    someone to call requires_grad_(True) on the module."""
+    lit = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=vgg22,
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+    assert not any(p.numel() > 100_000 for p in lit.parameters())
+
+
+# --- checkpoint hygiene ---
+
+
+def test_vgg_is_absent_from_the_modules_state_dict(vgg22):
+    """20M frozen params would be ~80MB in every .ckpt, and the template writes
+    two monitors at top-k 3. It would also break strict-mode loading of a
+    checkpoint trained under a different criterion."""
+    lit = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=vgg22,
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+    keys = list(lit.state_dict())
+
+    assert not any("criterion" in k for k in keys), keys
+    assert all(k.startswith("model.") for k in keys), keys
+
+
+def test_an_mse_checkpoint_loads_strictly_into_a_vgg_configured_module(vgg22):
+    """The practical payoff of keeping VGG out of state_dict: recipes stay
+    interchangeable across a resume."""
+    args = dict(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    mse_state = SRLightning(**args).state_dict()
+
+    SRLightning(**args, criterion=vgg22).load_state_dict(mse_state, strict=True)
+
+
+def test_to_moves_the_unregistered_vgg_with_the_module(vgg22):
+    """VGG lives outside the module tree, so .to() reaches it only through the
+    _apply override. Without it, the first real step dies on a device mismatch."""
+    vgg22.to(torch.float64)
+
+    assert next(vgg22._vgg.parameters()).dtype is torch.float64

--- a/tests/processors/test_base.py
+++ b/tests/processors/test_base.py
@@ -66,6 +66,28 @@ def test_srprocessor_subclass_missing_output_range_raises():
         _MissingOutputRange()
 
 
+def test_srprocessor_subclass_missing_output_colorspace_raises():
+    """output_colorspace is abstract too — model_channels/output_range alone isn't enough."""
+
+    class _MissingOutputColorspace(SRProcessor):
+        def extract(self, lr_rgb):
+            return lr_rgb
+
+        def reconstruct(self, sr_model_out, lr_rgb):
+            return sr_model_out
+
+        @property
+        def model_channels(self):
+            return 3
+
+        @property
+        def output_range(self):
+            return (0.0, 1.0)
+
+    with pytest.raises(TypeError, match="abstract"):
+        _MissingOutputColorspace()
+
+
 def test_srprocessor_complete_subclass_instantiates():
     """Subclass implementing all abstract members can be instantiated."""
 
@@ -84,6 +106,10 @@ def test_srprocessor_complete_subclass_instantiates():
         def output_range(self):
             return (0.0, 1.0)
 
+        @property
+        def output_colorspace(self):
+            return "RGB"
+
     p = _Complete()
     assert isinstance(p, SRProcessor)
     x = torch.zeros(1, 3, 4, 4)
@@ -91,6 +117,7 @@ def test_srprocessor_complete_subclass_instantiates():
     assert torch.equal(p.reconstruct(x, x), x)
     assert p.model_channels == 3
     assert p.output_range == (0.0, 1.0)
+    assert p.output_colorspace == "RGB"
 
 
 def test_extract_target_is_concrete_and_delegates_to_extract():
@@ -110,6 +137,10 @@ def test_extract_target_is_concrete_and_delegates_to_extract():
         @property
         def output_range(self):
             return (0.0, 1.0)
+
+        @property
+        def output_colorspace(self):
+            return "RGB"
 
     p = _Doubling()  # instantiates without defining extract_target
     x = torch.rand(1, 3, 4, 4)

--- a/tests/processors/test_rgb.py
+++ b/tests/processors/test_rgb.py
@@ -35,6 +35,10 @@ def test_rgb_output_range_is_unit():
     assert RGBProcessor().output_range == (0.0, 1.0)
 
 
+def test_rgb_output_colorspace_is_rgb():
+    assert RGBProcessor().output_colorspace == "RGB"
+
+
 def test_rgb_extract_target_defaults_to_extract():
     """RGBProcessor doesn't override extract_target, so LR and HR share one transform."""
     p = RGBProcessor()
@@ -76,3 +80,8 @@ def test_signed_output_is_srprocessor():
 def test_signed_output_output_range_is_signed():
     """The whole reason this processor exists: output_range is [-1, 1], not [0, 1]."""
     assert RGBSignedOutputProcessor().output_range == (-1.0, 1.0)
+
+
+def test_signed_output_output_colorspace_is_rgb():
+    """Only the range differs from RGBProcessor — the colorspace is still RGB."""
+    assert RGBSignedOutputProcessor().output_colorspace == "RGB"

--- a/tests/processors/test_y_channel.py
+++ b/tests/processors/test_y_channel.py
@@ -18,6 +18,10 @@ def test_y_channel_output_range_is_unit():
     assert YChannelProcessor().output_range == (0.0, 1.0)
 
 
+def test_y_channel_output_colorspace_is_y():
+    assert YChannelProcessor().output_colorspace == "Y"
+
+
 def test_y_channel_extract_returns_single_y_channel():
     """extract returns Y of the LR in YCbCr (shape [B,1,H,W])."""
     p = YChannelProcessor()

--- a/tests/processors/test_ycbcr.py
+++ b/tests/processors/test_ycbcr.py
@@ -18,6 +18,10 @@ def test_ycbcr_output_range_is_unit():
     assert YCbCrProcessor().output_range == (0.0, 1.0)
 
 
+def test_ycbcr_output_colorspace_is_ycbcr():
+    assert YCbCrProcessor().output_colorspace == "YCbCr"
+
+
 def test_ycbcr_extract_returns_full_ycbcr():
     """extract returns full YCbCr (shape [B,3,H,W]) matching rgb_to_ycbcr."""
     p = YCbCrProcessor()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,6 +114,56 @@ def test_srresnet_config_resolves_in_process():
     assert not hasattr(m.eval_config, "model_colorspace")
 
 
+def test_composite_criterion_resolves_through_the_real_cli(tmp_path: Path):
+    """The paper's SRResNet-VGG22 recipe (Ledig et al. §3.4: a VGG22 content
+    term plus total variation at 2e-8, no pixel term) resolved from YAML through
+    the real CLI, not constructed in Python.
+
+    WeightedSumLoss(terms: dict[str, torch.nn.Module]) with per-term nested
+    class_path/init_args relies on one specific jsonargparse capability that
+    every other composite test bypasses by building objects directly. This is
+    the one test that would catch a jsonargparse regression, a typo'd
+    class_path in the README/templates, or a terms/weights rename.
+
+    weights: null on the VGG term keeps this offline (random-init VGG) and
+    fires the "randomly initialised" UserWarning at instantiation time, which
+    the strict filterwarnings=error config would otherwise turn into a failure.
+    """
+    from sisr.losses import TotalVariationLoss, VGG19FeatureLoss, WeightedSumLoss
+
+    overlay = {
+        "model": {
+            "criterion": {
+                "class_path": "sisr.losses.WeightedSumLoss",
+                "init_args": {
+                    "terms": {
+                        "vgg22": {
+                            "class_path": "sisr.losses.VGG19FeatureLoss",
+                            "init_args": {"layer": "vgg22", "weights": None},
+                        },
+                        "tv": {"class_path": "sisr.losses.TotalVariationLoss"},
+                    },
+                    "weights": {"vgg22": 1.0, "tv": 2.0e-8},
+                },
+            }
+        }
+    }
+    overlay_path = tmp_path / "criterion_overlay.yaml"
+    # sort_keys=False: yaml.safe_dump's default alphabetical sort would reorder
+    # "terms" (tv before vgg22), and describe()'s order follows insertion order.
+    overlay_path.write_text(yaml.safe_dump(overlay, sort_keys=False))
+
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        cli = _resolve("--config", str(SRRESNET_TEMPLATE), "--config", str(overlay_path))
+
+    criterion = cli.model.criterion
+    assert isinstance(criterion, WeightedSumLoss)
+    assert isinstance(criterion.terms["vgg22"], VGG19FeatureLoss)
+    assert isinstance(criterion.terms["tv"], TotalVariationLoss)
+    assert criterion.weights == {"vgg22": pytest.approx(1.0), "tv": pytest.approx(2.0e-8)}
+    assert criterion.describe() == "1*vgg22 + 2e-08*tv"
+
+
 def test_test_subcommand_help_exposes_ckpt_path_in_process(capsys, monkeypatch):
     """`test --help` documents --ckpt_path and --data.test_datasets.
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -195,6 +195,7 @@ def test_to_onnx_writes_metadata_props(tmp_path):
     assert io_field["input"] == "pre_upsampled"
     assert io_field["input_channels"] == 1
     assert io_field["output_range"] == [0.0, 1.0]
+    assert io_field["output_colorspace"] == "Y"
 
     training_field = json.loads(props["training"])
     assert training_field == {

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -175,6 +175,7 @@ def test_to_onnx_writes_metadata_props(tmp_path):
         "versions",
         "model",
         "processor",
+        "criterion",
         "io",
         "eval_config",
         "training",

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -590,4 +590,5 @@ def test_cuda_graph_replay_keeps_per_term_losses_live():
     graphed, module = _run_composite_graph_fit(cuda_graph=True, n_samples=14, max_steps=12)
 
     assert module._cuda_graph is not None and module._cuda_graph.captured
+    assert len(graphed) == 12
     assert graphed == eager

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -539,13 +539,21 @@ def test_fast_dev_run_logs_per_term_loss_tags_for_a_composite_criterion(
     assert {"loss/val", "loss/val/vgg22", "loss/val/tv"} <= metrics
 
 
-@requires_cuda
-@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
-def test_cuda_graph_replay_keeps_per_term_losses_live():
-    """last_terms holds clones captured inside the graph. If a replay stopped
-    rewriting them the tags would freeze at their capture-time values while
-    loss/train kept moving — the same silent-staleness class as a severed
-    gradient."""
+class _TermTrace(lightning.Callback):
+    """Records the per-step ``last_terms`` values, for exact cross-run comparison."""
+
+    def __init__(self):
+        self.terms: list[dict[str, float]] = []
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        self.terms.append({name: float(v) for name, v in pl_module.criterion.last_terms.items()})
+
+
+def _run_composite_graph_fit(
+    cuda_graph: bool, n_samples: int, max_steps: int
+) -> tuple[list[dict[str, float]], SRLightning]:
+    """Fit a graphed-or-eager SRCNN under a named composite criterion and
+    return its per-step ``last_terms`` trace."""
     lightning.seed_everything(7, verbose=False)
     criterion = WeightedSumLoss(
         terms={"mse": torch.nn.MSELoss(), "tv": TotalVariationLoss()},
@@ -554,22 +562,32 @@ def test_cuda_graph_replay_keeps_per_term_losses_live():
     module = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(cuda_graph=True),
+        training_config=SRTrainingConfig(cuda_graph=cuda_graph),
         eval_config=SREvalConfig(crop_border=0),
         criterion=criterion,
         optimizer=functools.partial(torch.optim.SGD, lr=1e-2, momentum=0.9),
     )
-
-    class _TermTrace(lightning.Callback):
-        def __init__(self):
-            self.mse: list[float] = []
-
-        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
-            self.mse.append(float(pl_module.criterion.last_terms["mse"]))
-
     trace = _TermTrace()
-    loader = DataLoader(_FixedPairs(16), batch_size=4, num_workers=0, shuffle=False)
-    _graph_trainer([trace], max_steps=8).fit(module, train_dataloaders=loader)
+    loader = DataLoader(_FixedPairs(n_samples), batch_size=4, num_workers=0, shuffle=False)
+    _graph_trainer([trace], max_steps=max_steps).fit(module, train_dataloaders=loader)
+    return trace.terms, module
+
+
+@requires_cuda
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_cuda_graph_replay_keeps_per_term_losses_live():
+    """last_terms must be written in place, not rebound. 14 samples at batch 4
+    ends every epoch on a 2-sample batch the graph cannot replay, and
+    max_steps=12 spans more than one such epoch boundary, so an eager
+    fallback genuinely interleaves with graph replays — mirrors
+    test_cuda_graph_partial_last_batch_falls_back_without_stale_gradients's
+    idiom, but on the per-term breakdown instead of the summed total.
+    Rebinding last_terms on that fallback (the bug this guards) would strand
+    every later replay's per-term tag on the fallback's eager value,
+    diverging silently from the un-graphed trace while loss/train kept moving.
+    """
+    eager, _ = _run_composite_graph_fit(cuda_graph=False, n_samples=14, max_steps=12)
+    graphed, module = _run_composite_graph_fit(cuda_graph=True, n_samples=14, max_steps=12)
 
     assert module._cuda_graph is not None and module._cuda_graph.captured
-    assert len(set(trace.mse)) > 1, "per-term losses froze across graph replays"
+    assert graphed == eager

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -21,6 +21,7 @@ import torch
 from lightning.pytorch.callbacks import GradientAccumulationScheduler
 from torch.utils.data import DataLoader, Dataset
 
+from sisr.losses import TotalVariationLoss, VGG19FeatureLoss, WeightedSumLoss
 from sisr.models.srcnn import SRCNN
 from sisr.models.srresnet import SRResNetTrainingConfig
 from sisr.models.srresnet.model import SRResNet
@@ -495,3 +496,80 @@ def test_cuda_graph_capture_leaves_batchnorm_buffers_untouched():
     assert step.captured
     for name, buf in module.named_buffers():
         assert torch.equal(buf, before[name]), name
+
+
+# ---------------------------------------------------------------------------
+# composite criterion — per-term tags must appear through a real loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_fast_dev_run_logs_per_term_loss_tags_for_a_composite_criterion(
+    tiny_rgb_image_dir: Path,
+):
+    """Only a real fit proves training_step/validation_step actually read
+    last_terms — a direct _step() call populates the dict but logs nothing."""
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        vgg = VGG19FeatureLoss(layer="vgg22", weights=None)
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=WeightedSumLoss(
+            terms={"vgg22": vgg, "tv": TotalVariationLoss()},
+            weights={"vgg22": 1.0, "tv": 2.0e-8},
+        ),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    trainer = lightning.Trainer(
+        fast_dev_run=True,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+    trainer.fit(module, datamodule=_make_datamodule(tiny_rgb_image_dir))
+
+    metrics = set(trainer.callback_metrics)
+    assert {"loss/train", "loss/train/vgg22", "loss/train/tv"} <= metrics
+    assert {"loss/val", "loss/val/vgg22", "loss/val/tv"} <= metrics
+
+
+@requires_cuda
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_cuda_graph_replay_keeps_per_term_losses_live():
+    """last_terms holds clones captured inside the graph. If a replay stopped
+    rewriting them the tags would freeze at their capture-time values while
+    loss/train kept moving — the same silent-staleness class as a severed
+    gradient."""
+    lightning.seed_everything(7, verbose=False)
+    criterion = WeightedSumLoss(
+        terms={"mse": torch.nn.MSELoss(), "tv": TotalVariationLoss()},
+        weights={"mse": 1.0, "tv": 1e-3},
+    )
+    module = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(cuda_graph=True),
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=criterion,
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-2, momentum=0.9),
+    )
+
+    class _TermTrace(lightning.Callback):
+        def __init__(self):
+            self.mse: list[float] = []
+
+        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+            self.mse.append(float(pl_module.criterion.last_terms["mse"]))
+
+    trace = _TermTrace()
+    loader = DataLoader(_FixedPairs(16), batch_size=4, num_workers=0, shuffle=False)
+    _graph_trainer([trace], max_steps=8).fit(module, train_dataloaders=loader)
+
+    assert module._cuda_graph is not None and module._cuda_graph.captured
+    assert len(set(trace.mse)) > 1, "per-term losses froze across graph replays"

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -12,6 +12,7 @@ import torch._dynamo
 import torchmetrics
 from lightning.pytorch.callbacks import GradientAccumulationScheduler
 
+from sisr.losses import SRLoss
 from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
 from sisr.models.srresnet import SRResNetTrainingConfig
 from sisr.models.srresnet.model import SRResNet
@@ -2045,3 +2046,67 @@ def test_cuda_graph_disable_warns_once_and_sticks():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert step.run((torch.zeros(1),)) is None
+
+
+# ---------------------------------------------------------------------------
+# criterion binding
+# ---------------------------------------------------------------------------
+
+
+class _SpyLoss(SRLoss):
+    """Records every bind() call so wiring can be asserted, not assumed."""
+
+    def __init__(self):
+        super().__init__()
+        self.bound: list[SRProcessor] = []
+
+    def bind(self, processor: SRProcessor) -> None:
+        self.bound.append(processor)
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        return (pred - target).pow(2).mean()
+
+
+def _lit_with_criterion(criterion, processor):
+    return SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=processor,
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=criterion,
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def test_srloss_criterion_is_bound_once_to_the_modules_own_processor():
+    """The bind seam is the only way a loss learns output_range/model_channels.
+    Binding twice would let a stateful loss double-apply its range mapping."""
+    spy, processor = _SpyLoss(), RGBSignedOutputProcessor()
+
+    _lit_with_criterion(spy, processor)
+
+    assert spy.bound == [processor], "bind must run exactly once, with this module's processor"
+
+
+def test_plain_nn_module_criterion_is_never_bound_and_still_trains():
+    """Regression guard for the isinstance branch: torch.nn losses have no bind()
+    and must keep working untouched, including the MSELoss default."""
+    lit = _lit_with_criterion(torch.nn.L1Loss(), RGBProcessor())
+    lr, hr = torch.rand(2, 3, 8, 8), torch.rand(2, 3, 8, 8)
+
+    loss, *_ = lit._step((lr, hr))
+
+    assert torch.isfinite(loss)
+    assert lit.criterion_description == "L1Loss"
+
+
+def test_criterion_description_prefers_describe_for_srloss():
+    """One derivation point feeds both the HParams column and checkpoint metadata."""
+
+    class _Described(_SpyLoss):
+        def describe(self) -> str:
+            return "spy(recipe)"
+
+    lit = _lit_with_criterion(_Described(), RGBProcessor())
+
+    assert lit.criterion_description == "spy(recipe)"
+    assert lit._tb_hparams["criterion"] == "spy(recipe)"

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -88,11 +88,13 @@ def test_build_metadata_io_reflects_model_input_contract_and_processor():
     assert srcnn_meta["io"]["input"] == "pre_upsampled"
     assert srcnn_meta["io"]["input_channels"] == 1  # YChannelProcessor.model_channels
     assert srcnn_meta["io"]["output_range"] == [0.0, 1.0]
+    assert srcnn_meta["io"]["output_colorspace"] == "Y"
 
     srresnet_meta = build_metadata(_make_srresnet_lit())
     assert srresnet_meta["io"]["input"] == "native_lr"
     assert srresnet_meta["io"]["input_channels"] == 3  # RGBSignedOutputProcessor.model_channels
     assert srresnet_meta["io"]["output_range"] == [-1.0, 1.0]  # the asymmetric paper range
+    assert srresnet_meta["io"]["output_colorspace"] == "RGB"
 
 
 def test_build_metadata_scale_prefers_training_config_scale():

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -1,11 +1,13 @@
 import functools
 import json
 
+import pytest
 import torch
 
+from sisr.losses import TotalVariationLoss, VGG19FeatureLoss, WeightedSumLoss
 from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig
 from sisr.models.srresnet import SRResNet, SRResNetEvalConfig, SRResNetTrainingConfig
-from sisr.processors import RGBSignedOutputProcessor, YChannelProcessor
+from sisr.processors import RGBProcessor, RGBSignedOutputProcessor, YChannelProcessor
 from sisr.training import SRLightning, SRTrainingConfig
 from sisr.training.metadata import build_metadata
 
@@ -41,6 +43,7 @@ def test_build_metadata_top_level_shape():
         "versions",
         "model",
         "processor",
+        "criterion",
         "io",
         "eval_config",
         "training",
@@ -191,3 +194,51 @@ def test_build_metadata_every_field_json_encodable_individually():
         assert isinstance(encoded, str)
         if not isinstance(value, str):
             assert json.loads(encoded) == value
+
+
+def test_metadata_records_the_criterion_identity():
+    """Provenance for 'which loss produced these weights'. A VGG-trained model
+    and an MSE-trained one are indistinguishable from the tensors alone."""
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        vgg = VGG19FeatureLoss(layer="vgg22", weights=None)
+    module = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBSignedOutputProcessor(),
+        criterion=WeightedSumLoss(
+            terms={"vgg22": vgg, "tv": TotalVariationLoss()},
+            weights={"vgg22": 1.0, "tv": 2.0e-8},
+        ),
+    )
+
+    meta = build_metadata(module)
+
+    assert meta["criterion"]["class_path"] == "sisr.losses.composite.WeightedSumLoss"
+    assert meta["criterion"]["description"] == "1*vgg22 + 2e-08*tv"
+
+
+def test_metadata_criterion_defaults_to_the_class_name_for_a_plain_loss():
+    module = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+    )
+
+    meta = build_metadata(module)
+
+    assert meta["criterion"] == {
+        "class_path": "torch.nn.modules.loss.MSELoss",
+        "description": "MSELoss",
+    }
+
+
+def test_metadata_stays_weights_only_loadable_with_a_criterion_block(tmp_path):
+    """Every metadata value must remain a plain type — the checkpoint contract."""
+    module = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+    )
+    path = tmp_path / "meta.pt"
+    torch.save({"meta": build_metadata(module)}, path)
+
+    loaded = torch.load(path, weights_only=True)
+
+    assert loaded["meta"]["criterion"]["description"] == "MSELoss"


### PR DESCRIPTION
Adds pluggable loss functions selectable and combinable entirely from YAML: Charbonnier, isotropic total variation, and VGG16/VGG19 feature-space perceptual losses, plus a named weighted sum that composes them. L1 and MSE need no new class — `torch.nn.L1Loss` already works as a criterion — so they ship as documented recipes instead of wrappers.

## ⛔ Do not merge yet

Seven `@requires_cuda` tests are currently **skipped**, not passing: a training run owns the machine's only GPU, so they were deliberately held. One of them is the sole real-hardware guard on the CUDA-graph interaction below. Suite is **612 passed / 9 skipped** (2 data-dependent + 7 GPU-held). Merge after those seven run green.

## The design

`SRLightning.criterion` was already YAML-wired with an `MSELoss` default, so the gap was the losses themselves plus a way for a loss to learn the model's output space. That is the one new seam: an `SRLoss` base declaring **abstract** `bind(processor)`, called once in `SRLightning.__init__`. A loss reads `output_range` / `model_channels` / `output_colorspace` from the processor rather than restating them in YAML, so the two cannot disagree. Plain `torch.nn.Module` criteria keep working untouched.

`bind` is abstract rather than defaulted for the same stated reason `SRProcessor.output_range` is: a wrong inherited default is exactly the failure the declaration prevents.

The one perceptual recipe reproducible here without a discriminator is Ledig et al.'s SRResNet-VGG22 — a VGG22 content loss plus total variation at `2e-8`, with **no pixel term** — which is why composition is in scope at all.

## Paper fidelity

Quoted rather than recalled: `φ_{i,j}` is the feature map after the j-th convolution *after activation* before the i-th maxpool (ESRGAN's pre-activation variant is a flag); feature maps are rescaled `1/12.75`, so an MSE of them carries `0.0061513` — the paper's "≈0.006"; total variation at `2e-8` applies to SRResNet-VGG22 **only**; and the MSE-initialisation trick is scoped to the GAN, so SRResNet-VGG22 trains from scratch.

Layer resolution is exercised against real torchvision: `conv2_2` → index 7 and `conv5_4` → 34 on VGG19, `conv5_3` → 28 on VGG16. Any `φ_{i,j}` works; a layer a depth does not have raises and names the deepest one that exists (`vgg54` is valid on VGG19, invalid on VGG16).

## Two silent-wrongness paths closed by construction

- **Range.** The same picture in `[0,1]` and in `[-1,1]` must score identically. A test asserts exactly that, and no-op'ing `bind` makes it fail — so the seam is verified, not asserted.
- **Colour space.** `SRProcessor` gained an abstract `output_colorspace`, so a VGG loss now refuses a 3-channel **non-RGB** processor (`YCbCrProcessor`) unless `allow_non_rgb: true`. Previously it was accepted silently: VGG received Y/Cb/Cr planes as R/G/B, normalised with RGB ImageNet statistics, and returned a healthy-looking loss for a run that reproduced nothing. The 1-channel case stays inside the pre-existing `grayscale_to_rgb` gate, so one flag covers one intent.

## Checkpoints stay small, and recipes stay interchangeable

The frozen truncated VGG is held outside the module tree (`object.__setattr__`, the existing `_compiled` precedent) with `_apply` overridden so `.to()` and dtype casts still reach it. A `.ckpt` therefore stays ~19 MB instead of ~99 MB, and an MSE-trained checkpoint still loads `strict=True` into a VGG-configured module. Only the slice actually evaluated is retained — vgg22 keeps 260,160 parameters, not 20,024,384.

Side effects worth knowing: the VGG cannot be flipped to `train()` by a parent, and a parent-wide `requires_grad_(True)` cannot unfreeze it — both strictly safer than a registered submodule. The cost is that it is invisible in `ModelSummary`.

Which loss trained a model is now recorded in checkpoint/ONNX provenance, including non-default knobs, since `before_activation` and `distance` change the objective materially.

## One bug worth reading about

The final review caught a Critical that no per-task review could see. `WeightedSumLoss` **rebound** `last_terms[name]` each forward. A CUDA-graph replay re-executes only recorded kernels, never that Python line, so only the tensor present at capture can ever be updated — and any interleaved *eager* forward (mid-training validation, or an epoch's partial last batch) repointed the entry at a tensor no replay would touch. Every `loss/train/<term>` tag would freeze at a validation batch's value while `loss/train` kept moving, and the "terms sum to the total" property would quietly stop holding.

That is the same failure class as #75 — mid-training validation severing a graph-owned binding. Per-term values are now written **in place** into stable buffers, which also made the contract CPU-testable: the guard asserts the same tensor object across forwards with a changed value, and it fails on the pre-fix code.

The test originally written to guard this **would have passed with the bug present** (four exact batches, no validation loop, so no eager step ever interleaved). It has been rewritten to compare graphed and eager per-term traces with a partial last batch forcing an interleave — and it is one of the seven still awaiting the GPU.

## Verification

- **612 passed / 9 skipped**; ruff clean; `pyproject.toml` unchanged — **no new dependency**, torchvision was already required.
- Every VGG in a test builds with `weights=None`, so the suite never touches the network. A real first use downloads ~548 MB once.
- The import-weight guards still hold: `sisr/cache.py` and `sisr/datasets/hr_cache.py` remain torch-free.
- The composite recipe is resolved **through the real CLI**, not constructed in Python, so the nested `class_path`/`init_args` path is a regression guard rather than an assumption.
- Reviews mutation-tested each silent mechanism — the grad asymmetry, the range mapping, the unregistered VGG, `_apply`, `bind` forwarding, and the weighted `last_terms` — confirming a test fails when each is broken.

## Known limitations

`ModelSummary` invisibility; per-term logging is a structural protocol rather than a declared member; a resume whose config omits `criterion:` silently reverts to MSE (a mismatch warning is a candidate follow-up); and step-time and peak-memory figures for VGG runs are still unmeasured, VGG54 at 96×96×b16 being the specific memory risk.

Docs ship separately in the stacked doc-only PR, so this branch stays code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
