### PR TITLE
feat: add rolling last-N checkpoints and component weight files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ filterwarnings = [
     # stops calling torch's deprecated pytree API (track the next lightning/torch bump).
     # Upstream: https://github.com/Lightning-AI/pytorch-lightning (pytree LeafSpec deprecation)
     "ignore::FutureWarning:lightning.*",
+    # Manual optimization (SRGANLightning) + every_n_train_steps: Lightning warns
+    # that the saved state is post-optimization. That is exactly the state we
+    # want — a checkpoint should hold the weights the step produced.
+    "ignore:Using ModelCheckpoint with manual optimization:UserWarning",
 ]
 
 [tool.ruff]

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -25,7 +25,7 @@ from lightning.pytorch.callbacks import BasePredictionWriter, Callback, ModelChe
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 from ..perceptual import PERCEPTUAL_METRICS
-from .metadata import build_metadata
+from .metadata import build_component_metadata, build_metadata
 
 
 class BenchmarkSample(NamedTuple):
@@ -768,6 +768,8 @@ class SRCheckpoint(_RollingSaveMixin, ModelCheckpoint):
             filepath: Destination path, already formatted by ``ModelCheckpoint``.
         """
         super()._save_checkpoint(trainer, filepath)
+        # Any edit here must preserve this call -- see _RollingSaveMixin's
+        # docstring for why a rolling window can't be expressed via save_top_k alone.
         self._enforce_rolling_window(trainer, filepath)
 
     def setup(
@@ -810,18 +812,24 @@ class SRCheckpoint(_RollingSaveMixin, ModelCheckpoint):
 
 
 class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
-    """Model checkpoint that saves bare, optimizer-free SR model weights as ``.pt`` files.
+    """Model checkpoint that saves bare, optimizer-free weights as ``.pt`` files.
 
     A distributable sibling to :class:`SRCheckpoint`: that class produces resumable
     ``.ckpt`` files (full training state — optimizer moments, LR scheduler, callback
     state); this one produces ``.pt`` files containing only
-    ``pl_module.model.state_dict()`` (the bare :class:`~sisr.models.base.SRModel`, so
-    keys carry no ``model.`` wrapper prefix) plus the :func:`~sisr.training.metadata.build_metadata`
-    provenance dict. Both run side by side off the same validation metrics — top-k
-    selection, monitor validation (inherited from ``SRCheckpoint``'s ``setup``), and
-    filename formatting are inherited from :class:`~lightning.pytorch.callbacks.ModelCheckpoint`
-    unchanged; only :meth:`_save_checkpoint` — the single method that actually writes bytes
-    to disk — is overridden to swap the payload.
+    ``getattr(pl_module, attribute).state_dict()`` plus a matching provenance dict.
+    By default ``attribute='model'`` — the bare :class:`~sisr.models.base.SRModel` (so
+    keys carry no ``model.`` wrapper prefix), described by
+    :func:`~sisr.training.metadata.build_metadata`. Any other ``attribute`` (e.g.
+    ``'discriminator'``) saves that component instead, described by
+    :func:`~sisr.training.metadata.build_component_metadata` — ``build_metadata``'s
+    generator-scoped fields (``io.scale``, ``criterion``, ``eval_config``) would
+    describe something a non-generator file does not contain. Both run side by side
+    off the same validation metrics — top-k selection, monitor validation (inherited
+    from ``SRCheckpoint``'s ``setup``), and filename formatting are inherited from
+    :class:`~lightning.pytorch.callbacks.ModelCheckpoint` unchanged; only
+    :meth:`_save_checkpoint` — the single method that actually writes bytes to disk —
+    is overridden to swap the payload.
 
     ``_save_checkpoint`` is a private Lightning method, unlike the rest of this class's
     public-API surface. ``tests/training/test_callbacks.py``'s
@@ -847,6 +855,11 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         mode: ``'max'`` or ``'min'`` — same contract as :class:`SRCheckpoint`.
         keep_last: In rolling mode, number of most recent weight files to retain.
             Ignored when ``monitor_metric`` is set. Defaults to ``3``.
+        attribute: Name of the ``pl_module`` attribute whose ``state_dict()`` is saved.
+            Defaults to ``'model'`` (the SR model). Any other value saves that named
+            component instead (e.g. ``'discriminator'`` for an adversarial run's
+            discriminator), with metadata scoped to that component rather than the
+            generator — see the class docstring.
         **kwargs: Extra keyword arguments forwarded to
             :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
     """
@@ -861,6 +874,7 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         filename_prefix: str = "sr-weights",
         mode: str = "max",
         keep_last: int = 3,
+        attribute: str = "model",
         **kwargs: Any,
     ):
         if monitor_metric is None:
@@ -879,6 +893,7 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
             **kwargs,
         )
         self._init_rolling(keep_last)
+        self.attribute = attribute
 
     def setup(
         self,
@@ -910,7 +925,7 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         _validate_monitor_metric("SRWeightsCheckpoint", self.monitor, pl_module, mode=self.mode)
 
     def _save_checkpoint(self, trainer: lightning.Trainer, filepath: str) -> None:
-        """Write bare model weights + provenance metadata instead of a full checkpoint.
+        """Write one component's bare weights + matching provenance metadata.
 
         Overrides :meth:`ModelCheckpoint._save_checkpoint` — the private hook every
         public save path (``_save_topk_checkpoint``, ``_save_none_monitor_checkpoint``,
@@ -920,6 +935,12 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         ``_last_checkpoint_saved``, logger notification) so this callback stays a drop-in
         peer of :class:`SRCheckpoint` from the trainer's point of view.
 
+        ``self.attribute`` selects both the saved component and its metadata builder:
+        ``'model'`` (the default) uses :func:`~sisr.training.metadata.build_metadata`,
+        which describes the generator; anything else uses
+        :func:`~sisr.training.metadata.build_component_metadata`, so a discriminator's
+        ``.pt`` never carries metadata describing a network it does not contain.
+
         Rolling-mode deletion (:meth:`_RollingSaveMixin._enforce_rolling_window`) runs
         last, after this method's own writes — it does not go through ``super()``
         the way :class:`SRCheckpoint`'s does, since this override never calls
@@ -927,21 +948,32 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         optimizer-bearing payload this class exists to avoid).
 
         Args:
