### PR TITLE
chore: add a PR template that asks for the evidence a claim needs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,63 @@
+<!--
+Delete any section that does not apply. A short PR should have a short body.
+Conventions: CONTRIBUTING.md → "Making a change".
+-->
+
+## What changed
+
+<!-- The effect, not the mechanism. One or two sentences. -->
+
+## Why
+
+<!-- What made this necessary. The diff already shows what you did. -->
+
+## Evidence
+
+<!--
+Keep whichever applies; delete the rest. Assertions without evidence are the
+thing this section exists to prevent.
+-->
+
+**Bug fix** — the test that catches it:
+
+- Test: `tests/...::test_...`
+- Confirmed **RED** against the unfixed code, **GREEN** after.
+  <!-- A test that passes both ways documents nothing. Say how you proved it fails. -->
+
+**Performance** — before/after on real data:
+
+| | before | after |
+| --- | --- | --- |
+| <!-- ms/step, ops/s --> | | |
+
+- Medians with warm-up excluded; ___ iterations discarded.
+  <!-- A mean over a short run hides worker spawn / cache warm / autotune and can invert the result. -->
+- Measured on: <!-- which checkout, which dataset, which power state -->
+
+**Touches `sisr/imresize.py`** — byte-equality against the MATLAB reference set re-proven:
+
+- <!-- result, e.g. 357/357, max|diff| = 0 -->
+
+## Checklist
+
+- [ ] `pytest` passes locally, and I have said which tests **skipped** (a skip is not a pass)
+- [ ] `ruff check` and `ruff format --check` are clean
+- [ ] Commit subjects use a Conventional Commit type and describe the **effect**
+- [ ] Docs changes are in their own `docs:` commit, not mixed into a code commit
+- [ ] Breaking changes carry `!` and a `BREAKING CHANGE:` footer
+- [ ] No internal tracker identifiers in the code or commit messages
+
+## Merge strategy
+
+<!-- Pick one. This is not cosmetic: squashing a mixed PR collapses the docs
+     commit back into the code commit and defeats the separation rule. -->
+
+- [ ] **Squash** — single-purpose PR
+- [ ] **Rebase** — carries both code and docs commits
+
+---
+
+<sub>**Note on `codecov/patch`:** it is expected to fail and is not a required check. It
+reports on paths that cannot execute on CPU-only runners (cache-lock liveness, CUDA-graph
+capture). The real coverage gate is `--cov-fail-under=90` inside `test`. No need to
+investigate it.</sub>


### PR DESCRIPTION
Adds `.github/pull_request_template.md`. No code, no test impact.

## Why

This project already requires proof rather than assertion:

- a bug fix ships a test **proven red** against the unfixed code
- a performance claim ships **warm-up-excluded medians on real data**
- anything touching `sisr/imresize.py` **re-proves byte-equality**

Those are good rules and they were being followed — but they lived in review comments and habit. That means they were enforced by whoever happened to remember them, and the history shows what happens when someone doesn't: a `num_workers: 0` template change once shipped on figures measured in a worktree with no `data/`, and was only caught when a real-data run refuted it at 0.19×.

The template moves the ask to the point the claim is made.

## What it does

Prompts for the evidence that matches the change, and nothing else — every section says to delete it if it doesn't apply. The performance table explicitly asks **how many iterations were discarded** and **what it was measured on**, because a mean over a short run hides one-time setup costs and can invert the conclusion.

The checklist covers the commit conventions and, deliberately, asks which tests **skipped** — two byte-equality tests skip without `data/reference/`, and a skip is not a pass.

It also records the **merge strategy**. That is not cosmetic now: squashing a PR that carries both code and `docs:` commits collapses them back into one and defeats the separation rule.

The `codecov/patch` footnote exists to stop it being re-investigated — it fails on paths that cannot execute on CPU-only runners (cache-lock liveness, CUDA-graph capture) and is not a required check.

## Note

Complements #83, which documents the same conventions in `CONTRIBUTING.md`. The two are independent — this branches from `main` and touches a different file, so they can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)