### PR TITLE
docs: document the delivery workflow, commit conventions, and security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+Notable changes to this project, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Versioning will follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
+release is tagged. Nothing is released yet: the project is pre-1.0 and every entry below
+sits under **Unreleased**. Until a version is cut, any part of the API may change without
+notice.
+
+## [Unreleased]
+
+### Added
+
+- **SRResNet** and **SRCNN**, both fully wired — model, dataset pipeline, config
+  dataclasses, and an experiment template each.
+- **`sisr` console script** over a single `LightningCLI` entrypoint, with `fit`, `test`,
+  `predict` and `export` subcommands. One self-contained YAML drives an experiment.
+- **Pluggable losses** (`sisr/losses/`): `CharbonnierLoss`, `TotalVariationLoss`,
+  `VGG19FeatureLoss`, `VGG16FeatureLoss` and `WeightedSumLoss`, selectable and combinable
+  from YAML. L1 and MSE need no wrapper — `torch.nn.L1Loss` already works as a criterion.
+- **daala-methodology SSIM** (`sisr/ssim.py`) behind `SREvalConfig.ssim_impl`, the
+  convention Ledig et al. used, verified against daala's own C implementation.
+  `SRResNetEvalConfig` defaults to it; everything else stays on the field-standard fixed
+  11×11 gaussian.
+- **Vendored byte-exact MATLAB `imresize`** (`sisr/imresize.py`, MIT) as the sole LR
+  degradation, verified byte-identical to real MATLAB output across the benchmark sets.
+- **ONNX export** (`sisr/export.py`) behind the `[export]` extra, with dynamic spatial
+  axes and provenance written into `metadata_props`.
+- **Provenance metadata** (`sisr/training/metadata.py`) — one builder feeding checkpoints,
+  bare weight files, and ONNX exports, so the three cannot drift.
+- **`SRWeightsCheckpoint`** — distributable optimizer-free `.pt` weights, roughly a third
+  the size of a full checkpoint.
+- **Opt-in full-step CUDA-graph capture** (`SRTrainingConfig.cuda_graph`), which refuses
+  configurations it cannot capture soundly rather than capturing them anyway.
+- **LR-only prediction path** — `PredictDataset`, `predict_step`, and `SRPredictionWriter`.
+- **LMDB HR caching** shared by both architectures, with an advisory build lock so
+  concurrent builds do not duplicate work.
+
+### Changed
+
+- **Y-channel metrics are computed in BT.601 studio range**, matching MATLAB and the
+  published SR literature. Figures produced before this read systematically low.
+- **SR output is clamped to `[0, 1]` before scoring.**
+- **Both train datasets share one architecture-neutral raw-HR cache.** Cache validity
+  depends on the file manifest and a format tag only, so changing scale, crop size or
+  stride needs no rebuild, and caching a dataset for one architecture serves the other.
+- **Colorspace is chosen by composing an `SRProcessor`**, replacing a config string field.
+- **Google-style docstrings are enforced** via ruff's pydocstyle rules.
+
+### Fixed
+
+- **Graphed training froze at the first mid-training validation.** Lightning's pre-val
+  `zero_grad(set_to_none=True)` severed a live CUDA graph's gradient tensors from the
+  optimizer, so weights stopped updating while the reported loss kept moving.
+- **`--ckpt_path` could not reload any checkpoint this project had ever saved.**
+- **The LMDB cache could delete another process's in-progress build.** Deletion is now
+  restricted to proven corruption; environmental failures raise instead.
+- **SRCNN's paper weight-init std** corrected to the published `0.001`.
+- **`example_input_shape` pointed at the wrong size**, defeating compile warm-up and
+  misreporting FLOPs.
+
+### Removed
+
+- **`opencv-python-headless`** and the `cv2` degradation backend, along with
+  `resize_backend` and `blur_sigma`. MATLAB `imresize` is the only degradation path.
+- **`albumentationsx`** — AGPL-3.0 is incompatible with this project's MIT licence, and
+  its entire use was six primitives with no augmentation.
+
+### Security
+
+- **`torch>=2.6` floor**, excluding the `weights_only=True` bypass
+  (GHSA-53q9-r3pm-6pq6 / CVE-2025-32434). See [SECURITY.md](SECURITY.md).
+
+[Unreleased]: https://github.com/YeapJieShen/single-image-super-resolution/commits/main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,54 @@ Branch off `main`, add tests with your change, run `pytest`, open a PR. Three ch
 to pass: **test** (pytest + coverage), **build** (`pip install .` and imports work), and
 **lint** (`ruff check` + `ruff format --check`). `main` keeps linear history.
 
