### PR TITLE
Compare per-term loss traces to a tolerance, not exactly

### DIFF
--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -540,7 +540,7 @@ def test_fast_dev_run_logs_per_term_loss_tags_for_a_composite_criterion(
 
 
 class _TermTrace(lightning.Callback):
-    """Records the per-step ``last_terms`` values, for exact cross-run comparison."""
+    """Records the per-step ``last_terms`` values, for cross-run comparison."""
 
     def __init__(self):
         self.terms: list[dict[str, float]] = []
@@ -585,10 +585,22 @@ def test_cuda_graph_replay_keeps_per_term_losses_live():
     Rebinding last_terms on that fallback (the bug this guards) would strand
     every later replay's per-term tag on the fallback's eager value,
     diverging silently from the un-graphed trace while loss/train kept moving.
+
+    Compared to a tight relative tolerance rather than exactly. The sibling
+    loss-trace tests can demand bit-equality because they compare one MSE
+    total; the tv term reaches float32 through a sqrt, so with cuDNN
+    autotuning (``benchmark=True``) picking algorithms per process, the two
+    runs can differ in the last ulp — observed 2.70410837e-05 vs
+    2.70410874e-05, i.e. ~1.3e-7 relative. ``rel=1e-5`` sits ~80x above that
+    float32 noise floor and orders of magnitude below the stranding this
+    guards, which freezes a tag at a whole earlier step's value.
     """
     eager, _ = _run_composite_graph_fit(cuda_graph=False, n_samples=14, max_steps=12)
     graphed, module = _run_composite_graph_fit(cuda_graph=True, n_samples=14, max_steps=12)
 
     assert module._cuda_graph is not None and module._cuda_graph.captured
     assert len(graphed) == 12
-    assert graphed == eager
+    for step, (got, want) in enumerate(zip(graphed, eager, strict=True)):
+        assert got.keys() == want.keys(), step
+        for name, value in want.items():
+            assert got[name] == pytest.approx(value, rel=1e-5), (step, name)


### PR DESCRIPTION
Fixes a flaky test I introduced in #76. It went green seven consecutive times on the branch and in CI, then failed on the first full-suite run against `main` — which is the worst way for a test to be wrong.

```
FAILED tests/training/test_integration.py::test_cuda_graph_replay_keeps_per_term_losses_live
At index 11: tv 2.7041083740186878e-05 != 2.7041087378165685e-05
1 failed, 620 passed
```

## What was wrong

The test compares a graphed run's per-term loss trace against an eager run's, and demanded **bit-equality**. Its sibling `test_cuda_graph_loss_trace_is_bit_identical_to_eager` can legitimately demand that — it compares a single MSE total. The `tv` term cannot: it reaches float32 through a `sqrt`, and these tests run with `benchmark=True`, so cuDNN autotunes and can select different algorithms per process. The two runs then differ in the last ulp.

The observed gap is **~1.3e-7 relative**, which is float32 epsilon. Nothing was actually wrong with the code under test.

## The fix

Per-entry comparison at `rel=1e-5`, with the reasoning recorded in the docstring so nobody tightens it back later.

That tolerance is deliberately placed between two measured quantities rather than picked by feel:

| | relative size | |
|---|---|---|
| float32 ulp noise (observed) | 1.3e-7 | ~80× below the tolerance |
| `rel=1e-5` | 1e-5 | |
| the bug this guards (measured under mutation) | 3.9e-2 | ~4000× above the tolerance |

## Verification

- **Stability:** 5 consecutive runs, 5 passed / 0 failed.
- **Still catches the bug:** restoring the pre-fix rebind in `WeightedSumLoss.forward` makes it fail at **step 4** — the first partial-batch eager fallback, exactly the interleave the test is built to create:
  ```
  AssertionError: (4, 'mse')
  assert 0.3428382873535156 == 0.3298541307449341 ± 3.3e-06
  ```
  Mutation reverted; working tree clean.
- **Full suite on this branch, GPU visible and `data/` present: 621 passed, 0 skipped, 0 failed.** ruff clean.

Test-only change; no source file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
