### PR TITLE
feat: add LPIPS and DISTS perceptual evaluation metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ dependencies = [
     "torch>=2.6",
     "torchvision>=0.21",
     "lightning>=2.4",
-    "torchmetrics>=1.4",
+    # 1.9 is the version DISTS was verified present in on this project
+    # (torchmetrics.functional.image.deep_image_structure_and_texture_similarity).
+    # Lowering it means testing the lower version, not guessing.
+    "torchmetrics>=1.9",
     "jsonargparse[signatures]>=4.27",
     "lmdb>=1.4",
     "pillow>=10",
@@ -72,6 +75,11 @@ export = [
     "onnx>=1.16",
     "onnxruntime>=1.19",
 ]
+# LPIPS only. torchmetrics implements both LPIPS and DISTS, but gates LPIPS on
+# the `lpips` package (_LPIPS_AVAILABLE) while DISTS needs only torchvision,
+# already a core dep — so DISTS ships in core and this extra buys exactly one
+# metric. Optional because it is a scoring convention, not a training need.
+perceptual = ["lpips>=0.1"]
 
 [project.scripts]
 sisr = "sisr.cli:main"

--- a/sisr/perceptual.py
+++ b/sisr/perceptual.py
@@ -1,0 +1,85 @@
+"""LPIPS / DISTS perceptual metrics — the two conventions, in one place.
+
+Both are *scoring* metrics, never losses: LPIPS postdates Ledig et al. by a
+year, so an LPIPS-supervised generator is a different method, not SRGAN.
+
+They exist here because an adversarial objective makes PSNR and SSIM worse by
+design, so without a perceptual metric an SRGAN run has no quality signal at
+all. Neither is a substitute for the paper's MOS study; they correlate with it
+better than PSNR does, and that is the whole claim.
+
+DISTS costs nothing — torchmetrics implements it over torchvision's VGG16,
+both already required. LPIPS needs the ``lpips`` package (torchmetrics gates it
+on ``_LPIPS_AVAILABLE``), hence the ``[perceptual]`` extra.
+"""
+
+from collections.abc import Callable
+
+import torch
+
+#: Metric name -> is-lower-better. Consumed by the checkpoint-monitor direction
+#: check: PSNR/SSIM are higher-better and SRCheckpoint defaults to mode='max',
+#: so monitoring one of these at the default would keep the *worst* model.
+PERCEPTUAL_METRICS: dict[str, bool] = {"lpips": True, "dists": True}
+
+
+def _lpips_fn() -> Callable:
+    """Import LPIPS on demand, turning a missing extra into an actionable error.
+
+    Indirected through a function (rather than a module-level import) so the
+    import cost is only paid by runs that ask for it — this module is reachable
+    from spawned DataLoader workers, which pay every import twice on Windows.
+    """
+    from torchmetrics.utilities.imports import _LPIPS_AVAILABLE
+
+    if not _LPIPS_AVAILABLE:
+        raise ImportError(
+            "perceptual_metrics includes 'lpips', but torchmetrics reports the "
+            "`lpips` package is not installed. Install the extra: "
+            "pip install '.[perceptual]'. 'dists' needs no extra and can be used "
+            "on its own in the meantime."
+        )
+    from torchmetrics.functional.image import learned_perceptual_image_patch_similarity
+
+    return learned_perceptual_image_patch_similarity
+
+
+def _dists_fn() -> Callable:
+    """Import DISTS on demand. No availability gate — torchvision is a core dep."""
+    from torchmetrics.functional.image import deep_image_structure_and_texture_similarity
+
+    return deep_image_structure_and_texture_similarity
+
+
+def perceptual_score(
+    name: str, sr: torch.Tensor, hr: torch.Tensor, lpips_net: str = "alex"
+) -> torch.Tensor:
+    """Score one perceptual metric over a batch, reduced to a 0-dim tensor.
+
+    Args:
+        name: ``'lpips'`` or ``'dists'``.
+        sr: Reconstruction, ``(B, 3, H, W)`` RGB float in ``[0, 1]``.
+        hr: Reference, same shape and range.
+        lpips_net: LPIPS backbone — ``'alex'``, ``'vgg'`` or ``'squeeze'``.
+            Ignored by DISTS. A LPIPS figure is comparable only to one computed
+            under the same backbone, the same way an SSIM figure is comparable
+            only within one ``ssim_impl``.
+
+    Returns:
+        0-dim tensor, batch-meaned.
+
+    Raises:
+        ValueError: If ``name`` is not a supported metric.
+        ImportError: If ``name`` is ``'lpips'`` and the extra is not installed.
+    """
+    if name not in PERCEPTUAL_METRICS:
+        raise ValueError(
+            f"perceptual metric must be one of {sorted(PERCEPTUAL_METRICS)}; got {name!r}"
+        )
+    if name == "lpips":
+        # normalize=True declares "inputs are [0,1]". The default False means
+        # "already [-1,1]" and would score a squashed range without erroring.
+        # reduction is passed explicitly because DISTS below defaults to None
+        # while this defaults to 'mean' — relying on either gives two shapes.
+        return _lpips_fn()(sr, hr, net_type=lpips_net, reduction="mean", normalize=True)
+    return _dists_fn()(sr, hr, reduction="mean")

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -38,11 +38,13 @@ class BenchmarkSample(NamedTuple):
         filename: Stem of the source image path, used as the TensorBoard tag suffix.
         psnr: PSNR value per configured key (``eval_config.psnr_keys``).
         ssim: SSIM value per configured key (``eval_config.ssim_keys``).
+        perceptual: Perceptual score per configured metric (``eval_config.perceptual_keys``).
     """
 
     filename: str
     psnr: dict[str, float]
     ssim: dict[str, float]
+    perceptual: dict[str, float]
 
 
 class BenchmarkImageLogger(Callback):
@@ -67,9 +69,11 @@ class BenchmarkImageLogger(Callback):
     SR output is center-padded when smaller than HR (``padding='valid'``) so
     all three panels share the same spatial size.
 
-    Per-set means go under ``"psnr/{name}/{key}"`` and ``"ssim/{name}/{key}"``
-    every cycle. Per-image scalars under ``"per_image/{name}/psnr/{key}/{filename}"``
-    and ``"per_image/{name}/ssim/{key}/{filename}"`` are gated by
+    Per-set means go under ``"psnr/{name}/{key}"``, ``"ssim/{name}/{key}"`` and,
+    for each metric in ``eval_config.perceptual_keys``, ``"{metric}/{name}"``
+    (e.g. ``"lpips/Set5"``) every cycle. Per-image scalars under
+    ``"per_image/{name}/psnr/{key}/{filename}"`` and
+    ``"per_image/{name}/ssim/{key}/{filename}"`` are gated by
     ``log_per_image_metrics`` (default off — see that arg).
 
     Border cropping is sourced from ``pl_module.eval_config.crop_border`` at
@@ -82,7 +86,7 @@ class BenchmarkImageLogger(Callback):
     Buffering full-resolution LR/SR/HR CPU tensors for every image across
     every test set until epoch end cost ~0.5 GB per validation cycle purely
     to defer ``add_image``; only a :class:`BenchmarkSample` (filename +
-    PSNR/SSIM dicts) is buffered now, for the per-set mean computed in
+    PSNR/SSIM/perceptual dicts) is buffered now, for the per-set mean computed in
     :meth:`_flush_buffer`. The TensorBoard experiment is resolved once, in
     :meth:`setup`, rather than re-searched on every batch/epoch-end.
 
@@ -310,20 +314,22 @@ class BenchmarkImageLogger(Callback):
         *source_dataloaders* recovers the underlying dataset for filename
         resolution.
 
-        PSNR/SSIM are computed from the on-device ``sr``/``hr_cropped``
+        PSNR/SSIM/perceptual are computed from the on-device ``sr``/``hr_cropped``
         slices — mirroring the primary-val-loader path in
         ``SRLightning.validation_step`` — so only the scalar ``.item()``
-        results ever leave the GPU. SSIM goes through ``pl_module._mean_ssim``
-        rather than calling ``torchmetrics`` here directly, so this callback
+        results ever leave the GPU. SSIM and perceptual scores go through
+        ``pl_module._mean_ssim``/``pl_module._mean_perceptual`` rather than calling
+        ``torchmetrics``/``perceptual_score`` here directly, so this callback
         cannot silently diverge from ``validation_step`` on which SSIM
-        implementation a given ``eval_config.ssim_impl`` means. When
+        implementation or perceptual backbone a given ``eval_config`` means. When
         *should_log_images* (or
         ``self.log_per_image_metrics``), exactly one host transfer per image
         (``lr_img[i]``/``sr[i]``/``hr_img[i]`` each ``.cpu()`` at most once)
         composes the bicubic|SR|HR strip and/or the per-image scalars, and
         both are emitted to TensorBoard immediately — nothing image-shaped is
-        buffered. Only ``BenchmarkSample(filename, psnr_dict, ssim_dict)`` is
-        appended to ``self._buffer``, for :meth:`_flush_buffer`'s per-set mean.
+        buffered. Only ``BenchmarkSample(filename, psnr_dict, ssim_dict,
+        perceptual_dict)`` is appended to ``self._buffer``, for
+        :meth:`_flush_buffer`'s per-set mean.
         """
         lr_img, hr_img = batch
 
@@ -364,7 +370,13 @@ class BenchmarkImageLogger(Callback):
                 key: pl_module._mean_ssim(*metric_tensors[key]).item()
                 for key in pl_module.eval_config.ssim_keys
             }