-            trainer: The active trainer — supplies ``lightning_module`` (for the bare
-                ``model.state_dict()`` and metadata) and ``global_step``/``current_epoch``.
+            trainer: The active trainer — supplies ``lightning_module`` (for the
+                component's ``state_dict()`` and metadata) and ``global_step``/``current_epoch``.
             filepath: Destination path, already formatted by ``ModelCheckpoint``
                 (``.pt`` via ``FILE_EXTENSION``).
         """
         pl_module = trainer.lightning_module
+        component = getattr(pl_module, self.attribute)
         monitor_value = float(self.current_score) if self.current_score is not None else None
-        meta = build_metadata(
-            pl_module,
-            global_step=trainer.global_step,
-            epoch=trainer.current_epoch,
-            monitor=self.monitor,
-            monitor_value=monitor_value,
-        )
-        torch.save({"state_dict": pl_module.model.state_dict(), "meta": meta}, filepath)
+        if self.attribute == "model":
+            meta = build_metadata(
+                pl_module,
+                global_step=trainer.global_step,
+                epoch=trainer.current_epoch,
+                monitor=self.monitor,
+                monitor_value=monitor_value,
+            )
+        else:
+            meta = build_component_metadata(
+                pl_module,
+                self.attribute,
+                global_step=trainer.global_step,
+                epoch=trainer.current_epoch,
+                monitor=self.monitor,
+                monitor_value=monitor_value,
+            )
+        torch.save({"state_dict": component.state_dict(), "meta": meta}, filepath)
 
         self._last_global_step_saved = trainer.global_step
         self._last_checkpoint_saved = filepath
@@ -950,6 +982,8 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
             for logger in trainer.loggers:
                 logger.after_save_checkpoint(proxy(self))
 
+        # Any edit here must preserve this call -- see _RollingSaveMixin's
+        # docstring for why a rolling window can't be expressed via save_top_k alone.
         self._enforce_rolling_window(trainer, filepath)
 
 

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -643,7 +643,53 @@ def _validate_monitor_metric(
         )
 
 
-class SRCheckpoint(ModelCheckpoint):
+class _RollingSaveMixin:
+    """Oldest-first deletion for the no-monitor (rolling) case.
+
+    Lightning refuses ``ModelCheckpoint(monitor=None, save_top_k=N>1)``
+    ("No quantity for top_k to track"), so a rolling window cannot be
+    expressed through ``save_top_k`` at all. The legal construction is
+    ``monitor=None, save_top_k=-1`` (keep everything) with the window
+    enforced here. Verified on Lightning 2.6.5.
+
+    Shared by :class:`SRCheckpoint` and :class:`SRWeightsCheckpoint` —
+    siblings under :class:`~lightning.pytorch.callbacks.ModelCheckpoint`, not
+    parent/child, so this logic can't be reused via one ``super()`` chain
+    across both. The window bookkeeping itself lives in
+    :meth:`_enforce_rolling_window`, a seam distinct from ``_save_checkpoint``:
+    :class:`SRWeightsCheckpoint` already overrides ``_save_checkpoint`` to
+    write a bare ``.pt`` payload instead of Lightning's full checkpoint, and
+    that override does not call ``super()._save_checkpoint()`` — so a version
+    of this mixin that put the bookkeeping inside its own ``_save_checkpoint``
+    would be shadowed by that override and silently never run. Each
+    subclass's ``_save_checkpoint`` calls :meth:`_enforce_rolling_window`
+    explicitly instead.
+    """
+
+    def _init_rolling(self, keep_last: int) -> None:
+        if keep_last < 1:
+            raise ValueError(f"keep_last must be >= 1; got {keep_last}")
+        self.keep_last = keep_last
+        self._rolling: list[str] = []
+
+    def _enforce_rolling_window(self, trainer: lightning.Trainer, filepath: str) -> None:
+        """Track *filepath* and drop the oldest save(s) beyond ``keep_last``.
+
+        No-op when ``monitor`` is set — Lightning's own top-k selection owns
+        retention then, unmodified.
+
+        Args:
+            trainer: The active trainer, forwarded to ``_remove_checkpoint``.
+            filepath: Path just written by the caller's ``_save_checkpoint``.
+        """
+        if self.monitor is not None:
+            return
+        self._rolling.append(filepath)
+        while len(self._rolling) > self.keep_last:
+            self._remove_checkpoint(trainer, self._rolling.pop(0))
+
+
+class SRCheckpoint(_RollingSaveMixin, ModelCheckpoint):
     """Model checkpoint that monitors a super-resolution quality metric.
 
     A thin convenience wrapper around
@@ -666,24 +712,43 @@ class SRCheckpoint(ModelCheckpoint):
         monitor_metric: The validation metric to monitor. Any ``psnr/val/{key}``
             or ``ssim/val/{key}`` logged by the lightning module (e.g.
             ``"psnr/val/Y"``, ``"psnr/val/YCbCr"``, ``"ssim/val/RGB"``).
-        save_top_k: Number of best checkpoints to keep.
+            ``None`` selects rolling mode instead: no metric is tracked at
+            all, and the last ``keep_last`` checkpoints (by step) are kept.
+            Needed because under an adversarial objective (e.g. SRGAN) PSNR
+            and SSIM get worse by design, so top-k selection on either would
+            keep the LEAST adversarial checkpoint of the run — typically one
+            from the first few thousand steps.
+        save_top_k: Number of best checkpoints to keep. Ignored (forced to
+            ``-1``, i.e. keep-everything) when ``monitor_metric`` is ``None``
+            — Lightning refuses ``save_top_k > 1`` with no monitor outright,
+            so ``keep_last`` enforces the window instead.
         dirpath: Directory to save checkpoints.
         filename_prefix: Prefix for checkpoint filenames.
+        keep_last: In rolling mode, number of most recent checkpoints to
+            retain; oldest is deleted first. Ignored when ``monitor_metric``
+            is set. Defaults to ``3``.
         **kwargs: Extra keyword arguments forwarded to
             :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
     """
 
     def __init__(
         self,
-        monitor_metric: str = "psnr/val/RGB",
+        monitor_metric: str | None = "psnr/val/RGB",
         save_top_k: int = 3,
         dirpath: str | None = None,
         filename_prefix: str = "sr",
         mode: str = "max",
+        keep_last: int = 3,
         **kwargs: Any,
     ):
-        label = monitor_metric.replace("/", "_")
-        filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
+        if monitor_metric is None:
+            # Rolling: no metric in the filename (there is none), and step
+            # must be in it or every save overwrites the last.
+            filename = f"{filename_prefix}-{{step}}"
+            save_top_k = -1
+        else:
+            label = monitor_metric.replace("/", "_")
+            filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
         super().__init__(
             monitor=monitor_metric,
             mode=mode,
@@ -693,6 +758,17 @@ class SRCheckpoint(ModelCheckpoint):
             auto_insert_metric_name=False,
             **kwargs,
         )
+        self._init_rolling(keep_last)
+
+    def _save_checkpoint(self, trainer: lightning.Trainer, filepath: str) -> None:
+        """Save via :class:`~lightning.pytorch.callbacks.ModelCheckpoint`, then enforce rolling.
+
+        Args:
+            trainer: The active trainer.
+            filepath: Destination path, already formatted by ``ModelCheckpoint``.
+        """
+        super()._save_checkpoint(trainer, filepath)
+        self._enforce_rolling_window(trainer, filepath)
 
     def setup(
         self,
@@ -733,7 +809,7 @@ class SRCheckpoint(ModelCheckpoint):
         _validate_monitor_metric("SRCheckpoint", self.monitor, pl_module, mode=self.mode)
 
 
-class SRWeightsCheckpoint(ModelCheckpoint):
+class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
     """Model checkpoint that saves bare, optimizer-free SR model weights as ``.pt`` files.
 
     A distributable sibling to :class:`SRCheckpoint`: that class produces resumable
@@ -755,18 +831,22 @@ class SRWeightsCheckpoint(ModelCheckpoint):
     checkpoints under a misleadingly bare ``.pt`` extension.
 
     ``FILE_EXTENSION`` (public) and a distinct default ``filename_prefix`` keep this
-    callback's top-k deletion pass from ever touching :class:`SRCheckpoint`'s files when
-    both share one ``dirpath`` — each callback only ever names/deletes files matching its
-    own ``filename``/``FILE_EXTENSION`` combination.
+    callback's top-k deletion pass — and, in rolling mode, its own oldest-first deletion
+    (see :class:`_RollingSaveMixin`) — from ever touching :class:`SRCheckpoint`'s files
+    when both share one ``dirpath``: each callback only ever names/deletes files matching
+    its own ``filename``/``FILE_EXTENSION`` combination.
 
     Args:
         monitor_metric: The validation metric to monitor — same contract as
-            :class:`SRCheckpoint`.
-        save_top_k: Number of best weight files to keep.
+            :class:`SRCheckpoint`, including the ``None`` rolling-mode meaning.
+        save_top_k: Number of best weight files to keep. Ignored (forced to ``-1``)
+            when ``monitor_metric`` is ``None`` — same contract as :class:`SRCheckpoint`.
         dirpath: Directory to save weight files.
         filename_prefix: Prefix for weight filenames. Defaults to ``'sr-weights'``,
             distinct from ``SRCheckpoint``'s ``'sr'`` default.
         mode: ``'max'`` or ``'min'`` — same contract as :class:`SRCheckpoint`.
+        keep_last: In rolling mode, number of most recent weight files to retain.
+            Ignored when ``monitor_metric`` is set. Defaults to ``3``.
         **kwargs: Extra keyword arguments forwarded to
             :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
     """
@@ -775,15 +855,20 @@ class SRWeightsCheckpoint(ModelCheckpoint):
 
     def __init__(
         self,
-        monitor_metric: str = "psnr/val/RGB",
+        monitor_metric: str | None = "psnr/val/RGB",
         save_top_k: int = 3,
         dirpath: str | None = None,
         filename_prefix: str = "sr-weights",
         mode: str = "max",
+        keep_last: int = 3,
         **kwargs: Any,
     ):
-        label = monitor_metric.replace("/", "_")
-        filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
+        if monitor_metric is None:
+            filename = f"{filename_prefix}-{{step}}"
+            save_top_k = -1
+        else:
+            label = monitor_metric.replace("/", "_")
+            filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
         super().__init__(
             monitor=monitor_metric,
             mode=mode,
@@ -793,6 +878,7 @@ class SRWeightsCheckpoint(ModelCheckpoint):
             auto_insert_metric_name=False,
             **kwargs,
         )
+        self._init_rolling(keep_last)
 
     def setup(
         self,
@@ -834,6 +920,12 @@ class SRWeightsCheckpoint(ModelCheckpoint):
         ``_last_checkpoint_saved``, logger notification) so this callback stays a drop-in
         peer of :class:`SRCheckpoint` from the trainer's point of view.
 
+        Rolling-mode deletion (:meth:`_RollingSaveMixin._enforce_rolling_window`) runs
+        last, after this method's own writes — it does not go through ``super()``
+        the way :class:`SRCheckpoint`'s does, since this override never calls
+        ``ModelCheckpoint._save_checkpoint`` at all (that would write the full,
+        optimizer-bearing payload this class exists to avoid).
+
         Args:
             trainer: The active trainer — supplies ``lightning_module`` (for the bare
                 ``model.state_dict()`` and metadata) and ``global_step``/``current_epoch``.
@@ -857,6 +949,8 @@ class SRWeightsCheckpoint(ModelCheckpoint):
         if trainer.is_global_zero:
             for logger in trainer.loggers:
                 logger.after_save_checkpoint(proxy(self))
+
+        self._enforce_rolling_window(trainer, filepath)
 
 
 class SRPredictionWriter(BasePredictionWriter):

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -6,8 +6,21 @@ distributable ``.pt``), and :func:`sisr.export.to_onnx` (the ``.onnx``'s ``metad
 call :func:`build_metadata` so the three payloads cannot drift apart — mirrors how
 ``SREvalConfig.psnr_keys`` is the single derivation point for its three consumers.
 
-Carries ``format``, ``created``, ``versions``, ``model``, ``processor``, ``criterion``, ``io``,
-``eval_config``, and ``training``.
+:func:`build_component_metadata` is a second builder for a bare ``.pt`` that is **not** the SR
+model — e.g. a discriminator's weights. Both builders are built on one private :func:`_envelope`
+helper (``format``/``kind``/``created``/``versions``/``training``), so the two payload shapes
+cannot drift apart either. Each carries a ``kind`` field: ``"sr_model"`` for :func:`build_metadata`,
+``"component"`` for :func:`build_component_metadata`. This is an additive field, not a format
+change — ``FORMAT_VERSION`` is unchanged, and its absence on a file written before ``kind``
+existed means ``"sr_model"``, the only kind that existed then.
+
+:func:`build_metadata` carries ``format``, ``kind``, ``created``, ``versions``, ``model``,
+``processor``, ``criterion``, ``io``, ``eval_config``, and ``training`` — it describes the
+*generator*. :func:`build_component_metadata` carries ``format``, ``kind``, ``created``,
+``versions``, ``component``, ``io``, and ``training`` — it describes one other named component
+only. Attaching the former to the latter's weights would describe things the file does not
+contain (``io.scale``, ``criterion``, ``eval_config``); this is the silent-wrong-artifact class
+this metadata exists to prevent, so the two never share a shape beyond the envelope.
 
 Deliberately omits dataset paths: Ultralytics' ``train_args`` leaks local filesystem layout into
 distributed files; this stays leak-free by construction. If dataset provenance is ever added,
@@ -47,6 +60,39 @@ def _class_path(obj: Any) -> str:
     return f"{cls.__module__}.{cls.__qualname__}"
 
 
+def _envelope(
+    kind: str,
+    global_step: int | None,
+    epoch: int | None,
+    monitor: str | None,
+    monitor_value: float | None,
+) -> dict[str, Any]:
+    """Fields every sisr artifact carries, whatever it holds.
+
+    The one thing :func:`build_metadata` and :func:`build_component_metadata` build on
+    in common, so ``format``/``versions``/``training`` cannot drift apart between them.
+    """
+    return {
+        "format": FORMAT_VERSION,
+        "kind": kind,
+        "created": datetime.now(UTC).isoformat(),
+        "versions": {
+            # str(...) matters here: torch.__version__ is a TorchVersion (str
+            # subclass), which torch.load(weights_only=True) refuses to unpickle
+            # as an unlisted global. Coerce to plain str for every field.
+            "sisr": str(sisr.__version__),
+            "torch": str(torch.__version__),
+            "lightning": str(lightning.__version__),
+        },
+        "training": {
+            "global_step": global_step,
+            "epoch": epoch,
+            "monitor": monitor,
+            "monitor_value": monitor_value,
+        },
+    }
+
+
 def build_metadata(
     module: SRLightning,
     *,
@@ -68,11 +114,11 @@ def build_metadata(
         monitor_value: Value of ``monitor`` at save time (``None`` otherwise).
 
     Returns:
-        A dict tree carrying ``format``, ``created``, ``versions``, ``model``, ``processor``,
-        ``criterion``, ``io``, ``eval_config``, and ``training``. Contains only ``dict``/
-        ``list``/``str``/``int``/``float``/``bool``/``None`` values — safe for ``torch.save``/
-        ``torch.load(weights_only=True)`` and, per top-level field, for JSON-encoding into
-        ONNX ``metadata_props``.
+        A dict tree carrying ``format``, ``kind`` (``"sr_model"``), ``created``, ``versions``,
+        ``model``, ``processor``, ``criterion``, ``io``, ``eval_config``, and ``training``.
+        Contains only ``dict``/``list``/``str``/``int``/``float``/``bool``/``None`` values —
+        safe for ``torch.save``/``torch.load(weights_only=True)`` and, per top-level field, for
+        JSON-encoding into ONNX ``metadata_props``.
     """
     model = module.model
     processor = module.processor
@@ -81,40 +127,72 @@ def build_metadata(
     if scale is None:
         scale = model.hparams.get("scale")
 
-    return {
-        "format": FORMAT_VERSION,
-        "created": datetime.now(UTC).isoformat(),
-        "versions": {
-            # str(...) matters here: torch.__version__ is a TorchVersion (str
-            # subclass), which torch.load(weights_only=True) refuses to unpickle
-            # as an unlisted global. Coerce to plain str for every field.
-            "sisr": str(sisr.__version__),
-            "torch": str(torch.__version__),
-            "lightning": str(lightning.__version__),
-        },
-        "model": {
-            "class_path": _class_path(model),
-            "init_args": _to_plain(model.hparams),
-        },
-        "processor": {
-            "class_path": _class_path(processor),
-        },
-        "criterion": {
-            "class_path": _class_path(module.criterion),
-            "description": module.criterion_description,
-        },
-        "io": {
-            "scale": scale,
-            "input": model.input_contract,
-            "input_channels": processor.model_channels,
-            "output_range": list(processor.output_range),
-            "output_colorspace": processor.output_colorspace,
-        },
-        "eval_config": _to_plain(dataclasses.asdict(module.eval_config)),
-        "training": {
-            "global_step": global_step,
-            "epoch": epoch,
-            "monitor": monitor,
-            "monitor_value": monitor_value,
-        },
+    meta = _envelope("sr_model", global_step, epoch, monitor, monitor_value)
+    meta["model"] = {
+        "class_path": _class_path(model),
+        "init_args": _to_plain(model.hparams),
     }
+    meta["processor"] = {
+        "class_path": _class_path(processor),
+    }
+    meta["criterion"] = {
+        "class_path": _class_path(module.criterion),
+        "description": module.criterion_description,
+    }
+    meta["io"] = {
+        "scale": scale,
+        "input": model.input_contract,
+        "input_channels": processor.model_channels,
+        "output_range": list(processor.output_range),
+        "output_colorspace": processor.output_colorspace,
+    }
+    meta["eval_config"] = _to_plain(dataclasses.asdict(module.eval_config))
+    return meta
+
+
+def build_component_metadata(
+    module: SRLightning,
+    attribute: str,
+    *,
+    global_step: int | None = None,
+    epoch: int | None = None,
+    monitor: str | None = None,
+    monitor_value: float | None = None,
+) -> dict[str, Any]:
+    """Provenance for a bare weights file that is **not** the SR model.
+
+    :func:`build_metadata` describes the *generator* — ``io.scale``, ``io.input``,
+    ``criterion``, ``eval_config``. Attaching that to a discriminator's weights would
+    describe something the file does not contain, which is the silent-wrong-artifact
+    failure this metadata exists to prevent.
+
+    ``io.input_range`` is the load-bearing field: a discriminator is trained on
+    model-space tensors (``[-1, 1]`` under ``RGBSignedOutputProcessor``), and feeding
+    it ``[0, 1]`` data later is wrong with no error.
+
+    Args:
+        module: The Lightning module owning the component.
+        attribute: Attribute name of the component on ``module`` (e.g. ``'discriminator'``).
+        global_step: Optimizer step at save time, when known.
+        epoch: Training epoch at save time, when known.
+        monitor: Metric that triggered this save, when monitor-driven.
+        monitor_value: Value of ``monitor`` at save time.
+
+    Returns:
+        A dict tree carrying ``format``, ``kind`` (``"component"``), ``created``,
+        ``versions``, ``component``, ``io``, and ``training`` — a plain dict, ``torch.load
+        (weights_only=True)``-safe like :func:`build_metadata`.
+    """
+    component = getattr(module, attribute)
+    processor = module.processor
+    meta = _envelope("component", global_step, epoch, monitor, monitor_value)
+    meta["component"] = {
+        "name": attribute,
+        "class_path": _class_path(component),
+        "init_args": _to_plain(getattr(component, "hparams", {})),
+    }
+    meta["io"] = {
+        "input_range": list(processor.output_range),
+        "input_colorspace": processor.output_colorspace,
+    }
+    return meta

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -171,6 +171,7 @@ def test_to_onnx_writes_metadata_props(tmp_path):
     props = {p.key: p.value for p in onnx_model.metadata_props}
     assert set(props.keys()) == {
         "format",
+        "kind",
         "created",
         "versions",
         "model",
@@ -181,6 +182,7 @@ def test_to_onnx_writes_metadata_props(tmp_path):
         "training",
     }
     assert props["format"] == "sisr-meta-v1"  # stored as-is: already a str
+    assert props["kind"] == "sr_model"  # stored as-is: already a str
 
     model_field = json.loads(props["model"])
     assert model_field["class_path"] == "sisr.models.srcnn.model.SRCNN"

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -1,14 +1,18 @@
 import functools
+import shutil
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import lightning
+import numpy as np
 import pytest
 import torch
 import torchmetrics.functional
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
+from PIL import Image
 
 from sisr.models.srcnn import SRCNN
 from sisr.processors import RGBProcessor, YChannelProcessor
@@ -554,6 +558,177 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
 
     fresh_model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     fresh_model.load_state_dict(bare["state_dict"], strict=True)  # the real proof
+
+
+# ---------------------------------------------------------------------------
+# Rolling last-N checkpoint mode (monitor_metric=None)
+# ---------------------------------------------------------------------------
+
+
+def _run_tiny_fit(callbacks: list, n_batches: int) -> lightning.Trainer:
+    """Real `Trainer.fit` for `n_batches` steps, driving `callbacks`'s real save path.
+
+    Rolling-mode retention depends on Lightning's actual save cadence, filename
+    formatting, and `_remove_checkpoint` bookkeeping, so (unlike most of this
+    file) a mocked hook can't stand in for the Trainer here. Images live in
+    their own throwaway dir rather than a `tmp_path` fixture, since callers
+    pass their checkpoint `dirpath` as `tmp_path` itself and
+    `ModelCheckpoint.setup` errors (-> strict filterwarnings) if that dir is
+    non-empty at startup. Teardown uses `ignore_errors=True`: LMDB keeps
+    `data.mdb` memory-mapped past the dataset object's own lifetime on
+    Windows, so a strict rmtree here intermittently raises `PermissionError`
+    -- immaterial to what this helper actually verifies.
+    """
+    image_dir = Path(tempfile.mkdtemp())
+    try:
+        rng = np.random.default_rng(seed=0)
+        for i in range(3):
+            arr = rng.integers(0, 256, size=(36, 36, 3), dtype=np.uint8)
+            Image.fromarray(arr).save(image_dir / f"img_{i:02d}.png")
+
+        model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+        module = SRLightning(
+            model=model,
+            processor=RGBProcessor(),
+            eval_config=SREvalConfig(crop_border=0),
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4, momentum=0.9),
+        )
+        trainer = lightning.Trainer(
+            max_epochs=-1,
+            max_steps=n_batches,
+            limit_val_batches=0,
+            num_sanity_val_steps=0,
+            accelerator="cpu",
+            devices=1,
+            logger=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            callbacks=callbacks,
+        )
+        trainer.fit(module, datamodule=_make_srcnn_datamodule(image_dir))
+        return trainer
+    finally:
+        shutil.rmtree(image_dir, ignore_errors=True)
+
+
+@_ignore_gpu_warning
+def test_rolling_mode_keeps_only_the_last_n(tmp_path):
+    """monitor_metric=None keeps a sliding window of recent checkpoints.
+
+    Needed because an adversarial objective makes PSNR/SSIM worse by design, so
+    a metric-monitored save_top_k selects the LEAST adversarial model — very
+    likely one from the first few thousand steps.
+    """
+    cb = SRCheckpoint(
+        monitor_metric=None, keep_last=3, every_n_train_steps=2, dirpath=str(tmp_path)
+    )
+    _run_tiny_fit(callbacks=[cb], n_batches=20)
+    files = sorted(p.name for p in tmp_path.glob("*.ckpt"))
+    assert len(files) == 3, files
+    # Not just any 3 -- the 3 *newest* by step (oldest-first deletion), matching
+    # the mechanism spike's own result (20 batches, every_n_train_steps=2, keep_last=3
+    # -> steps 16/18/20 survive out of the 10 saved at steps 2, 4, ..., 20).
+    assert files == ["sr-16.ckpt", "sr-18.ckpt", "sr-20.ckpt"], files
+
+
+@_ignore_gpu_warning
+def test_rolling_mode_needs_no_monitor_validation(tmp_path: Path):
+    """Rolling mode monitors nothing, so monitor validation must not fire.
+
+    A bare `unittest.mock.Mock` trainer can't stand in for `.setup()` here —
+    `ModelCheckpoint.setup` unconditionally calls
+    `trainer.strategy.broadcast(dirpath)`, which returns a nonsense Mock
+    instead of the path and crashes downstream filesystem resolution,
+    regardless of monitor. `_make_bare_trainer()` (used by every other
+    `.setup()` test in this file) is a real, unfitted Trainer that clears
+    that machinery without running an actual loop, isolating this test to
+    what it actually claims: that `_validate_monitor_metric` doesn't fire.
+    """
+    cb = SRCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    cb.setup(trainer=_make_bare_trainer(), pl_module=build_module(), stage="fit")  # must not raise
+
+
+def test_srcheckpoint_rolling_filename_has_no_metric_placeholder(tmp_path: Path):
+    """Rolling mode has no monitored metric, so the filename must be
+    step-only — MEASURED FACT 3: omitting {step} would make every save
+    overwrite the last."""
+    ckpt = SRCheckpoint(monitor_metric=None, dirpath=str(tmp_path))
+    assert ckpt.filename == "sr-{step}"
+    assert ckpt.save_top_k == -1
+    assert ckpt.monitor is None
+    assert ckpt.keep_last == 3
+
+
+@_ignore_gpu_warning
+def test_sr_weights_checkpoint_rolling_mode_keeps_only_the_last_n(tmp_path):
+    """SRWeightsCheckpoint's own _save_checkpoint override (bare .pt weights)
+    must still compose with rolling deletion — it doesn't inherit
+    ModelCheckpoint's save path the way SRCheckpoint does, so this is the
+    place a mixin-only implementation would silently do nothing."""
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+    )
+    _run_tiny_fit(callbacks=[cb], n_batches=20)
+    files = sorted(p.name for p in tmp_path.glob("*.pt"))
+    assert files == ["sr-weights-18.pt", "sr-weights-20.pt"], files
+
+
+def test_sr_weights_checkpoint_rolling_filename_has_no_metric_placeholder(tmp_path: Path):
+    ckpt = SRWeightsCheckpoint(monitor_metric=None, dirpath=str(tmp_path))
+    assert ckpt.filename == "sr-weights-{step}"
+    assert ckpt.save_top_k == -1
+    assert ckpt.monitor is None
+    assert ckpt.keep_last == 3
+
+
+@_ignore_gpu_warning
+def test_rolling_checkpoints_coexist_without_cross_deletion(tmp_path):
+    """SRCheckpoint and SRWeightsCheckpoint, both rolling, sharing one dirpath,
+    must never delete each other's files — each tracks its own _rolling list
+    of its own filepaths, and FILE_EXTENSION/filename_prefix already keep the
+    two from colliding by name."""
+    sr_ckpt = SRCheckpoint(
+        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+    )
+    sr_weights_ckpt = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+    )
+    _run_tiny_fit(callbacks=[sr_ckpt, sr_weights_ckpt], n_batches=20)
+    ckpt_files = sorted(p.name for p in tmp_path.glob("sr-*.ckpt"))
+    pt_files = sorted(p.name for p in tmp_path.glob("sr-weights-*.pt"))
+    all_files = sorted(p.name for p in tmp_path.iterdir())
+    assert ckpt_files == ["sr-18.ckpt", "sr-20.ckpt"], ckpt_files
+    assert pt_files == ["sr-weights-18.pt", "sr-weights-20.pt"], pt_files
+    assert len(all_files) == 4, all_files
+
+
+@pytest.mark.parametrize("cls", [SRCheckpoint, SRWeightsCheckpoint])
+def test_rolling_mode_rejects_keep_last_below_one(cls, tmp_path: Path):
+    with pytest.raises(ValueError, match="keep_last"):
+        cls(monitor_metric=None, keep_last=0, dirpath=str(tmp_path))
+
+
+@pytest.mark.parametrize("cls", [SRCheckpoint, SRWeightsCheckpoint])
+def test_enforce_rolling_window_is_noop_when_monitor_is_set(cls, tmp_path: Path):
+    """With a monitor set, _enforce_rolling_window must not track saves or
+    delete anything -- Lightning's own top-k selection owns retention then.
+
+    A version that tracked saves unconditionally would eventually evict a
+    file top-k still wants to keep once more than keep_last saves accumulate
+    (e.g. save_top_k=1 keeps exactly 1 file at a time; FIFO-evicting by save
+    count rather than by top-k's own bookkeeping can target that surviving
+    file once the metric plateaus for keep_last+ saves), silently leaving the
+    run with zero checkpoints until the next save recreates one. Calling
+    _enforce_rolling_window directly, rather than through a full Trainer.fit,
+    isolates this to the guard itself rather than needing a metric-plateau
+    scenario reproduced end-to-end.
+    """
+    ckpt = cls(monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(tmp_path))
+    trainer = MagicMock()
+    for i in range(ckpt.keep_last + 2):
+        ckpt._enforce_rolling_window(trainer, f"fake-{i}{ckpt.FILE_EXTENSION}")
+    assert ckpt._rolling == []
+    trainer.strategy.remove_checkpoint.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -457,6 +457,63 @@ def test_sr_weights_checkpoint_save_checkpoint_is_actually_overridden():
     assert SRWeightsCheckpoint._save_checkpoint is not ModelCheckpoint._save_checkpoint
 
 
