### PR TITLE
Document the two SSIM conventions and the ssim_impl override

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,35 +169,79 @@ both are pinned:
   [`SRResNetEvalConfig`](sisr/models/srresnet/config.py) overrides it to `'daala'`
   because that is the convention its paper used; SRCNN keeps `'wang'`, the field
   standard. The switch is **in place**: `ssim/val/RGB` and `ssim/val/Y` name the
-  metric identically either way, so the convention is not visible in the tag — it is
-  recorded in `hparams` and in every artifact's `sisr_meta` instead. Consequently, an
+  metric identically either way, and checkpoint filenames
+  (`sr-{step}-ssim_val_RGB={value:.4f}.ckpt`, built by
+  [`SRCheckpoint`](sisr/training/callbacks.py)) carry only the bare number — so
+  neither the tag nor the filename reveals which convention produced a given value.
+  It is recorded in `hparams` and in every artifact's `sisr_meta` instead. Consequently, an
   SRResNet SSIM figure is comparable to Ledig et al. and **not** to Wang-based tables
   (the EDSR/RCAN/SwinIR/BasicSR lineage); always say which convention a number came
   from.
 
-## Re-scoring a checkpoint with a different `ssim_impl`
+## `--ckpt_path` silently drops subclass-only `eval_config` defaults
 
 Checkpoints saved before `ssim_impl` existed do not pick up its new default when
-reloaded. `SRLightning` stores `eval_config` in `hparams` as a bare dict with no class
-identity, and `SRLightningCLI._parse_ckpt_path` reads that dict back from
-`--ckpt_path` and re-applies it as `model.*` CLI options — which **override**
-whatever you pass on the command line. So
+reloaded — and the mechanism is not "the checkpoint overrides the CLI"; it is more
+structural than that. `SRLightning` saves `eval_config` in `hparams` as
+`dataclasses.asdict(self.eval_config)` — a bare dict with no `class_path`
+([`sisr/training/lightning_module.py`](sisr/training/lightning_module.py)).
+`SRLightningCLI._parse_ckpt_path` rebuilds that dict via `_reconstruct_ckpt_hparams`
+and hands it to jsonargparse as the `model.eval_config` value
+([`sisr/cli.py`](sisr/cli.py)). Because the dict carries no class identity,
+jsonargparse instantiates the field's **annotation type** — the base `SREvalConfig`
+— never the subclass (`SRResNetEvalConfig`) that actually produced the value, and it
+does this whether or not a CLI override was also given, since the replacement runs
+after argument parsing. Keys the dict happens to carry survive as explicit values;
+any key it is missing falls back to `SREvalConfig`'s own default, not the subclass's.
+A checkpoint saved before `ssim_impl` existed simply has no such key, so nothing
+"overrides" anything — the field falls to the base default, `wang`. `crop_border=4`
+and `psnr_channels=['RGB', 'Y']` survive reload only because `dataclasses.asdict`
+happened to record them explicitly at save time, not because the subclass identity
+is preserved.
+
+**This generalises past `ssim_impl`.** Any `SREvalConfig` field an architecture
+subclass overrides is equally at risk the moment a checkpoint predates that field, on
+**every** subcommand that accepts `--ckpt_path` — `fit` resume included, not just
+`validate`/`test`. That makes resume the more damaging case: resuming a pre-change
+SRResNet run from an old checkpoint trains and checkpoints on `wang` `ssim/val/RGB`
+for the rest of the run, while a fresh `fit` from the identical YAML uses `daala` —
+two runs of "the same config" whose monitored metric means different things,
+distinguishable only by reading `hparams`, not by anything in the logs or filenames.
+This behaviour is locked in (deliberately not fixed) by
+`test_ckpt_path_loses_subclass_only_eval_defaults` in
+[`tests/test_cli.py`](tests/test_cli.py) — read it for the exact mechanics, including
+why a CLI override alongside `--ckpt_path` doesn't help.
+
+For example:
 
 ```bash
 sisr validate --config my.yaml --ckpt_path old.ckpt --model.eval_config.ssim_impl=daala
 ```
 
 silently scores with `wang`: the emitted config confirms `wang`, and the SSIM values
-come back bit-identical to a pre-upgrade run. This is a one-time migration issue, not
-an ongoing bug — checkpoints written after this change carry `ssim_impl` and restore
-it correctly.
+come back bit-identical to a pre-upgrade run. This is a one-time migration issue per
+field, not an ongoing bug — a checkpoint written after a given field was added
+carries it explicitly and restores it correctly; it is only checkpoints predating
+that field that fall back.
 