-            self._buffer[dataset_name].append(BenchmarkSample(filename, psnr_dict, ssim_dict))
+            perceptual_dict = {
+                name: pl_module._mean_perceptual(name, sr_metric, hr_metric).item()
+                for name in pl_module.eval_config.perceptual_keys
+            }
+            self._buffer[dataset_name].append(
+                BenchmarkSample(filename, psnr_dict, ssim_dict, perceptual_dict)
+            )
 
             if self._tb_experiment is None:
                 continue
@@ -406,13 +418,15 @@ class BenchmarkImageLogger(Callback):
             )
 
     def _flush_buffer(self, pl_module: lightning.LightningModule):
-        """Log per-set mean PSNR/SSIM from the buffered samples.
+        """Log per-set mean PSNR/SSIM/perceptual scores from the buffered samples.
 
         Shared between :meth:`on_validation_epoch_end` and
         :meth:`on_test_epoch_end`. Per-image scalars and image strips were
         already streamed to TensorBoard from :meth:`_collect_batch`; this
-        only reduces the buffered ``BenchmarkSample.psnr``/``.ssim`` dicts to
-        a mean per dataset/key.
+        only reduces the buffered ``BenchmarkSample.psnr``/``.ssim``/``.perceptual``
+        dicts to a mean per dataset/key. Perceptual tags are metric-first
+        (``lpips/{dataset_name}``, ``dists/{dataset_name}``) with no ``perceptual/``
+        prefix segment, matching ``psnr/{dataset_name}/{key}``'s hierarchy.
         """
         for dataset_name, samples in self._buffer.items():
             if not samples:
@@ -427,6 +441,9 @@ class BenchmarkImageLogger(Callback):
             for key in ssim_keys:
                 mean_ssim = sum(s.ssim[key] for s in samples) / len(samples)
                 pl_module.log(f"ssim/{dataset_name}/{key}", mean_ssim, add_dataloader_idx=False)
+            for name in samples[0].perceptual:
+                mean = sum(s.perceptual[name] for s in samples) / len(samples)
+                pl_module.log(f"{name}/{dataset_name}", mean, add_dataloader_idx=False)
 
         self._buffer.clear()
 

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -24,6 +24,7 @@ import torchvision
 from lightning.pytorch.callbacks import BasePredictionWriter, Callback, ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
+from ..perceptual import PERCEPTUAL_METRICS
 from .metadata import build_metadata
 
 
@@ -581,31 +582,64 @@ class WeightHistogramLogger(Callback):
 
 
 def _validate_monitor_metric(
-    label: str, monitor: str | None, pl_module: lightning.LightningModule
+    label: str, monitor: str | None, pl_module: lightning.LightningModule, mode: str
 ) -> None:
-    """Raise if ``monitor`` doesn't name a ``psnr/val/*`` or ``ssim/val/*`` metric.
+    """Raise if ``monitor`` names no logged metric, or is monitored in the wrong direction.
 
     Shared by :class:`SRCheckpoint` and :class:`SRWeightsCheckpoint`'s ``setup`` —
     they are siblings under :class:`~lightning.pytorch.callbacks.ModelCheckpoint`,
     not parent/child, so this check cannot be reused via ``super()`` across them.
 
+    The direction half exists because both classes default to ``mode='max'``,
+    which is right for PSNR/SSIM and exactly inverted for LPIPS/DISTS — the
+    failure is silent, keeping the worst checkpoint of the run with nothing in
+    the logs or filenames to indicate it. Which perceptual metrics are
+    lower-is-better comes from ``PERCEPTUAL_METRICS`` rather than being
+    restated here, so a future higher-is-better perceptual metric would still
+    be checked in the right direction.
+
     Args:
         label: Name of the calling class, for the error message only.
-        monitor: The ``monitor`` value to validate (``self.monitor``).
+        monitor: The ``monitor`` value to validate (``self.monitor``). ``None``
+            means rolling mode, which monitors nothing and is always valid.
         pl_module: The model being trained; must expose ``eval_config``.
+        mode: The callback's ``mode`` — ``'max'`` or ``'min'``.
 
     Raises:
         MisconfigurationException: If ``monitor`` does not name a metric
-            ``SRLightning`` will log during ``fit``.
+            ``SRLightning`` will log during ``fit``, or if ``mode`` disagrees
+            with that metric's direction.
     """
