### PR TITLE
docs: stop quoting a cuda-graph speedup that no measurement produced

### DIFF
--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -135,8 +135,7 @@ class SRTrainingConfig:
             mistraining. Mutually exclusive with ``compile_backend`` (see
             :meth:`__post_init__`). Validation, test and predict always stay
             eager — their image sizes vary, and graphs need static shapes.
-            Measured ~2.6x steps/s on one RTX 5060 Laptop with bit-identical
-            losses; the figures live in
+            Losses are bit-identical to eager; the measured speedups live in
             ``templates/config.srcnn.template.yaml`` so there is one place to
             keep current. The win is proportional to how launch-bound the
             architecture is, so it is far smaller for SRResNet, whose GPU floor

--- a/sisr/training/cuda_graph.py
+++ b/sisr/training/cuda_graph.py
@@ -4,9 +4,9 @@ An SRCNN training step is kernel-launch-bound, not compute-bound: measured 78
 ``cudaLaunchKernel`` calls per step, with the CPU's launch time equal to the
 step's wall time and the GPU at under 30% utilisation. Replaying one captured
 graph runs the identical kernels as a single ``cudaGraphLaunch`` at near-full
-utilisation, cutting device-side time roughly in half and the whole Lightning
-step by ~2.6x — see the measured figures in ``templates/config.srcnn.template.yaml``,
-which is the one place they are quoted and kept current.
+utilisation, cutting device-side time roughly in half — see the measured
+figures in ``templates/config.srcnn.template.yaml``, which is the one place
+they are quoted and kept current.
 
 Only ``{zero_grad, forward, loss, backward}`` is captured — ``optimizer.step()``
 stays eager and stays Lightning's. Capturing it too saves a further 0.07 ms/step


### PR DESCRIPTION
Removes a stale `~2.6x` figure from two docstrings. Docstrings only — no behaviour change.

## The problem

Both `sisr/training/config.py` (the `cuda_graph` Args block) and `sisr/training/cuda_graph.py` (module docstring) quoted **~2.6x**, and *both then named* `templates/config.srcnn.template.yaml` as the single source that is "kept current".

That template says **~1.8x**:

```yaml
# geometry (num_workers 16, pin_memory false): 14.9 -> 8.3 ms/step (~1.8x; the
```

So each docstring named a source and then disagreed with it. No measurement anywhere produced 2.6× — the recorded golden-config figures are **1.78× (SRCNN)** and **1.40× (SRResNet)**.

Nothing computes on these strings, so the only cost is a reader forming a wrong expectation of the knob — but a docstring that contradicts its own pointer is worse than one with no number at all, because it looks authoritative.

## The fix

**Deleted rather than corrected.** Restating the figure is what allowed it to drift; the pointer to the template already does the job, and the surrounding sentences (losses bit-identical to eager, the win being proportional to how launch-bound the architecture is) carry the useful meaning without a number that can rot.

## How the second one was found

Reading found only the `config.py` instance. The `cuda_graph.py` one surfaced from a repo-wide `grep -rn "2\.6x" sisr/ templates/` run as a verification step *after* the first fix.

Worth generalising: **a doc-drift fix should end with a repo-wide grep for the wrong value**, because a figure that got duplicated once has usually been duplicated more than once.

## Verification

- `grep -rn "2\.6x\|2\.6×" sisr/ templates/` → no matches remain
- `ruff check` + `ruff format --check` clean over `sisr/`
- **Full suite: 794 passed, 0 failed, 0 skipped** (158.5 s serial, data-present box) — unchanged from `main`

No test added: this is a documentation correction, not a behaviour fix, so there is no regression a test could catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)