### PR TITLE
Document the loss options and the SRResNet-VGG22 recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,65 @@ means writing a network and a config dataclass, not a new Lightning module. See
 | SRCNN | [Dong et al. 2015](https://arxiv.org/pdf/1501.00092) | pre-upsampled to HR size | none, same-resolution refinement |
 | SRResNet | [Ledig et al. 2017](https://arxiv.org/pdf/1609.04802) | true low-resolution | ×scale sub-pixel convolution |
 
+## Losses
+
+The criterion is wired from YAML like everything else, and defaults to
+`torch.nn.MSELoss`. Any `nn.Module` taking `(pred, target)` works, so L1 needs no
+class of ours:
+
+```yaml
+model:
+  criterion:
+    class_path: torch.nn.L1Loss
+```
+
+| Class | What it is |
+|---|---|
+| `torch.nn.MSELoss` | the default; both papers' baseline |
+| `torch.nn.L1Loss` | plain L1 |
+| `sisr.losses.CharbonnierLoss` | `sqrt(diff² + eps²)` — L1 with a finite gradient at zero |
+| `sisr.losses.TotalVariationLoss` | isotropic TV regulariser; ignores its target |
+| `sisr.losses.VGG19FeatureLoss` | VGG19 feature-space perceptual loss, any `φ_{i,j}` |
+| `sisr.losses.VGG16FeatureLoss` | the same on VGG16 (deepest layer is `vgg53`) |
+| `sisr.losses.WeightedSumLoss` | named weighted sum of any of the above |
+
+Combining them logs each term separately as `loss/train/{name}` and
+`loss/val/{name}`, so you can see which one dominates:
+
+```yaml
+model:
+  criterion:
+    class_path: sisr.losses.WeightedSumLoss
+    init_args:
+      terms:
+        vgg22:
+          class_path: sisr.losses.VGG19FeatureLoss
+          init_args:
+            layer: vgg22
+        tv:
+          class_path: sisr.losses.TotalVariationLoss
+      weights: {vgg22: 1.0, tv: 2.0e-8}
+```
+
+That is Ledig et al.'s SRResNet-VGG22 recipe: a VGG22 content loss plus total
+variation at `2e-8`, no pixel term, trained from scratch. Three things to know
+before running it:
+
+- **The first use downloads ~548 MB** of VGG19 weights into the torch hub cache.
+  Pass `weights: null` to skip the download, but only for tests — it builds a
+  random VGG and warns, because the loss it then computes is meaningless.
+- **TV's `2e-8` presumes a `[-1, 1]` model output range**, i.e.
+  `RGBSignedOutputProcessor`. Under a `[0, 1]` processor the same image has half
+  the total variation, so the effective weight differs by 2×.
+- **A perceptual run scores worse PSNR by design.** The shipped templates monitor
+  `psnr/val/RGB`, which then no longer tracks the training objective — re-point
+  `SRCheckpoint.monitor_metric` at an SSIM key, or accept it knowingly.
+
+A VGG loss needs 3-channel RGB, so it refuses a 1-channel processor (SRCNN's
+`YChannelProcessor`) unless you set `grayscale_to_rgb: true`. The frozen VGG is
+deliberately excluded from checkpoints, so a `.ckpt` trained under one criterion
+loads into a module configured with another.
+
 ## Comparability
 
 Benchmark numbers only mean something if the inputs and the metrics match the papers', so

--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ before running it:
   criterion the PSNR-monitored "best" no longer tracks the training objective, so
   decide which monitored checkpoint you actually want.
 
+### What a perceptual run costs
+
+Measured on an RTX 5060 Laptop (8 GB) at SRResNet's paper geometry — batch 16,
+96×96 HR crops, ×4, real DIV2K — as steady-state medians with warmup discarded.
+`cuda_graph: true` throughout; peak memory is `torch.cuda.max_memory_reserved`
+with the val loop excluded.
+
+| criterion | ms/step | vs MSE | peak reserved | 1e6 steps |
+|---|---|---|---|---|
+| `MSELoss` | 28.5 | 1.00× | 618 MiB | ~7.9 h |
+| `vgg22` + `tv` | 40.8 | 1.43× | 1352 MiB | ~11.3 h |
+| `vgg54` | 59.3 | 2.08× | 1490 MiB | ~16.5 h |
+
+Two things worth knowing before you plan a run: **CUDA-graph capture works with a
+VGG in the captured region** at every depth (graphs are still worth 1.22–1.37×
+under a perceptual loss, versus 1.52× under MSE — the VGG forward is real GPU work
+that graphs cannot remove), and **memory is not the constraint at this geometry**.
+Your own numbers will differ with hardware, crop size and batch size; the ratios
+travel better than the absolute times.
+
 A VGG loss normalises with RGB ImageNet statistics, so it refuses a 1-channel
 processor (SRCNN's `YChannelProcessor`) unless you set `grayscale_to_rgb: true`,
 and it refuses a 3-channel non-RGB processor (`YCbCrProcessor`) unless you set

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ model:
 | `torch.nn.L1Loss` | plain L1 |
 | `sisr.losses.CharbonnierLoss` | `sqrt(diff² + eps²)` — L1 with a finite gradient at zero |
 | `sisr.losses.TotalVariationLoss` | isotropic TV regulariser; ignores its target |
-| `sisr.losses.VGG19FeatureLoss` | VGG19 feature-space perceptual loss, any `φ_{i,j}` |
-| `sisr.losses.VGG16FeatureLoss` | the same on VGG16 (deepest layer is `vgg53`) |
+| `sisr.losses.VGG19FeatureLoss` | VGG19 feature-space perceptual loss, any `φ_{i,j}` — blocks 1-2 have 2 convolutions, blocks 3-5 have 4 (up to `vgg54`) |
+| `sisr.losses.VGG16FeatureLoss` | the same on VGG16, but blocks 3-5 have 3 convolutions instead of 4 (deepest is `vgg53`) — experimentation only, no published SR recipe uses this depth |
 | `sisr.losses.WeightedSumLoss` | named weighted sum of any of the above |
 
 Combining them logs each term separately as `loss/train/{name}` and
@@ -125,14 +125,18 @@ before running it:
 - **TV's `2e-8` presumes a `[-1, 1]` model output range**, i.e.
   `RGBSignedOutputProcessor`. Under a `[0, 1]` processor the same image has half
   the total variation, so the effective weight differs by 2×.
-- **A perceptual run scores worse PSNR by design.** The shipped templates monitor
-  `psnr/val/RGB`, which then no longer tracks the training objective — re-point
-  `SRCheckpoint.monitor_metric` at an SSIM key, or accept it knowingly.
+- **A perceptual run scores worse PSNR by design.** The shipped templates already
+  checkpoint on both `psnr/val/RGB` and `ssim/val/RGB` — under a perceptual
+  criterion the PSNR-monitored "best" no longer tracks the training objective, so
+  decide which monitored checkpoint you actually want.
 
-A VGG loss needs 3-channel RGB, so it refuses a 1-channel processor (SRCNN's
-`YChannelProcessor`) unless you set `grayscale_to_rgb: true`. The frozen VGG is
-deliberately excluded from checkpoints, so a `.ckpt` trained under one criterion
-loads into a module configured with another.
+A VGG loss normalises with RGB ImageNet statistics, so it refuses a 1-channel
+processor (SRCNN's `YChannelProcessor`) unless you set `grayscale_to_rgb: true`,
+and it refuses a 3-channel non-RGB processor (`YCbCrProcessor`) unless you set
+`allow_non_rgb: true` — feeding Y/Cb/Cr planes to VGG as though they were R/G/B
+trains on features that mean nothing. The frozen VGG is deliberately excluded
+from checkpoints, so a `.ckpt` trained under one criterion loads into a module
+configured with another.
 
 ## Comparability
 

--- a/README.md
+++ b/README.md
@@ -130,26 +130,6 @@ before running it:
   criterion the PSNR-monitored "best" no longer tracks the training objective, so
   decide which monitored checkpoint you actually want.
 
-### What a perceptual run costs
-
-Measured on an RTX 5060 Laptop (8 GB) at SRResNet's paper geometry — batch 16,
-96×96 HR crops, ×4, real DIV2K — as steady-state medians with warmup discarded.
-`cuda_graph: true` throughout; peak memory is `torch.cuda.max_memory_reserved`
-with the val loop excluded.
-
-| criterion | ms/step | vs MSE | peak reserved | 1e6 steps |
-|---|---|---|---|---|
-| `MSELoss` | 28.5 | 1.00× | 618 MiB | ~7.9 h |
-| `vgg22` + `tv` | 40.8 | 1.43× | 1352 MiB | ~11.3 h |
-| `vgg54` | 59.3 | 2.08× | 1490 MiB | ~16.5 h |
-
-Two things worth knowing before you plan a run: **CUDA-graph capture works with a
-VGG in the captured region** at every depth (graphs are still worth 1.22–1.37×
-under a perceptual loss, versus 1.52× under MSE — the VGG forward is real GPU work
-that graphs cannot remove), and **memory is not the constraint at this geometry**.
-Your own numbers will differ with hardware, crop size and batch size; the ratios
-travel better than the absolute times.
-
 A VGG loss normalises with RGB ImageNet statistics, so it refuses a 1-channel
 processor (SRCNN's `YChannelProcessor`) unless you set `grayscale_to_rgb: true`,
 and it refuses a 3-channel non-RGB processor (`YCbCrProcessor`) unless you set

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -35,6 +35,10 @@ model:
   # Two caveats before running it: the first use downloads ~548 MB of VGG19
   # weights to the torch hub cache, and TV's 2e-8 presumes the [-1, 1] output
   # range that RGBSignedOutputProcessor above provides.
+  # Cost at this geometry (RTX 5060 Laptop, graphed, steady-state medians): MSE
+  # 28.5 ms/step, this vgg22+tv recipe 40.8 (1.43x, ~11.3 h for 1e6 steps), bare
+  # vgg54 59.3 (2.08x). Graph capture DOES engage with a VGG in the captured
+  # region, and peak memory stays ~1.4 GB -- neither is the constraint here.
   # criterion:
   #   class_path: sisr.losses.WeightedSumLoss
   #   init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -35,10 +35,8 @@ model:
   # Two caveats before running it: the first use downloads ~548 MB of VGG19
   # weights to the torch hub cache, and TV's 2e-8 presumes the [-1, 1] output
   # range that RGBSignedOutputProcessor above provides.
-  # Cost at this geometry (RTX 5060 Laptop, graphed, steady-state medians): MSE
-  # 28.5 ms/step, this vgg22+tv recipe 40.8 (1.43x, ~11.3 h for 1e6 steps), bare
-  # vgg54 59.3 (2.08x). Graph capture DOES engage with a VGG in the captured
-  # region, and peak memory stays ~1.4 GB -- neither is the constraint here.
+  # cuda_graph: true is compatible with a VGG term -- capture engages with the
+  # VGG inside the captured region.
   # criterion:
   #   class_path: sisr.losses.WeightedSumLoss
   #   init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -47,10 +47,12 @@ model:
   #         class_path: sisr.losses.TotalVariationLoss
   #     weights: {vgg22: 1.0, tv: 2.0e-8}
   #
-  # Any phi_{i,j} works (vgg11..vgg54 on VGG19, vgg11..vgg53 on VGG16), and
-  # before_activation: true selects ESRGAN's pre-ReLU features. A perceptual run
-  # scores WORSE PSNR by design, so the psnr/val/RGB monitors below no longer
-  # track the training objective -- re-point them at ssim/val/RGB or accept it.
+  # phi_{i,j}: blocks 1-2 have 2 convs on both depths (vgg11-vgg22); blocks 3-5
+  # have 4 on VGG19 (up to vgg54) or 3 on VGG16 (up to vgg53). before_activation:
+  # true selects ESRGAN's pre-ReLU features. A perceptual run scores WORSE PSNR
+  # by design; the callbacks below already checkpoint on ssim/val/RGB too, so
+  # the PSNR-monitored "best" no longer tracks the training objective -- decide
+  # which monitored checkpoint you actually want.
   training_config:
     class_path: sisr.models.srresnet.SRResNetTrainingConfig
     init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -23,6 +23,34 @@ model:
     # Paper's range (Ledig et al. §3.2): LR [0,1] in, HR/target [-1,1].
     # Use RGBProcessor instead to reproduce pre-2026-08-02 runs.
     class_path: sisr.processors.RGBSignedOutputProcessor
+  # Loss. Unset means torch.nn.MSELoss, which is what both papers' baselines use.
+  # Any nn.Module taking (pred, target) works, so L1 needs no sisr class:
+  #   criterion: {class_path: torch.nn.L1Loss}
+  #   criterion: {class_path: sisr.losses.CharbonnierLoss}
+  #
+  # Ledig et al.'s SRResNet-VGG22, faithfully: a VGG22 content loss plus total
+  # variation at 2e-8, with NO pixel term, trained from scratch on the schedule
+  # already configured below (1e6 steps at lr 1e-4). The MSE-initialisation trick
+  # in the paper applies to the SRGAN variants, not to this one.
+  # Two caveats before running it: the first use downloads ~548 MB of VGG19
+  # weights to the torch hub cache, and TV's 2e-8 presumes the [-1, 1] output
+  # range that RGBSignedOutputProcessor above provides.
+  # criterion:
+  #   class_path: sisr.losses.WeightedSumLoss
+  #   init_args:
+  #     terms:
+  #       vgg22:
+  #         class_path: sisr.losses.VGG19FeatureLoss
+  #         init_args:
+  #           layer: vgg22
+  #       tv:
+  #         class_path: sisr.losses.TotalVariationLoss
+  #     weights: {vgg22: 1.0, tv: 2.0e-8}
+  #
+  # Any phi_{i,j} works (vgg11..vgg54 on VGG19, vgg11..vgg53 on VGG16), and
+  # before_activation: true selects ESRGAN's pre-ReLU features. A perceptual run
+  # scores WORSE PSNR by design, so the psnr/val/RGB monitors below no longer
+  # track the training objective -- re-point them at ssim/val/RGB or accept it.
   training_config:
     class_path: sisr.models.srresnet.SRResNetTrainingConfig
     init_args:


### PR DESCRIPTION
Documents the loss options added in #76: a `## Losses` section in the README and commented recipes in the SRResNet template. No code.

**Stacked on #76** — merge that first. Base is `feat/losses`; retarget to `main` after #76 lands.

## Why this is a separate PR rather than a separate commit

This repo squash-merges, so one PR becomes exactly one commit. Pairing the docs with #76's code would flatten them into a single commit and break the standing rule that doc-only changes are their own commit. Splitting is what preserves it.

## What it says

The criterion is wired from YAML like everything else and defaults to `torch.nn.MSELoss`. Any `nn.Module` taking `(pred, target)` works, so **L1 needs no class of ours** — that is documented as a recipe rather than shipped as a wrapper. A table covers the six available losses, and the composite example is Ledig et al.'s SRResNet-VGG22: VGG22 at 1.0 plus total variation at `2e-8`, no pixel term, trained from scratch.

The template's default stays MSE and every recipe stays commented.

## The four traps it records

These are the things that cost real time to establish, so they are written down rather than left to be rediscovered:

- **First use downloads ~548 MB** of VGG19 weights into the torch hub cache. `weights: null` skips it but builds a random VGG and warns — tests only.
- **Total variation's `2e-8` presumes a `[-1, 1]` output range** (`RGBSignedOutputProcessor`, which the template already wires). Under a `[0, 1]` processor the same image has exactly half the total variation, so the effective weight differs by 2×.
- **A VGG loss refuses non-RGB input.** 1-channel needs `grayscale_to_rgb: true`; 3-channel non-RGB (`YCbCrProcessor`) needs `allow_non_rgb: true`. The reason is that VGG normalises with RGB ImageNet statistics, so Y/Cb/Cr planes fed as R/G/B produce a healthy-looking loss over meaningless features.
- **A perceptual run scores worse PSNR by design**, so the PSNR-monitored "best" checkpoint stops tracking the training objective. The template already writes SSIM-monitored checkpoints alongside, so this is a choice of which artifact you want rather than setup work.

Layer names are given as per-block convolution counts rather than a range, because `vgg11`–`vgg54` reads contiguous while `vgg13`, `vgg23` and `vgg35` do not exist. VGG16 is marked as offered for experimentation rather than fidelity — no published SR number uses it.

## Verification

Both the shipped template and a copy with the recipe uncommented resolve through the real CLI (`--print_config`), the latter yielding `sisr.losses.WeightedSumLoss` with both terms — so the commented YAML is valid once uncommented, not merely plausible. Every factual claim was checked against the code on this branch, including the ~548 MB figure (574,673,361 bytes). ruff clean; no `.py` file touched.

Still missing, pending measurement: step-time and peak-memory figures for VGG runs, so a first `vgg54` launch has no documented cost expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