-    valid_metrics = {f"psnr/val/{key}" for key in pl_module.eval_config.psnr_keys}
-    valid_metrics |= {f"ssim/val/{key}" for key in pl_module.eval_config.ssim_keys}
-    if monitor is not None and monitor not in valid_metrics:
+    if monitor is None:
+        return
+
+    higher_better = {f"psnr/val/{key}" for key in pl_module.eval_config.psnr_keys}
+    higher_better |= {f"ssim/val/{key}" for key in pl_module.eval_config.ssim_keys}
+    higher_better |= {
+        f"{name}/val"
+        for name in pl_module.eval_config.perceptual_keys
+        if not PERCEPTUAL_METRICS[name]
+    }
+    lower_better = {
+        f"{name}/val" for name in pl_module.eval_config.perceptual_keys if PERCEPTUAL_METRICS[name]
+    }
+
+    valid_metrics = higher_better | lower_better
+    if monitor not in valid_metrics:
         raise MisconfigurationException(
             f"`{label}(monitor_metric={monitor!r})` does not match any "
             f"metric `SRLightning` will log: {sorted(valid_metrics)}. HINT: check "
-            f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, or "
-            f"`eval_config.ssim_channels`."
+            f"`eval_config.psnr_channels` / `eval_config.separate_psnr`, "
+            f"`eval_config.ssim_channels`, or `eval_config.perceptual_metrics`."
+        )
+
+    wanted = "min" if monitor in lower_better else "max"
+    if mode != wanted:
+        direction = "lower-is-better" if wanted == "min" else "higher-is-better"
+        raise MisconfigurationException(
+            f"`{label}(monitor_metric={monitor!r}, mode={mode!r})` monitors a "
+            f"{direction} metric in the wrong direction — it would keep the worst "
+            f"checkpoint of the run, silently. Set mode={wanted!r}."
         )
 
 
@@ -689,12 +723,14 @@ class SRCheckpoint(ModelCheckpoint):
 
         Raises:
             MisconfigurationException: If ``monitor`` does not name a
-                metric ``SRLightning`` will log during ``fit``.
+                metric ``SRLightning`` will log during ``fit``, or if
+                ``mode`` disagrees with that metric's direction (PSNR/SSIM
+                are higher-is-better; LPIPS/DISTS are lower-is-better).
         """
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
             return
-        _validate_monitor_metric("SRCheckpoint", self.monitor, pl_module)
+        _validate_monitor_metric("SRCheckpoint", self.monitor, pl_module, mode=self.mode)
 
 
 class SRWeightsCheckpoint(ModelCheckpoint):
@@ -778,12 +814,14 @@ class SRWeightsCheckpoint(ModelCheckpoint):
 
         Raises:
             MisconfigurationException: If ``monitor`` does not name a metric
-                ``SRLightning`` will log during ``fit``.
+                ``SRLightning`` will log during ``fit``, or if ``mode``
+                disagrees with that metric's direction (PSNR/SSIM are
+                higher-is-better; LPIPS/DISTS are lower-is-better).
         """
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
             return
-        _validate_monitor_metric("SRWeightsCheckpoint", self.monitor, pl_module)
+        _validate_monitor_metric("SRWeightsCheckpoint", self.monitor, pl_module, mode=self.mode)
 
     def _save_checkpoint(self, trainer: lightning.Trainer, filepath: str) -> None:
         """Write bare model weights + provenance metadata instead of a full checkpoint.

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -32,6 +32,7 @@ from typing import Literal
 import torch
 
 from ..models.base import SRModel
+from ..perceptual import PERCEPTUAL_METRICS
 from ..processors.base import SRProcessor
 
 # Colorspace entries map to their sub-channel names, expanded only when
@@ -276,6 +277,21 @@ class SREvalConfig:
             change, so a figure is comparable only to one computed under the
             same setting. The value is recorded in ``hparams`` and in every
             artifact's ``sisr_meta`` so any checkpoint can be traced back.
+
+        perceptual_metrics: Perceptual metrics to report, from ``'lpips'`` and
+            ``'dists'``. Empty by default, so an architecture that never asks
+            for them logs exactly the tags it logged before. Both are
+            lower-is-better and RGB-only (no colorspace decomposition), so they
+            get their own tag families ``lpips/val`` / ``dists/val`` rather than
+            a key under the PSNR/SSIM scheme. ``'lpips'`` requires the
+            ``[perceptual]`` extra.
+
+        lpips_net: LPIPS backbone — ``'alex'`` (default, and what the SR
+            literature usually reports), ``'vgg'`` or ``'squeeze'``. **A LPIPS
+            figure is comparable only to one computed under the same backbone**,
+            exactly as an SSIM figure is comparable only within one
+            ``ssim_impl``. Recorded in ``hparams`` and in every artifact's
+            ``sisr_meta``, so any number can be traced back. Ignored by DISTS.
     """
 
     crop_border: int = 0
