### PR TITLE
feat: add the SRGAN discriminator, adversarial loss, and configs

### DIFF
--- a/sisr/losses/__init__.py
+++ b/sisr/losses/__init__.py
@@ -1,5 +1,6 @@
 """Pluggable loss functions, wired via YAML ``model.criterion``."""
 
+from .adversarial import AdversarialLoss
 from .base import SRLoss
 from .composite import WeightedSumLoss
 from .pixel import CharbonnierLoss, TotalVariationLoss
@@ -7,6 +8,7 @@ from .vgg import VGG16FeatureLoss, VGG19FeatureLoss
 
 __all__ = [
     "SRLoss",
+    "AdversarialLoss",
     "CharbonnierLoss",
     "TotalVariationLoss",
     "VGG16FeatureLoss",

--- a/sisr/losses/adversarial.py
+++ b/sisr/losses/adversarial.py
@@ -1,0 +1,56 @@
+"""The SRGAN adversarial objective (Ledig et al. §2.2)."""
+
+import torch
+
+
+class AdversarialLoss(torch.nn.Module):
+    """Non-saturating GAN objective over discriminator **logits**.
+
+    Deliberately **not** an :class:`~sisr.losses.base.SRLoss`: that contract is
+    ``forward(pred, target)`` in model space, and the generator's term
+    ``-log D(G(I_LR))`` has no target at all. Bending it to fit would put a
+    dummy argument in the signature the whole loss library depends on. Being a
+    separate class also makes the objective testable without a training loop
+    and swappable from YAML (LSGAN, relativistic) without touching the module.
+
+    Takes logits, not probabilities — see
+    :class:`~sisr.models.srgan.SRDiscriminator`. Parameter-free, so it adds
+    nothing to any ``state_dict``.
+    """
+
+    def generator_loss(self, logits_fake: torch.Tensor) -> torch.Tensor:
+        """Generator's adversarial term: make the discriminator call fakes real.
+
+        The **non-saturating** form (``-log D(G(x))``, i.e. BCE against a
+        *real* target) rather than ``+log(1 - D(G(x)))`` — the latter's gradient
+        vanishes exactly when the discriminator is winning, which is when the
+        generator most needs signal.
+
+        Args:
+            logits_fake: Discriminator logits for generated images, ``(B, 1)``.
+
+        Returns:
+            0-dim tensor.
+        """
+        return torch.nn.functional.binary_cross_entropy_with_logits(
+            logits_fake, torch.ones_like(logits_fake)
+        )
+
+    def discriminator_loss(
+        self, logits_real: torch.Tensor, logits_fake: torch.Tensor
+    ) -> torch.Tensor:
+        """Discriminator's objective: real as real, fake as fake.
+
+        Args:
+            logits_real: Logits for ground-truth HR images, ``(B, 1)``.
+            logits_fake: Logits for generated images, ``(B, 1)``. The caller
+                passes these **detached** — the discriminator update must not
+                propagate into the generator.
+
+        Returns:
+            0-dim tensor.
+        """
+        bce = torch.nn.functional.binary_cross_entropy_with_logits
+        return bce(logits_real, torch.ones_like(logits_real)) + bce(
+            logits_fake, torch.zeros_like(logits_fake)
+        )

--- a/sisr/models/srgan/__init__.py
+++ b/sisr/models/srgan/__init__.py
@@ -1,5 +1,6 @@
 """SRGAN — discriminator and paper-faithful configs. The generator is SRResNet."""
 
+from .config import SRGANEvalConfig, SRGANTrainingConfig
 from .discriminator import SRDiscriminator
 
-__all__ = ["SRDiscriminator"]
+__all__ = ["SRDiscriminator", "SRGANEvalConfig", "SRGANTrainingConfig"]

--- a/sisr/models/srgan/__init__.py
+++ b/sisr/models/srgan/__init__.py
@@ -1,0 +1,5 @@
+"""SRGAN — discriminator and paper-faithful configs. The generator is SRResNet."""
+
+from .discriminator import SRDiscriminator
+
+__all__ = ["SRDiscriminator"]

--- a/sisr/models/srgan/config.py
+++ b/sisr/models/srgan/config.py
@@ -1,0 +1,70 @@
+"""SRGAN-paper-faithful training and evaluation defaults.
+
+Reference: Photo-Realistic Single Image Super-Resolution Using a Generative
+Adversarial Network (https://arxiv.org/pdf/1609.04802), Section 3.2.
+"""
+
+from dataclasses import dataclass, field
+
+from sisr.models.srresnet.config import SRResNetEvalConfig, SRResNetTrainingConfig
+
+
+@dataclass
+class SRGANTrainingConfig(SRResNetTrainingConfig):
+    """SRGAN training defaults. The generator is SRResNet, so ``scale=4`` is inherited.
+
+    Args:
+        init_from: Path to a bare-weights ``.pt`` whose generator weights
+            initialise this run's generator. The paper scopes the MSE-init
+            trick to "when training the actual GAN", so a paper-faithful SRGAN
+            run starts from an MSE-trained SRResNet. Optional: unset trains
+            from scratch, which is what tests and smoke runs use.
+
+        adversarial_weight: Weight on the adversarial term of the generator's
+            loss. Defaults to ``1e-3``, the paper's value. The content term is
+            whatever ``criterion`` the module was given, so the total is
+            ``content + adversarial_weight * adversarial``.
+
+        d_steps_per_g_step: Goodfellow's ``k`` — discriminator updates per
+            generator update. Defaults to ``1``, which is Ledig's 1:1
+            alternation.
+
+    Raises:
+        ValueError: If ``d_steps_per_g_step`` is below 1, or ``cuda_graph`` is
+            set.
+    """
+
+    init_from: str | None = None
+    adversarial_weight: float = 1e-3
+    d_steps_per_g_step: int = 1
+
+    def __post_init__(self) -> None:
+        """Reject settings this training mode cannot honour."""
+        super().__post_init__()
+        if self.d_steps_per_g_step < 1:
+            raise ValueError(f"d_steps_per_g_step must be >= 1; got {self.d_steps_per_g_step}.")
+        if self.cuda_graph:
+            raise ValueError(
+                "training_config.cuda_graph=True is not supported for adversarial "
+                "training: CUDAGraphStep captures one {zero_grad, forward, loss, "
+                "backward} around one optimizer, and this mode runs two optimizers "
+                "alternately under manual optimization. Set cuda_graph to false."
+            )
+
+
+@dataclass
+class SRGANEvalConfig(SRResNetEvalConfig):
+    """SRGAN eval defaults — SRResNet's scoring, plus perceptual metrics.
+
+    Inherits ``crop_border=4``, ``psnr_channels=['RGB', 'Y']`` and
+    ``ssim_impl='daala'``, so an SRGAN number stays comparable to the SRResNet
+    baseline computed the same way.
+
+    Args:
+        perceptual_metrics: Overrides the base default to ``['lpips', 'dists']``.
+            An adversarial objective makes PSNR and SSIM **worse by design**, so
+            without these an SRGAN run has no metric that tracks what it is
+            optimising. ``'lpips'`` requires the ``[perceptual]`` extra.
+    """
+
+    perceptual_metrics: list[str] = field(default_factory=lambda: ["lpips", "dists"])

--- a/sisr/models/srgan/discriminator.py
+++ b/sisr/models/srgan/discriminator.py
@@ -58,7 +58,8 @@ class SRDiscriminator(torch.nn.Module):
         stride_factor = 2**_DOWNSAMPLES
         if hr_input_size < stride_factor or hr_input_size % stride_factor:
             raise ValueError(
-                f"hr_input_size must be divisible by 16 (the discriminator has "
+                f"hr_input_size must be a positive multiple of {stride_factor} "
+                f"(divisible by {stride_factor}; the discriminator has "
                 f"{_DOWNSAMPLES} stride-2 convolutions); got {hr_input_size}."
             )
 

--- a/sisr/models/srgan/discriminator.py
+++ b/sisr/models/srgan/discriminator.py
@@ -1,0 +1,112 @@
+"""SRGAN's discriminator — the classifier from Ledig et al. (2017), Figure 4.
+
+Reference: Photo-Realistic Single Image Super-Resolution Using a Generative
+Adversarial Network (https://arxiv.org/pdf/1609.04802).
+"""
+
+import torch
+
+#: (out_channels_multiplier, stride) for the 7 blocks after the stem, per Fig. 4.
+_BLOCKS: tuple[tuple[int, int], ...] = ((1, 2), (2, 1), (2, 2), (4, 1), (4, 2), (8, 1), (8, 2))
+
+#: Number of stride-2 convolutions above; the spatial reduction factor is 2**this.
+_DOWNSAMPLES = sum(1 for _, stride in _BLOCKS if stride == 2)
+
+
+class SRDiscriminator(torch.nn.Module):
+    """SRGAN discriminator: conv stem, 7 strided conv-BN-LeakyReLU blocks, dense head.
+
+    Deliberately **not** an :class:`~sisr.models.base.SRModel`: it is a
+    classifier, not an SR mapping, so ``input_contract`` and
+    ``reset_parameters`` would be contracts it cannot honour. It carries
+    ``hparams`` only so provenance metadata can describe it the same way.
+
+    **Emits logits, not probabilities.** Ledig's Figure 4 ends in a sigmoid;
+    pairing an unactivated output with ``BCEWithLogitsLoss`` computes the same
+    objective in a numerically stable way. Do not add the sigmoid back — with
+    the loss this project pairs it with, that double-activates.
+
+    The dense head fixes the accepted input size, which is why
+    ``hr_input_size`` is declared rather than inferred: a later task validates
+    it against the real training crop, so a mismatch there is a readable
+    error instead of a raw ``Linear`` shape failure mid-run.
+
+    Args:
+        in_channels: Input channel count. Defaults to ``3`` (RGB).
+        hr_input_size: Spatial size of the square HR patch this discriminator
+            accepts. Must be divisible by 16 (four stride-2 convolutions).
+            Defaults to ``96`` — the paper's crop.
+        base_channels: Channel count of the stem; later blocks are multiples of
+            it, per Figure 4. Defaults to ``64``.
+        dense_features: Width of the first dense layer. Defaults to ``1024``,
+            the paper's value.
+        negative_slope: LeakyReLU slope. Defaults to ``0.2``, the paper's value.
+
+    Raises:
+        ValueError: If ``hr_input_size`` is not a positive multiple of 16.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        hr_input_size: int = 96,
+        base_channels: int = 64,
+        dense_features: int = 1024,
+        negative_slope: float = 0.2,
+    ):
+        super().__init__()
+        stride_factor = 2**_DOWNSAMPLES
+        if hr_input_size < stride_factor or hr_input_size % stride_factor:
+            raise ValueError(
+                f"hr_input_size must be divisible by 16 (the discriminator has "
+                f"{_DOWNSAMPLES} stride-2 convolutions); got {hr_input_size}."
+            )
+
+        self._hparams = {
+            "in_channels": in_channels,
+            "hr_input_size": hr_input_size,
+            "base_channels": base_channels,
+            "dense_features": dense_features,
+            "negative_slope": negative_slope,
+        }
+
+        layers: list[torch.nn.Module] = [
+            torch.nn.Conv2d(in_channels, base_channels, kernel_size=3, padding=1),
+            torch.nn.LeakyReLU(negative_slope, inplace=True),
+        ]
+        channels = base_channels
+        for multiplier, stride in _BLOCKS:
+            out_channels = base_channels * multiplier
+            layers += [
+                torch.nn.Conv2d(channels, out_channels, kernel_size=3, stride=stride, padding=1),
+                torch.nn.BatchNorm2d(out_channels),
+                torch.nn.LeakyReLU(negative_slope, inplace=True),
+            ]
+            channels = out_channels
+        self.features = torch.nn.Sequential(*layers)
+
+        spatial = hr_input_size // stride_factor
+        self.classifier = torch.nn.Sequential(
+            torch.nn.Linear(channels * spatial * spatial, dense_features),
+            torch.nn.LeakyReLU(negative_slope, inplace=True),
+            torch.nn.Linear(dense_features, 1),
+        )
+
+    @property
+    def hparams(self) -> dict:
+        """Architecture hyperparameters, for provenance metadata."""
+        return self._hparams
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Score a batch of HR-sized images.
+
+        Args:
+            x: ``(B, in_channels, hr_input_size, hr_input_size)`` in the
+                generator's **model output space** (e.g. ``[-1, 1]`` under
+                ``RGBSignedOutputProcessor``), not display range.
+
+        Returns:
+            ``(B, 1)`` **logits** — higher means "more real". Feed these to
+            ``BCEWithLogitsLoss``; do not apply a sigmoid first.
+        """
+        return self.classifier(self.features(x).flatten(1))

--- a/tests/losses/test_adversarial.py
+++ b/tests/losses/test_adversarial.py
@@ -1,0 +1,39 @@
+import torch
+import torch.nn.functional as F
+
+from sisr.losses import AdversarialLoss
+
+
+def test_generator_loss_is_non_saturating_bce_against_real():
+    loss = AdversarialLoss()
+    logits = torch.tensor([[0.3], [-1.2]])
+    expected = F.binary_cross_entropy_with_logits(logits, torch.ones_like(logits))
+    assert torch.allclose(loss.generator_loss(logits), expected)
+
+
+def test_discriminator_loss_is_the_two_term_sum():
+    loss = AdversarialLoss()
+    real, fake = torch.tensor([[2.0]]), torch.tensor([[-2.0]])
+    expected = F.binary_cross_entropy_with_logits(
+        real, torch.ones_like(real)
+    ) + F.binary_cross_entropy_with_logits(fake, torch.zeros_like(fake))
+    assert torch.allclose(loss.discriminator_loss(real, fake), expected)
+
+
+def test_a_confident_correct_discriminator_scores_near_zero():
+    loss = AdversarialLoss()
+    d = loss.discriminator_loss(torch.full((8, 1), 20.0), torch.full((8, 1), -20.0))
+    assert d.item() < 1e-6
+
+
+def test_generator_gradient_pushes_fake_logits_up():
+    """The generator's objective is to make D call its output real."""
+    loss = AdversarialLoss()
+    logits = torch.zeros(4, 1, requires_grad=True)
+    loss.generator_loss(logits).backward()
+    assert (logits.grad < 0).all()
+
+
+def test_it_holds_no_parameters():
+    """A parameter-bearing criterion would land in every checkpoint's state_dict."""
+    assert list(AdversarialLoss().parameters()) == []

--- a/tests/models/srgan/test_config.py
+++ b/tests/models/srgan/test_config.py
@@ -1,0 +1,59 @@
+"""Defaults, subclass, and validation tests for SRGAN's paper-faithful configs."""
+
+import pytest
+
+from sisr.models.srgan import SRGANEvalConfig, SRGANTrainingConfig
+from sisr.models.srresnet import SRResNetEvalConfig, SRResNetTrainingConfig
+
+
+def test_paper_defaults():
+    cfg = SRGANTrainingConfig()
+    assert cfg.adversarial_weight == pytest.approx(1e-3)
+    assert cfg.d_steps_per_g_step == 1  # Ledig's 1:1 alternation
+    assert cfg.scale == 4  # inherited from SRResNetTrainingConfig
+    assert cfg.init_from is None  # optional: unset trains from scratch
+
+
+def test_k_must_be_positive():
+    with pytest.raises(ValueError, match="d_steps_per_g_step"):
+        SRGANTrainingConfig(d_steps_per_g_step=0)
+
+
+def test_cuda_graph_refused_at_construction():
+    """Manual optimization with two alternating optimizers cannot be captured."""
+    with pytest.raises(ValueError, match="cuda_graph"):
+        SRGANTrainingConfig(cuda_graph=True)
+
+
+def test_eval_config_turns_perceptual_metrics_on():
+    """PSNR/SSIM get worse by design here, so the run needs a metric that means
+    something."""
+    cfg = SRGANEvalConfig()
+    assert cfg.perceptual_keys == ["lpips", "dists"]
+    assert cfg.ssim_impl == "daala"  # inherited
+    assert cfg.crop_border == 4  # inherited
+
+
+def test_training_config_subclass():
+    assert issubclass(SRGANTrainingConfig, SRResNetTrainingConfig)
+
+
+def test_eval_config_subclass():
+    assert issubclass(SRGANEvalConfig, SRResNetEvalConfig)
+
+
+def test_cuda_graph_and_compile_backend_both_set_reports_base_error_first():
+    """super().__post_init__() runs before the SRGAN-only checks, so the inherited
+    cuda_graph/compile_backend conflict (not the SRGAN cuda_graph-is-unsupported
+    message) is what surfaces when both are set."""
+    with pytest.raises(ValueError, match="compile_backend"):
+        SRGANTrainingConfig(cuda_graph=True, compile_backend="inductor")
+
+
+def test_eval_config_perceptual_metrics_independent_per_instance():
+    """`default_factory` produces a fresh list per instance — guards against a
+    mutable-default bug (the same class of bug SRResNet's psnr_channels test guards)."""
+    a = SRGANEvalConfig()
+    b = SRGANEvalConfig()
+    a.perceptual_metrics.append("x")
+    assert b.perceptual_keys == ["lpips", "dists"]

--- a/tests/models/srgan/test_discriminator.py
+++ b/tests/models/srgan/test_discriminator.py
@@ -35,6 +35,16 @@ def test_indivisible_input_size_rejected():
         SRDiscriminator(hr_input_size=100)
 
 
+def test_non_positive_input_size_message_says_positive_multiple():
+    """0 and negative multiples of 16 ARE divisible by 16, so the check's real
+    condition is 'positive multiple' — the message must say that, not just
+    'divisible', or a hr_input_size=0 error reads as self-contradictory."""
+    with pytest.raises(ValueError, match="positive multiple"):
+        SRDiscriminator(hr_input_size=0)
+    with pytest.raises(ValueError, match="positive multiple"):
+        SRDiscriminator(hr_input_size=-16)
+
+
 def test_hparams_roundtrip_for_metadata():
     d = SRDiscriminator(hr_input_size=96, dense_features=512)
     assert d.hparams["hr_input_size"] == 96

--- a/tests/models/srgan/test_discriminator.py
+++ b/tests/models/srgan/test_discriminator.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from sisr.models.srgan import SRDiscriminator
+
+
+def test_output_is_one_logit_per_image():
+    d = SRDiscriminator(hr_input_size=96)
+    out = d(torch.randn(4, 3, 96, 96))
+    assert out.shape == (4, 1)
+
+
+def test_output_is_logits_not_probabilities():
+    """No sigmoid: the head is paired with BCEWithLogitsLoss, which is the same
+    objective and numerically stable. A restored sigmoid would double-activate."""
+    d = SRDiscriminator(hr_input_size=96)
+    out = d(torch.randn(64, 3, 96, 96) * 50)
+    assert (out < 0).any() or (out > 1).any()
+
+
+@pytest.mark.parametrize(("size", "expected"), [(96, 512 * 6 * 6), (128, 512 * 8 * 8)])
+def test_dense_in_features_derived_from_declared_input_size(size, expected):
+    """Four stride-2 convs => s = hr_input_size // 16."""
+    d = SRDiscriminator(hr_input_size=size)
+    assert d.classifier[0].in_features == expected
+
+
+def test_dense_features_is_configurable():
+    d = SRDiscriminator(hr_input_size=96, dense_features=512)
+    assert d.classifier[0].out_features == 512
+
+
+def test_indivisible_input_size_rejected():
+    with pytest.raises(ValueError, match="divisible by 16"):
+        SRDiscriminator(hr_input_size=100)
+
+
+def test_hparams_roundtrip_for_metadata():
+    d = SRDiscriminator(hr_input_size=96, dense_features=512)
+    assert d.hparams["hr_input_size"] == 96
+    assert d.hparams["dense_features"] == 512


### PR DESCRIPTION
⛔ **Do not merge yet — 4th of a 6-PR stack.** Based on `feat/rolling-checkpoints`; merge the three below it first.

The SRGAN components: discriminator, adversarial objective, and paper-faithful configs. **No training loop yet** — that is the next PR, so nothing here changes any existing run's behaviour.

Reference: Ledig et al., [*Photo-Realistic Single Image Super-Resolution Using a Generative Adversarial Network*](https://arxiv.org/pdf/1609.04802).

## `SRDiscriminator` — Ledig Figure 4

`k3n64s1 + LeakyReLU` → 7 × `(Conv-BN-LeakyReLU)` at `(64 s2, 128 s1, 128 s2, 256 s1, 256 s2, 512 s1, 512 s2)` → `Dense(dense_features)` → LeakyReLU → `Dense(1)`.

Three choices that are deliberate and documented in the code, because each has an obvious-looking "fix" that would be wrong:

- **Not an `SRModel`.** It is a classifier, not an SR mapping, so `input_contract` and `reset_parameters` would be contracts it cannot honour. It is a plain `nn.Module` carrying `hparams` purely so provenance metadata can describe it.
- **Emits logits — no sigmoid.** Figure 4 ends in a sigmoid; pairing an unactivated output with `BCEWithLogitsLoss` computes the identical objective, numerically stably. Restoring the sigmoid would **double-activate**.
- **`hr_input_size` is declared, not inferred**, because the dense head fixes the accepted input size. `Linear.in_features` derives from it (four stride-2 convs → `s = hr_input_size // 16`). A later PR validates the declared value against the real training crop, which is why it must be explicit. `dense_features` is a real argument whose default is the paper's 1024.

## `AdversarialLoss`

Non-saturating generator term plus the two-term discriminator objective, over logits.

**Deliberately not an `SRLoss`:** that ABC's contract is `forward(pred, target)` in model space, and the generator's term `−log D(G(I_LR))` **has no target**. Bending it to fit would put a dummy argument into the one signature the whole loss library depends on. Two named methods instead — which also makes the objective testable without a training loop and swappable from YAML later (LSGAN, relativistic) without touching the training module. Parameter-free, so it adds nothing to any `state_dict`.

`discriminator_loss` expects **already-detached** fake logits; it does not detach internally, which would silently mask a caller's mistake.

## Configs

`SRGANTrainingConfig(SRResNetTrainingConfig)` — the generator *is* SRResNet, so `scale=4` and the rest are inherited. Adds `init_from` (optional; unset trains from scratch), `adversarial_weight=1e-3` (the paper's), and `d_steps_per_g_step=1` — Goodfellow's `k`, where 1 is Ledig's 1:1 alternation.

`cuda_graph=True` is **refused**: the graph machinery captures one `{zero_grad, forward, loss, backward}` around **one** optimizer, and this mode will run two alternately under manual optimization. `super().__post_init__()` runs first so the inherited checks still apply.

`SRGANEvalConfig(SRResNetEvalConfig)` inherits `crop_border=4`, `psnr_channels=['RGB','Y']` and `ssim_impl='daala'`, so SRGAN numbers stay comparable to the SRResNet baseline, and turns perceptual metrics on (`['lpips','dists']`) because PSNR and SSIM get *worse* by design here.

That last one is a subclass-only **default**, not a subclass-only **field** — the fields live on base `SREvalConfig`. The distinction is load-bearing: a subclass-only field is dumped into a checkpoint by `dataclasses.asdict` and then handed to the base class on reload as an unexpected keyword argument, which is a hard failure.

## Testing

851 passed / 0 skipped / 0 failed. `ruff check` and `ruff format --check` clean.

Every test ships with the mutation that proves it fails. One result worth recording: the generator-loss **gradient-direction** test cannot distinguish the non-saturating form from the saturating one — both produce a strictly negative gradient at every input. Only the test pinning the formula against an independently-computed `binary_cross_entropy_with_logits` value catches that swap. A test that merely checked the loss was finite and pushed logits the right way would have been decorative.

Also folded in: the discriminator's size-validation message now says "positive multiple" (it rejects `0` and negative multiples of 16, for which "divisible by 16" was misleading) and interpolates the computed stride factor instead of hardcoding `16`, which would have drifted if the block table changed.

## Stack

```
main
 └─ CLI subclass mode
     └─ perceptual metrics (LPIPS/DISTS)
         └─ rolling checkpoints + component weights
             └─ THIS PR  · SRGAN discriminator, adversarial loss, configs
                 └─ SRGAN Lightning module + template
                     └─ docs
```

**Do not use "delete branch on merge"** — it races and closes the child PR instead of retargeting it.
