### PR TITLE
feat: run LightningCLI in subclass mode so a config can name its Lightning module

### DIFF
--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -267,8 +267,12 @@ class SRLightningCLI(LightningCLI):
         parsed through the *subcommand's own* parser/config branch
         (``self._parser(subcommand)``, ``self.config[subcommand]``), never through
         the top-level subcommand-dispatching one (``self.parser``, ``self.config``),
-        even though both expose the same ``model.init_args.<key>`` option path and
-        neither raises at parse time.
+        even though both expose the same ``model.init_args.<key>`` option path.
+        The top-level route parses without a syntax error, but per-field the
+        outcome is either a hard ``SystemExit`` (``model``, ``processor``: no
+        default, required) or a silent revert to the bare-annotation default
+        (any nested subclass field with a fallback, e.g. ``eval_config``) — see
+        below for which and why.
 
         The reason: jsonargparse's subclass-merge machinery
         (``ActionTypeHint._check_type``) looks up the field's *previous* value as

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -223,13 +223,14 @@ class SRLightningCLI(LightningCLI):
     def add_arguments_to_parser(self, parser):
         """Wire top-level ``optimizer:`` / ``lr_scheduler:`` / ``matmul_precision:`` keys.
 
-        Non-subclass mode (``model_class=SRLightning`` fixed) means
-        ``SRLightning``'s init args land at ``model.<arg>``, not
-        ``model.init_args.<arg>`` — that's why the link targets omit
-        ``init_args``.
+        Subclass mode (``subclass_mode_model=True``) means the module's init args
+        live under ``model.init_args.<arg>``, which is what these links must
+        target. Subclass mode exists so a YAML can name its Lightning module by
+        ``class_path`` — without it ``model_class`` is fixed and no config can
+        select :class:`~sisr.training.SRGANLightning`.
         """