@@ -283,15 +299,22 @@ class SREvalConfig:
     separate_psnr: bool = False
     ssim_channels: list[str] = field(default_factory=lambda: ["RGB", "Y"])
     ssim_impl: Literal["wang", "daala"] = "wang"
+    perceptual_metrics: list[str] = field(default_factory=list)
+    lpips_net: Literal["alex", "vgg", "squeeze"] = "alex"
 
     def __post_init__(self) -> None:
-        """Validate ``psnr_channels``, ``ssim_channels`` and ``ssim_impl`` at construction.
+        """Validate all channel/metric fields at construction.
+
+        Covers ``psnr_channels``, ``ssim_channels``, ``ssim_impl``,
+        ``perceptual_metrics`` and ``lpips_net``.
 
         Raises:
             ValueError: If any entry of either channel field is not a
                 supported colorspace or single-channel name (see
-                ``_CHANNEL_SUBNAMES``), or if ``ssim_impl`` is not ``'wang'``
-                or ``'daala'``.
+                ``_CHANNEL_SUBNAMES``), if ``ssim_impl`` is not ``'wang'`` or
+                ``'daala'``, if any entry of ``perceptual_metrics`` is not a
+                supported metric (see ``PERCEPTUAL_METRICS``), or if
+                ``lpips_net`` is not ``'alex'``, ``'vgg'`` or ``'squeeze'``.
         """
         valid = tuple(_CHANNEL_SUBNAMES)
         for field_name in ("psnr_channels", "ssim_channels"):
@@ -307,6 +330,18 @@ class SREvalConfig:
                 f"SREvalConfig.ssim_impl must be 'wang' or 'daala'; got "
                 f"{self.ssim_impl!r}. Fix model.eval_config.init_args.ssim_impl "
                 f"in your YAML."
+            )
+        unsupported = [m for m in self.perceptual_metrics if m not in PERCEPTUAL_METRICS]
+        if unsupported:
+            raise ValueError(
+                f"SREvalConfig.perceptual_metrics entries must be one of "
+                f"{sorted(PERCEPTUAL_METRICS)}; got unsupported {unsupported}. Fix "
+                f"model.eval_config.init_args.perceptual_metrics in your YAML."
+            )
+        if self.lpips_net not in ("alex", "vgg", "squeeze"):
+            raise ValueError(
+                f"SREvalConfig.lpips_net must be 'alex', 'vgg' or 'squeeze'; got "
+                f"{self.lpips_net!r}. Fix model.eval_config.init_args.lpips_net."
             )
 
     @property
@@ -354,3 +389,18 @@ class SREvalConfig:
             Ordered list of SSIM keys, e.g. ``['RGB', 'Y']``.
         """
         return list(self.ssim_channels)
+
+    @property
+    def perceptual_keys(self) -> list[str]:
+        """Ordered perceptual metric names this config requests.
+
+        The single derivation of the perceptual key list, mirroring
+        ``psnr_keys`` / ``ssim_keys`` — consumed by ``SRLightning`` (validation
+        logging, HParams registration), ``BenchmarkImageLogger`` (test-set
+        scoring) and the checkpoint-monitor validator, so the three cannot
+        disagree about which tags exist.
+
+        Returns:
+            e.g. ``['lpips', 'dists']``, or ``[]`` when none are requested.
+        """
+        return list(self.perceptual_metrics)

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -23,6 +23,7 @@ from lightning.pytorch.utilities.types import OptimizerLRScheduler
 from ..colorspace import rgb_to_ycbcr_studio
 from ..losses import SRLoss
 from ..models.base import SRModel
+from ..perceptual import perceptual_score
 from ..processors import SRProcessor
 from ..ssim import daala_ssim
 from .config import SREvalConfig, SRTrainingConfig
@@ -524,6 +525,26 @@ class SRLightning(lightning.LightningModule):
             sr, hr, data_range=1.0
         )
 
+    def _mean_perceptual(self, name: str, sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
+        """Mean perceptual score under the configured backbone.
+
+        The single decision point for which perceptual metric this project
+        computes, mirroring :meth:`_mean_ssim` — consumed by
+        :meth:`validation_step` and by
+        :class:`~sisr.training.callbacks.BenchmarkImageLogger`, so the
+        validation and benchmark paths cannot report different quantities under
+        the same tag.
+
+        Args:
+            name: ``'lpips'`` or ``'dists'``.
+            sr: Reconstruction, ``(B, 3, H, W)`` RGB float in ``[0, 1]``.
+            hr: Reference, same shape.
+
+        Returns:
+            0-dim tensor.
+        """
+        return perceptual_score(name, sr, hr, lpips_net=self.eval_config.lpips_net)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the wrapped SR model on ``x`` and return its raw output.
 
@@ -943,6 +964,13 @@ class SRLightning(lightning.LightningModule):
                 on_step=False,
                 add_dataloader_idx=False,
             )