+class _StubComponent(torch.nn.Module):
+    """Stand-in for a not-yet-existing named component (e.g. a discriminator).
+
+    Deliberately not named after any real architecture -- SRDiscriminator
+    doesn't exist until a later task, and asserting metadata against a
+    hardcoded "SRDiscriminator" string here would test a coincidence of
+    naming, not the mechanism (it would keep passing even if the real class
+    were later renamed). test_metadata.py's twin stub covers the metadata
+    builder directly; this one only needs a state_dict this callback can
+    save and load back.
+    """
+
+    def __init__(self, hr_input_size: int):
+        super().__init__()
+        self.hparams = {"hr_input_size": hr_input_size}
+        self.net = torch.nn.Conv2d(3, 4, kernel_size=3, padding=1)
+
+
+def build_module_with_component() -> SRLightning:
+    """An SRLightning carrying an extra, non-generator component under a
+    `discriminator` attribute.
+
+    Deliberately not SRGANLightning -- that class does not exist until a
+    later PR, and this behaviour is about the callback, not the training
+    loop. The component itself is a local stand-in (`_StubComponent`), not
+    the real SRDiscriminator either -- that architecture is a later task's
+    job; this only exercises the generic attribute/metadata mechanism.
+    """
+    module = build_module()
+    module.discriminator = _StubComponent(hr_input_size=96)
+    return module
+
+
+def test_weights_checkpoint_can_save_a_named_component(tmp_path):
+    module = build_module_with_component()
+    # MagicMock, not Mock: _save_checkpoint's post-save logger notification
+    # does `for logger in trainer.loggers`, and a plain Mock's auto-attrs
+    # don't support __iter__ (raises TypeError) -- MagicMock's do.
+    trainer = MagicMock(lightning_module=module, global_step=7, current_epoch=0)
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=1, attribute="discriminator", dirpath=str(tmp_path)
+    )
+    cb.current_score = None
+
+    cb._save_checkpoint(trainer, str(tmp_path / "d-weights-7.pt"))
+
+    saved = torch.load(tmp_path / "d-weights-7.pt", weights_only=True)
+    assert set(saved["state_dict"]) == set(module.discriminator.state_dict())
+    # build_module()'s generator is SRCNN, whose top-level submodules are
+    # feat/mapping/recon -- a "feat."-prefixed key here would mean the
+    # generator's weights leaked into what must be a discriminator-only file.
+    assert not any(key.startswith("feat.") for key in saved["state_dict"]), (
+        "generator weights must not appear in a discriminator file"
+    )
+    assert saved["meta"]["kind"] == "component"
+
+
 def _make_srcnn_datamodule(image_dir: Path):
     """Tiny SRDataModule (3 fixture images) mirroring test_integration.py's helper —
     real Trainer.fit needs a real datamodule to reach ModelCheckpoint's save path."""

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -9,7 +9,7 @@ from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig
 from sisr.models.srresnet import SRResNet, SRResNetEvalConfig, SRResNetTrainingConfig
 from sisr.processors import RGBProcessor, RGBSignedOutputProcessor, YChannelProcessor
 from sisr.training import SRLightning, SRTrainingConfig