-        parser.add_optimizer_args(link_to="model.optimizer")
-        parser.add_lr_scheduler_args(link_to="model.lr_scheduler")
+        parser.add_optimizer_args(link_to="model.init_args.optimizer")
+        parser.add_lr_scheduler_args(link_to="model.init_args.lr_scheduler")
         parser.add_argument(
             "--matmul_precision",
             type=Literal["highest", "high", "medium"] | None,
@@ -306,6 +307,7 @@ def main() -> None:
     SRLightningCLI(
         model_class=SRLightning,
         datamodule_class=SRDataModule,
+        subclass_mode_model=True,
         save_config_kwargs={"overwrite": True},
         auto_configure_optimizers=False,
     )

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -254,25 +254,58 @@ class SRLightningCLI(LightningCLI):
         """Reload ``--ckpt_path`` hyperparameters via ``_reconstruct_ckpt_hparams`` first.
 
         Duplicates ``LightningCLI._parse_ckpt_path`` (``lightning/pytorch/cli.py``)
-        with one substitution: the raw ``hyper_parameters`` dict is rebuilt through
-        :func:`_reconstruct_ckpt_hparams` before being handed to
-        ``parser.parse_object``, so both the current nested format and checkpoints
-        saved before that fix (which reload with a jsonargparse ``SystemExit``
-        otherwise — see that function's docstring) work through every subcommand
-        that accepts ``--ckpt_path`` (``fit`` resume, ``validate``, ``test``, ``export``).
+        with two substitutions. First, the raw ``hyper_parameters`` dict is rebuilt
+        through :func:`_reconstruct_ckpt_hparams` before being handed to
+        ``parse_object``, so both the current nested format and checkpoints saved
+        before that fix (which reload with a jsonargparse ``SystemExit`` otherwise —
+        see that function's docstring) work through every subcommand that accepts
+        ``--ckpt_path`` (``fit`` resume, ``validate``, ``test``, ``export``).
+
+        Second, under ``subclass_mode_model=True`` the module's fields are options
+        at ``model.init_args.<key>``, not ``model.<key>``, so the reconstructed
+        hparams are nested one level deeper — and that nested override MUST be
+        parsed through the *subcommand's own* parser/config branch
+        (``self._parser(subcommand)``, ``self.config[subcommand]``), never through
+        the top-level subcommand-dispatching one (``self.parser``, ``self.config``),
+        even though both expose the same ``model.init_args.<key>`` option path and
+        neither raises at parse time.
+
+        The reason: jsonargparse's subclass-merge machinery
+        (``ActionTypeHint._check_type``) looks up the field's *previous* value as
+        ``cfg.get(self.dest)`` — ``self.dest`` is the action's bare name (``"model"``),
+        not a subcommand-qualified one. Reached through the subcommand's own
+        parser, ``cfg`` is already scoped to that subcommand, so ``cfg.get("model")``
+        finds the real, already-resolved value and merges our override's keys onto
+        it, preserving every sibling key we don't mention (``model``, ``processor``,
+        nested ``class_path`` identities) and any subclass-only default our override
+        never names. Reached through the top-level parser, ``cfg`` is the
+        *unscoped* full config, so the same ``cfg.get("model")`` misses the value
+        (it actually lives at ``cfg["validate"]["model"]``) and silently gets
+        "no previous value" instead of a lookup error — jsonargparse then rebuilds
+        the field from schema defaults, which are ``None`` for ``model``/
+        ``processor`` (no default; required) and the bare annotation type for any
+        nested subclass field (``eval_config`` reverts to base ``SREvalConfig``).
+        A resumed run would then either hit that "arguments are required"
+        ``SystemExit`` outright, or — for a field with a valid bare-default
+        fallback — silently drop back to the config file's/annotation's values with
+        nothing in the logs to say so. Re-inlining this as ``self.parser`` "for
+        simplicity" reintroduces exactly that.
         """
         if not self.config.get("subcommand"):
             return
-        ckpt_path = self.config[self.config.subcommand].get("ckpt_path")
+        subcommand = self.config.subcommand
+        ckpt_path = self.config[subcommand].get("ckpt_path")
         if not (ckpt_path and Path(ckpt_path).is_file()):
             return
         ckpt = torch.load(ckpt_path, weights_only=True, map_location="cpu")
         hparams = _reconstruct_ckpt_hparams(ckpt.get("hyper_parameters", {}))
         if not hparams:
             return
-        hparams = {self.config.subcommand: {"model": hparams}}
+        hparams = {"model": {"init_args": hparams}}
         try:
-            self.config = self.parser.parse_object(hparams, self.config)
+            self.config[subcommand] = self._parser(subcommand).parse_object(
+                hparams, self.config[subcommand]
+            )
         except SystemExit:
             sys.stderr.write("Parsing of ckpt_path hyperparameters failed!\n")
             raise

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -11,48 +11,50 @@ optimizer:
     momentum: 0.9
 
 model:
-  model:
-    class_path: sisr.models.srcnn.SRCNN
-    init_args:
-      num_channels: 1                    # Y-channel only (was 3 — latent bug fix)
-      num_filters: [64, 32]
-      kernel_sizes: [9, 1, 5]
-      padding: 0
-  processor:
-    class_path: sisr.processors.YChannelProcessor
-  training_config:
-    class_path: sisr.models.srcnn.SRCNNTrainingConfig
-    init_args:
-      # Must match the real training input: 1-channel Y at subimg_size x subimg_size.
-      # No longer only a TensorBoard-graph dummy -- it also shapes the compile warm-up
-      # (a wrong size compiles once then recompiles on step 1) and ModelSummary's FLOPs.
-      example_input_shape: [1, 33, 33]
-      # Replay one captured graph of {zero_grad, forward, loss, backward} per step
-      # instead of relaunching 78 kernels. Real-DIV2K measurement at this template's
-      # geometry (num_workers 16, pin_memory false): 14.9 -> 8.3 ms/step (~1.8x; the
-      # full 1e7-step budget drops ~41 h -> ~23 h), losses bit-identical to eager.
-      # SRCNN's step is launch-bound, so removing the launches is nearly all of it;
-      # compute-bound architectures gain less but still gain (SRResNet ~1.4x).
-      # Off by default: requires precision 32-true, one device, no gradient
-      # accumulation and no compile_backend (SRLightning refuses the rest rather
-      # than mistrain quietly -- re-checked every epoch, since a callback can
-      # switch accumulation on after fit starts).
-      # When enabling this, also set pin_memory: false below: the pin-memory
-      # thread's cudaHostAlloc can invalidate a capture mid-flight (the only
-      # measured capture crashes came from graphs + workers + pinning), so that
-      # combination is refused with a warning and trains eagerly. Dropping pinning
-      # measured neutral-to-positive here (the pin thread contends for the GIL).
-      # cuda_graph: true
-  # No init_args: the dataclass default leaves ssim_impl at wang -- the field
-  # standard fixed 11x11 gaussian (sigma 1.5), what torchmetrics/MATLAB/BasicSR
-  # compute and what most SR papers report (SRResNet's paper is the exception --
-  # see the daala note in its template). Override with:
-  #   eval_config:
-  #     class_path: sisr.models.srcnn.SRCNNEvalConfig
-  #     init_args:
-  #       ssim_impl: daala
-  eval_config:
-    class_path: sisr.models.srcnn.SRCNNEvalConfig
+  class_path: sisr.training.SRLightning
+  init_args:
+      model:
+        class_path: sisr.models.srcnn.SRCNN
+        init_args:
+          num_channels: 1                    # Y-channel only (was 3 — latent bug fix)
+          num_filters: [64, 32]
+          kernel_sizes: [9, 1, 5]
+          padding: 0
+      processor:
+        class_path: sisr.processors.YChannelProcessor
+      training_config:
+        class_path: sisr.models.srcnn.SRCNNTrainingConfig
+        init_args:
+          # Must match the real training input: 1-channel Y at subimg_size x subimg_size.
+          # No longer only a TensorBoard-graph dummy -- it also shapes the compile warm-up
+          # (a wrong size compiles once then recompiles on step 1) and ModelSummary's FLOPs.
+          example_input_shape: [1, 33, 33]
+          # Replay one captured graph of {zero_grad, forward, loss, backward} per step
+          # instead of relaunching 78 kernels. Real-DIV2K measurement at this template's
+          # geometry (num_workers 16, pin_memory false): 14.9 -> 8.3 ms/step (~1.8x; the
+          # full 1e7-step budget drops ~41 h -> ~23 h), losses bit-identical to eager.
+          # SRCNN's step is launch-bound, so removing the launches is nearly all of it;
+          # compute-bound architectures gain less but still gain (SRResNet ~1.4x).
+          # Off by default: requires precision 32-true, one device, no gradient
+          # accumulation and no compile_backend (SRLightning refuses the rest rather
+          # than mistrain quietly -- re-checked every epoch, since a callback can
+          # switch accumulation on after fit starts).
+          # When enabling this, also set pin_memory: false below: the pin-memory
+          # thread's cudaHostAlloc can invalidate a capture mid-flight (the only
+          # measured capture crashes came from graphs + workers + pinning), so that
+          # combination is refused with a warning and trains eagerly. Dropping pinning
+          # measured neutral-to-positive here (the pin thread contends for the GIL).
+          # cuda_graph: true
+      # No init_args: the dataclass default leaves ssim_impl at wang -- the field
+      # standard fixed 11x11 gaussian (sigma 1.5), what torchmetrics/MATLAB/BasicSR
+      # compute and what most SR papers report (SRResNet's paper is the exception --
+      # see the daala note in its template). Override with:
+      #   eval_config:
+      #     class_path: sisr.models.srcnn.SRCNNEvalConfig
+      #     init_args:
+      #       ssim_impl: daala
+      eval_config:
+        class_path: sisr.models.srcnn.SRCNNEvalConfig
 
 data:
   # LR is derived via MATLAB-compatible antialiased bicubic resizing (see

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -10,69 +10,71 @@ optimizer:
     lr: 1.0e-4
 
 model:
-  model:
-    class_path: sisr.models.srresnet.SRResNet
-    init_args:
-      scale: &scale 4
-      in_out_channels: 3
-      hidden_channel: 64
-      kernel_sizes: [9, 3, 9]
-      num_residual_blocks: 16
-      padding: same
-  processor:
-    # Paper's range (Ledig et al. §3.2): LR [0,1] in, HR/target [-1,1].
-    # Use RGBProcessor instead to reproduce pre-2026-08-02 runs.
-    class_path: sisr.processors.RGBSignedOutputProcessor
-  # Loss. Unset means torch.nn.MSELoss, which is what both papers' baselines use.
-  # Any nn.Module taking (pred, target) works, so L1 needs no sisr class:
-  #   criterion: {class_path: torch.nn.L1Loss}
-  #   criterion: {class_path: sisr.losses.CharbonnierLoss}
-  #
-  # Ledig et al.'s SRResNet-VGG22, faithfully: a VGG22 content loss plus total
-  # variation at 2e-8, with NO pixel term, trained from scratch on the schedule
-  # already configured below (1e6 steps at lr 1e-4). The MSE-initialisation trick
-  # in the paper applies to the SRGAN variants, not to this one.
-  # Two caveats before running it: the first use downloads ~548 MB of VGG19
-  # weights to the torch hub cache, and TV's 2e-8 presumes the [-1, 1] output
-  # range that RGBSignedOutputProcessor above provides.
-  # cuda_graph: true is compatible with a VGG term -- capture engages with the
-  # VGG inside the captured region.
-  # criterion:
-  #   class_path: sisr.losses.WeightedSumLoss
-  #   init_args:
-  #     terms:
-  #       vgg22:
-  #         class_path: sisr.losses.VGG19FeatureLoss
-  #         init_args:
-  #           layer: vgg22
-  #       tv:
-  #         class_path: sisr.losses.TotalVariationLoss
-  #     weights: {vgg22: 1.0, tv: 2.0e-8}
-  #
-  # phi_{i,j}: blocks 1-2 have 2 convs on both depths (vgg11-vgg22); blocks 3-5
-  # have 4 on VGG19 (up to vgg54) or 3 on VGG16 (up to vgg53). before_activation:
-  # true selects ESRGAN's pre-ReLU features. A perceptual run scores WORSE PSNR
-  # by design; the callbacks below already checkpoint on ssim/val/RGB too, so
-  # the PSNR-monitored "best" no longer tracks the training objective -- decide
-  # which monitored checkpoint you actually want.
-  training_config:
-    class_path: sisr.models.srresnet.SRResNetTrainingConfig
-    init_args:
-      # Matches the real training input: RGB at hr_crop_size / scale. Not only a
-      # TensorBoard-graph dummy -- it also shapes the compile warm-up (a wrong size
-      # compiles once then recompiles on step 1) and ModelSummary's FLOPs.
-      example_input_shape: [3, 24, 24]
-  # No init_args: the dataclass default already sets ssim_impl: daala, the
-  # convention Ledig et al.'s paper actually used (sigma scales with image height,
-  # not Wang's fixed 11x11 -- see sisr/ssim.py). That makes this run's SSIM
-  # comparable to the paper and NOT to the Wang-based numbers the rest of the SR
-  # literature reports (EDSR/RCAN/SwinIR/BasicSR lineage). Override with:
-  #   eval_config:
-  #     class_path: sisr.models.srresnet.SRResNetEvalConfig
-  #     init_args:
-  #       ssim_impl: wang
-  eval_config:
-    class_path: sisr.models.srresnet.SRResNetEvalConfig
+  class_path: sisr.training.SRLightning
+  init_args:
+      model:
+        class_path: sisr.models.srresnet.SRResNet
+        init_args:
+          scale: &scale 4
+          in_out_channels: 3
+          hidden_channel: 64
+          kernel_sizes: [9, 3, 9]
+          num_residual_blocks: 16
+          padding: same
+      processor:
+        # Paper's range (Ledig et al. §3.2): LR [0,1] in, HR/target [-1,1].
+        # Use RGBProcessor instead to reproduce pre-2026-08-02 runs.
+        class_path: sisr.processors.RGBSignedOutputProcessor
+      # Loss. Unset means torch.nn.MSELoss, which is what both papers' baselines use.
+      # Any nn.Module taking (pred, target) works, so L1 needs no sisr class:
+      #   criterion: {class_path: torch.nn.L1Loss}
+      #   criterion: {class_path: sisr.losses.CharbonnierLoss}
+      #
+      # Ledig et al.'s SRResNet-VGG22, faithfully: a VGG22 content loss plus total
+      # variation at 2e-8, with NO pixel term, trained from scratch on the schedule
+      # already configured below (1e6 steps at lr 1e-4). The MSE-initialisation trick
+      # in the paper applies to the SRGAN variants, not to this one.
+      # Two caveats before running it: the first use downloads ~548 MB of VGG19
+      # weights to the torch hub cache, and TV's 2e-8 presumes the [-1, 1] output
+      # range that RGBSignedOutputProcessor above provides.
+      # cuda_graph: true is compatible with a VGG term -- capture engages with the
+      # VGG inside the captured region.
+      # criterion:
+      #   class_path: sisr.losses.WeightedSumLoss
+      #   init_args:
+      #     terms:
+      #       vgg22:
+      #         class_path: sisr.losses.VGG19FeatureLoss
+      #         init_args:
+      #           layer: vgg22
+      #       tv:
+      #         class_path: sisr.losses.TotalVariationLoss
+      #     weights: {vgg22: 1.0, tv: 2.0e-8}
+      #
+      # phi_{i,j}: blocks 1-2 have 2 convs on both depths (vgg11-vgg22); blocks 3-5
+      # have 4 on VGG19 (up to vgg54) or 3 on VGG16 (up to vgg53). before_activation:
+      # true selects ESRGAN's pre-ReLU features. A perceptual run scores WORSE PSNR
+      # by design; the callbacks below already checkpoint on ssim/val/RGB too, so
+      # the PSNR-monitored "best" no longer tracks the training objective -- decide
+      # which monitored checkpoint you actually want.
+      training_config:
+        class_path: sisr.models.srresnet.SRResNetTrainingConfig
+        init_args:
+          # Matches the real training input: RGB at hr_crop_size / scale. Not only a
+          # TensorBoard-graph dummy -- it also shapes the compile warm-up (a wrong size
+          # compiles once then recompiles on step 1) and ModelSummary's FLOPs.
+          example_input_shape: [3, 24, 24]
+      # No init_args: the dataclass default already sets ssim_impl: daala, the
+      # convention Ledig et al.'s paper actually used (sigma scales with image height,
+      # not Wang's fixed 11x11 -- see sisr/ssim.py). That makes this run's SSIM
+      # comparable to the paper and NOT to the Wang-based numbers the rest of the SR
+      # literature reports (EDSR/RCAN/SwinIR/BasicSR lineage). Override with:
+      #   eval_config:
+      #     class_path: sisr.models.srresnet.SRResNetEvalConfig
+      #     init_args:
+      #       ssim_impl: wang
+      eval_config:
+        class_path: sisr.models.srresnet.SRResNetEvalConfig
 
 data:
   # LR is derived via MATLAB-compatible antialiased bicubic resizing (see

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,45 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE = REPO_ROOT / "templates" / "config.srcnn.template.yaml"
 SRRESNET_TEMPLATE = REPO_ROOT / "templates" / "config.srresnet.template.yaml"
 
+SUBCLASS_MODE_CONFIG = """
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1.0e-4
+model:
+  class_path: sisr.training.SRLightning
+  init_args:
+    model:
+      class_path: sisr.models.srresnet.SRResNet
+      init_args:
+        scale: 4
+    processor:
+      class_path: sisr.processors.RGBSignedOutputProcessor
+    training_config:
+      class_path: sisr.models.srresnet.SRResNetTrainingConfig
+      init_args:
+        example_input_shape: [3, 24, 24]
+    eval_config:
+      class_path: sisr.models.srresnet.SRResNetEvalConfig
+data:
+  train_dataset:
+    class_path: sisr.datasets.srresnet.TrainDataset
+    init_args:
+      img_dir: IMG_DIR
+      scale: 4
+      hr_crop_size: 96
+  val_dataset:
+    class_path: sisr.datasets.srresnet.ValidationDataset
+    init_args:
+      img_dir: IMG_DIR
+      scale: 4
+trainer:
+  accelerator: cpu
+  devices: 1
+  logger: false
+  enable_checkpointing: false
+"""
+
 
 def _resolve(*args: str):
     """Resolve a config fully in-process via ``SRLightningCLI(run=False)``.
@@ -49,6 +88,7 @@ def _resolve(*args: str):
             return SRLightningCLI(
                 model_class=SRLightning,
                 datamodule_class=SRDataModule,
+                subclass_mode_model=True,
                 auto_configure_optimizers=False,
                 save_config_kwargs={"overwrite": True},
                 args=[*args, "--trainer.accelerator=cpu", "--trainer.devices=1"],
@@ -56,6 +96,48 @@ def _resolve(*args: str):
             )
     finally:
         sys.argv = saved_argv
+
+
+def test_subclass_mode_accepts_a_class_path_model_block(tmp_path):
+    """A YAML naming its Lightning module by class_path builds that module.
+
+    Guards the whole point of subclass mode: before it, model_class was fixed
+    and no config could select a different module.
+    """
+    from sisr.cli import SRLightningCLI
+    from sisr.training import SRDataModule, SRLightning
+
+    cfg = tmp_path / "c.yaml"
+    cfg.write_text(
+        SUBCLASS_MODE_CONFIG.replace("IMG_DIR", str(tmp_path).replace("\\", "/")),
+        encoding="utf-8",
+    )
+    # See _resolve's comment: LightningCLI warns when both args= and pytest's own
+    # sys.argv are set, which the strict global filterwarnings=error would fail on.
+    # SUBCLASS_MODE_CONFIG also carries no seed_everything: (unlike the shipped
+    # templates), so Lightning's own "No seed found" UserWarning needs the same
+    # local suppression.
+    saved_argv = sys.argv
+    sys.argv = saved_argv[:1]
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", message="GPU available but not used.*")
+            warnings.filterwarnings("ignore", message="No seed found.*")
+            cli = SRLightningCLI(
+                model_class=SRLightning,
+                datamodule_class=SRDataModule,
+                subclass_mode_model=True,
+                auto_configure_optimizers=False,
+                run=False,
+                args=["--config", str(cfg)],
+            )
+    finally:
+        sys.argv = saved_argv
+    assert isinstance(cli.model, SRLightning)
+    optimizer = cli.model.optimizer([torch.zeros(1, requires_grad=True)])
+    assert isinstance(optimizer, torch.optim.Adam)
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(1e-4)
 
 
 def test_srcnn_config_resolves_in_process():
@@ -181,6 +263,7 @@ def test_test_subcommand_help_exposes_ckpt_path_in_process(capsys, monkeypatch):
         SRLightningCLI(
             model_class=SRLightning,
             datamodule_class=SRDataModule,
+            subclass_mode_model=True,
             auto_configure_optimizers=False,
             save_config_kwargs={"overwrite": True},
             args=["test", "--help"],
@@ -206,6 +289,7 @@ def test_export_subcommand_help_exposes_its_args_in_process(capsys, monkeypatch)
         SRLightningCLI(
             model_class=SRLightning,
             datamodule_class=SRDataModule,
+            subclass_mode_model=True,
             auto_configure_optimizers=False,
             save_config_kwargs={"overwrite": True},
             args=["export", "--help"],
@@ -239,6 +323,7 @@ def test_export_subcommand_runs_end_to_end_in_process(tmp_path):
             SRLightningCLI(
                 model_class=SRLightning,
                 datamodule_class=SRDataModule,
+                subclass_mode_model=True,
                 auto_configure_optimizers=False,
                 save_config_kwargs={"overwrite": True},
                 args=[
@@ -477,6 +562,7 @@ def _run_cli(args: list[str]):
             return SRLightningCLI(
                 model_class=SRLightning,
                 datamodule_class=SRDataModule,
+                subclass_mode_model=True,
                 auto_configure_optimizers=False,
                 save_config_callback=None,
                 args=args,
@@ -495,19 +581,22 @@ def _build_srcnn_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path) -> tuple[P
     ckpt_dir = tmp_path / "checkpoints"
     config = {
         "model": {
-            "model": {
-                "class_path": "sisr.models.srcnn.SRCNN",
-                "init_args": {
-                    "num_channels": 3,
-                    "num_filters": [64, 32],
-                    "kernel_sizes": [9, 1, 5],
-                    "padding": 0,
+            "class_path": "sisr.training.SRLightning",
+            "init_args": {
+                "model": {
+                    "class_path": "sisr.models.srcnn.SRCNN",
+                    "init_args": {
+                        "num_channels": 3,
+                        "num_filters": [64, 32],
+                        "kernel_sizes": [9, 1, 5],
+                        "padding": 0,
+                    },
                 },
-            },
-            "processor": {"class_path": "sisr.processors.RGBProcessor"},
-            "eval_config": {
-                "class_path": "sisr.training.SREvalConfig",
-                "init_args": {"crop_border": 0},
+                "processor": {"class_path": "sisr.processors.RGBProcessor"},
+                "eval_config": {
+                    "class_path": "sisr.training.SREvalConfig",
+                    "init_args": {"crop_border": 0},
+                },
             },
         },
         "optimizer": {"class_path": "torch.optim.SGD", "init_args": {"lr": 1.0e-4}},
@@ -576,23 +665,26 @@ def _build_srresnet_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path) -> tupl
     ckpt_dir = tmp_path / "checkpoints"
     config = {
         "model": {
-            "model": {
-                "class_path": "sisr.models.srresnet.SRResNet",
-                "init_args": {
-                    "scale": 2,
-                    "in_out_channels": 3,
-                    "hidden_channel": 4,
-                    "kernel_sizes": [3, 3, 3],
-                    "num_residual_blocks": 1,
-                    "padding": "same",
+            "class_path": "sisr.training.SRLightning",
+            "init_args": {
+                "model": {
+                    "class_path": "sisr.models.srresnet.SRResNet",
+                    "init_args": {
+                        "scale": 2,
+                        "in_out_channels": 3,
+                        "hidden_channel": 4,
+                        "kernel_sizes": [3, 3, 3],
+                        "num_residual_blocks": 1,
+                        "padding": "same",
+                    },
                 },
+                "processor": {"class_path": "sisr.processors.RGBProcessor"},
+                "training_config": {
+                    "class_path": "sisr.models.srresnet.SRResNetTrainingConfig",
+                    "init_args": {"scale": 2},
+                },
+                "eval_config": {"class_path": "sisr.models.srresnet.SRResNetEvalConfig"},
             },
-            "processor": {"class_path": "sisr.processors.RGBProcessor"},
-            "training_config": {
-                "class_path": "sisr.models.srresnet.SRResNetTrainingConfig",
-                "init_args": {"scale": 2},
-            },
-            "eval_config": {"class_path": "sisr.models.srresnet.SRResNetEvalConfig"},
         },
         "optimizer": {"class_path": "torch.optim.SGD", "init_args": {"lr": 1.0e-4}},
         "data": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -797,38 +797,39 @@ def test_ckpt_path_reloads_a_legacy_flattened_checkpoint(tiny_rgb_image_dir: Pat
     _run_cli(["validate", "--config", str(config_path), "--ckpt_path", str(ckpt_path)])
 
 
-def test_ckpt_path_loses_subclass_only_eval_defaults(tiny_rgb_image_dir: Path, tmp_path: Path):
-    """Regression (documented, not fixed): `--ckpt_path` silently drops any
-    subclass-only ``eval_config`` default a checkpoint's stored hparams doesn't
-    happen to carry.
+def test_ckpt_path_preserves_eval_config_subclass_identity(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """`--ckpt_path` reload must keep `eval_config`'s subclass, not just its values.
 
-    ``_reconstruct_ckpt_hparams`` always rebuilds ``eval_config`` as a bare dict
-    with no ``class_path`` — it has no way to know the value was originally an
-    ``SRResNetEvalConfig`` rather than the base ``SREvalConfig``, and current
-    checkpoints don't record that identity either. ``parser.parse_object`` then
-    instantiates the field's *annotation* type (``SREvalConfig``) from that bare
-    dict: keys the dict happens to carry survive as explicit values, but any key
-    it is missing falls back to ``SREvalConfig``'s own default, not the
-    subclass's — silently discarding the architecture-specific override. A CLI
-    override given alongside ``--ckpt_path`` doesn't help either, since the same
-    bare-dict replacement runs after argument parsing and clobbers it too.
+    A regression here would revert to instantiating the field's bare annotation
+    type (base ``SREvalConfig``) from the checkpoint's stored dict instead of
+    merging onto the class the config file already selected
+    (``SRResNetEvalConfig``) — the two assertions below can fail independently:
+    the reloaded object's *class*, and a subclass-only *default* the checkpoint's
+    stored dict never mentions at all.
 
-    Demonstrated here with ``ssim_impl`` (base default ``'wang'``,
-    ``SRResNetEvalConfig``'s ``'daala'``) because it is the field this branch
-    just added, but the trap is general: **any** future ``SREvalConfig`` field
-    with an architecture-specific override is equally at risk on a
-    ``--ckpt_path`` reload of a checkpoint saved before that field existed.
-    This test exists to protect the next one, not just this one.
-
-    Deliberately not a fix — ``SRLightningCLI`` is unchanged here. This locks in
-    the measured behaviour so any future change to checkpoint-reload semantics
-    is a deliberate, reviewed decision instead of an accidental regression.
+    ``_parse_ckpt_path`` merges the reconstructed ``training_config``/
+    ``eval_config`` dict through the *subcommand's own* parser
+    (``self._parser(subcommand)``) onto the already-resolved
+    ``model.init_args.eval_config`` namespace, whose ``class_path`` is already
+    ``SRResNetEvalConfig`` from ``--config``. That merge fills in the given keys
+    as ``init_args`` overrides on the class already selected, so a subclass-only
+    default the checkpoint's dict doesn't mention (``ssim_impl``, demonstrated
+    here since it's the field this arc added) still applies. Routing the same
+    merge through the top-level, subcommand-dispatching parser instead forces
+    jsonargparse to re-validate the whole subclass spec from scratch and fall
+    back to the field's bare annotation type — the base class, wrong default.
     """
+    from sisr.models.srresnet import SRResNetEvalConfig
+
     config_path, ckpt_path = _build_srresnet_checkpoint(tiny_rgb_image_dir, tmp_path)
 
     # Simulates a checkpoint saved before `ssim_impl` existed: the field simply
     # isn't a key in its stored eval_config dict (dataclasses.asdict at save
-    # time wouldn't have produced one yet).
+    # time wouldn't have produced one yet) — SRResNetEvalConfig's own
+    # ssim_impl='daala' default must still apply on reload, not the base's
+    # 'wang'.
     raw = torch.load(ckpt_path, weights_only=True, map_location="cpu")
     legacy_hparams = {k: dict(v) for k, v in raw["hyper_parameters"].items()}
     del legacy_hparams["eval_config"]["ssim_impl"]
@@ -836,31 +837,15 @@ def test_ckpt_path_loses_subclass_only_eval_defaults(tiny_rgb_image_dir: Path, t
     legacy_ckpt_path = tmp_path / "legacy.ckpt"
     torch.save(raw, legacy_ckpt_path)
 
-    # 1. Legacy checkpoint, no CLI override: SRResNetEvalConfig's ssim_impl='daala'
-    # default is lost; the reload falls back to the base SREvalConfig default.
     cli = _run_cli(["validate", "--config", str(config_path), "--ckpt_path", str(legacy_ckpt_path)])
-    assert cli.model.eval_config.ssim_impl == "wang"
+    assert isinstance(cli.model.eval_config, SRResNetEvalConfig)
+    assert cli.model.eval_config.ssim_impl == "daala"
 
-    # 2. Same legacy checkpoint, but the user also asks for daala on the CLI: the
-    # --ckpt_path reload runs after argument parsing and replaces the whole
-    # eval_config object wholesale, so the explicit CLI request is lost too.
-    cli = _run_cli(
-        [
-            "validate",
-            "--config",
-            str(config_path),
-            "--ckpt_path",
-            str(legacy_ckpt_path),
-            "--model.eval_config.ssim_impl=daala",
-        ]
-    )
-    assert cli.model.eval_config.ssim_impl == "wang"
-
-    # 3. A checkpoint saved by the current code *does* carry `ssim_impl`
-    # explicitly (dataclasses.asdict includes every current field), so it
-    # survives reload — not because the subclass identity is preserved, but
-    # because the value arrives as an explicit key rather than a fallback default.
+    # A checkpoint saved by the current code carries `ssim_impl` explicitly
+    # (dataclasses.asdict includes every current field) — confirms identity
+    # holds for the ordinary round trip too, not just the missing-key case above.
     cli = _run_cli(["validate", "--config", str(config_path), "--ckpt_path", str(ckpt_path)])
+    assert isinstance(cli.model.eval_config, SRResNetEvalConfig)
     assert cli.model.eval_config.ssim_impl == "daala"
 
 
@@ -940,3 +925,71 @@ def test_fit_resume_via_ckpt_path_is_not_just_validate_test(
             "--trainer.max_steps=2",
         ]
     )
+
+
+def test_ckpt_path_reload_survives_subclass_mode(tmp_path, monkeypatch):
+    """--ckpt_path must still seed model config after the subclass-mode move.
+
+    _parse_ckpt_path injects the checkpoint's hyper_parameters as CLI options.
+    In subclass mode those options live one level deeper (model.init_args.*),
+    so the un-nested injection silently stops applying — a resumed run would
+    quietly fall back to the config file's values.
+
+    ``--ckpt_path`` is only a recognized option under subcommand-based parsing
+    (``run=True``, the default) — ``run=False`` has no ``ckpt_path`` argument
+    at all, so this reload can't be observed through ``_resolve``'s pattern.
+    ``Trainer.validate`` is stubbed to a no-op so the subcommand completes
+    without needing real data: hparams are already merged into ``cli.model``
+    by the time ``instantiate_classes`` finishes, before ``validate`` runs.
+    """
+    import functools
+
+    from sisr.cli import SRLightningCLI
+    from sisr.training import SRDataModule, SRLightning
+
+    # jsonargparse derives --ckpt_path/--verbose from Trainer.validate's signature
+    # (add_method_arguments), so the stub must preserve it — functools.wraps sets
+    # __wrapped__, which inspect.signature follows by default.
+    @functools.wraps(lightning.pytorch.Trainer.validate)
+    def _noop_validate(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(lightning.pytorch.Trainer, "validate", _noop_validate)
+
+    ckpt = tmp_path / "fake.ckpt"
+    torch.save(
+        {
+            "hyper_parameters": {
+                "training_config": {"example_input_shape": [3, 24, 24]},
+                "eval_config": {"crop_border": 4},
+            }
+        },
+        ckpt,
+    )
+    cfg = tmp_path / "c.yaml"
+    cfg.write_text(
+        SUBCLASS_MODE_CONFIG.replace("IMG_DIR", str(tmp_path).replace("\\", "/")),
+        encoding="utf-8",
+    )
+    # See _resolve's comment: LightningCLI warns when both args= and pytest's own
+    # sys.argv are set, and Lightning's own "No seed found" fires since
+    # SUBCLASS_MODE_CONFIG carries no seed_everything: — both need local
+    # suppression under the strict global filterwarnings=error.
+    saved_argv = sys.argv
+    sys.argv = saved_argv[:1]
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", message="GPU available but not used.*")
+            warnings.filterwarnings("ignore", message="No seed found.*")
+            cli = SRLightningCLI(
+                model_class=SRLightning,
+                datamodule_class=SRDataModule,
+                subclass_mode_model=True,
+                auto_configure_optimizers=False,
+                save_config_callback=None,
+                args=["validate", "--config", str(cfg), "--ckpt_path", str(ckpt)],
+            )
+    finally:
+        sys.argv = saved_argv
+    assert cli.model.eval_config.crop_border == 4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -821,6 +821,10 @@ def test_ckpt_path_preserves_eval_config_subclass_identity(
     jsonargparse to re-validate the whole subclass spec from scratch and fall
     back to the field's bare annotation type — the base class, wrong default.
     """
+    # Pre-fix RED is a construction-time SystemExit ("model, processor"
+    # required), raised before either assertion below runs — structural, not
+    # untried: `model` is Union-typed and required with no fallback, so any
+    # un-nested override hits it before ever reaching eval_config's resolution.
     from sisr.models.srresnet import SRResNetEvalConfig
 
     config_path, ckpt_path = _build_srresnet_checkpoint(tiny_rgb_image_dir, tmp_path)
@@ -931,9 +935,10 @@ def test_ckpt_path_reload_survives_subclass_mode(tmp_path, monkeypatch):
     """--ckpt_path must still seed model config after the subclass-mode move.
 
     _parse_ckpt_path injects the checkpoint's hyper_parameters as CLI options.
-    In subclass mode those options live one level deeper (model.init_args.*),
-    so the un-nested injection silently stops applying — a resumed run would
-    quietly fall back to the config file's values.
+    In subclass mode those options live one level deeper (model.init_args.*):
+    un-nested, the injected dict lands on `model` itself, which is Union-typed
+    and required under subclass mode, so jsonargparse can't resolve it and
+    raises SystemExit outright rather than quietly falling back.
 
     ``--ckpt_path`` is only a recognized option under subcommand-based parsing
     (``run=True``, the default) — ``run=False`` has no ``ckpt_path`` argument


### PR DESCRIPTION
⛔ **Do not merge yet — bottom of a 6-PR stack.** Merge order is strict; see *Stack* below.

Runs `LightningCLI` with `subclass_mode_model=True`, so `model:` in a config carries `class_path` + `init_args` like every other component and a YAML can name its Lightning module.

## Why

`model_class=SRLightning` was fixed at the CLI, so **no config could select a different Lightning module** — the blocker for the adversarial training module later in this stack. `model:` was also the sole component in the config not following the project's own `class_path` + `init_args` convention, so this removes an inconsistency rather than adding one.

## What changed

- `sisr/cli.py` — `subclass_mode_model=True`; optimizer/lr_scheduler links retargeted to `model.init_args.*`.
- Both templates re-nested under `class_path: sisr.training.SRLightning` / `init_args:`. Every existing comment was preserved verbatim and moved with the key it documents — they record measured findings (the VGG22 + total-variation recipe, the SSIM convention default, why `example_input_shape` exists).
- `sisr/cli.py` — `_parse_ckpt_path` now merges the checkpoint's hyperparameters through the **subcommand's own parser**, not the top-level one.

## The `_parse_ckpt_path` fix, precisely

The obvious one-line change (nesting the injected dict one level deeper while still parsing through `self.parser`) **does not work**, and was measured failing before the real fix was written.

The cause is `jsonargparse`'s `ActionTypeHint._check_type`, which does `prev_val = cfg.get(self.dest)` where `self.dest` is the action's **parser-local** name (`"model"`). That is correct when `cfg` is already scoped to the subcommand's parser, and a **silent miss — not an error** — when reached through the top-level dispatching parser, where the value actually lives one level deeper at `cfg["<subcommand>"]["model"]`.

Routing through `self._parser(subcommand)` fixes it. The docstring records the mechanism and carries an explicit warning against "simplifying" it back, because the failure is silent in exactly the fields that have a usable fallback.

## Side effect: checkpoint reload now preserves eval-config subclass identity

Reloading via `--ckpt_path` previously rebuilt `eval_config` as the **base** class, silently dropping every default an architecture subclass had overridden — so a resumed SRResNet run could monitor a different SSIM convention than a fresh run from the identical YAML, distinguishable only by reading `hparams`.

That shares its root cause with the parser-scoping bug above and is fixed by the same change. The characterisation test that documented the defect has been **replaced, not deleted**, per its own recorded acceptance criteria: `test_ckpt_path_preserves_eval_config_subclass_identity` now asserts two independently-failable things — that the reloaded object is the subclass, and that a subclass-only default (`ssim_impl == "daala"`) survives from a checkpoint whose stored dict **never contained that key**.

**Evidence caveat, stated plainly:** a clean RED for this specific guarantee is structurally unreachable in this configuration. Under subclass mode `model` is Union-typed and required with no fallback, so any un-nested state crashes there before `eval_config` resolution is ever reached — the pre-fix failure is a construction-time `SystemExit`, not the silent reversion itself. The forward guarantee is directly asserted; the RED half is a generic failure. This limitation is recorded in a comment on the test rather than only in review notes.

## Testing

796 passed / 0 skipped / 0 failed. `ruff check` and `ruff format --check` clean. No skips — the two data-gated byte-equality tests have their data on the dev box and ran.

## Stack

```
main
 └─ THIS PR  · CLI subclass mode
     └─ perceptual metrics (LPIPS/DISTS)
         └─ rolling checkpoints
             └─ SRGAN discriminator + adversarial loss
                 └─ SRGAN Lightning module + template
                     └─ docs
```

Merge this one first; GitHub retargets the next PR's base to `main` automatically. **Do not use "delete branch on merge"** — deleting the head branch races and closes the child PR instead of retargeting it.