+        for name in self.eval_config.perceptual_keys:
+            self.log(
+                f"{name}/val",
+                self._mean_perceptual(name, sr, hr_cropped),
+                on_step=False,
+                add_dataloader_idx=False,
+            )
 
     def on_fit_start(self) -> None:
         """Check the CUDA-graph prerequisites, then warm up the compiled training path.
@@ -1079,6 +1107,7 @@ class SRLightning(lightning.LightningModule):
         metrics = {
             **{f"psnr/val/{k}": 0.0 for k in self.eval_config.psnr_keys},
             **{f"ssim/val/{k}": 0.0 for k in self.eval_config.ssim_keys},
+            **{f"{name}/val": 0.0 for name in self.eval_config.perceptual_keys},
         }
         for tb in tb_loggers:
             tb.log_hyperparams(self._tb_hparams, metrics)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,6 +5,7 @@ import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 
 
 def test_pyyaml_declared_in_dev_extra():
@@ -44,3 +45,14 @@ def test_torch_floor_excludes_weights_only_bypass():
     deps = pyproject["project"]["dependencies"]
     assert _floor(deps, "torch") >= (2, 6), f"torch floor must be >= 2.6: {deps}"
     assert _floor(deps, "torchvision") >= (0, 21), f"torchvision floor must be >= 0.21: {deps}"
+
+
+def test_perceptual_extra_declares_lpips():
+    """LPIPS needs the `lpips` package; torchmetrics gates it on _LPIPS_AVAILABLE.
+
+    DISTS deliberately stays out of any extra — it needs only torchvision,
+    already a core dependency.
+    """
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    extras = pyproject["project"]["optional-dependencies"]
+    assert any(dep.startswith("lpips") for dep in extras["perceptual"])

--- a/tests/test_perceptual.py
+++ b/tests/test_perceptual.py
@@ -1,0 +1,66 @@
+import pytest
+import torch
+
+from sisr.perceptual import PERCEPTUAL_METRICS, perceptual_score
+
+
+def test_lpips_receives_normalize_true(monkeypatch):
+    """[0,1] inputs must be declared as such to LPIPS.
+
+    torchmetrics defaults normalize=False, which means "inputs are already
+    [-1,1]". Our metric tensors are RGB [0,1], so the default silently scores
+    a squashed range: a plausible number, no error, uncomparable to anything.
+    """
+    seen = {}
+
+    def spy(img1, img2, net_type, reduction, normalize):
+        seen.update(net_type=net_type, reduction=reduction, normalize=normalize)
+        return torch.tensor(0.25)
+
+    monkeypatch.setattr("sisr.perceptual._lpips_fn", lambda: spy)
+    perceptual_score("lpips", torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32))
+
+    assert seen["normalize"] is True
+    assert seen["reduction"] == "mean"
+    assert seen["net_type"] == "alex"
+
+
+def test_dists_reduction_is_passed_explicitly(monkeypatch):
+    """DISTS defaults reduction=None (per-image), LPIPS defaults 'mean'.
+
+    Relying on either default gives a scalar from one metric and a tensor from
+    the other under the same self.log call.
+    """
+    seen = {}
+
+    def spy(preds, target, reduction):
+        seen["reduction"] = reduction
+        return torch.tensor(0.1)
+
+    monkeypatch.setattr("sisr.perceptual._dists_fn", lambda: spy)
+    perceptual_score("dists", torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32))
+
+    assert seen["reduction"] == "mean"
+
+
+def test_unknown_metric_names_the_supported_set():
+    with pytest.raises(ValueError, match="lpips"):
+        perceptual_score("ssim", torch.rand(1, 3, 8, 8), torch.rand(1, 3, 8, 8))
+
+
+def test_every_metric_declares_a_direction():
+    """A metric with no declared direction would be monitored with the wrong mode."""
+    assert PERCEPTUAL_METRICS == {"lpips": True, "dists": True}
+
+
+def test_missing_lpips_extra_names_the_install_command(monkeypatch):
+    """A missing `lpips` package must fail with the install command, not a bare error.
+
+    torchmetrics gates LPIPS behind `_LPIPS_AVAILABLE`; regressing to a generic
+    ImportError (or any error that drops the extra's name) would leave anyone
+    hitting this with no way to know which package fixes it.
+    """
+    monkeypatch.setattr("torchmetrics.utilities.imports._LPIPS_AVAILABLE", False)
+
+    with pytest.raises(ImportError, match=r"pip install '\.\[perceptual\]'"):
+        perceptual_score("lpips", torch.rand(1, 3, 8, 8), torch.rand(1, 3, 8, 8))

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -24,6 +24,7 @@ from sisr.training import (
     WeightHistogramLogger,
 )
 from sisr.training.callbacks import BenchmarkSample
+from tests.training.test_lightning_module import build_module, capture_logged_metrics
 
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
@@ -743,8 +744,8 @@ def test_benchmark_validation_epoch_end_logs_means():
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
     cb._buffer["Set5"] = [
-        BenchmarkSample("img_0", {"RGB": 30.0}, {"RGB": 0.9}),
-        BenchmarkSample("img_1", {"RGB": 32.0}, {"RGB": 0.85}),
+        BenchmarkSample("img_0", {"RGB": 30.0}, {"RGB": 0.9}, {}),
+        BenchmarkSample("img_1", {"RGB": 32.0}, {"RGB": 0.85}, {}),
     ]
     cb.on_validation_epoch_end(trainer=SimpleNamespace(), pl_module=pl_module)
     # Two log calls per dataset: psnr + ssim.
@@ -1022,11 +1023,78 @@ def test_benchmark_test_epoch_end_logs_means():
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="test")
     pl_module = MagicMock()
     cb.on_test_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
-    cb._buffer["Set5"] = [BenchmarkSample("img_0", {"RGB": 28.0}, {"RGB": 0.7})]
+    cb._buffer["Set5"] = [BenchmarkSample("img_0", {"RGB": 28.0}, {"RGB": 0.7}, {})]
     cb.on_test_epoch_end(trainer=SimpleNamespace(), pl_module=pl_module)
     log_keys = [call.args[0] for call in pl_module.log.call_args_list]
     assert "psnr/Set5/RGB" in log_keys
     assert "ssim/Set5/RGB" in log_keys
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkImageLogger perceptual metrics (LPIPS/DISTS) per benchmark set
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
+    """_collect_batch must route perceptual scoring through pl_module._mean_perceptual
+    (mocked here at its perceptual_score seam, so no real LPIPS/DISTS weights load),
+    landing in BenchmarkSample.perceptual under eval_config.perceptual_keys."""
+    monkeypatch.setattr(
+        "sisr.training.lightning_module.perceptual_score",
+        lambda name, sr, hr, lpips_net: torch.tensor(0.42),
+    )
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    pl_module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=SREvalConfig(crop_border=0, perceptual_metrics=["lpips"]),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    ds = _stub_dataset_with_img_paths(n=1, name="Set5")
+    trainer = SimpleNamespace(val_dataloaders=[_stub_dataloader(None), _stub_dataloader(ds)])
+    batch = (torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    cb.on_validation_batch_end(
+        trainer=trainer,
+        pl_module=pl_module,
+        outputs=None,
+        batch=batch,
+        batch_idx=0,
+        dataloader_idx=1,
+    )
+    sample = cb._buffer["Set5"][0]
+    assert sample.perceptual == pytest.approx({"lpips": 0.42})
+
+
+def test_benchmark_logs_perceptual_per_set(monkeypatch):
+    """Test-set scoring must offer the same metric families validation does.
+
+    Routed through pl_module._mean_perceptual, not perceptual_score directly:
+    the PSNR/SSIM pair used to call torchmetrics independently from these two
+    places, and only one of them learning about a new convention is exactly how
+    two tags under one name come to mean different things.
+    """
+    monkeypatch.setattr(
+        "sisr.training.lightning_module.perceptual_score",
+        lambda name, sr, hr, lpips_net: torch.tensor(0.5),
+    )
+    module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips"]))
+    logger = BenchmarkImageLogger()
+    logger.dataset_names = ["Set5"]
+    logger._buffer = {
+        "Set5": [
+            BenchmarkSample("a.png", {"RGB": 30.0}, {"RGB": 0.9}, {"lpips": 0.5}),
+            BenchmarkSample("b.png", {"RGB": 32.0}, {"RGB": 0.8}, {"lpips": 0.3}),
+        ]
+    }
+    logged = capture_logged_metrics(module)
+
+    logger._flush_buffer(pl_module=module)
+
+    assert logged["lpips/Set5"] == pytest.approx(0.4)  # mean of 0.5 and 0.3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -24,7 +24,6 @@ from sisr.training import (
     WeightHistogramLogger,
 )
 from sisr.training.callbacks import BenchmarkSample
-from tests.training.test_lightning_module import build_module, capture_logged_metrics
 
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
@@ -1036,12 +1035,17 @@ def test_benchmark_test_epoch_end_logs_means():
 
 
 def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
-    """_collect_batch must route perceptual scoring through pl_module._mean_perceptual
-    (mocked here at its perceptual_score seam, so no real LPIPS/DISTS weights load),
-    landing in BenchmarkSample.perceptual under eval_config.perceptual_keys."""
+    """_collect_batch must pass the per-image, border-cropped SR/HR pair into
+    pl_module._mean_perceptual (mocked here at its perceptual_score seam, so no
+    real LPIPS/DISTS weights load) -- not the un-cropped batch-level tensors or
+    anything else in scope. The mock's return depends on sr/hr
+    (``sr.sum() - hr.sum()``) rather than being a constant, so a wrong tensor
+    pair changes the recorded value instead of passing regardless of it; a
+    non-zero crop_border also means a wrong (un-cropped) pair differs in shape,
+    not just content."""
     monkeypatch.setattr(
         "sisr.training.lightning_module.perceptual_score",
-        lambda name, sr, hr, lpips_net: torch.tensor(0.42),
+        lambda name, sr, hr, lpips_net: sr.sum() - hr.sum(),
     )
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
@@ -1050,8 +1054,13 @@ def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
         model=model,
         processor=RGBProcessor(),
         training_config=SRTrainingConfig(),
-        eval_config=SREvalConfig(crop_border=0, perceptual_metrics=["lpips"]),
+        eval_config=SREvalConfig(crop_border=2, perceptual_metrics=["lpips"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    sr_fixed = torch.rand(1, 3, 16, 16, generator=torch.Generator().manual_seed(0))
+    hr_cropped_fixed = torch.rand(1, 3, 16, 16, generator=torch.Generator().manual_seed(1))
+    monkeypatch.setattr(
+        pl_module, "predict_rgb", MagicMock(return_value=(sr_fixed, hr_cropped_fixed))
     )
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
     ds = _stub_dataset_with_img_paths(n=1, name="Set5")
@@ -1065,36 +1074,37 @@ def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
         batch_idx=0,
         dataloader_idx=1,
     )
+
+    n = pl_module.eval_config.crop_border
+    expected_sr = sr_fixed[0:1][..., n:-n, n:-n]
+    expected_hr = hr_cropped_fixed[0:1][..., n:-n, n:-n]
+    expected = (expected_sr.sum() - expected_hr.sum()).item()
+
     sample = cb._buffer["Set5"][0]
-    assert sample.perceptual == pytest.approx({"lpips": 0.42})
+    assert sample.perceptual == pytest.approx({"lpips": expected})
 
 
-def test_benchmark_logs_perceptual_per_set(monkeypatch):
+def test_benchmark_logs_perceptual_per_set():
     """Test-set scoring must offer the same metric families validation does.
 
-    Routed through pl_module._mean_perceptual, not perceptual_score directly:
-    the PSNR/SSIM pair used to call torchmetrics independently from these two
-    places, and only one of them learning about a new convention is exactly how
-    two tags under one name come to mean different things.
+    _flush_buffer only reduces already-buffered floats -- perceptual scoring
+    itself happens upstream in _collect_batch (see
+    test_benchmark_collect_batch_populates_perceptual_dict) -- so a plain
+    MagicMock pl_module is enough here, mirroring
+    test_benchmark_validation_epoch_end_logs_means.
     """
-    monkeypatch.setattr(
-        "sisr.training.lightning_module.perceptual_score",
-        lambda name, sr, hr, lpips_net: torch.tensor(0.5),
-    )
-    module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips"]))
-    logger = BenchmarkImageLogger()
-    logger.dataset_names = ["Set5"]
-    logger._buffer = {
-        "Set5": [
-            BenchmarkSample("a.png", {"RGB": 30.0}, {"RGB": 0.9}, {"lpips": 0.5}),
-            BenchmarkSample("b.png", {"RGB": 32.0}, {"RGB": 0.8}, {"lpips": 0.3}),
-        ]
-    }
-    logged = capture_logged_metrics(module)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=99)
+    cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
+    pl_module = MagicMock()
+    cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
+    cb._buffer["Set5"] = [
+        BenchmarkSample("a.png", {"RGB": 30.0}, {"RGB": 0.9}, {"lpips": 0.5}),
+        BenchmarkSample("b.png", {"RGB": 32.0}, {"RGB": 0.8}, {"lpips": 0.3}),
+    ]
+    cb.on_validation_epoch_end(trainer=SimpleNamespace(), pl_module=pl_module)
 
-    logger._flush_buffer(pl_module=module)
-
-    assert logged["lpips/Set5"] == pytest.approx(0.4)  # mean of 0.5 and 0.3
+    lpips_call = next(c for c in pl_module.log.call_args_list if c.args[0] == "lpips/Set5")
+    assert lpips_call.args[1] == pytest.approx(0.4)  # mean of 0.5 and 0.3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -23,7 +23,7 @@ from sisr.training import (
     SRWeightsCheckpoint,
     WeightHistogramLogger,
 )
-from sisr.training.callbacks import BenchmarkSample
+from sisr.training.callbacks import BenchmarkSample, _validate_monitor_metric
 
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
@@ -363,6 +363,45 @@ def test_srcheckpoint_setup_error_lists_valid_metrics(tmp_path: Path):
     assert "psnr/val/RGB" in str(exc_info.value)
     assert "ssim/val/RGB" in str(exc_info.value)
     assert "ssim/val/Y" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _validate_monitor_metric direction check (LPIPS/DISTS are lower-is-better)
+# ---------------------------------------------------------------------------
+
+
+def build_module(eval_config: SREvalConfig | None = None) -> SRLightning:
+    """Real SRLightning exposing only the `eval_config` `_validate_monitor_metric` reads."""
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    return SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(),
+        eval_config=eval_config or SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def test_perceptual_monitor_is_accepted():
+    module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips"]))
+    _validate_monitor_metric("SRCheckpoint", "lpips/val", module, mode="min")  # must not raise
+
+
+def test_lower_is_better_metric_rejects_mode_max():
+    """SRCheckpoint defaults mode='max'; LPIPS and DISTS are lower-better.
+
+    Monitoring lpips/val at the default keeps the WORST model for the whole
+    run, and nothing in the logs, tags or filenames says so.
+    """
+    module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips"]))
+    with pytest.raises(MisconfigurationException, match="lower-is-better"):
+        _validate_monitor_metric("SRCheckpoint", "lpips/val", module, mode="max")
+
+
+def test_psnr_monitor_still_requires_mode_max():
+    module = build_module(eval_config=SREvalConfig())
+    with pytest.raises(MisconfigurationException, match="higher-is-better"):
+        _validate_monitor_metric("SRCheckpoint", "psnr/val/RGB", module, mode="min")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import fields
 
 import pytest
@@ -84,6 +85,8 @@ def test_sr_eval_config_field_names():
         "separate_psnr",
         "ssim_channels",
         "ssim_impl",
+        "perceptual_metrics",
+        "lpips_net",
     }
 
 
@@ -215,6 +218,40 @@ def test_ssim_keys_equals_ssim_channels_verbatim(ssim_channels):
 def test_ssim_keys_is_not_a_dataclass_field():
     names = {f.name for f in fields(SREvalConfig)}
     assert "ssim_keys" not in names
+
+
+# ---------------------------------------------------------------------------
+# perceptual_metrics / lpips_net / perceptual_keys
+# ---------------------------------------------------------------------------
+
+
+def test_perceptual_metrics_default_off():
+    """Existing architectures must log exactly the tags they logged before."""
+    assert SREvalConfig().perceptual_keys == []
+
+
+def test_perceptual_metrics_validated_at_construction():
+    with pytest.raises(ValueError, match="perceptual_metrics"):
+        SREvalConfig(perceptual_metrics=["lpips", "psnr"])
+
+
+def test_lpips_net_validated_at_construction():
+    with pytest.raises(ValueError, match="lpips_net"):
+        SREvalConfig(lpips_net="resnet")
+
+
+def test_perceptual_fields_live_on_the_base_class():
+    """A subclass-only *field* breaks --ckpt_path outright, not just silently.
+
+    dataclasses.asdict dumps every field into the checkpoint's hyper_parameters;
+    on reload that dict is handed to the *annotation* type, which is base
+    SREvalConfig. A field only the subclass declares is then an unexpected
+    keyword argument — a hard failure, strictly worse than reverting to a base
+    default. ssim_impl is the precedent: field on the base, default on the
+    subclass.
+    """
+    field_names = {f.name for f in dataclasses.fields(SREvalConfig)}
+    assert {"perceptual_metrics", "lpips_net"} <= field_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -880,6 +880,8 @@ def test_hparams_stay_nested_plain_dicts_for_checkpoint_reload():
         "separate_psnr": False,
         "ssim_channels": ["RGB", "Y"],
         "ssim_impl": "wang",
+        "perceptual_metrics": [],
+        "lpips_net": "alex",
     }
     assert isinstance(lit.hparams["training_config"], dict)
     assert not any("/" in k for k in lit.hparams)

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -2181,3 +2181,64 @@ def test_criterion_description_prefers_describe_for_srloss():
 
     assert lit.criterion_description == "spy(recipe)"
     assert lit._tb_hparams["criterion"] == "spy(recipe)"
+
+
+# ---------------------------------------------------------------------------
+# validation_step — perceptual metric logging (lpips/dists)
+# ---------------------------------------------------------------------------
+
+
+def build_module(eval_config: SREvalConfig | None = None) -> SRLightning:
+    """Native-LR SRLightning (SRResNet-style, scale=4) for validation_step-level tests.
+
+    lr (1, 3, 8, 8) -> sr (1, 3, 32, 32), matching the hr size these tests use, so
+    validation_step's HR-not-smaller-than-SR check never fires.
+    """
+    model = SRResNet(scale=4, num_residual_blocks=1)
+    return SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=4),
+        eval_config=eval_config or SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def capture_logged_metrics(module: SRLightning) -> dict[str, float]:
+    """Monkeypatch module.log to record name -> float(value), bypassing the real
+    Trainer-attached self.log (which validation_step's callers would otherwise need).
+
+    Detaches tensors before the float() cast — validation_step runs outside
+    torch.no_grad() here (no real Trainer to enter it), so logged tensors carry
+    requires_grad, and float() on those warns (an error under filterwarnings).
+    """
+    logged: dict[str, float] = {}
+
+    def fake_log(name, value, **kwargs):
+        logged[name] = float(value.detach()) if isinstance(value, torch.Tensor) else float(value)
+
+    module.log = fake_log
+    return logged
+
+
+def test_validation_logs_perceptual_tags(monkeypatch):
+    """Requested perceptual metrics reach TensorBoard under their own tag family."""
+    monkeypatch.setattr(
+        "sisr.training.lightning_module.perceptual_score",
+        lambda name, sr, hr, lpips_net: torch.tensor(0.5 if name == "lpips" else 0.25),
+    )
+    module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips", "dists"]))
+    logged = capture_logged_metrics(module)
+
+    module.validation_step((torch.rand(1, 3, 8, 8), torch.rand(1, 3, 32, 32)), 0)
+
+    assert logged["lpips/val"] == pytest.approx(0.5)
+    assert logged["dists/val"] == pytest.approx(0.25)
+
+
+def test_no_perceptual_tags_when_unrequested(monkeypatch):
+    """Default-off must mean no new tags for existing SRCNN/SRResNet runs."""
+    module = build_module(eval_config=SREvalConfig())
+    logged = capture_logged_metrics(module)
+    module.validation_step((torch.rand(1, 3, 8, 8), torch.rand(1, 3, 32, 32)), 0)
+    assert not [tag for tag in logged if tag.startswith(("lpips", "dists"))]


### PR DESCRIPTION
⛔ **Do not merge yet — 2nd of a 6-PR stack.** Based on `feat/cli-subclass-mode`; merge that one first.

Adds LPIPS and DISTS as evaluation metrics, reported for the validation set and for each benchmark set.

## Why

An adversarial objective makes PSNR and SSIM **worse by design**, so the SRGAN work later in this stack would otherwise ship a training mode with no metric that tracks what it is optimising. LPIPS and DISTS correlate with human judgement better than PSNR does. Neither is a substitute for the paper's MOS study, and nothing here claims otherwise.

## What changed

- **`sisr/perceptual.py`** — `PERCEPTUAL_METRICS` (name → is-lower-better) and `perceptual_score(...)`. The one place either library's argument conventions are known.
- **`SREvalConfig`** — `perceptual_metrics: list[str] = []` and `lpips_net: Literal["alex","vgg","squeeze"] = "alex"`, plus a `perceptual_keys` property mirroring `psnr_keys`/`ssim_keys`.
- **`SRLightning._mean_perceptual`** — the single decision point for which perceptual metric this project computes, beside `_mean_ssim` for the same reason that one exists.
- **Tags** — `lpips/val` · `dists/val` · `lpips/{set}` · `dists/{set}`. No colorspace segment: both metrics are RGB-only by definition.
- **`_validate_monitor_metric`** — now also validates metric *direction*.
- **Packaging** — new `perceptual` extra (`lpips`); `torchmetrics` floor raised to `>=1.9`.

## Defaults are off, deliberately

`perceptual_metrics` is empty by default, so **every existing SRCNN/SRResNet run logs exactly the tags it logged before**. A test asserts no perceptual tag appears when unrequested.

## Two argument conventions, both silent-failure shaped

These are why the module exists as a seam rather than two inline calls:

1. **LPIPS needs `normalize=True`.** Its default `False` means "inputs are already `[-1,1]`"; this project's tensors are RGB `[0,1]`, so the default silently scores a squashed range — a plausible number, no error.
2. **The two disagree on reduction defaults** (LPIPS `'mean'`, DISTS `None`), so one would return a scalar and the other a per-image tensor under the same logging call. Both are passed explicitly.

Both are pinned by tests whose spies declare the parameters **without defaults**, so omitting either fails with `TypeError` rather than silently passing a wrong value.

## Monitor direction is now validated

Both checkpoint classes default to `mode="max"` — correct for PSNR/SSIM, exactly inverted for LPIPS/DISTS. `monitor_metric: lpips/val` at the default would have kept the **worst** checkpoint of the run, with nothing in the logs, tags or filenames revealing it. The validator now rejects the mismatch and names the mode to set instead. Direction is looked up per metric from `PERCEPTUAL_METRICS`, not restated.

All eight checkpoint entries across the three shipped templates monitor `psnr/val/RGB` or `ssim/val/RGB` at the default mode and continue to validate unchanged.

## Dependencies

**DISTS costs nothing** — torchmetrics implements it over torchvision's VGG16, both already required. **LPIPS needs the `lpips` package**, so it sits behind `pip install '.[perceptual]'` with an error naming the extra. The `torchmetrics>=1.9` floor is the version DISTS was *verified* present in here; it was not lowered to a version nobody tested.

## Testing

813 passed / 0 skipped / 0 failed. `ruff check` and `ruff format --check` clean.

**CI stays hermetic:** the torch hub cache is empty and CI has no network, so every test monkeypatches at a seam that is actually reached — none can trigger a weights download (~230 MB AlexNet / ~528 MB VGG16). Each new test ships with the mutation that proves it fails; one test that mocked a constant, and so was blind to the tensor choice it was named for, was caught in review and rebuilt to depend on its inputs.

## Stack

```
main
 └─ CLI subclass mode
     └─ THIS PR  · perceptual metrics (LPIPS/DISTS)
         └─ rolling checkpoints
             └─ SRGAN discriminator + adversarial loss
                 └─ SRGAN Lightning module + template
                     └─ docs
```

**Do not use "delete branch on merge"** — it races and closes the child PR instead of retargeting it.