-from sisr.training.metadata import build_metadata
+from sisr.training.metadata import build_component_metadata, build_metadata
 
 
 def _make_srcnn_lit() -> SRLightning:
@@ -39,6 +39,7 @@ def test_build_metadata_top_level_shape():
     meta = build_metadata(lit)
     assert set(meta.keys()) == {
         "format",
+        "kind",
         "created",
         "versions",
         "model",
@@ -252,3 +253,103 @@ def test_metadata_stays_weights_only_loadable_with_a_criterion_block(tmp_path):
     loaded = torch.load(path, weights_only=True)
 
     assert loaded["meta"]["criterion"]["description"] == "MSELoss"
+
+
+# ---------------------------------------------------------------------------
+# build_component_metadata — provenance for a non-generator component (e.g.
+# a future discriminator; SRDiscriminator itself doesn't exist until a later
+# task, so these use a local stand-in exercising the same generic mechanism).
+# ---------------------------------------------------------------------------
+
+
+class _StubComponent(torch.nn.Module):
+    """Stand-in for a not-yet-existing named component (e.g. a discriminator).
+
+    Deliberately not named after any real architecture: a class_path
+    assertion must check the metadata against *this* class's own real path,
+    not coincide with a hardcoded string that would keep passing even if the
+    real component were later renamed.
+    """
+
+    def __init__(self, hr_input_size: int):
+        super().__init__()
+        self.hparams = {"hr_input_size": hr_input_size}
+        self.net = torch.nn.Conv2d(3, 4, kernel_size=3, padding=1)
+
+
+class _StubComponentNoHparams(torch.nn.Module):
+    """Same shape, but with no `hparams` attribute — exercises
+    build_component_metadata's `getattr(component, 'hparams', {})` default."""
+
+    def __init__(self):
+        super().__init__()
+        self.net = torch.nn.Conv2d(3, 2, kernel_size=1)
+
+
+def _make_srresnet_lit_with_component(component: torch.nn.Module) -> SRLightning:
+    lit = _make_srresnet_lit()
+    lit.discriminator = component
+    return lit
+
+
+def test_generator_metadata_declares_its_kind():
+    meta = build_metadata(_make_srcnn_lit())
+    assert meta["kind"] == "sr_model"
+
+
+def test_component_metadata_describes_the_component_not_the_generator():
+    """A D weights file carrying the generator's metadata is the exact
+    silent-wrong-artifact class sisr_meta exists to prevent."""
+    stub = _StubComponent(hr_input_size=96)
+    module = _make_srresnet_lit_with_component(stub)
+    meta = build_component_metadata(module, "discriminator")
+
+    assert meta["kind"] == "component"
+    assert meta["component"]["name"] == "discriminator"
+    # Checked against the stub's own real path, not a hardcoded string --
+    # a coincidental match wouldn't prove build_component_metadata records
+    # the *actual* class of the component it was given.
+    assert meta["component"]["class_path"] == f"{type(stub).__module__}.{type(stub).__qualname__}"
+    # input_range is load-bearing: D is trained on model-space [-1,1] tensors,
+    # and feeding it [0,1] later is wrong with no error.
+    assert meta["io"]["input_range"] == [-1.0, 1.0]
+    assert "scale" not in meta["io"]
+    assert "criterion" not in meta
+
+
+def test_component_metadata_records_the_components_own_init_args():
+    module = _make_srresnet_lit_with_component(_StubComponent(hr_input_size=96))
+    meta = build_component_metadata(module, "discriminator")
+    assert meta["component"]["init_args"] == {"hr_input_size": 96}
+
+
+def test_component_metadata_init_args_defaults_to_empty_without_hparams():
+    """A component with no `hparams` attribute (a plain nn.Module) must not
+    crash build_component_metadata -- init_args just defaults to empty."""
+    module = _make_srresnet_lit_with_component(_StubComponentNoHparams())
+    meta = build_component_metadata(module, "discriminator")
+    assert meta["component"]["init_args"] == {}
+
+
+def test_component_metadata_training_fields_forwarded():
+    module = _make_srresnet_lit_with_component(_StubComponent(hr_input_size=96))
+    meta = build_component_metadata(
+        module, "discriminator", global_step=100, epoch=2, monitor=None, monitor_value=None
+    )
+    assert meta["training"] == {
+        "global_step": 100,
+        "epoch": 2,
+        "monitor": None,
+        "monitor_value": None,
+    }
+
+
+def test_component_metadata_is_weights_only_safe(tmp_path):
+    module = _make_srresnet_lit_with_component(_StubComponent(hr_input_size=96))
+    meta = build_component_metadata(module, "discriminator", global_step=7, epoch=0)
+    path = tmp_path / "component_meta.pt"
+    torch.save({"meta": meta}, path)
+
+    loaded = torch.load(path, weights_only=True)
+
+    assert loaded["meta"] == meta


### PR DESCRIPTION
⛔ **Do not merge yet — 3rd of a 6-PR stack.** Based on `feat/perceptual-metrics`; merge the two below it first.

Adds a rolling last-N checkpoint mode, and lets one checkpoint callback save **any** named component's bare weights with provenance that describes *that component*.

## Why rolling mode

Under an adversarial objective PSNR and SSIM get **worse by design**. A metric-monitored `save_top_k` therefore selects the **least adversarial** model — very likely a checkpoint from the first few thousand steps. For a GAN, metric-monitored selection is not merely uninformative, it is inverted. Rolling mode keeps a window of recent checkpoints instead.

## How it had to be built

Lightning **refuses** `ModelCheckpoint(monitor=None, save_top_k=3)` outright:

```
MisconfigurationException: ModelCheckpoint(save_top_k=3, monitor=None) is not a
valid configuration. No quantity for top_k to track.
```

So a rolling window cannot be expressed through `save_top_k` at all. The working construction is `monitor=None, save_top_k=-1` (keep everything) with the window enforced by our own oldest-first deletion through `ModelCheckpoint._remove_checkpoint`. The filename must carry `{step}` or every save overwrites the last.

**One structural trap worth recording:** the deletion hook cannot live in a mixin that overrides `_save_checkpoint`. `SRWeightsCheckpoint` already overrides that method to write bare `.pt` weights and never calls `super()`, and Python resolves the class's own attribute before any base — so a mixin's version would have been **shadowed and silently never run**, leaving `.pt` files to accumulate forever with nothing erroring. The logic is therefore a separate `_enforce_rolling_window` seam called explicitly from each class's `_save_checkpoint`, with a comment at both call sites saying the call must be preserved.

## Component weights and matching provenance

`SRWeightsCheckpoint` gains `attribute: str = "model"`, so one callback can emit both `sr-weights-*.pt` (generator) and `d-weights-*.pt` (a second network). Their distinct `filename_prefix` and `FILE_EXTENSION` already keep each one's deletion pass off the other's files.

A non-generator file must **not** carry `build_metadata`'s output — that describes the generator (`io.scale`, `io.input`, `criterion`, `eval_config`), and attaching it to another network's weights would describe something the file does not contain. That is precisely the silent-wrong-artifact class this metadata exists to prevent. So `metadata.py` gains a second builder:

```
build_component_metadata(module, attribute) ->
  {format, kind: "component", created, versions,
   component: {name, class_path, init_args},
   io: {input_range, input_colorspace},
   training: {...}}
```

`io.input_range` is the load-bearing field: a discriminator is trained on model-space `[-1, 1]` tensors, and feeding it `[0, 1]` later is wrong with no error.

Both builders share one private `_envelope(...)` — the module's whole premise is one function feeding several sinks so the payloads cannot drift. That also preserves the existing `str(torch.__version__)` coercion, without which `torch.load(weights_only=True)` refuses the file (`TorchVersion` is a `str` subclass it won't unpickle).

**`FORMAT_VERSION` is not bumped** — this is a new artifact *kind*, not a change to an existing one. A `kind` field is added to both builders; its absence on pre-existing files means `"sr_model"`, and the module docstring says so.

## Testing

830 passed / 0 skipped / 0 failed. `ruff check` and `ruff format --check` clean.

Every new test ships with the mutation that proves it fails. One mutation — removing the `monitor is not None` guard — **slipped past every originally-planned test**, which is what prompted the extra test that now covers it.

A narrowly-scoped `filterwarnings` ignore is added for Lightning's manual-optimization checkpoint warning ("the checkpoint will contain the model state AFTER optimization"). That state is exactly what a checkpoint should hold, but this repo runs `filterwarnings = ["error", ...]`. It is unexercised on this branch and lands here for the adversarial work above it.

## Stack

```
main
 └─ CLI subclass mode
     └─ perceptual metrics (LPIPS/DISTS)
         └─ THIS PR  · rolling checkpoints + component weights
             └─ SRGAN discriminator + adversarial loss
                 └─ SRGAN Lightning module + template
                     └─ docs
```

**Do not use "delete branch on merge"** — it races and closes the child PR instead of retargeting it.