-Workaround: patch a **copy** of the checkpoint and re-score from the copy.
+Workaround: patch a **copy** of the checkpoint and re-score (or resume) from the
+copy. Handle both hparams formats the codebase supports — current checkpoints nest
+`eval_config` as a dict, but checkpoints from before `SRLightning` stopped
+flattening `self.hparams` store `'/'`-joined keys instead (e.g.
+`"eval_config/ssim_impl"`; see `_reconstruct_ckpt_hparams` in
+[`sisr/cli.py`](sisr/cli.py) and the legacy-flattened-checkpoint test in
+[`tests/test_cli.py`](tests/test_cli.py)) — and old checkpoints are exactly the
+population this section targets:
 
 ```python
 import torch
+
 ckpt = torch.load("old.ckpt", weights_only=True, map_location="cpu")
-ckpt["hyper_parameters"]["eval_config"]["ssim_impl"] = "daala"
+hp = ckpt["hyper_parameters"]
+if "eval_config" in hp and isinstance(hp["eval_config"], dict):
+    hp["eval_config"]["ssim_impl"] = "daala"  # current nested format
+else:
+    hp["eval_config/ssim_impl"] = "daala"  # legacy '/'-flattened format
 torch.save(ckpt, "old_daala.ckpt")
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,55 @@ both are pinned:
   the [EDSR authors](https://github.com/sanghyun-son/EDSR-PyTorch).
 - **Metrics** are Y-channel PSNR/SSIM in BT.601 studio range (MATLAB's `rgb2ycbcr`
   convention, which is what published figures use), computed on output clamped to `[0, 1]`.
+- **SSIM has two incompatible conventions, and unlike PSNR the choice is not
+  cosmetic.** PSNR is a closed-form function of squared error, so any correct
+  implementation agrees with any other. SSIM depends on a local-window gaussian that
+  the SR field never standardised on: Wang et al.'s original uses a fixed 11×11 window
+  at sigma 1.5 — what `torchmetrics`, MATLAB's reference code, and BasicSR's
+  `calculate_ssim` all compute, and therefore what most SR papers report. Ledig et al.
+  (SRResNet/SRGAN) instead scored with the **daala** video-codec package, whose
+  gaussian sigma scales with image height (`_h*(1.5/256)`) rather than staying fixed.
+  The same image therefore scores differently under the two conventions, and a
+  benchmark set's aggregate partly reflects the pixel dimensions of its images, not
+  only reconstruction quality. [`sisr/ssim.py`](sisr/ssim.py) ports daala's method,
+  verified against daala's own compiled C reference on 133 cases, and
+  `SREvalConfig.ssim_impl` (`'wang'` or `'daala'`, see
+  [`sisr/training/config.py`](sisr/training/config.py)) selects between them —
+  `'wang'` is the base default, and
+  [`SRResNetEvalConfig`](sisr/models/srresnet/config.py) overrides it to `'daala'`
+  because that is the convention its paper used; SRCNN keeps `'wang'`, the field
+  standard. The switch is **in place**: `ssim/val/RGB` and `ssim/val/Y` name the
+  metric identically either way, so the convention is not visible in the tag — it is
+  recorded in `hparams` and in every artifact's `sisr_meta` instead. Consequently, an
+  SRResNet SSIM figure is comparable to Ledig et al. and **not** to Wang-based tables
+  (the EDSR/RCAN/SwinIR/BasicSR lineage); always say which convention a number came
+  from.
+
+## Re-scoring a checkpoint with a different `ssim_impl`
+
+Checkpoints saved before `ssim_impl` existed do not pick up its new default when
+reloaded. `SRLightning` stores `eval_config` in `hparams` as a bare dict with no class
+identity, and `SRLightningCLI._parse_ckpt_path` reads that dict back from
+`--ckpt_path` and re-applies it as `model.*` CLI options — which **override**
+whatever you pass on the command line. So
+
+```bash
+sisr validate --config my.yaml --ckpt_path old.ckpt --model.eval_config.ssim_impl=daala
+```
+
+silently scores with `wang`: the emitted config confirms `wang`, and the SSIM values
+come back bit-identical to a pre-upgrade run. This is a one-time migration issue, not
+an ongoing bug — checkpoints written after this change carry `ssim_impl` and restore
+it correctly.
+
+Workaround: patch a **copy** of the checkpoint and re-score from the copy.
+
+```python
+import torch
+ckpt = torch.load("old.ckpt", weights_only=True, map_location="cpu")
+ckpt["hyper_parameters"]["eval_config"]["ssim_impl"] = "daala"
+torch.save(ckpt, "old_daala.ckpt")
+```
 
 ## ONNX export
 

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -43,6 +43,14 @@ model:
       # combination is refused with a warning and trains eagerly. Dropping pinning
       # measured neutral-to-positive here (the pin thread contends for the GIL).
       # cuda_graph: true
+  # No init_args: the dataclass default leaves ssim_impl at wang -- the field
+  # standard fixed 11x11 gaussian (sigma 1.5), what torchmetrics/MATLAB/BasicSR
+  # compute and what most SR papers report (SRResNet's paper is the exception --
+  # see the daala note in its template). Override with:
+  #   eval_config:
+  #     class_path: sisr.models.srcnn.SRCNNEvalConfig
+  #     init_args:
+  #       ssim_impl: daala
   eval_config:
     class_path: sisr.models.srcnn.SRCNNEvalConfig
 

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -62,6 +62,15 @@ model:
       # TensorBoard-graph dummy -- it also shapes the compile warm-up (a wrong size
       # compiles once then recompiles on step 1) and ModelSummary's FLOPs.
       example_input_shape: [3, 24, 24]
+  # No init_args: the dataclass default already sets ssim_impl: daala, the
+  # convention Ledig et al.'s paper actually used (sigma scales with image height,
+  # not Wang's fixed 11x11 -- see sisr/ssim.py). That makes this run's SSIM
+  # comparable to the paper and NOT to the Wang-based numbers the rest of the SR
+  # literature reports (EDSR/RCAN/SwinIR/BasicSR lineage). Override with:
+  #   eval_config:
+  #     class_path: sisr.models.srresnet.SRResNetEvalConfig
+  #     init_args:
+  #       ssim_impl: wang
   eval_config:
     class_path: sisr.models.srresnet.SRResNetEvalConfig
 


### PR DESCRIPTION
⛔ **Stacked on #80 — do not merge until #80 lands.** Base retargets to `main` automatically when #80 merges. CI does not run while the base is a feature branch; it fires on the rebase+push that follows #80's merge.

Doc-only counterpart to #80. Separate PR rather than a separate commit because this repo squash-merges — pairing them would flatten the standing doc-only-separate-commit rule.

## What

**`README.md` → Comparability** — explains why SSIM has two incompatible conventions and PSNR does not: PSNR is a closed-form function of squared error, so any correct implementation agrees; SSIM depends on a local-window gaussian the field never standardised. Wang's is fixed 11×11 σ=1.5; daala's sigma scales with image height. States the hazard plainly — an SRResNet SSIM figure is comparable to Ledig et al. and **not** to Wang-based tables (EDSR/RCAN/SwinIR/BasicSR lineage) — and notes that because the switch is in place, neither the metric tag nor the checkpoint filename reveals which convention produced a number.

**Both templates** — comments on the bare `eval_config:` blocks explaining which default applies and how to override, in each architecture's own terms.

**`README.md` → a new section on `--ckpt_path`.** This documents a **pre-existing trap** that this work surfaced rather than caused:

`SRLightningCLI._parse_ckpt_path` reconstructs `eval_config` from a checkpoint's stored hparams as a **bare dict with no `class_path`**, so jsonargparse instantiates the *annotation* type — base `SREvalConfig` — **discarding the subclass and every subclass-only default**. Fields the checkpoint stores explicitly (`crop_border`, `psnr_channels`) survive; fields it doesn't fall back to the base default.

Consequences worth knowing:
- Re-scoring a pre-change checkpoint silently uses `wang`, and a command-line `--model.eval_config.ssim_impl=daala` does **not** help.
- It applies to `fit --ckpt_path` resume too, which is the more damaging case: a resumed run trains and *checkpoints* on `wang` `ssim/val/RGB` while a fresh `fit` from the identical YAML uses `daala`.
- **It is general** — any future `SREvalConfig` field with an architecture override will behave this way. `test_ckpt_path_loses_subclass_only_eval_defaults` (in #80) is the executable statement of the rule.

The workaround snippet handles both the nested and the legacy `/`-flattened hparams formats, and was verified by execution against a real checkpoint (original confirmed unmodified by SHA-256).

No paper-vs-ours results table — that publication decision remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)