-Commits:
+The path a change takes:
 
-- Imperative subject, for example "Add ...", "Fix ...", "Remove ...".
-- Docs-only changes go in their own commit, never mixed with code.
+| Stage | What it means |
+| --- | --- |
+| **Design** | Anything touching a public contract, a metric, or the data path gets agreed before it gets written. A typo fix does not. |
+| **Branch** | `<type>/<topic>`, e.g. `fix/cache-locking`, `docs/workflow`. |
+| **Verify** | Correctness: a test that fails before your change and passes after. Performance: before/after numbers, on real data. |
+| **PR** | Opened against `main`. Stacked PRs must be retargeted to `main` before their final push, or CI never runs on them. |
+| **Merge** | Squash for a single-purpose PR; rebase for one carrying both code and docs, so the commits stay separate. |
+
+### Evidence
+
+Two claims need proof in the PR, not just assertion:
+
+- **A bug fix** ships the test that catches it. Run it against the unfixed code and confirm
+  it fails — a test that passes both ways documents nothing. Name it for the failure, not
+  the fix.
+- **A performance claim** ships before/after numbers measured on real data, reporting
+  **medians with warm-up excluded**. A mean over a short run hides one-time setup costs
+  (worker spawn, cache warm, autotune) and can invert the conclusion. Say how many
+  iterations you discarded.
+
+Anything touching `sisr/imresize.py` must re-prove byte-identical output against the
+MATLAB reference set; that byte-equality is the basis of every comparison to published
+results.
+
+### Commits
+
+Conventional Commit types, with subjects that describe the effect:
+
+```
+<type>: <what changes, in the imperative>
+
+<why — never a restatement of the diff>
+```
+
+- **Types:** `feat`, `fix`, `docs`, `perf`, `refactor`, `test`, `chore`.
+- **Describe the effect, not the mechanism.**
+  `fix: make the cache build lock unable to destroy live data`, not
+  `fix: refactor _try_load`. Sentence case, no trailing period.
+- **Code and docs may share a PR but never a commit.** Put docs in their own `docs:`
+  commit. A PR carrying both is rebase-merged so the split survives.
+- **Breaking changes** take `!` and a footer: `feat!: ...` plus
+  `BREAKING CHANGE: <what downstream code must do>`.
+- **The body explains why.** The diff already shows what. Omit it when the change is
+  self-evident.
+- Reference PRs (`#42`) freely; the history is public, so keep internal tracker ids out
+  of it.
 
 ## Style
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security
+
+## Supported versions
+
+This project is pre-release (`0.1.0`, alpha) and publishes no tagged releases. Only the
+current `main` branch is supported. Fixes land on `main`; there are no backports.
+
+## Reporting a vulnerability
+
+Report privately through GitHub's
+[security advisory form](https://github.com/YeapJieShen/single-image-super-resolution/security/advisories/new).
+Please do not open a public issue for a suspected vulnerability.
+
+## Threat model
+
+The realistic risk in a super-resolution framework is **loading someone else's model
+file**. Checkpoints get shared, and a PyTorch checkpoint is a pickle: deserializing an
+untrusted one can execute arbitrary code.
+
+### What this project does
+
+Every checkpoint read in `sisr/` passes `weights_only=True`, which restricts
+deserialization to plain tensors and primitives instead of arbitrary pickled objects:
+
+- `sisr/export.py` — loading a checkpoint before ONNX export.
+- `sisr/cli.py` — reading stored hyperparameters for `--ckpt_path`.
+
+That constraint shapes the code rather than being bolted on. `sisr/training/metadata.py`
+writes provenance as **plain types only** — no live objects, no dataclass instances — and
+coerces `torch.__version__` with `str()` because `TorchVersion` is a `str` subclass that
+`weights_only=True` refuses to unpickle. Configs are stored via `dataclasses.asdict`
+rather than as objects for the same reason. Keeping artifacts loadable under
+`weights_only=True` is a deliberate contract, so a change that breaks it is a security
+regression, not an inconvenience.
+
+`torch>=2.6` is a hard floor in `pyproject.toml`, because earlier versions allowed that
+flag to be bypassed (GHSA-53q9-r3pm-6pq6 / CVE-2025-32434).
+
+Provenance metadata deliberately **excludes dataset paths**, so a shared checkpoint does
+not leak local filesystem layout.
+
+### What it does not do
+
+- **It does not make third-party checkpoints safe.** `weights_only=True` narrows the
+  attack surface; it is not a sandbox. Treat a checkpoint from an untrusted source the
+  way you would treat an executable from one.
+- **Resuming training through PyTorch Lightning loads a full checkpoint**, including
+  optimizer and callback state, and that path is outside this project's control. Only
+  resume from checkpoints you produced or trust.
+- **`sisr predict` reads arbitrary image files** via Pillow. Image decoders have their own
+  history of vulnerabilities; keep Pillow current.
+- **Config files are executable by intent.** A YAML passed to `sisr fit` names Python
+  classes to import and instantiate via `class_path`. Running an untrusted config is
+  equivalent to running untrusted code — by design, since that is how the framework
+  selects architectures.


### PR DESCRIPTION
Adds three documents. No code changes, so `squash` is the right merge here.

## Why

The delivery workflow and the evidence expectations were real but undocumented — they lived in review comments and habit, so a contributor could only learn them by getting a PR corrected.

## What changed

**`CONTRIBUTING.md`** — a "Making a change" lifecycle table (design → branch → verify → PR → merge), an **Evidence** section, and a rewritten **Commits** section.

Two rules are worth calling out because they interact:

1. **Code and docs may share a PR but never a commit.**
2. **Conventional Commit types** (`feat`/`fix`/`docs`/`perf`/`refactor`/`test`/`chore`).

The second exists to make the first checkable. "Separate commits" is unverifiable by anything without a marker in the subject; `docs:` makes the split visible in `git log`.

This also means **merge strategy now matters per PR**: a squash would collapse a `docs:` commit back into its code commit and silently defeat rule 1. So single-purpose PRs squash, and mixed code+docs PRs **rebase-merge** — which also satisfies the linear-history requirement.

The subject convention deliberately preserves what this repo already does well: subjects describe the **effect**, not the mechanism (`fix: make the cache build lock unable to destroy live data`, not `fix: refactor _try_load`).

**`SECURITY.md`** — states a contract the code already keeps. Every checkpoint read in `sisr/` passes `weights_only=True` (`export.py`, `cli.py`), and `training/metadata.py` is shaped around staying loadable under it — plain types only, `str()`-coerced `torch.__version__`, configs stored via `asdict`. That was previously recorded only in a `pyproject.toml` comment. Documenting it means a change that breaks it reads as a security regression rather than an inconvenience.

It is also explicit about what the project does **not** guarantee: `weights_only=True` narrows the attack surface but is not a sandbox, Lightning's full-checkpoint resume path is outside this project's control, and a `class_path` config is executable by design.

**`CHANGELOG.md`** — Keep a Changelog format, everything under `Unreleased`, no tags. The project is pre-1.0 with no releases, so tagging now would imply a stability commitment that does not exist.

## Verification

Docs-only; no tests affected. Content was checked against the code rather than transcribed from memory — the `weights_only=True` call sites and the `torch>=2.6` CVE floor were both verified in-tree before being described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)