### PR TITLE
feat: add SRGANLightning, generator initialisation, and the SRGAN template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,10 @@ Conventional Commit types, with subjects that describe the effect:
 ## Adding a new architecture
 
 You don't write a Lightning module. `SRLightning` already composes an `SRModel` with an
-`SRProcessor`, fed by `SRDataModule`.
+`SRProcessor`, fed by `SRDataModule`. The one exception is a second optimizer: adversarial
+training drives two networks alternately, which Lightning's automatic loop cannot express,
+so `SRGANLightning` subclasses `SRLightning` and owns its own training step. Anything that
+trains one network needs no new module.
 
 1. Subclass `sisr.models.base.SRModel`: `forward`, `self._hparams`, and optionally
    `reset_parameters(**kwargs)` for a paper-faithful init.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,10 @@ dependencies = [
     "torch>=2.6",
     "torchvision>=0.21",
     "lightning>=2.4",
-    # 1.9 is the version DISTS was verified present in on this project
-    # (torchmetrics.functional.image.deep_image_structure_and_texture_similarity).
+    # 1.9 is the version DISTS was verified present in on this project. sisr/perceptual.py
+    # caches the backbones directly (torchmetrics.functional.image.dists.DISTSNetwork and
+    # torchmetrics.image.lpip.LearnedPerceptualImagePatchSimilarity.net), so the pin covers
+    # those, not just the functional entry points.
     # Lowering it means testing the lower version, not guessing.
     "torchmetrics>=1.9",
     "jsonargparse[signatures]>=4.27",

--- a/sisr/perceptual.py
+++ b/sisr/perceptual.py
@@ -11,9 +11,19 @@ better than PSNR does, and that is the whole claim.
 DISTS costs nothing — torchmetrics implements it over torchvision's VGG16,
 both already required. LPIPS needs the ``lpips`` package (torchmetrics gates it
 on ``_LPIPS_AVAILABLE``), hence the ``[perceptual]`` extra.
-"""
 
-from collections.abc import Callable
+**Both backbones are memoised here, module-level, keyed by
+``(metric, lpips_net, device, dtype)``.** torchmetrics' *functional* API builds
+a fresh network per call, which dominated the metric entirely: measured on CPU
+at 1x3x256x256, 605.0 ms/call of which 27.3 ms was LPIPS itself, and
+1716.1 ms/call of which 386.8 ms was DISTS itself. One validation cycle of the
+shipped adversarial template scores ~219 images per metric, so that was ~7
+minutes of pure construction per cycle, paid again at step 0 through
+``num_sanity_val_steps``. The cache is a module global rather than an attribute
+on the Lightning module for the same reason the VGG19 criterion is held outside
+the module tree: an ``nn.Module`` attribute would put ~230 MB of AlexNet (or
+~528 MB of VGG16) into every ``state_dict`` this project writes.
+"""
 
 import torch
 
@@ -22,13 +32,21 @@ import torch
 #: so monitoring one of these at the default would keep the *worst* model.
 PERCEPTUAL_METRICS: dict[str, bool] = {"lpips": True, "dists": True}
 
+#: Memoised backbones, keyed by ``(name, lpips_net, device, dtype)``. Populated by
+#: :func:`_cached_net`; never read directly.
+_NET_CACHE: dict[tuple[str, str, torch.device, torch.dtype], torch.nn.Module] = {}
 
-def _lpips_fn() -> Callable:
+
+def _lpips_metric_cls() -> type:
     """Import LPIPS on demand, turning a missing extra into an actionable error.
 
     Indirected through a function (rather than a module-level import) so the
     import cost is only paid by runs that ask for it — this module is reachable
     from spawned DataLoader workers, which pay every import twice on Windows.
+
+    Returns the *modular* metric class, not the functional entry point: it holds
+    its ``_NoTrainLpips`` backbone as ``self.net``, built once at construction,
+    which is what makes it cacheable.
     """
     from torchmetrics.utilities.imports import _LPIPS_AVAILABLE
 
@@ -39,16 +57,61 @@ def _lpips_fn() -> Callable:
             "pip install '.[perceptual]'. 'dists' needs no extra and can be used "
             "on its own in the meantime."
         )
-    from torchmetrics.functional.image import learned_perceptual_image_patch_similarity
+    from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
 
-    return learned_perceptual_image_patch_similarity
+    return LearnedPerceptualImagePatchSimilarity
 
 
-def _dists_fn() -> Callable:
-    """Import DISTS on demand. No availability gate — torchvision is a core dep."""
-    from torchmetrics.functional.image import deep_image_structure_and_texture_similarity
+def _dists_net_cls() -> type:
+    """Import DISTS's backbone on demand. No availability gate — torchvision is a core dep.
 
-    return deep_image_structure_and_texture_similarity
+    The bare network, not torchmetrics' ``DeepImageStructureAndTextureSimilarity``:
+    that metric's ``update`` calls ``_dists_update``, which constructs a whole
+    ``DISTSNetwork`` per call, so the modular class is exactly as expensive as
+    the functional one and cannot be cached (verified on torchmetrics 1.9.0).
+    LPIPS's modular class does hold its backbone, hence the asymmetry.
+    """
+    from torchmetrics.functional.image.dists import DISTSNetwork
+
+    return DISTSNetwork
+
+
+def _cached_net(
+    name: str, lpips_net: str, device: torch.device, dtype: torch.dtype
+) -> torch.nn.Module:
+    """Return the memoised backbone for one metric on one device/dtype.
+
+    Built in ``eval()`` with every parameter detached from autograd, so a cached
+    backbone can neither train nor leak gradients into the model being scored.
+    Construction is forced out of ``inference_mode`` — Lightning's validation
+    loop runs inside it, and weights allocated there would be inference tensors
+    baked into a cache that outlives the block.
+
+    Args:
+        name: ``'lpips'`` or ``'dists'``.
+        lpips_net: LPIPS backbone name; ignored (and normalised out of the cache
+            key) for DISTS.
+        device: Device the scored tensors live on.
+        dtype: Dtype the scored tensors carry.
+
+    Returns:
+        The cached ``nn.Module``, already on ``device``/``dtype``.
+    """
+    key = (name, lpips_net if name == "lpips" else "", device, dtype)
+    net = _NET_CACHE.get(key)
+    if net is None:
+        with torch.inference_mode(False):
+            if name == "lpips":
+                # normalize=True declares "inputs are [0,1]". The default False means
+                # "already [-1,1]" and would score a squashed range without erroring.
+                # reduction is passed explicitly because DISTS defaults to None while
+                # this defaults to 'mean' — relying on either gives two shapes.
+                net = _lpips_metric_cls()(net_type=lpips_net, reduction="mean", normalize=True)
+            else:
+                net = _dists_net_cls()()
+            net = net.to(device=device, dtype=dtype).eval().requires_grad_(False)
+        _NET_CACHE[key] = net
+    return net
 
 
 def perceptual_score(
@@ -76,10 +139,16 @@ def perceptual_score(
         raise ValueError(
             f"perceptual metric must be one of {sorted(PERCEPTUAL_METRICS)}; got {name!r}"
         )
-    if name == "lpips":
-        # normalize=True declares "inputs are [0,1]". The default False means
-        # "already [-1,1]" and would score a squashed range without erroring.
-        # reduction is passed explicitly because DISTS below defaults to None
-        # while this defaults to 'mean' — relying on either gives two shapes.
-        return _lpips_fn()(sr, hr, net_type=lpips_net, reduction="mean", normalize=True)
-    return _dists_fn()(sr, hr, reduction="mean")
+    net = _cached_net(name, lpips_net, sr.device, sr.dtype)
+    with torch.no_grad():
+        if name == "lpips":
+            score = net(sr, hr)
+            # The metric object is reused, so its accumulators must not be: LPIPS
+            # keeps a list state and would retain one tensor per call for the whole
+            # run. Only the per-call value returned above is ever read.
+            net.reset()
+            return score
+        # require_grad=False matches what the functional path passes for the
+        # no-grad tensors a val loop produces, and is unconditional here because
+        # nothing may build a graph through a scoring metric.
+        return net(sr, hr, require_grad=False).mean()

--- a/sisr/training/__init__.py
+++ b/sisr/training/__init__.py
@@ -18,6 +18,7 @@ from .lightning_module import SRLightning
 
 __all__ = [
     "SRLightning",
+    "SRGANLightning",
     "SRDataModule",
     "SRTrainingConfig",
     "SREvalConfig",
@@ -28,3 +29,35 @@ __all__ = [
     "SRPredictionWriter",
     "WeightHistogramLogger",
 ]
+
+
+def __getattr__(name: str):
+    """Resolve ``SRGANLightning`` on first access, not at package import.
+
+    Every other re-export above is a plain import; this one cannot be. Each
+    per-architecture config (``sisr.models.srgan.config``,
+    ``sisr.models.srresnet.config``, ...) imports ``sisr.training.config``,
+    which runs *this* module first — so an eager ``from .gan_module import
+    SRGANLightning`` here re-enters a half-built ``sisr.models.srgan`` (or
+    ``sisr.models.srresnet``) whenever a model package is what got imported
+    first, which is what the model-side tests and any ``class_path`` do.
+    Deferring to first attribute access resolves the cycle without weakening
+    ``SRGANLightning``'s own signature to base types: by the time anything asks
+    for the class, both packages are fully imported. ``from sisr.training
+    import SRGANLightning`` and ``class_path: sisr.training.SRGANLightning``
+    both go through here.
+
+    Args:
+        name: Attribute being looked up on this package.
+
+    Returns:
+        The requested attribute.
+
+    Raises:
+        AttributeError: For any name other than ``SRGANLightning``.
+    """
+    if name == "SRGANLightning":
+        from .gan_module import SRGANLightning
+
+        return SRGANLightning
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -11,6 +11,7 @@ training signals; :class:`SRCheckpoint` is a thin
 output to disk as PNGs.
 """
 
+import re
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -664,13 +665,58 @@ class _RollingSaveMixin:
     would be shadowed by that override and silently never run. Each
     subclass's ``_save_checkpoint`` calls :meth:`_enforce_rolling_window`
     explicitly instead.
+
+    The window itself is never persisted in ``state_dict`` — it is rebuilt from
+    the files already on disk when a run resumes (:meth:`on_train_start`), which
+    is what keeps ``fit --ckpt_path`` from orphaning the pre-resume saves.
     """
 
-    def _init_rolling(self, keep_last: int) -> None:
+    def _init_rolling(self, keep_last: int, filename_prefix: str) -> None:
         if keep_last < 1:
             raise ValueError(f"keep_last must be >= 1; got {keep_last}")
         self.keep_last = keep_last
         self._rolling: list[str] = []
+        # Rolling filenames are exactly f"{filename_prefix}-{step}{FILE_EXTENSION}",
+        # so this matches every file THIS callback writes and nothing else: a
+        # sibling callback in the same dirpath differs in prefix or extension, and
+        # `last.ckpt`/a monitored callback's metric-bearing name never match.
+        self._rolling_pattern = re.compile(
+            rf"{re.escape(filename_prefix)}-(\d+){re.escape(self.FILE_EXTENSION)}"
+        )
+
+    def on_train_start(
+        self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
+    ) -> None:
+        """Seed the rolling window from disk when this run is resuming.
+
+        Nothing persists the window: ``ModelCheckpoint.state_dict`` carries
+        ``monitor``/``best_*``/``kth_*``/``dirpath``/``last_model_path`` only. So
+        without this, a ``fit --ckpt_path`` resume starts with an empty window and
+        every pre-resume file is orphaned — never counted, never deleted, up to
+        ``keep_last`` per callback per resume (three rolling callbacks run in the
+        shipped adversarial template).
+
+        Only a resume seeds. A fresh run into a populated ``dirpath`` leaves those
+        files alone rather than adopting — and eventually deleting — checkpoints it
+        did not write.
+
+        Runs here rather than in ``setup`` because ``trainer.ckpt_path`` is not
+        assigned until the checkpoint connector restores state, which is after
+        every ``setup`` hook.
+
+        Args:
+            trainer: The active trainer — supplies ``ckpt_path``.
+            pl_module: Unused; part of the hook signature.
+        """
+        super().on_train_start(trainer, pl_module)
+        if self.monitor is not None or not trainer.ckpt_path or not self.dirpath:
+            return
+        found = sorted(
+            (int(match.group(1)), str(path))
+            for path in Path(self.dirpath).iterdir()
+            if (match := self._rolling_pattern.fullmatch(path.name))
+        )
+        self._rolling = [path for _, path in found]
 
     def _enforce_rolling_window(self, trainer: lightning.Trainer, filepath: str) -> None:
         """Track *filepath* and drop the oldest save(s) beyond ``keep_last``.
@@ -758,7 +804,7 @@ class SRCheckpoint(_RollingSaveMixin, ModelCheckpoint):
             auto_insert_metric_name=False,
             **kwargs,
         )
-        self._init_rolling(keep_last)
+        self._init_rolling(keep_last, filename_prefix)
 
     def _save_checkpoint(self, trainer: lightning.Trainer, filepath: str) -> None:
         """Save via :class:`~lightning.pytorch.callbacks.ModelCheckpoint`, then enforce rolling.
@@ -892,7 +938,7 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
             auto_insert_metric_name=False,
             **kwargs,
         )
-        self._init_rolling(keep_last)
+        self._init_rolling(keep_last, filename_prefix)
         self.attribute = attribute
 
     @property
@@ -915,8 +961,9 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         suffix finds no state under the new key, so this callback's monitored
         bookkeeping (``best_model_score``/``best_k_models``, i.e. what a
         ``save_top_k`` run has already kept) restarts from empty for the rest of
-        that run. Rolling mode loses nothing — its window is recomputed from
-        the files on disk and was never persisted.
+        that run. Rolling mode loses nothing — its window was never persisted
+        under any key, and :meth:`_RollingSaveMixin.on_train_start` rebuilds it
+        from this callback's own files on disk before the first save.
 
         Returns:
             A key unique per ``(monitor, mode, cadence, attribute)``.

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -976,28 +976,44 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         pl_module: lightning.LightningModule,
         stage: str,
     ) -> None:
-        """Validate ``monitor`` against the metrics ``SRLightning`` will log.
+        """Validate ``monitor`` against the metrics ``SRLightning`` will log, and ``attribute``.
 
-        Same check as :meth:`SRCheckpoint.setup` (via the shared
-        ``_validate_monitor_metric`` helper — the two classes are siblings, not
-        parent/child, so the check can't be reused via ``super()`` across them).
+        The ``monitor`` check is the same as :meth:`SRCheckpoint.setup` (via the
+        shared ``_validate_monitor_metric`` helper — the two classes are siblings,
+        not parent/child, so the check can't be reused via ``super()`` across them).
+
+        ``attribute`` is otherwise only read when a checkpoint is written, so a
+        typo — or ``attribute='discriminator'`` on a plain
+        :class:`~sisr.training.SRLightning` — would cost a whole checkpoint
+        interval before dying with a bare ``AttributeError`` from deep inside the
+        save path. Same reasoning as moving the monitor check to startup.
 
         Args:
             trainer: The active trainer.
-            pl_module: The model being trained; must expose ``eval_config``.
+            pl_module: The model being trained; must expose ``eval_config`` and
+                the component named by ``attribute``.
             stage: Lightning trainer stage. Only ``"fit"`` is checked — see
                 ``SRCheckpoint.setup``.
 
         Raises:
             MisconfigurationException: If ``monitor`` does not name a metric
-                ``SRLightning`` will log during ``fit``, or if ``mode``
+                ``SRLightning`` will log during ``fit``, if ``mode``
                 disagrees with that metric's direction (PSNR/SSIM are
-                higher-is-better; LPIPS/DISTS are lower-is-better).
+                higher-is-better; LPIPS/DISTS are lower-is-better), or if
+                ``pl_module`` has no attribute named ``attribute``.
         """
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
             return
         _validate_monitor_metric("SRWeightsCheckpoint", self.monitor, pl_module, mode=self.mode)
+        if not hasattr(pl_module, self.attribute):
+            raise MisconfigurationException(
+                f"`SRWeightsCheckpoint(attribute={self.attribute!r})` has nothing to save: "
+                f"{type(pl_module).__name__} has no attribute {self.attribute!r}. Name a "
+                f"component the module actually defines — 'model' (the generator, the "
+                f"default) on any SRLightning, 'discriminator' only on an adversarial "
+                f"module. Fix the callback's `attribute` in your YAML."
+            )
 
     def _save_checkpoint(self, trainer: lightning.Trainer, filepath: str) -> None:
         """Write one component's bare weights + matching provenance metadata.

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -895,6 +895,27 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         self._init_rolling(keep_last)
         self.attribute = attribute
 
+    @property
+    def state_key(self) -> str:
+        """Lightning's callback-state key, widened by ``attribute``.
+
+        ``ModelCheckpoint``'s own key is built from ``monitor``/``mode`` and the
+        cadence fields only — not from ``attribute``, ``dirpath`` or
+        ``filename``. Lightning refuses two stateful callbacks that share a key
+        (``_validate_callbacks_list``), so without this, one generator and one
+        discriminator weights callback on the same monitor and cadence — the
+        configuration ``attribute`` exists for, and the one the SRGAN template
+        ships — cannot be constructed at all.
+
+        Appended to ``super()``'s key rather than rebuilding it, so a Lightning
+        release that adds or renames a key field is carried through here
+        unchanged instead of silently dropping it.
+
+        Returns:
+            A key unique per ``(monitor, mode, cadence, attribute)``.
+        """
+        return f"{super().state_key}[attribute={self.attribute}]"
+
     def setup(
         self,
         trainer: lightning.Trainer,

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -911,6 +911,13 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         release that adds or renames a key field is carried through here
         unchanged instead of silently dropping it.
 
+        Resuming a ``.ckpt`` written before this key gained its ``attribute``
+        suffix finds no state under the new key, so this callback's monitored
+        bookkeeping (``best_model_score``/``best_k_models``, i.e. what a
+        ``save_top_k`` run has already kept) restarts from empty for the rest of
+        that run. Rolling mode loses nothing — its window is recomputed from
+        the files on disk and was never persisted.
+
         Returns:
             A key unique per ``(monitor, mode, cadence, attribute)``.
         """

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -1,0 +1,300 @@
+"""Adversarial Lightning wrapper for SRGAN — :class:`SRGANLightning`.
+
+Everything but the optimization surface is inherited from
+:class:`~sisr.training.lightning_module.SRLightning`: the forward pipeline,
+the colorspace handling, validation metrics and checkpoint provenance are the
+generator's and are unchanged by training it adversarially. What this subclass
+adds is the second network, the second optimizer, and the alternating step that
+drives them.
+
+Reference: Photo-Realistic Single Image Super-Resolution Using a Generative
+Adversarial Network (https://arxiv.org/pdf/1609.04802), Section 3.2; the
+alternation follows Goodfellow et al. (2014) Algorithm 1.
+"""
+
+from typing import Any
+
+import torch
+from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+from lightning.pytorch.utilities.types import OptimizerLRScheduler
+
+from ..losses import AdversarialLoss
+from ..models.base import SRModel
+from ..models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
+from ..processors import SRProcessor
+from .config import SREvalConfig
+from .lightning_module import SRLightning
+
+
+class SRGANLightning(SRLightning):
+    """SRResNet generator + SRGAN discriminator, trained by alternating updates.
+
+    Two optimizers cannot be driven by Lightning's automatic loop, so this
+    module sets ``automatic_optimization = False`` and owns the whole
+    ``{zero_grad, backward, step}`` sequence for both networks (see
+    :meth:`training_step`). One consequence is worth stating up front:
+    ``trainer.global_step`` counts **optimizer** steps, and this module takes
+    two per batch, so after ``N`` batches it reads ``N + N // k`` rather than
+    ``N``. Every step-denominated knob (``max_steps``, ``val_check_interval``,
+    checkpoint filenames) is in that unit — a ``max_steps`` copied from the
+    SRResNet template therefore trains for roughly half the batches.
+
+    Args:
+        model: The generator — an initialised :class:`SRModel` subclass,
+            normally :class:`~sisr.models.srresnet.SRResNet`. Required.
+        processor: An :class:`SRProcessor` subclass. The discriminator scores
+            the generator's output in this processor's *model output* space
+            (``[-1, 1]`` under
+            :class:`~sisr.processors.RGBSignedOutputProcessor`), not display
+            range. Required.
+        discriminator: The critic, normally
+            :class:`~sisr.models.srgan.SRDiscriminator`. Emits logits; it is
+            paired with an ``adversarial_loss`` that applies the sigmoid
+            itself. Required.
+        training_config: Defaults to :class:`SRGANTrainingConfig`, which
+            supplies ``adversarial_weight`` and ``d_steps_per_g_step`` — both
+            read by :meth:`training_step` — and refuses ``cuda_graph``.
+        eval_config: Defaults to :class:`SRGANEvalConfig` (SRResNet's scoring
+            plus perceptual metrics, which are the only metrics that track what
+            an adversarial objective optimises).
+        criterion: The generator's **content** loss, e.g.
+            :class:`torch.nn.MSELoss` or
+            :class:`~sisr.losses.VGG19FeatureLoss`. Defaults to
+            :class:`torch.nn.MSELoss`. The adversarial term is added on top,
+            weighted by ``training_config.adversarial_weight``.
+        optimizer: ``OptimizerCallable`` for the **generator**, from top-level
+            YAML ``optimizer:``. Defaults to :class:`torch.optim.Adam`.
+        lr_scheduler: ``LRSchedulerCallable`` for the generator's optimizer, or
+            ``None``. Stepped per batch by :meth:`on_train_batch_end`.
+        adversarial_loss: The GAN objective. Defaults to
+            :class:`~sisr.losses.AdversarialLoss` (non-saturating, over logits).
+        discriminator_optimizer: ``OptimizerCallable`` for the discriminator.
+            Defaults to :class:`torch.optim.Adam`. Separate from ``optimizer``
+            so the two networks can be tuned independently.
+        discriminator_lr_scheduler: ``LRSchedulerCallable`` for the
+            discriminator's optimizer, or ``None``.
+
+    Raises:
+        ValueError: If ``discriminator``'s ``in_channels`` disagrees with
+            ``processor.model_channels``.
+        TypeError: Via :class:`SRLightning` if ``model`` / ``processor`` are
+            not of the required base types.
+    """
+
+    def __init__(
+        self,
+        model: SRModel,
+        processor: SRProcessor,
+        discriminator: SRDiscriminator,
+        training_config: SRGANTrainingConfig | None = None,
+        eval_config: SREvalConfig | None = None,
+        criterion: torch.nn.Module | None = None,
+        optimizer: OptimizerCallable = torch.optim.Adam,
+        lr_scheduler: LRSchedulerCallable | None = None,
+        adversarial_loss: AdversarialLoss | None = None,
+        discriminator_optimizer: OptimizerCallable = torch.optim.Adam,
+        discriminator_lr_scheduler: LRSchedulerCallable | None = None,
+    ):
+        super().__init__(
+            model=model,
+            processor=processor,
+            training_config=training_config or SRGANTrainingConfig(),
+            eval_config=eval_config or SRGANEvalConfig(),
+            criterion=criterion,
+            optimizer=optimizer,
+            lr_scheduler=lr_scheduler,
+        )
+        # The correlated check SRGANTrainingConfig.validate_against cannot do:
+        # its (model, processor) signature never sees the discriminator.
+        if discriminator.hparams["in_channels"] != processor.model_channels:
+            raise ValueError(
+                f"SRDiscriminator in_channels={discriminator.hparams['in_channels']} does "
+                f"not match {type(processor).__name__}.model_channels="
+                f"{processor.model_channels}. The discriminator scores the generator's "
+                f"output in model space, so it must accept the same channel count the "
+                f"generator emits — otherwise the first step fails as a raw Conv2d shape "
+                f"mismatch."
+            )
+
+        self.discriminator = discriminator
+        # `is not None`, not `or`: a container-backed loss (nn.ModuleList with no
+        # entries yet) is falsy and would be silently swapped for the default.
+        self.adversarial_loss = (
+            adversarial_loss if adversarial_loss is not None else AdversarialLoss()
+        )
+        self.discriminator_optimizer = discriminator_optimizer
+        self.discriminator_lr_scheduler = discriminator_lr_scheduler
+        self.automatic_optimization = False
+
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        """Build the generator and discriminator optimizers, in that order.
+
+        The generator's optimizer is built from ``self.model.parameters()``,
+        **never** ``self.parameters()``: the latter includes the discriminator,
+        whose parameters would then be stepped to *minimise* the adversarial
+        loss — training the discriminator to lose. Nothing fails when that
+        happens; both loss curves keep moving and look healthy.
+
+        Returns:
+            ``([opt_g, opt_d], schedulers)``, where ``schedulers`` holds the
+            generator's then the discriminator's, and is empty when neither is
+            set. The shape is always this pair — never a bare optimizer list —
+            so callers never branch on it; :meth:`training_step` unpacks the
+            optimizers positionally and the order is part of the contract.
+        """
+        opt_g = self.optimizer(self.model.parameters())
+        opt_d = self.discriminator_optimizer(self.discriminator.parameters())
+        schedulers = []
+        if self.lr_scheduler is not None:
+            schedulers.append(self.lr_scheduler(opt_g))
+        if self.discriminator_lr_scheduler is not None:
+            schedulers.append(self.discriminator_lr_scheduler(opt_d))
+        return [opt_g, opt_d], schedulers
+
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> None:
+        """One Goodfellow outer iteration: a discriminator step, plus every k-th a generator one.
+
+        Order is discriminator-first (Algorithm 1), so the generator is updated
+        against the discriminator that just moved. ``k``
+        (``training_config.d_steps_per_g_step``) is spent *across* batches
+        rather than looped here, giving each discriminator step a fresh
+        minibatch as Algorithm 1 specifies.
+
+        One generator forward per batch, reused: the discriminator's backward
+        runs on ``sr.detach()`` so it never touches the generator's graph, and
+        the generator's backward then flows through a second, fresh
+        discriminator forward. No ``retain_graph`` is needed anywhere.
+
+        Args:
+            batch: ``(lr_img, hr_img)`` tuple from the train loader. Both RGB,
+                ``float32`` in ``[0, 1]``.
+            batch_idx: Index of the batch within the current epoch. Also the
+                alternation counter, so ``k`` restarts its cycle each epoch.
+
+        Returns:
+            ``None``: under manual optimization Lightning does not consume a
+            returned loss.
+        """
+        lr_img, hr_img = batch
+        opt_g, opt_d = self.optimizers()
+
+        sr, _, hr_cropped = self._forward_sr(lr_img, hr_img, need_sr_rgb=False)
+        hr_for_loss = self.processor.extract_target(hr_cropped)
+
+        self.toggle_optimizer(opt_d)
+        d_loss = self.adversarial_loss.discriminator_loss(
+            self.discriminator(hr_for_loss), self.discriminator(sr.detach())
+        )
+        opt_d.zero_grad()
+        self.manual_backward(d_loss)
+        opt_d.step()
+        self.untoggle_optimizer(opt_d)
+        self.log("loss/train/d", d_loss, on_step=True, prog_bar=True)
+
+        if (batch_idx + 1) % self.training_config.d_steps_per_g_step:
+            return
+
+        # toggle_optimizer flips requires_grad off for every parameter outside
+        # opt_g, so the generator's backward — which must pass THROUGH the
+        # discriminator to reach the generator — stops accumulating into the
+        # discriminator's .grad on the way. Measured: without it, that backward
+        # changes 34 of the discriminator's gradient tensors. It survives today
+        # only because opt_d.zero_grad() above clears the debris before the next
+        # discriminator backward, which is an emergent property of the current
+        # ordering rather than anything stated. The generator still receives its
+        # gradient either way (also measured).
+        self.toggle_optimizer(opt_g)
+        content = self.criterion(sr, hr_for_loss)
+        adversarial = self.adversarial_loss.generator_loss(self.discriminator(sr))
+        g_loss = content + self.training_config.adversarial_weight * adversarial
+        opt_g.zero_grad()
+        self.manual_backward(g_loss)
+        opt_g.step()
+        self.untoggle_optimizer(opt_g)
+
+        self.log("loss/train", g_loss, prog_bar=True, on_step=True)
+        self.log("loss/train/content", content, on_step=True)
+        self.log("loss/train/adv", adversarial, on_step=True)
+        self._log_loss_terms("train")
+
+    def on_train_batch_end(self, outputs: Any, batch: Any, batch_idx: int) -> None:
+        """Step the LR schedulers by hand — manual optimization does not.
+
+        Milestones are therefore counted in **batches**, which is the correct
+        unit for the paper's schedule (1e5 iterations at 1e-4, then 1e5 at
+        1e-5) and deliberately *not* the unit ``trainer.global_step`` reports
+        (see the class docstring).
+
+        Args:
+            outputs: Whatever :meth:`training_step` returned — always ``None``
+                here. Unused.
+            batch: The batch just processed. Unused.
+            batch_idx: Index of the batch within the current epoch. Unused —
+                every batch steps the schedulers, including the ones that skip
+                the generator, since the discriminator stepped regardless.
+        """
+        schedulers = self.lr_schedulers()
+        if schedulers is None:
+            return
+        # lr_schedulers() returns the scheduler ITSELF when exactly one is
+        # configured, and a list only when there are several.
+        if not isinstance(schedulers, list):
+            schedulers = [schedulers]
+        for scheduler in schedulers:
+            scheduler.step()
+
+    def on_fit_start(self) -> None:
+        """Refuse distributed training, then run the base's compile warm-up.
+
+        Manual optimization opts out of Lightning's gradient synchronisation:
+        with ``automatic_optimization = False`` the strategy's backward no
+        longer wraps the step in DDP's ``no_sync``/reducer handling, so the two
+        networks' gradients would be reduced at whatever points DDP's hooks
+        happen to fire across an alternating schedule where one of the two
+        optimizers is idle on most ranks' k-th batches. Supporting it means
+        writing that synchronisation explicitly, so this refuses rather than
+        training silently out of sync.
+
+        The base's CUDA-graph path is unreachable from here — it is gated on
+        ``training_config.cuda_graph``, which :class:`SRGANTrainingConfig`
+        refuses at construction — so what ``super()`` contributes is the
+        ``torch.compile`` warm-up and the graph-state reset.
+
+        Raises:
+            RuntimeError: If ``trainer.world_size > 1``.
+        """
+        if self.trainer.world_size > 1:
+            raise RuntimeError(
+                f"SRGANLightning does not support distributed training "
+                f"(trainer.world_size={self.trainer.world_size}). It trains under manual "
+                f"optimization, which opts out of Lightning's automatic gradient "
+                f"synchronisation, so the generator's and discriminator's gradients would "
+                f"not be reduced across ranks — each rank would train its own divergent "
+                f"pair with nothing failing. Train on one device."
+            )
+        super().on_fit_start()
+
+    def _extra_probe(self, lr: torch.Tensor, hr: torch.Tensor, source: str) -> None:
+        """Check the discriminator's declared input size against the real HR crop.
+
+        Args:
+            lr: LR sample, ``(C, H, W)``. Unused — the discriminator only ever
+                sees HR-sized tensors.
+            hr: HR sample, ``(C, H, W)``.
+            source: Config path the sample came from, for the error message.
+
+        Raises:
+            ValueError: If the HR patch is not square at the declared
+                ``hr_input_size``.
+        """
+        declared = self.discriminator.hparams["hr_input_size"]
+        actual = tuple(hr.shape[-2:])
+        if actual == (declared, declared):
+            return
+        raise ValueError(
+            f"discriminator hr_input_size={declared} does not match the HR patch "
+            f"data.{source} serves ({actual[0]}x{actual[1]}). The discriminator's "
+            f"dense head fixes its input size, so a mismatch is a raw Linear shape "
+            f"error on the first step otherwise. Set hr_crop_size={declared} on the "
+            f"train dataset, or hr_input_size={actual[0]} on the discriminator."
+        )

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -175,6 +175,17 @@ class SRGANLightning(SRLightning):
         pretrained weights and silently restart it, while the discriminator and
         the optimizer state carried on from where they were.
 
+        On a ``fit --ckpt_path`` resume, this runs (``Trainer._run`` calls the
+        setup hook at line 1039) *before* the resume restores the module's own
+        state (line 1046), so the resumed generator wins and the final model
+        state is correct either way. The costs are one wasted weights read and
+        a hard dependency on ``init_from``'s artifact existing on the resuming
+        box, even though its result is about to be discarded. The upside: the
+        five metadata refusals below still run on every resume, so a config
+        that has drifted from the run being resumed (a changed architecture,
+        processor, or scale) is still caught rather than only checked on a
+        fresh ``fit``.
+
         Args:
             stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
                 ``'test'`` or ``'predict'``. Only ``'fit'`` loads.

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -2,16 +2,18 @@
 
 Everything but the optimization surface is inherited from
 :class:`~sisr.training.lightning_module.SRLightning`: the forward pipeline,
-the colorspace handling, validation metrics and checkpoint provenance are the
-generator's and are unchanged by training it adversarially. What this subclass
-adds is the second network, the second optimizer, and the alternating step that
-drives them.
+the colorspace handling and the validation metrics are the generator's and are
+unchanged by training it adversarially. What this subclass adds is the second
+network, the second optimizer, the alternating step that drives them, the
+generator's optional MSE initialisation, and the adversarial half of the
+checkpoint's provenance.
 
 Reference: Photo-Realistic Single Image Super-Resolution Using a Generative
 Adversarial Network (https://arxiv.org/pdf/1609.04802), Section 3.2; the
 alternation follows Goodfellow et al. (2014) Algorithm 1.
 """
 
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -24,6 +26,20 @@ from ..models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
 from ..processors import SRProcessor
 from .config import SREvalConfig
 from .lightning_module import SRLightning
+from .metadata import _class_path, build_metadata
+
+#: ``(section, key)`` of every ``build_metadata`` field ``init_from`` validates —
+#: the properties that decide whether one run's generator weights mean anything in
+#: another. Reported dotted (``io.scale``) so the message names the YAML the user
+#: has to change. Compared against ``build_metadata(self)``, the same builder that
+#: wrote the file, so the two sides cannot drift.
+_INIT_FROM_FIELDS: tuple[tuple[str, str], ...] = (
+    ("model", "class_path"),
+    ("model", "init_args"),
+    ("processor", "class_path"),
+    ("io", "output_range"),
+    ("io", "scale"),
+)
 
 
 class SRGANLightning(SRLightning):
@@ -53,7 +69,8 @@ class SRGANLightning(SRLightning):
             itself. Required.
         training_config: Defaults to :class:`SRGANTrainingConfig`, which
             supplies ``adversarial_weight`` and ``d_steps_per_g_step`` — both
-            read by :meth:`training_step` — and refuses ``cuda_graph``.
+            read by :meth:`training_step` — plus ``init_from`` (read here), and
+            refuses ``cuda_graph``.
         eval_config: Defaults to :class:`SRGANEvalConfig` (SRResNet's scoring
             plus perceptual metrics, which are the only metrics that track what
             an adversarial objective optimises).
@@ -76,7 +93,9 @@ class SRGANLightning(SRLightning):
 
     Raises:
         ValueError: If ``discriminator``'s ``in_channels`` disagrees with
-            ``processor.model_channels``.
+            ``processor.model_channels``, or if ``training_config.init_from``
+            names an artifact this run's generator cannot be initialised from
+            (see :meth:`_init_generator_from`).
         TypeError: Via :class:`SRLightning` if ``model`` / ``processor`` are
             not of the required base types.
     """
@@ -138,6 +157,78 @@ class SRGANLightning(SRLightning):
         self.discriminator_optimizer = discriminator_optimizer
         self.discriminator_lr_scheduler = discriminator_lr_scheduler
         self.automatic_optimization = False
+
+        # Last: after the base's own init_strategy pass, whose weights this
+        # deliberately overwrites, and after every refusal above — a load is the
+        # one step here that touches the filesystem.
+        if self.training_config.init_from is not None:
+            self._init_generator_from(self.training_config.init_from)
+
+    def _init_generator_from(self, init_from: str) -> None:
+        """Initialise the **generator only** from a bare-weights ``.pt``.
+
+        Ledig et al. scope the MSE-initialisation trick to "when training the
+        actual GAN", so a paper-faithful SRGAN run starts from an MSE-trained
+        SRResNet rather than from scratch. The discriminator is not in that file
+        and is not touched: the adversarial half starts fresh by design.
+
+        Every mismatch is refused rather than warned about. Weights trained
+        under a different architecture, processor, output range or scale load
+        into a model that then trains and scores without ever erroring — only
+        the numbers are wrong, which is indistinguishable from a bad run.
+
+        Args:
+            init_from: Path to a ``.pt`` written by
+                :class:`~sisr.training.callbacks.SRWeightsCheckpoint` with
+                ``attribute='model'`` — a ``{'state_dict', 'meta'}`` payload.
+
+        Raises:
+            ValueError: If ``init_from`` names a ``.ckpt``; if the payload
+                carries no ``meta`` to validate against; or if any of
+                :data:`_INIT_FROM_FIELDS` disagrees with this run.
+            RuntimeError: From ``load_state_dict(strict=True)`` if the metadata
+                matches but the tensors do not.
+        """
+        path = Path(init_from)
+        if path.suffix == ".ckpt":
+            raise ValueError(
+                f"init_from expects a bare-weights .pt, but got the resumable checkpoint "
+                f"{path.name!r}. A .ckpt holds the whole LightningModule under "
+                f"'model.'-prefixed keys (plus optimizer state, and no per-network "
+                f"provenance to validate), so loading it into the bare generator is an "
+                f"unreadable key dump at best. Point init_from at the sibling "
+                f"sr-weights-*.pt that SRWeightsCheckpoint writes alongside it, or resume "
+                f"the whole run with --ckpt_path instead."
+            )
+
+        payload = torch.load(path, weights_only=True, map_location="cpu")
+        meta = payload.get("meta") if isinstance(payload, dict) else None
+        if meta is None or "state_dict" not in payload:
+            raise ValueError(
+                f"init_from={path.name!r} is not a sisr weights file: it has no "
+                f"'state_dict'/'meta' pair. Without the meta block none of the checks "
+                f"that decide whether these weights mean anything in this run "
+                f"(architecture, processor, output range, upscaling factor) can run, so "
+                f"accepting it would reinstate exactly the silent mistraining they exist "
+                f"to prevent."
+            )
+
+        expected = build_metadata(self)
+        for section, key in _INIT_FROM_FIELDS:
+            want = expected[section][key]
+            got = meta.get(section, {}).get(key)
+            if got == want:
+                continue
+            raise ValueError(
+                f"init_from={path.name!r} was written by a run whose {section}.{key} is "
+                f"{got!r}, but this run's is {want!r}. A generator initialised from "
+                f"weights trained under a different architecture, processor, output range "
+                f"or upscaling factor trains and scores without ever erroring — only the "
+                f"numbers are wrong. Point init_from at a matching artifact, or align "
+                f"this run's config with the one that produced it."
+            )
+
+        self.model.load_state_dict(payload["state_dict"], strict=True)
 
     def configure_optimizers(self) -> OptimizerLRScheduler:
         """Build the generator and discriminator optimizers, in that order.
@@ -304,6 +395,31 @@ class SRGANLightning(SRLightning):
             )
         super().on_fit_start()
 
+    def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        """Append the adversarial half of this run's provenance.
+
+        The base builds ``sisr_meta`` around ``module.model`` — still correct,
+        since the generator is the distributable artifact. These blocks are
+        added only to the ``.ckpt``: the bare ``.pt`` written by
+        :class:`~sisr.training.callbacks.SRWeightsCheckpoint` holds one
+        network's weights and gets metadata describing *that* network, not this
+        run's whole adversarial setup.
+
+        Args:
+            checkpoint: The checkpoint dict Lightning is about to write;
+                mutated in place.
+        """
+        super().on_save_checkpoint(checkpoint)
+        checkpoint["sisr_meta"]["discriminator"] = {
+            "class_path": _class_path(self.discriminator),
+            "init_args": dict(self.discriminator.hparams),
+        }
+        checkpoint["sisr_meta"]["adversarial"] = {
+            "loss": _class_path(self.adversarial_loss),
+            "weight": self.training_config.adversarial_weight,
+            "d_steps_per_g_step": self.training_config.d_steps_per_g_step,
+        }
+
     def _extra_probe(self, lr: torch.Tensor, hr: torch.Tensor, source: str) -> None:
         """Check the discriminator's declared input size against the HR crop it will score.
 
@@ -314,9 +430,22 @@ class SRGANLightning(SRLightning):
         emits exactly ``scale x lr``, which is an SRResNet property rather than
         anything this module requires.
 
-        The probe forward runs in ``eval`` mode under ``no_grad`` — a train-mode
-        forward would fold this sample into the generator's BatchNorm running
-        statistics before training has taken a single step.
+        Scoped to the **train** dataset. ``hr_input_size`` constrains the
+        training crop and nothing else — a ``validate``/``test`` run hands
+        :meth:`~sisr.training.lightning_module.SRLightning.setup` a full image,
+        which would both fail this check for no reason and pay a
+        full-resolution generator forward on CPU at setup.
+
+        The probe forward puts the **whole module** in ``eval`` mode under
+        ``no_grad``, not just ``self.model``: the forward selector reads
+        ``self.training`` (the LightningModule's flag), so ``self.model.eval()``
+        alone would still route a compiled run through ``self._compiled`` and
+        trigger a dynamo compile here — before, and at a different shape from,
+        the deliberate :meth:`on_fit_start` warm-up. ``self.eval()`` recurses
+        into ``self.model``, so the reason the eval-mode forward existed in the
+        first place still holds: a train-mode forward would fold this sample
+        into the generator's BatchNorm running statistics before training has
+        taken a single step.
 
         Args:
             lr: LR sample, ``(C, H, W)``.
@@ -327,14 +456,16 @@ class SRGANLightning(SRLightning):
             ValueError: If the cropped HR the discriminator would score is not
                 square at the declared ``hr_input_size``.
         """
+        if source != "train_dataset":
+            return
         declared = self.discriminator.hparams["hr_input_size"]
-        was_training = self.model.training
-        self.model.eval()
+        was_training = self.training
+        self.eval()
         try:
             with torch.no_grad():
                 _, _, hr_cropped = self._forward_sr(lr[None], hr[None], need_sr_rgb=False)
         finally:
-            self.model.train(was_training)
+            self.train(was_training)
         actual = tuple(self.processor.extract_target(hr_cropped).shape[-2:])
         if actual == (declared, declared):
             return

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -69,8 +69,8 @@ class SRGANLightning(SRLightning):
             itself. Required.
         training_config: Defaults to :class:`SRGANTrainingConfig`, which
             supplies ``adversarial_weight`` and ``d_steps_per_g_step`` — both
-            read by :meth:`training_step` — plus ``init_from`` (read here), and
-            refuses ``cuda_graph``.
+            read by :meth:`training_step` — plus ``init_from`` (read by
+            :meth:`setup`, on ``fit`` only), and refuses ``cuda_graph``.
         eval_config: Defaults to :class:`SRGANEvalConfig` (SRResNet's scoring
             plus perceptual metrics, which are the only metrics that track what
             an adversarial objective optimises).
@@ -93,9 +93,8 @@ class SRGANLightning(SRLightning):
 
     Raises:
         ValueError: If ``discriminator``'s ``in_channels`` disagrees with
-            ``processor.model_channels``, or if ``training_config.init_from``
-            names an artifact this run's generator cannot be initialised from
-            (see :meth:`_init_generator_from`).
+            ``processor.model_channels``. ``training_config.init_from`` is
+            validated in :meth:`setup` instead — construction touches no files.
         TypeError: Via :class:`SRLightning` if ``model`` / ``processor`` are
             not of the required base types.
     """
@@ -158,10 +157,34 @@ class SRGANLightning(SRLightning):
         self.discriminator_lr_scheduler = discriminator_lr_scheduler
         self.automatic_optimization = False
 
-        # Last: after the base's own init_strategy pass, whose weights this
-        # deliberately overwrites, and after every refusal above — a load is the
-        # one step here that touches the filesystem.
-        if self.training_config.init_from is not None:
+    def setup(self, stage: str | None = None) -> None:
+        """Run the base's sample probe, then MSE-initialise the generator — ``fit`` only.
+
+        The load is gated on the stage because *every* subcommand instantiates
+        the model from config, ``--ckpt_path`` included: an ``__init__``-time
+        read made ``validate``/``test``/``export`` depend on an artifact they
+        never use, so they died with ``FileNotFoundError`` on any machine
+        without it (every clone, every worktree, CI).
+
+        Here rather than in :meth:`on_fit_start` because Lightning restores a
+        ``--ckpt_path`` resume *between* the two hooks (``Trainer._run``): from
+        the later one this load would overwrite the resumed generator with the
+        pretrained weights and silently restart it, while the discriminator and
+        the optimizer state carried on from where they were.
+
+        Args:
+            stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
+                ``'test'`` or ``'predict'``. Only ``'fit'`` loads.
+
+        Raises:
+            ValueError: Via :meth:`_init_generator_from`, if
+                ``training_config.init_from`` names an artifact this run's
+                generator cannot be initialised from.
+        """
+        super().setup(stage)
+        # Last: after the base's own probe, and after every construction-time
+        # refusal — a load is the one step here that touches the filesystem.
+        if stage == "fit" and self.training_config.init_from is not None:
             self._init_generator_from(self.training_config.init_from)
 
     def _init_generator_from(self, init_from: str) -> None:
@@ -183,12 +206,23 @@ class SRGANLightning(SRLightning):
                 ``attribute='model'`` — a ``{'state_dict', 'meta'}`` payload.
 
         Raises:
-            ValueError: If ``init_from`` names a ``.ckpt``; if the payload
-                carries no ``meta`` to validate against; or if any of
-                :data:`_INIT_FROM_FIELDS` disagrees with this run.
+            ValueError: If ``init_from`` is the string ``'None'`` a CLI
+                ``=null`` collapses to; if it names a ``.ckpt`` or another
+                network's component ``.pt``; if the payload carries no ``meta``
+                to validate against; or if any of :data:`_INIT_FROM_FIELDS`
+                disagrees with this run.
             RuntimeError: From ``load_state_dict(strict=True)`` if the metadata
                 matches but the tensors do not.
         """
+        if init_from == "None":
+            raise ValueError(
+                "init_from is the literal string 'None', not a path. jsonargparse "
+                "coerces a null CLI override of a `str | None` field to that string, so "
+                "--...init_from=null does not unset init_from — it renames the file "
+                "being looked for. Pass an overlay instead: --config a YAML setting "
+                "init_from: null."
+            )
+
         path = Path(init_from)
         if path.suffix == ".ckpt":
             raise ValueError(
@@ -211,6 +245,19 @@ class SRGANLightning(SRLightning):
                 f"(architecture, processor, output range, upscaling factor) can run, so "
                 f"accepting it would reinstate exactly the silent mistraining they exist "
                 f"to prevent."
+            )
+
+        # Only when 'kind' is present: it is an additive field, and the golden
+        # artifact the template ships predates it. Absent means generator.
+        if meta.get("kind") == "component":
+            name = meta.get("component", {}).get("name", "unnamed")
+            raise ValueError(
+                f"init_from={path.name!r} holds this run's {name!r} component, not a "
+                f"generator: an SRWeightsCheckpoint with attribute={name!r} wrote it, and "
+                f"the SRGAN template writes both kinds into one dirpath. Its metadata "
+                f"describes only that component, so none of the generator checks "
+                f"(architecture, processor, output range, upscaling factor) can run "
+                f"against it. Point init_from at the sr-weights-*.pt sibling."
             )
 
         expected = build_metadata(self)

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -51,9 +51,12 @@ class SRGANLightning(SRLightning):
     :meth:`training_step`). One consequence is worth stating up front:
     ``trainer.global_step`` counts **optimizer** steps, and this module takes
     two per batch, so after ``N`` batches it reads ``N + N // k`` rather than
-    ``N``. Every step-denominated knob (``max_steps``, ``val_check_interval``,
-    checkpoint filenames) is in that unit — a ``max_steps`` copied from the
+    ``N``. Every global-step knob (``max_steps``, checkpoint filenames,
+    ``every_n_train_steps``) is in that unit — a ``max_steps`` copied from the
     SRResNet template therefore trains for roughly half the batches.
+    ``val_check_interval`` is *not*: Lightning counts it in batches whenever
+    ``check_val_every_n_epoch`` is ``None``, as does this module's own
+    scheduler stepping (:meth:`on_train_batch_end`).
 
     Args:
         model: The generator — an initialised :class:`SRModel` subclass,

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -104,6 +104,19 @@ class SRGANLightning(SRLightning):
             optimizer=optimizer,
             lr_scheduler=lr_scheduler,
         )
+        # The type hint is not enforced at runtime, and everything this module
+        # asserts about its config rests on the subclass: the base carries no
+        # adversarial_weight/d_steps_per_g_step, and does not refuse cuda_graph.
+        if not isinstance(self.training_config, SRGANTrainingConfig):
+            raise TypeError(
+                f"training_config must be an SRGANTrainingConfig, got "
+                f"{type(self.training_config).__name__}. This module reads "
+                f"adversarial_weight and d_steps_per_g_step off it on every step, and "
+                f"only that subclass refuses cuda_graph — which no two-optimizer manual "
+                f"loop can honour, and which SRLightning.on_fit_start would otherwise "
+                f"accept and start checking graph prerequisites for."
+            )
+
         # The correlated check SRGANTrainingConfig.validate_against cannot do:
         # its (model, processor) signature never sees the discriminator.
         if discriminator.hparams["in_channels"] != processor.model_channels:
@@ -141,7 +154,23 @@ class SRGANLightning(SRLightning):
             set. The shape is always this pair — never a bare optimizer list —
             so callers never branch on it; :meth:`training_step` unpacks the
             optimizers positionally and the order is part of the contract.
+
+        Raises:
+            ValueError: If ``training_config.layer_lrs`` is set.
         """
+        # Inherited through SRResNetTrainingConfig, so YAML can set it; this
+        # override never reads it, and a silent uniform-LR fallback is the one
+        # unsignalled misconfiguration in a module that refuses four others.
+        if self.training_config.layer_lrs is not None:
+            raise ValueError(
+                f"training_config.layer_lrs is not supported for adversarial training "
+                f"(got {len(self.training_config.layer_lrs)} entries). SRLightning's "
+                f"per-Conv2d param_groups are built by the base configure_optimizers, "
+                f"which this override replaces to build one optimizer per network, so "
+                f"the setting would be silently ignored and both networks would train "
+                f"at their optimizer's uniform lr. Set layer_lrs to null and tune "
+                f"optimizer.lr / discriminator_optimizer.lr instead."
+            )
         opt_g = self.optimizer(self.model.parameters())
         opt_d = self.discriminator_optimizer(self.discriminator.parameters())
         schedulers = []
@@ -257,8 +286,9 @@ class SRGANLightning(SRLightning):
 
         The base's CUDA-graph path is unreachable from here — it is gated on
         ``training_config.cuda_graph``, which :class:`SRGANTrainingConfig`
-        refuses at construction — so what ``super()`` contributes is the
-        ``torch.compile`` warm-up and the graph-state reset.
+        refuses at construction, and :meth:`__init__` refuses any other config
+        type — so what ``super()`` contributes is the ``torch.compile`` warm-up
+        and the graph-state reset.
 
         Raises:
             RuntimeError: If ``trainer.world_size > 1``.
@@ -275,26 +305,45 @@ class SRGANLightning(SRLightning):
         super().on_fit_start()
 
     def _extra_probe(self, lr: torch.Tensor, hr: torch.Tensor, source: str) -> None:
-        """Check the discriminator's declared input size against the real HR crop.
+        """Check the discriminator's declared input size against the HR crop it will score.
+
+        Keys on the **post-crop** size, not the raw HR patch: what
+        :meth:`training_step` feeds the discriminator is
+        ``extract_target(hr_cropped)``, and ``_forward_sr`` center-crops HR to
+        the generator's output size. The two coincide only while the generator
+        emits exactly ``scale x lr``, which is an SRResNet property rather than
+        anything this module requires.
+
+        The probe forward runs in ``eval`` mode under ``no_grad`` — a train-mode
+        forward would fold this sample into the generator's BatchNorm running
+        statistics before training has taken a single step.
 
         Args:
-            lr: LR sample, ``(C, H, W)``. Unused — the discriminator only ever
-                sees HR-sized tensors.
+            lr: LR sample, ``(C, H, W)``.
             hr: HR sample, ``(C, H, W)``.
             source: Config path the sample came from, for the error message.
 
         Raises:
-            ValueError: If the HR patch is not square at the declared
-                ``hr_input_size``.
+            ValueError: If the cropped HR the discriminator would score is not
+                square at the declared ``hr_input_size``.
         """
         declared = self.discriminator.hparams["hr_input_size"]
-        actual = tuple(hr.shape[-2:])
+        was_training = self.model.training
+        self.model.eval()
+        try:
+            with torch.no_grad():
+                _, _, hr_cropped = self._forward_sr(lr[None], hr[None], need_sr_rgb=False)
+        finally:
+            self.model.train(was_training)
+        actual = tuple(self.processor.extract_target(hr_cropped).shape[-2:])
         if actual == (declared, declared):
             return
         raise ValueError(
-            f"discriminator hr_input_size={declared} does not match the HR patch "
-            f"data.{source} serves ({actual[0]}x{actual[1]}). The discriminator's "
-            f"dense head fixes its input size, so a mismatch is a raw Linear shape "
-            f"error on the first step otherwise. Set hr_crop_size={declared} on the "
-            f"train dataset, or hr_input_size={actual[0]} on the discriminator."
+            f"discriminator hr_input_size={declared} does not match the HR crop it "
+            f"would score ({actual[0]}x{actual[1]}) for the samples data.{source} "
+            f"serves ({tuple(hr.shape[-2:])} before {type(self.model).__name__}'s "
+            f"output size crops it). The discriminator's dense head fixes its input "
+            f"size, so a mismatch is a raw Linear shape error on the first step "
+            f"otherwise. Set hr_input_size={actual[0]} on the discriminator, or size "
+            f"the dataset's crops so the generator emits {declared}x{declared}."
         )

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -249,6 +249,7 @@ class SRLightning(lightning.LightningModule):
                 source, dataset = probe
                 lr, hr = self._sample_zero(dataset)
                 self._check_input_contract(lr, hr, source, dataset)
+                self._extra_probe(lr, hr, source)
                 if source == "train_dataset":
                     train_lr = lr  # reuse below instead of re-sampling index 0
 
@@ -399,6 +400,20 @@ class SRLightning(lightning.LightningModule):
             f"native-LR dataset (e.g. sisr.datasets.srresnet), or fix "
             f"training_config.scale."
         )
+
+    def _extra_probe(self, lr: torch.Tensor, hr: torch.Tensor, source: str) -> None:
+        """Subclass hook: additional checks against a real ``(lr, hr)`` sample.
+
+        No-op by default. Exists so a subclass can validate its own components
+        against real data without repeating :meth:`setup`'s RNG snapshot and
+        pickle-clone sampling — repeating that means consuming random draws the
+        training loop needs, which shifts every seeded crop after it.
+
+        Args:
+            lr: LR sample, ``(C, H, W)``.
+            hr: HR sample, ``(C, H, W)``.
+            source: Config path the sample came from, for error messages.
+        """
 
     def _check_example_input_shape(self, lr: torch.Tensor, train_dataset: Any) -> None:
         """Raise if ``example_input_shape``'s H/W disagrees with the real train LR patch.

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -163,11 +163,21 @@ data:
     # cost, and num_workers=0 hits a hard serial floor (real DIV2K steady-state:
     # 56.0 ms/step at w0 vs 40.1 ms/step at w16 -- 0.72x). The ~2-minute one-time
     # spawn cost amortizes to nothing over a full run.
+    # These counts OOM'd host RAM on a 16-worker box -- see the note beside
+    # val_dataloader_kwargs below.
     num_workers: 16
     pin_memory: true
     persistent_workers: true
   val_dataloader_kwargs:
     batch_size: 1
+    # These worker counts (16 train, 2 val) OOM'd host RAM on a 16-worker box: a
+    # val worker's float64 imresize on a full-size DIV2K image (2040px wide)
+    # raised numpy._ArrayMemoryError, at the FIRST validation, not step 0. This
+    # module is more exposed than the SRResNet template on the same data path --
+    # a resident discriminator plus a VGG19 feature extractor eat the RAM the
+    # SRResNet template doesn't need. A smoke run only got through at 4 train /
+    # 0 val workers; the safe counts on any given box are unmeasured -- lower
+    # these if you OOM.
     num_workers: 2
     persistent_workers: true
 

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -1,0 +1,254 @@
+seed_everything: 42
+
+# TF32 matmul on Ampere+ GPUs. Measured no-op on this repo's conv stacks: conv runs
+# through cuDNN, whose allow_tf32 already defaults True — kept for matmul-heavy archs.
+matmul_precision: high
+
+# The GENERATOR's optimizer. Linked into model.init_args.optimizer by SRLightningCLI.
+# The discriminator's is nested under model.init_args below — see the comment there.
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1.0e-4
+
+# No lr_scheduler by default. SRGANLightning steps its schedulers by hand in
+# on_train_batch_end (manual optimization does not step them), so milestones are
+# counted in BATCHES — not the global-step unit everything under trainer: uses.
+# Ledig et al. decay 1e-4 -> 1e-5 after 1e5 generator iterations, which is exactly
+# where max_steps below stops; running the paper's second phase means raising
+# max_steps to 400000 and uncommenting this.
+# lr_scheduler:
+#   class_path: torch.optim.lr_scheduler.MultiStepLR
+#   init_args:
+#     milestones: [100000]   # BATCHES, not global steps
+#     gamma: 0.1
+
+model:
+  class_path: sisr.training.SRGANLightning
+  init_args:
+      # The generator: the same SRResNet the baseline template trains, unchanged.
+      # Only how it is trained differs.
+      model:
+        class_path: sisr.models.srresnet.SRResNet
+        init_args:
+          scale: &scale 4
+          in_out_channels: 3
+          hidden_channel: 64
+          kernel_sizes: [9, 3, 9]
+          num_residual_blocks: 16
+          padding: same
+      processor:
+        # Paper's range (Ledig et al. §3.2): LR [0,1] in, HR/target [-1,1]. The
+        # discriminator scores the generator's output in THIS space, so changing
+        # the processor renumbers what the critic is trained on.
+        class_path: sisr.processors.RGBSignedOutputProcessor
+      # The generator's CONTENT loss. The adversarial term is added on top by
+      # SRGANLightning, weighted by training_config.adversarial_weight.
+      # phi_{5,4} is SRGAN-VGG54, the paper's headline variant. NO total-variation
+      # term: Ledig et al. scope TV at 2e-8 to SRResNet-VGG22, not to the GAN
+      # variants, and adding one here is not the published recipe.
+      # First use downloads ~548 MB of VGG19 weights to the torch hub cache.
+      criterion:
+        class_path: sisr.losses.VGG19FeatureLoss
+        init_args:
+          layer: vgg54
+      # The critic. Its dense head fixes the accepted input size, so hr_input_size
+      # must equal the HR crop the training data serves — data.train_dataset.
+      # hr_crop_size below is anchored to this very value, and SRGANLightning's
+      # setup probe re-checks it against a real sample before the first step.
+      discriminator:
+        class_path: sisr.models.srgan.SRDiscriminator
+        init_args:
+          hr_input_size: &hr_crop 96
+      # Nested under model.init_args rather than being a second top-level key
+      # alongside optimizer:. A top-level one would need a second
+      # parser.add_optimizer_args(link_to=...) in SRLightningCLI, and that link
+      # targets an argument SRLightning does not have — it would break every
+      # non-GAN config the moment it were added. Nesting keeps the second
+      # optimizer local to the only module that has one.
+      discriminator_optimizer:
+        class_path: torch.optim.Adam
+        init_args:
+          lr: 1.0e-4
+      # discriminator_lr_scheduler: same shape, also nested; unset by default.
+      # adversarial_loss: unset means sisr.losses.AdversarialLoss — the
+      # non-saturating objective over the discriminator's LOGITS. Do not pair it
+      # with a sigmoid-terminated critic; SRDiscriminator deliberately emits logits.
+      training_config:
+        class_path: sisr.models.srgan.SRGANTrainingConfig
+        init_args:
+          # Ledig et al. scope the MSE-initialisation trick to "when training the
+          # actual GAN", so a paper-faithful run starts from an MSE-trained
+          # SRResNet — this repo's golden 1e6-step baseline. Bare weights (.pt),
+          # never the sibling .ckpt: a .ckpt holds the whole LightningModule.
+          # The generator's architecture, processor, output range and scale are
+          # all checked against the file's own metadata and refused on any
+          # mismatch — loading weights trained under a different one produces a
+          # model that trains and scores without ever erroring.
+          # Set to null to train the GAN from scratch (not the paper's recipe).
+          init_from: "experiments/SRResNet/golden/checkpoints/sr-weights-1000000-psnr_val_RGB=28.8635.pt"
+          # Matches the real training input: RGB at hr_crop_size / scale. Not only a
+          # TensorBoard-graph dummy -- it also shapes the compile warm-up (a wrong size
+          # compiles once then recompiles on step 1) and ModelSummary's FLOPs.
+          example_input_shape: [3, 24, 24]
+          # adversarial_weight: 1.0e-3 (paper) and d_steps_per_g_step: 1
+          # (Goodfellow's k, Ledig's 1:1 alternation) are the dataclass defaults.
+          # cuda_graph is refused outright here — no two-optimizer manual loop can
+          # honour a capture built around one optimizer.
+      # No init_args: the dataclass already adds lpips + dists on top of the
+      # SRResNet scoring (crop_border 4, PSNR on RGB+Y, daala SSIM). An adversarial
+      # objective makes PSNR and SSIM WORSE by design, so the perceptual pair is
+      # the only metric family that tracks what this run is actually optimising.
+      # 'lpips' needs the [perceptual] extra installed.
+      eval_config:
+        class_path: sisr.models.srgan.SRGANEvalConfig
+
+data:
+  # LR is derived via MATLAB-compatible antialiased bicubic resizing (see
+  # sisr/imresize.py), comparable to published paper numbers.
+  train_dataset:
+    class_path: sisr.datasets.srresnet.TrainDataset
+    init_args:
+      img_dir: data/DIV2K_train_HR
+      scale: *scale
+      # Anchored to the discriminator's hr_input_size above: the critic scores
+      # this exact crop, and a mismatch is a raw Linear shape error otherwise.
+      hr_crop_size: *hr_crop
+      crops_per_image: 1
+      use_tqdm: true
+      cache_dir: .lmdb_cache/DIV2K_train_HR
+  val_dataset:
+    class_path: sisr.datasets.srresnet.ValidationDataset
+    init_args:
+      img_dir: data/DIV2K_valid_HR
+      scale: *scale
+  test_datasets:
+    Set5:
+      class_path: sisr.datasets.srresnet.ValidationDataset
+      init_args:
+        img_dir: data/Set5_HR
+        scale: *scale
+    Set14:
+      class_path: sisr.datasets.srresnet.ValidationDataset
+      init_args:
+        img_dir: data/Set14_HR
+        scale: *scale
+    BSD100:
+      class_path: sisr.datasets.srresnet.ValidationDataset
+      init_args:
+        img_dir: data/BSD100_HR
+        scale: *scale
+  train_dataloader_kwargs:
+    batch_size: 16
+    # Workers are load-bearing on real data: per-sample LR derivation is a real
+    # cost, and num_workers=0 hits a hard serial floor (real DIV2K steady-state:
+    # 56.0 ms/step at w0 vs 40.1 ms/step at w16 -- 0.72x). The ~2-minute one-time
+    # spawn cost amortizes to nothing over a full run.
+    num_workers: 16
+    pin_memory: true
+    persistent_workers: true
+  val_dataloader_kwargs:
+    batch_size: 1
+    num_workers: 2
+    persistent_workers: true
+
+trainer:
+  max_epochs: -1
+  # global_step counts optimizer steps, and this module takes TWO per batch (one
+  # discriminator, one generator), so it advances N + N//k per N batches -- 2x at
+  # the default k=1. That is unchanged Lightning behaviour, not a quirk of manual
+  # optimization: measured, manual optimization with a SINGLE optimizer still
+  # gives global_step == batches. Every other architecture here is unaffected.
+  # max_steps, val_check_interval and checkpoint filenames are all in global-step
+  # units. every_n_train_steps is too, and its condition is checked once per
+  # batch -- so an EVEN value halves the batch cadence (1000 -> every 500
+  # batches) while an odd one does not (5 -> still every 5). The LR scheduler is
+  # stepped by hand per batch, so its milestones are in BATCHES.
+  # 200000 here = the paper's 1e5 generator iterations.
+  max_steps: 200000
+  val_check_interval: 10000
+  check_val_every_n_epoch: null
+  num_sanity_val_steps: -1
+  log_every_n_steps: 1000
+  deterministic: false
+  # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
+  # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
+  # above, hence it lives here rather than as a custom key.
+  benchmark: true
+  accelerator: cuda
+  # One device only. SRGANLightning refuses world_size > 1: manual optimization
+  # opts out of Lightning's gradient synchronisation, so the two networks would
+  # train out of sync across ranks with nothing failing.
+  devices: [0]
+  enable_progress_bar: true
+  enable_model_summary: true
+  callbacks:
+    - class_path: sisr.training.BenchmarkImageLogger
+      init_args:
+        log_every_n_val_runs: 1
+    # Primary artifacts: rolling, monitor-free. PSNR and SSIM get WORSE by design
+    # under an adversarial objective, so top-k on either would keep the LEAST
+    # adversarial state of the run (typically one from the first few thousand
+    # steps). Rolling keeps the last `keep_last` saves by step instead.
+    # every_n_train_steps is in GLOBAL steps -- see the max_steps comment above:
+    # 10000 is even, so it fires every 5000 batches.
+    - class_path: sisr.training.SRCheckpoint
+      init_args:
+        monitor_metric: null
+        keep_last: 3
+        every_n_train_steps: 10000
+    # Distributable, optimizer-free weights (.pt) for BOTH networks. The generator
+    # is what gets handed out; the discriminator's is what makes a run resumable
+    # as a GAN from bare weights alone. Distinct filename_prefix keeps each
+    # callback's rolling deletion off the other's files in a shared dirpath.
+    - class_path: sisr.training.SRWeightsCheckpoint
+      init_args:
+        monitor_metric: null
+        keep_last: 3
+        every_n_train_steps: 10000
+        attribute: model
+        filename_prefix: sr-weights
+    - class_path: sisr.training.SRWeightsCheckpoint
+      init_args:
+        monitor_metric: null
+        keep_last: 3
+        every_n_train_steps: 10000
+        attribute: discriminator
+        filename_prefix: d-weights
+    # --- Metric-monitored alternatives, for reference. NOT enabled. ---
+    # A PSNR- or SSIM-monitored "best" tracks the least adversarial model here,
+    # which is the opposite of what this run is for. A perceptual monitor tracks
+    # the objective, but lpips/dists are lower-is-better: mode MUST be min, or
+    # the callback silently keeps the worst checkpoint of the run (SRCheckpoint
+    # refuses the wrong direction at setup rather than letting that happen).
+    # - class_path: sisr.training.SRCheckpoint
+    #   init_args:
+    #     monitor_metric: lpips/val
+    #     mode: min
+    #     save_top_k: 3
+    # - class_path: sisr.training.SRWeightsCheckpoint
+    #   init_args:
+    #     monitor_metric: lpips/val
+    #     mode: min
+    #     save_top_k: 3
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    # GradNormLogger is deliberately absent. Measured on this module: its
+    # on_after_backward hook fires TWICE per batch (once per network's backward),
+    # and pl_module.parameters() spans both networks (58 tensors = 24 generator +
+    # 34 discriminator), so the single diag/grad_norm scalar it logs mixes the two
+    # and alternates between two different meanings. Log per-network norms by hand
+    # if you need them.
+  logger:
+    - class_path: lightning.pytorch.loggers.TensorBoardLogger
+      init_args:
+        <<: &log_dest
+          save_dir: experiments
+          name: SRGAN
+          version: baseline
+        log_graph: true
+        default_hp_metric: false
+    - class_path: lightning.pytorch.loggers.CSVLogger
+      init_args:
+        <<: *log_dest

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -86,7 +86,10 @@ model:
           # all checked against the file's own metadata and refused on any
           # mismatch — loading weights trained under a different one produces a
           # model that trains and scores without ever erroring.
-          # Set to null to train the GAN from scratch (not the paper's recipe).
+          # Set to null HERE (or in a --config overlay) to train the GAN from
+          # scratch -- not the paper's recipe. --...init_from=null on the command
+          # line does not work: jsonargparse coerces it to the string 'None',
+          # which SRGANLightning refuses by name rather than hunting for a file.
           init_from: "experiments/SRResNet/golden/checkpoints/sr-weights-1000000-psnr_val_RGB=28.8635.pt"
           # Matches the real training input: RGB at hr_crop_size / scale. Not only a
           # TensorBoard-graph dummy -- it also shapes the compile warm-up (a wrong size

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -11,17 +11,16 @@ optimizer:
   init_args:
     lr: 1.0e-4
 
-# No lr_scheduler by default. SRGANLightning steps its schedulers by hand in
-# on_train_batch_end (manual optimization does not step them), so milestones are
-# counted in BATCHES — not the global-step unit everything under trainer: uses.
-# Ledig et al. decay 1e-4 -> 1e-5 after 1e5 generator iterations, which is exactly
-# where max_steps below stops; running the paper's second phase means raising
-# max_steps to 400000 and uncommenting this.
-# lr_scheduler:
-#   class_path: torch.optim.lr_scheduler.MultiStepLR
-#   init_args:
-#     milestones: [100000]   # BATCHES, not global steps
-#     gamma: 0.1
+# The generator's LR schedule, and the paper's second training phase: Ledig et al.
+# decay 1e-4 -> 1e-5 after 1e5 generator iterations, then train 1e5 more.
+# SRGANLightning steps its schedulers by hand in on_train_batch_end (manual
+# optimization does not step them), so milestones are counted in BATCHES — at the
+# default k=1 one batch is one generator iteration.
+lr_scheduler:
+  class_path: torch.optim.lr_scheduler.MultiStepLR
+  init_args:
+    milestones: [100000]   # BATCHES, not global steps
+    gamma: 0.1
 
 model:
   class_path: sisr.training.SRGANLightning
@@ -70,7 +69,9 @@ model:
         class_path: torch.optim.Adam
         init_args:
           lr: 1.0e-4
-      # discriminator_lr_scheduler: same shape, also nested; unset by default.
+      # discriminator_lr_scheduler: same shape, also nested. Unset, so the critic
+      # holds 1e-4 while the generator decays -- Ledig et al. give one schedule
+      # without splitting it per network.
       # adversarial_loss: unset means sisr.losses.AdversarialLoss — the
       # non-saturating objective over the discriminator's LOGITS. Do not pair it
       # with a sigmoid-terminated critic; SRDiscriminator deliberately emits logits.
@@ -159,14 +160,17 @@ trainer:
   # the default k=1. That is unchanged Lightning behaviour, not a quirk of manual
   # optimization: measured, manual optimization with a SINGLE optimizer still
   # gives global_step == batches. Every other architecture here is unaffected.
-  # max_steps, val_check_interval and checkpoint filenames are all in global-step
-  # units. every_n_train_steps is too, and its condition is checked once per
-  # batch -- so an EVEN value halves the batch cadence (1000 -> every 500
-  # batches) while an odd one does not (5 -> still every 5). The LR scheduler is
-  # stepped by hand per batch, so its milestones are in BATCHES.
-  # 200000 here = the paper's 1e5 generator iterations.
-  max_steps: 200000
-  val_check_interval: 10000
+  # The units differ, so read this before changing any of them. max_steps,
+  # checkpoint filenames and every_n_train_steps are in GLOBAL STEPS;
+  # val_check_interval and the hand-stepped LR scheduler's milestones are in
+  # BATCHES (Lightning keys val_check_interval on total_batch_idx whenever
+  # check_val_every_n_epoch is null, as it is below). every_n_train_steps' own
+  # condition is checked once per batch, so an EVEN value halves the batch cadence
+  # (10000 -> every 5000 batches) while an odd one does not (5 -> still every 5).
+  # 400000 here = the paper's 2e5 generator iterations (1e5 at 1e-4 + 1e5 at 1e-5).
+  max_steps: 400000
+  # 5000 batches = every 10000 global steps: the checkpoint cadence below.
+  val_check_interval: 5000
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
   log_every_n_steps: 1000

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -180,17 +180,25 @@ trainer:
   # gives global_step == batches. Every other architecture here is unaffected.
   # The units differ, so read this before changing any of them. max_steps,
   # checkpoint filenames and every_n_train_steps are in GLOBAL STEPS;
-  # val_check_interval and the hand-stepped LR scheduler's milestones are in
-  # BATCHES (Lightning keys val_check_interval on total_batch_idx whenever
-  # check_val_every_n_epoch is null, as it is below). every_n_train_steps' own
-  # condition is checked once per batch, so an EVEN value halves the batch cadence
-  # (10000 -> every 5000 batches) while an odd one does not (5 -> still every 5).
+  # val_check_interval, log_every_n_steps and the hand-stepped LR scheduler's
+  # milestones are in BATCHES (Lightning keys val_check_interval on
+  # total_batch_idx whenever check_val_every_n_epoch is null, as it is below;
+  # log_every_n_steps tests the same _batches_that_stepped counter unconditionally
+  # -- logger_connector.py:59,64). every_n_train_steps' own condition is checked
+  # once per batch, so an EVEN value halves the batch cadence (10000 -> every
+  # 5000 batches) while an odd one does not (5 -> still every 5).
+  # _batches_that_stepped is also the DEFAULT X-AXIS every logged metric is
+  # plotted against, so TensorBoard shows this run in batches while checkpoint
+  # filenames carry global_step: sr-weights-10000.pt is the state at
+  # TensorBoard x=5000, not x=10000 -- a 2x offset between a curve and the
+  # checkpoint pulled off it.
   # 400000 here = the paper's 2e5 generator iterations (1e5 at 1e-4 + 1e5 at 1e-5).
   max_steps: 400000
   # 5000 batches = every 10000 global steps: the checkpoint cadence below.
   val_check_interval: 5000
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
+  # BATCHES too -- see the units comment above.
   log_every_n_steps: 1000
   deterministic: false
   # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
@@ -219,10 +227,12 @@ trainer:
         monitor_metric: null
         keep_last: 3
         every_n_train_steps: 10000
-    # Distributable, optimizer-free weights (.pt) for BOTH networks. The generator
-    # is what gets handed out; the discriminator's is what makes a run resumable
-    # as a GAN from bare weights alone. Distinct filename_prefix keeps each
-    # callback's rolling deletion off the other's files in a shared dirpath.
+    # Distributable, optimizer-free weights (.pt) for BOTH networks. The generator's
+    # is what gets handed out, and is what init_from above consumes. The
+    # discriminator's is kept so the critic can be restored by hand, or by a
+    # future run that accepts one -- nothing shipped consumes a d-weights-*.pt
+    # today; there is no init_discriminator_from. Distinct filename_prefix keeps
+    # each callback's rolling deletion off the other's files in a shared dirpath.
     - class_path: sisr.training.SRWeightsCheckpoint
       init_args:
         monitor_metric: null

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -12,7 +12,12 @@ optimizer:
     lr: 1.0e-4
 
 # The generator's LR schedule, and the paper's second training phase: Ledig et al.
-# decay 1e-4 -> 1e-5 after 1e5 generator iterations, then train 1e5 more.
+# decay 1e-4 -> 1e-5 after 1e5 generator iterations, then train 1e5 more. The
+# discriminator_lr_scheduler nested under model.init_args below mirrors this
+# block exactly, so both networks decay together — Ledig's sentence describes
+# the SRGAN networks as a whole, not the generator alone, and a critic left at
+# 1e-4 for the whole second phase while the generator drops to 1e-5 is a
+# standard way to saturate the generator's adversarial gradient.
 # SRGANLightning steps its schedulers by hand in on_train_batch_end (manual
 # optimization does not step them), so milestones are counted in BATCHES — at the
 # default k=1 one batch is one generator iteration.
@@ -69,9 +74,19 @@ model:
         class_path: torch.optim.Adam
         init_args:
           lr: 1.0e-4
-      # discriminator_lr_scheduler: same shape, also nested. Unset, so the critic
-      # holds 1e-4 while the generator decays -- Ledig et al. give one schedule
-      # without splitting it per network.
+      # Same shape as the top-level lr_scheduler:, also nested, and set to the
+      # same milestone/gamma so both networks decay together. Ledig et al.'s
+      # sentence ("All SRGAN variants were trained with 1e5 update iterations
+      # at a learning rate of 1e-4 and another 1e5 iterations at a lower rate
+      # of 1e-5") describes the SRGAN networks as a whole; leaving this unset
+      # would hold the critic at 1e-4 for the entire second phase while the
+      # generator it scores drops to 1e-5 — 10x faster, a standard way to
+      # saturate the generator's adversarial gradient.
+      discriminator_lr_scheduler:
+        class_path: torch.optim.lr_scheduler.MultiStepLR
+        init_args:
+          milestones: [100000]   # BATCHES, not global steps
+          gamma: 0.1
       # adversarial_loss: unset means sisr.losses.AdversarialLoss — the
       # non-saturating objective over the discriminator's LOGITS. Do not pair it
       # with a sigmoid-terminated critic; SRDiscriminator deliberately emits logits.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,6 +375,70 @@ def test_srgan_template_ships_a_real_init_from_path():
     assert "sr-weights" in init_from
 
 
+@_ignore_random_vgg
+def test_dotted_override_reverts_eval_config_but_not_training_config(tmp_path: Path):
+    """Characterisation: a dotted CLI override of one nested field is not neutral.
+
+    jsonargparse rebuilds the whole subclass field from its *bare annotation*
+    when a dotted override touches it, so the outcome depends on how the
+    module's ``__init__`` types that argument:
+
+    * ``training_config`` is annotated ``SRGANTrainingConfig | None`` — the bare
+      annotation already **is** the subclass, so nothing is lost.
+    * ``eval_config`` is annotated ``SREvalConfig | None`` on the base module, so
+      overriding any field on it silently drops back to the base class and every
+      subclass-only default with it: ``perceptual_metrics`` empties (the only
+      metric family an adversarial run can be judged by) and ``ssim_impl`` flips
+      from ``'daala'`` to ``'wang'``, renumbering SSIM against a different
+      convention. Nothing is logged.
+
+    **The second half is a known open defect, not desired behaviour.** It is
+    pinned here so a jsonargparse release that changes the merge — in either
+    direction — shows up as a failing test rather than as a silently different
+    experiment. The same annotation-dependence governs the checkpoint-reload
+    merge in ``_parse_ckpt_path``.
+    """
+    from sisr.models.srgan import SRGANEvalConfig, SRGANTrainingConfig
+    from sisr.training import SREvalConfig
+
+    overlay = tmp_path / "overlay.yaml"
+    overlay.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "init_args": {
+                        "training_config": {
+                            "init_args": {"init_from": str(tmp_path / "absent.pt")}
+                        },
+                        "criterion": {
+                            "class_path": "sisr.losses.VGG19FeatureLoss",
+                            "init_args": {"layer": "vgg54", "weights": None},
+                        },
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    args = ["--config", str(SRGAN_TEMPLATE), "--config", str(overlay)]
+
+    kept = _resolve(*args, "--model.init_args.training_config.adversarial_weight=0.5").model
+    assert isinstance(kept.training_config, SRGANTrainingConfig)
+    assert kept.training_config.adversarial_weight == pytest.approx(0.5)
+    # Both are absent from the base class or default differently there, so their
+    # survival is what says no rebuild happened.
+    assert kept.training_config.init_from == str(tmp_path / "absent.pt")
+    assert kept.training_config.example_input_shape == (3, 24, 24)
+
+    reverted = _resolve(*args, "--model.init_args.eval_config.crop_border=0").model
+    assert not isinstance(reverted.eval_config, SRGANEvalConfig)
+    assert type(reverted.eval_config) is SREvalConfig
+    assert reverted.eval_config.crop_border == 0
+    assert reverted.eval_config.perceptual_metrics == []
+    assert reverted.eval_config.ssim_impl == "wang"
+
+
 def test_composite_criterion_resolves_through_the_real_cli(tmp_path: Path):
     """The paper's SRResNet-VGG22 recipe (Ledig et al. §3.4: a VGG22 content
     term plus total variation at 2e-8, no pixel term) resolved from YAML through

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -838,7 +838,7 @@ def _build_srresnet_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path) -> tupl
     Mirrors ``_build_srcnn_checkpoint``, but over SRResNet's native-LR pipeline
     and its ``SRResNetEvalConfig`` — the only shipped eval_config subclass with
     a subclass-only default (``ssim_impl='daala'``), which is what
-    ``test_ckpt_path_loses_subclass_only_eval_defaults`` needs to observe.
+    ``test_ckpt_path_preserves_eval_config_subclass_identity`` needs to observe.
     """
     ckpt_dir = tmp_path / "checkpoints"
     config = {
@@ -984,8 +984,15 @@ def test_ckpt_path_preserves_eval_config_subclass_identity(
     type (base ``SREvalConfig``) from the checkpoint's stored dict instead of
     merging onto the class the config file already selected
     (``SRResNetEvalConfig``) — the two assertions below can fail independently:
-    the reloaded object's *class*, and a subclass-only *default* the checkpoint's
-    stored dict never mentions at all.
+    the reloaded object's *class*, a subclass-only *default* the checkpoint's
+    stored dict never mentions at all, and a stored value that differs from the
+    one ``--config`` resolves to.
+
+    That third assertion is what makes the other two non-vacuous: ``--config``
+    alone already selects ``SRResNetEvalConfig`` and already yields
+    ``ssim_impl='daala'``, so both checkpoints below have their stored
+    ``crop_border`` rewritten to 7 — a value nothing in the config produces (the
+    class default is 4). Deleting the merge entirely leaves 4 behind and fails.
 
     ``_parse_ckpt_path`` merges the reconstructed ``training_config``/
     ``eval_config`` dict through the *subcommand's own* parser
@@ -1013,22 +1020,30 @@ def test_ckpt_path_preserves_eval_config_subclass_identity(
     # ssim_impl='daala' default must still apply on reload, not the base's
     # 'wang'.
     raw = torch.load(ckpt_path, weights_only=True, map_location="cpu")
-    legacy_hparams = {k: dict(v) for k, v in raw["hyper_parameters"].items()}
+    current_hparams = {k: dict(v) for k, v in raw["hyper_parameters"].items()}
+    current_hparams["eval_config"]["crop_border"] = 7
+    legacy_hparams = {k: dict(v) for k, v in current_hparams.items()}
     del legacy_hparams["eval_config"]["ssim_impl"]
-    raw["hyper_parameters"] = legacy_hparams
+
     legacy_ckpt_path = tmp_path / "legacy.ckpt"
-    torch.save(raw, legacy_ckpt_path)
+    torch.save({**raw, "hyper_parameters": legacy_hparams}, legacy_ckpt_path)
+    current_ckpt_path = tmp_path / "current.ckpt"
+    torch.save({**raw, "hyper_parameters": current_hparams}, current_ckpt_path)
 
     cli = _run_cli(["validate", "--config", str(config_path), "--ckpt_path", str(legacy_ckpt_path)])
     assert isinstance(cli.model.eval_config, SRResNetEvalConfig)
     assert cli.model.eval_config.ssim_impl == "daala"
+    assert cli.model.eval_config.crop_border == 7
 
     # A checkpoint saved by the current code carries `ssim_impl` explicitly
     # (dataclasses.asdict includes every current field) — confirms identity
     # holds for the ordinary round trip too, not just the missing-key case above.
-    cli = _run_cli(["validate", "--config", str(config_path), "--ckpt_path", str(ckpt_path)])
+    cli = _run_cli(
+        ["validate", "--config", str(config_path), "--ckpt_path", str(current_ckpt_path)]
+    )
     assert isinstance(cli.model.eval_config, SRResNetEvalConfig)
     assert cli.model.eval_config.ssim_impl == "daala"
+    assert cli.model.eval_config.crop_border == 7
 
 
 def test_reconstruct_ckpt_hparams_unflattens_legacy_keys():
@@ -1139,12 +1154,17 @@ def test_ckpt_path_reload_survives_subclass_mode(tmp_path, monkeypatch):
 
     monkeypatch.setattr(lightning.pytorch.Trainer, "validate", _noop_validate)
 
+    # Every stored value here is one the resolved config does NOT produce:
+    # SUBCLASS_MODE_CONFIG sets example_input_shape [3, 24, 24] and selects
+    # SRResNetEvalConfig, whose crop_border default is 4. Storing the config's
+    # own values instead would make the assertions below pass with the whole
+    # merge deleted.
     ckpt = tmp_path / "fake.ckpt"
     torch.save(
         {
             "hyper_parameters": {
-                "training_config": {"example_input_shape": [3, 24, 24]},
-                "eval_config": {"crop_border": 4},
+                "training_config": {"example_input_shape": [3, 32, 32]},
+                "eval_config": {"crop_border": 7},
             }
         },
         ckpt,
@@ -1175,4 +1195,8 @@ def test_ckpt_path_reload_survives_subclass_mode(tmp_path, monkeypatch):
             )
     finally:
         sys.argv = saved_argv
-    assert cli.model.eval_config.crop_border == 4
+    assert cli.model.eval_config.crop_border == 7
+    # A tuple, not the stored list: the merge lands on the dataclass field, whose
+    # annotation coerces it — more evidence the value came through the config
+    # machinery rather than being read off the checkpoint dict directly.
+    assert cli.model.training_config.example_input_shape == (3, 32, 32)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,46 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE = REPO_ROOT / "templates" / "config.srcnn.template.yaml"
 SRRESNET_TEMPLATE = REPO_ROOT / "templates" / "config.srresnet.template.yaml"
+SRGAN_TEMPLATE = REPO_ROOT / "templates" / "config.srgan.template.yaml"
+
+_ignore_random_vgg = pytest.mark.filterwarnings("ignore:.*randomly initialised.*:UserWarning")
+
+
+def _offline_args(template_path: Path, tmp_path: Path) -> list[str]:
+    """Extra ``--config`` overlay a template needs to resolve off a training box.
+
+    Only the SRGAN template needs one; every other template resolves as shipped.
+    Written as an overlay rather than ``--key=null`` because jsonargparse coerces
+    a ``null`` CLI value for a ``str | None`` field to the *string* ``'None'``,
+    which is exactly the silent-wrong-value class these two settings guard.
+
+    ``init_from`` points at a golden ``.pt`` under the gitignored ``experiments/``
+    tree — present on a training box, absent in CI and in every worktree.
+    ``criterion.weights`` would otherwise download ~548 MB of VGG19 weights just
+    to resolve a config; ``null`` builds a random VGG (and warns).
+    """
+    if template_path.name != SRGAN_TEMPLATE.name:
+        return []
+    overlay = tmp_path / "srgan_offline_overlay.yaml"
+    overlay.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "init_args": {
+                        "training_config": {"init_args": {"init_from": None}},
+                        "criterion": {
+                            "class_path": "sisr.losses.VGG19FeatureLoss",
+                            "init_args": {"layer": "vgg54", "weights": None},
+                        },
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return ["--config", str(overlay)]
+
 
 SUBCLASS_MODE_CONFIG = """
 optimizer:
@@ -196,6 +236,67 @@ def test_srresnet_config_resolves_in_process():
     # The removed model_colorspace field must not reappear anywhere.
     assert not hasattr(m, "model_colorspace")
     assert not hasattr(m.eval_config, "model_colorspace")
+
+
+@_ignore_random_vgg
+def test_srgan_template_parses_and_builds(tmp_path: Path):
+    """The YAML path is the whole point; constructing the module in Python proves
+    nothing about it. A prior arc shipped a composite-loss feature whose only
+    tests built it in Python, leaving the YAML wiring — the deliverable —
+    unguarded.
+
+    The nested discriminator/discriminator_optimizer blocks are the part most
+    likely to break: they are nested under ``model.init_args`` rather than
+    top-level precisely because a second ``add_optimizer_args(link_to=...)``
+    would target an argument ``SRLightning`` does not have, so nothing else in
+    the repo exercises that shape.
+    """
+    from sisr.losses import AdversarialLoss, VGG19FeatureLoss
+    from sisr.models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
+    from sisr.models.srresnet import SRResNet
+    from sisr.processors import RGBSignedOutputProcessor
+    from sisr.training import SRGANLightning
+
+    cli = _resolve("--config", str(SRGAN_TEMPLATE), *_offline_args(SRGAN_TEMPLATE, tmp_path))
+
+    m = cli.model
+    assert isinstance(m, SRGANLightning)
+    assert isinstance(m.model, SRResNet)
+    assert isinstance(m.processor, RGBSignedOutputProcessor)
+    assert isinstance(m.discriminator, SRDiscriminator)
+    assert isinstance(m.adversarial_loss, AdversarialLoss)
+    assert isinstance(m.training_config, SRGANTrainingConfig)
+    assert isinstance(m.eval_config, SRGANEvalConfig)
+    # Ledig's phi_5,4 content loss, with no total-variation term: TV at 2e-8 is
+    # scoped in the paper to SRResNet-VGG22, not to the GAN variants.
+    assert isinstance(m.criterion, VGG19FeatureLoss)
+    assert m.criterion.layer == "vgg54"
+    assert m.training_config.adversarial_weight == pytest.approx(1e-3)
+    # The discriminator's dense head fixes its input size, so the train crop has
+    # to agree with it or the first step is a raw Linear shape error.
+    assert m.discriminator.hparams["hr_input_size"] == 96
+    assert cli.config.data.train_dataset["init_args"]["hr_crop_size"] == 96
+    # The nested optimizer block really produces a discriminator optimizer —
+    # OptimizerCallable resolution off a nested key, not off a linked top-level one.
+    opt_d = m.discriminator_optimizer(m.discriminator.parameters())
+    assert isinstance(opt_d, torch.optim.Adam)
+    assert opt_d.param_groups[0]["lr"] == pytest.approx(1e-4)
+    assert {id(p) for group in opt_d.param_groups for p in group["params"]} == {
+        id(p) for p in m.discriminator.parameters()
+    }
+
+
+def test_srgan_template_ships_a_real_init_from_path():
+    """The template's own init_from is exercised nowhere else — the test above
+    overrides it to null so it can run without the gitignored experiments/ tree.
+    Assert the shipped value at least names a bare-weights .pt, which is the one
+    thing SRGANLightning refuses at construction time."""
+    with SRGAN_TEMPLATE.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    init_from = data["model"]["init_args"]["training_config"]["init_args"]["init_from"]
+    assert init_from.endswith(".pt")
+    assert "sr-weights" in init_from
 
 
 def test_composite_criterion_resolves_through_the_real_cli(tmp_path: Path):
@@ -513,14 +614,15 @@ def test_template_yaml_parses(template_path: Path):
     assert "trainer" in data and "model" in data and "data" in data
 
 
+@_ignore_random_vgg
 @pytest.mark.parametrize("template_path", TEMPLATE_PATHS, ids=[p.name for p in TEMPLATE_PATHS])
-def test_template_disables_default_hp_metric(template_path: Path):
+def test_template_disables_default_hp_metric(template_path: Path, tmp_path: Path):
     """Each shipped template must disable TensorBoard's hp_metric: -1 placeholder.
 
     Resolved in-process: cli.config is the same merged config --print_config would
     dump, so an inherited/overridden default is honored (checking the raw YAML
     would miss that)."""
-    cli = _resolve("--config", str(template_path))
+    cli = _resolve("--config", str(template_path), *_offline_args(template_path, tmp_path))
     loggers = cli.config.trainer.logger
     tb = next(logger for logger in loggers if str(logger.class_path).endswith("TensorBoardLogger"))
     assert tb.init_args.default_hp_metric is False, (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -284,6 +284,69 @@ def test_srgan_template_parses_and_builds(tmp_path: Path):
     assert {id(p) for group in opt_d.param_groups for p in group["params"]} == {
         id(p) for p in m.discriminator.parameters()
     }
+    # ...and the top-level lr_scheduler: key still links into the GAN module under
+    # subclass mode, which is what carries the paper's second training phase.
+    opt_g = m.optimizer(m.model.parameters())
+    assert isinstance(m.lr_scheduler(opt_g), torch.optim.lr_scheduler.MultiStepLR)
+
+
+def test_srgan_template_ships_the_papers_full_two_phase_schedule():
+    """Ledig trains 1e5 generator iterations at 1e-4, then 1e5 more at 1e-5.
+
+    This module takes two optimizer steps per batch, so 2e5 iterations is
+    ``max_steps: 400000`` *global steps*, while the decay milestone is in BATCHES —
+    ``SRGANLightning`` steps its schedulers by hand, once per batch. Shipping half
+    the schedule, or the full length with the scheduler commented out, reproduces
+    neither phase of the paper.
+
+    ``val_check_interval`` is in batches too (Lightning keys it on
+    ``total_batch_idx`` whenever ``check_val_every_n_epoch`` is null, which this
+    template sets), so 5000 there is the same 10000-global-step cadence the
+    checkpoint callbacks fire on.
+    """
+    with SRGAN_TEMPLATE.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    assert data["trainer"]["max_steps"] == 400000
+    assert data["trainer"]["check_val_every_n_epoch"] is None
+    assert data["trainer"]["val_check_interval"] == 5000
+    assert data["lr_scheduler"]["class_path"].endswith("MultiStepLR")
+    assert data["lr_scheduler"]["init_args"]["milestones"] == [100000]
+    assert data["lr_scheduler"]["init_args"]["gamma"] == pytest.approx(0.1)
+
+
+@_ignore_random_vgg
+def test_srgan_template_resolves_without_the_init_from_artifact(tmp_path: Path):
+    """Instantiating the model is what every subcommand does — ``validate``/``test``/
+    ``export --ckpt_path`` included — so reading ``init_from`` at construction made
+    all of them depend on the gitignored golden ``.pt``. This resolves the shipped
+    template with ``init_from`` pointed at a file that does not exist: it must build,
+    because nothing here is fitting.
+    """
+    overlay = tmp_path / "missing_init_from.yaml"
+    overlay.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "init_args": {
+                        "training_config": {
+                            "init_args": {"init_from": str(tmp_path / "absent.pt")}
+                        },
+                        "criterion": {
+                            "class_path": "sisr.losses.VGG19FeatureLoss",
+                            "init_args": {"layer": "vgg54", "weights": None},
+                        },
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    cli = _resolve("--config", str(SRGAN_TEMPLATE), "--config", str(overlay))
+
+    assert cli.model.training_config.init_from == str(tmp_path / "absent.pt")
 
 
 def test_srgan_template_ships_a_real_init_from_path():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -364,9 +364,9 @@ def test_srgan_template_resolves_without_the_init_from_artifact(tmp_path: Path):
 
 def test_srgan_template_ships_a_real_init_from_path():
     """The template's own init_from is exercised nowhere else — the test above
-    overrides it to null so it can run without the gitignored experiments/ tree.
-    Assert the shipped value at least names a bare-weights .pt, which is the one
-    thing SRGANLightning refuses at construction time."""
+    overrides it to a missing path so it can run without the gitignored
+    experiments/ tree. Assert the shipped value at least names a bare-weights
+    .pt, which is one of the artifacts SRGANLightning's setup refuses."""
     with SRGAN_TEMPLATE.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,6 +288,10 @@ def test_srgan_template_parses_and_builds(tmp_path: Path):
     # subclass mode, which is what carries the paper's second training phase.
     opt_g = m.optimizer(m.model.parameters())
     assert isinstance(m.lr_scheduler(opt_g), torch.optim.lr_scheduler.MultiStepLR)
+    # ...and the nested discriminator_lr_scheduler decays the critic in step with
+    # the generator — Ledig et al.'s one schedule describes the SRGAN networks as
+    # a whole, not the generator alone.
+    assert isinstance(m.discriminator_lr_scheduler(opt_d), torch.optim.lr_scheduler.MultiStepLR)
 
 
 def test_srgan_template_ships_the_papers_full_two_phase_schedule():
@@ -303,6 +307,11 @@ def test_srgan_template_ships_the_papers_full_two_phase_schedule():
     ``total_batch_idx`` whenever ``check_val_every_n_epoch`` is null, which this
     template sets), so 5000 there is the same 10000-global-step cadence the
     checkpoint callbacks fire on.
+
+    The discriminator must decay on the same schedule as the generator: Ledig et
+    al.'s sentence describes the SRGAN networks as a whole, and a critic left at
+    1e-4 for the whole second phase while the generator drops to 1e-5 is a
+    standard way to saturate the generator's adversarial gradient.
     """
     with SRGAN_TEMPLATE.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
@@ -313,6 +322,10 @@ def test_srgan_template_ships_the_papers_full_two_phase_schedule():
     assert data["lr_scheduler"]["class_path"].endswith("MultiStepLR")
     assert data["lr_scheduler"]["init_args"]["milestones"] == [100000]
     assert data["lr_scheduler"]["init_args"]["gamma"] == pytest.approx(0.1)
+    d_scheduler = data["model"]["init_args"]["discriminator_lr_scheduler"]
+    assert d_scheduler["class_path"].endswith("MultiStepLR")
+    assert d_scheduler["init_args"]["milestones"] == [100000]
+    assert d_scheduler["init_args"]["gamma"] == pytest.approx(0.1)
 
 
 @_ignore_random_vgg

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -18,6 +18,7 @@ def test_public_exports():
         SRCheckpoint,
         SRDataModule,
         SREvalConfig,
+        SRGANLightning,
         SRLightning,
         SRTrainingConfig,
         SRWeightsCheckpoint,

--- a/tests/test_perceptual.py
+++ b/tests/test_perceptual.py
@@ -1,46 +1,150 @@
+"""Perceptual-metric tests.
+
+Every test that would otherwise build a backbone monkeypatches the import seam
+(``_lpips_metric_cls`` / ``_dists_net_cls``): a real construction downloads
+~230 MB of AlexNet or ~528 MB of VGG16 into the torch hub cache, which CI has
+neither the network nor the cache for. ``_NET_CACHE`` is swapped for a fresh
+dict alongside, so a spy from one test can never be served to another.
+"""
+
 import pytest
 import torch
 
 from sisr.perceptual import PERCEPTUAL_METRICS, perceptual_score
 
 
-def test_lpips_receives_normalize_true(monkeypatch):
+class _LpipsSpy(torch.nn.Module):
+    """Stands in for ``LearnedPerceptualImagePatchSimilarity``.
+
+    Records its construction kwargs (the metric's two conventions live there
+    now, not at the call site) and whether the per-call state reset fired.
+    """
+
+    seen: dict = {}
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        _LpipsSpy.seen = {**kwargs, "constructions": _LpipsSpy.seen.get("constructions", 0) + 1}
+        self.param = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, img1, img2):
+        return torch.tensor(0.25)
+
+    def reset(self):
+        _LpipsSpy.seen["reset"] = _LpipsSpy.seen.get("reset", 0) + 1
+
+
+class _DistsSpy(torch.nn.Module):
+    """Stands in for ``DISTSNetwork`` — returns one score per image, unreduced."""
+
+    constructions = 0
+
+    def __init__(self):
+        super().__init__()
+        _DistsSpy.constructions += 1
+        self.param = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, x, y, require_grad=False):
+        return torch.tensor([0.1, 0.3])
+
+
+@pytest.fixture
+def spies(monkeypatch):
+    """Both import seams stubbed, on a cache private to this test."""
+    _LpipsSpy.seen = {}
+    _DistsSpy.constructions = 0
+    monkeypatch.setattr("sisr.perceptual._NET_CACHE", {})
+    monkeypatch.setattr("sisr.perceptual._lpips_metric_cls", lambda: _LpipsSpy)
+    monkeypatch.setattr("sisr.perceptual._dists_net_cls", lambda: _DistsSpy)
+
+
+@pytest.mark.parametrize("net", ["alex", "vgg", "squeeze"])
+def test_lpips_backbone_is_threaded_through(spies, net):
+    """`lpips_net` must reach the backbone, and a LPIPS figure is comparable only
+    to one computed under the same backbone — a hardcoded 'alex' would be a
+    silently uncomparable number, not an error."""
+    perceptual_score("lpips", torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32), lpips_net=net)
+
+    assert _LpipsSpy.seen["net_type"] == net
+
+
+def test_lpips_receives_normalize_true(spies):
     """[0,1] inputs must be declared as such to LPIPS.
 
     torchmetrics defaults normalize=False, which means "inputs are already
     [-1,1]". Our metric tensors are RGB [0,1], so the default silently scores
     a squashed range: a plausible number, no error, uncomparable to anything.
+
+    Passed at construction rather than per call now that the backbone is
+    memoised — the modular metric takes both conventions in ``__init__``.
     """
-    seen = {}
-
-    def spy(img1, img2, net_type, reduction, normalize):
-        seen.update(net_type=net_type, reduction=reduction, normalize=normalize)
-        return torch.tensor(0.25)
-
-    monkeypatch.setattr("sisr.perceptual._lpips_fn", lambda: spy)
     perceptual_score("lpips", torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32))
 
-    assert seen["normalize"] is True
-    assert seen["reduction"] == "mean"
-    assert seen["net_type"] == "alex"
+    assert _LpipsSpy.seen["normalize"] is True
+    assert _LpipsSpy.seen["reduction"] == "mean"
 
 
-def test_dists_reduction_is_passed_explicitly(monkeypatch):
-    """DISTS defaults reduction=None (per-image), LPIPS defaults 'mean'.
+def test_dists_is_reduced_to_a_batch_mean(spies):
+    """DISTS's own default reduction is None (per-image), LPIPS's is 'mean'.
 
     Relying on either default gives a scalar from one metric and a tensor from
-    the other under the same self.log call.
+    the other under the same self.log call. The reduction is applied here rather
+    than passed as an argument now — the cached backbone is the bare network,
+    below torchmetrics' reduction layer — so this asserts the resulting shape and
+    value instead of the argument.
     """
-    seen = {}
+    score = perceptual_score("dists", torch.rand(2, 3, 32, 32), torch.rand(2, 3, 32, 32))
 
-    def spy(preds, target, reduction):
-        seen["reduction"] = reduction
-        return torch.tensor(0.1)
+    assert score.ndim == 0
+    assert score.item() == pytest.approx(0.2)
 
-    monkeypatch.setattr("sisr.perceptual._dists_fn", lambda: spy)
-    perceptual_score("dists", torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32))
 
-    assert seen["reduction"] == "mean"
+@pytest.mark.parametrize("name", ["lpips", "dists"])
+def test_backbone_is_built_once_across_calls(spies, name):
+    """The whole cost of these metrics was rebuilding the backbone per call.
+
+    Measured on CPU at 1x3x256x256: 605.0 -> 27.3 ms/call for LPIPS and
+    1716.1 -> 386.8 ms/call for DISTS. One validation cycle of the shipped
+    adversarial template scores ~219 images per metric.
+    """
+    for _ in range(3):
+        perceptual_score(name, torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32))
+
+    built = _LpipsSpy.seen["constructions"] if name == "lpips" else _DistsSpy.constructions
+    assert built == 1
+
+
+def test_each_lpips_backbone_gets_its_own_cache_entry(spies):
+    """Caching on the metric name alone would serve an 'alex' backbone to a run
+    that asked for 'vgg' — the same uncomparable-number failure, cached."""
+    for net in ("alex", "vgg", "alex"):
+        perceptual_score("lpips", torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32), lpips_net=net)
+
+    assert _LpipsSpy.seen["constructions"] == 2
+
+
+def test_lpips_state_is_reset_after_every_call(spies):
+    """The modular metric accumulates a list state per update. Reused across a
+    400k-step run without a reset, it retains one tensor per scored image."""
+    perceptual_score("lpips", torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32))
+
+    assert _LpipsSpy.seen["reset"] == 1
+
+
+@pytest.mark.parametrize("name", ["lpips", "dists"])
+def test_cached_backbone_cannot_train_or_leak_gradients(spies, name):
+    """A memoised backbone outlives the call that built it, so it must be inert:
+    eval mode, detached parameters, and no graph reaching the scored tensors."""
+    from sisr.perceptual import _cached_net
+
+    sr = torch.rand(1, 3, 32, 32, requires_grad=True)
+    score = perceptual_score(name, sr, torch.rand(1, 3, 32, 32))
+    net = _cached_net(name, "alex", sr.device, sr.dtype)
+
+    assert not net.training
+    assert not any(p.requires_grad for p in net.parameters())
+    assert not score.requires_grad
+    assert score.grad_fn is None
 
 
 def test_unknown_metric_names_the_supported_set():
@@ -60,6 +164,7 @@ def test_missing_lpips_extra_names_the_install_command(monkeypatch):
     ImportError (or any error that drops the extra's name) would leave anyone
     hitting this with no way to know which package fixes it.
     """
+    monkeypatch.setattr("sisr.perceptual._NET_CACHE", {})
     monkeypatch.setattr("torchmetrics.utilities.imports._LPIPS_AVAILABLE", False)
 
     with pytest.raises(ImportError, match=r"pip install '\.\[perceptual\]'"):

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -514,6 +514,27 @@ def test_weights_checkpoint_can_save_a_named_component(tmp_path):
     assert saved["meta"]["kind"] == "component"
 
 
+def test_two_weights_checkpoints_can_watch_different_components():
+    """Generator and discriminator side by side is the whole reason ``attribute``
+    exists, and it is unconstructable without this.
+
+    Lightning refuses two stateful callbacks sharing a ``state_key``, and
+    ``ModelCheckpoint``'s key is built from ``monitor``/``mode``/the cadence
+    fields only — not from ``attribute``, ``dirpath`` or ``filename``. Two
+    rolling weights callbacks differing only in which network they save
+    therefore collide at ``Trainer`` construction, which is where the shipped
+    SRGAN template puts them.
+    """
+    generator = SRWeightsCheckpoint(monitor_metric=None, attribute="model")
+    discriminator = SRWeightsCheckpoint(monitor_metric=None, attribute="discriminator")
+
+    assert generator.state_key != discriminator.state_key
+    # Same config still keys the same, or saved callback state stops round-tripping.
+    assert generator.state_key == SRWeightsCheckpoint(monitor_metric=None).state_key
+    # The real failure path: Trainer validates the callback list on construction.
+    lightning.Trainer(callbacks=[generator, discriminator], logger=False)
+
+
 def _make_srcnn_datamodule(image_dir: Path):
     """Tiny SRDataModule (3 fixture images) mirroring test_integration.py's helper —
     real Trainer.fit needs a real datamodule to reach ModelCheckpoint's save path."""

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -643,7 +643,9 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
 # ---------------------------------------------------------------------------
 
 
-def _run_tiny_fit(callbacks: list, n_batches: int) -> lightning.Trainer:
+def _run_tiny_fit(
+    callbacks: list, n_batches: int, ckpt_path: str | None = None
+) -> lightning.Trainer:
     """Real `Trainer.fit` for `n_batches` steps, driving `callbacks`'s real save path.
 
     Rolling-mode retention depends on Lightning's actual save cadence, filename
@@ -683,7 +685,7 @@ def _run_tiny_fit(callbacks: list, n_batches: int) -> lightning.Trainer:
             enable_model_summary=False,
             callbacks=callbacks,
         )
-        trainer.fit(module, datamodule=_make_srcnn_datamodule(image_dir))
+        trainer.fit(module, datamodule=_make_srcnn_datamodule(image_dir), ckpt_path=ckpt_path)
         return trainer
     finally:
         shutil.rmtree(image_dir, ignore_errors=True)
@@ -807,6 +809,125 @@ def test_enforce_rolling_window_is_noop_when_monitor_is_set(cls, tmp_path: Path)
         ckpt._enforce_rolling_window(trainer, f"fake-{i}{ckpt.FILE_EXTENSION}")
     assert ckpt._rolling == []
     trainer.strategy.remove_checkpoint.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Rolling window seeding on resume
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("cls", "prefix"), [(SRCheckpoint, "sr"), (SRWeightsCheckpoint, "sr-weights")]
+)
+def test_rolling_window_is_seeded_from_disk_on_resume(cls, prefix, tmp_path: Path):
+    """A resumed run must adopt its own pre-resume files, not orphan them.
+
+    Nothing persists the window (``ModelCheckpoint.state_dict`` carries
+    ``monitor``/``best_*``/``kth_*``/``dirpath``/``last_model_path`` only), so
+    without seeding every file written before the resume is never counted and
+    never deleted — up to ``keep_last`` leaked per callback per resume, and the
+    shipped adversarial template runs three rolling callbacks over a run long
+    enough to be resumed repeatedly.
+
+    ``dirpath`` is passed explicitly so the hook can be exercised without
+    ``setup``'s dirpath resolution (which also warns on a non-empty directory,
+    an error under this suite's strict filter).
+    """
+    for step in (4, 20, 12):
+        (tmp_path / f"{prefix}-{step}{cls.FILE_EXTENSION}").touch()
+    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+
+    cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
+
+    # Ordered by step, not lexicographically -- "12" sorts before "4" as text,
+    # and deletion is oldest-first, so a string sort would evict the newest file.
+    assert cb._rolling == [
+        str(tmp_path / f"{prefix}-{step}{cls.FILE_EXTENSION}") for step in (4, 12, 20)
+    ]
+
+
+def test_rolling_seed_only_adopts_this_callbacks_own_files(tmp_path: Path):
+    """Seeding must not let one rolling callback delete another's files.
+
+    The shipped adversarial template puts three rolling callbacks in one
+    ``dirpath`` (``sr-*.ckpt``, ``sr-weights-*.pt``, ``d-weights-*.pt``), and
+    ``sr-weights`` is a strict prefix extension of ``sr`` — a prefix-only or
+    extension-only filter adopts a sibling's files and eventually deletes them.
+    """
+    for name in ("sr-weights-2.pt", "d-weights-2.pt", "sr-2.ckpt", "last.ckpt", "sr-weights-x.pt"):
+        (tmp_path / name).touch()
+    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=3, dirpath=str(tmp_path))
+
+    cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
+
+    assert cb._rolling == [str(tmp_path / "sr-weights-2.pt")]
+
+
+def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
+    """A fresh run must leave a populated dirpath alone.
+
+    Seeding unconditionally would make a from-scratch run adopt — and, on its
+    third save, silently delete — checkpoints a previous run wrote.
+    """
+    (tmp_path / "sr-weights-2.pt").touch()
+    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+
+    cb.on_train_start(MagicMock(ckpt_path=None), MagicMock())
+
+    assert cb._rolling == []
+
+
+def test_rolling_seed_is_noop_when_monitor_is_set(tmp_path: Path):
+    """With a monitor, Lightning's top-k owns retention — seeding would evict
+    files top-k still wants, exactly as ``_enforce_rolling_window`` must not."""
+    (tmp_path / "sr-weights-2.pt").touch()
+    cb = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(tmp_path))
+
+    cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
+
+    assert cb._rolling == []
+
+
+def test_seeded_window_deletes_the_oldest_pre_resume_file(tmp_path: Path):
+    """Seeding is only worth anything if the next save then evicts a pre-resume
+    file — the orphaning this fixes is a deletion that never happens."""
+    for step in (2, 4):
+        (tmp_path / f"sr-weights-{step}.pt").touch()
+    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    trainer = MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt"))
+
+    cb.on_train_start(trainer, MagicMock())
+    cb._enforce_rolling_window(trainer, str(tmp_path / "sr-weights-6.pt"))
+
+    trainer.strategy.remove_checkpoint.assert_called_once_with(str(tmp_path / "sr-weights-2.pt"))
+
+
+@_ignore_gpu_warning
+@pytest.mark.filterwarnings("ignore:Checkpoint directory .* exists and is not empty.:UserWarning")
+def test_real_resume_keeps_the_window_at_keep_last(tmp_path: Path):
+    """End-to-end: the hook fires with ``trainer.ckpt_path`` already assigned.
+
+    The seeding gate reads ``trainer.ckpt_path``, which the checkpoint connector
+    does not assign until it restores state — after every ``setup`` hook, which
+    is why seeding lives in ``on_train_start``. Only a real resume proves the
+    ordering; the hook-level tests above cannot.
+
+    First fit saves at steps 2/4/6 and keeps 4/6. Resuming to step 12 saves at
+    8/10/12. With the window seeded, four deletions leave exactly ``keep_last``
+    files; unseeded, steps 4 and 6 are orphaned and six files survive.
+    """
+    ckpt_cb = SRCheckpoint(
+        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+    )
+    _run_tiny_fit(callbacks=[ckpt_cb], n_batches=6)
+    assert sorted(p.name for p in tmp_path.glob("*.ckpt")) == ["sr-4.ckpt", "sr-6.ckpt"]
+
+    resumed_cb = SRCheckpoint(
+        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+    )
+    _run_tiny_fit(callbacks=[resumed_cb], n_batches=12, ckpt_path=str(tmp_path / "sr-6.ckpt"))
+
+    assert sorted(p.name for p in tmp_path.glob("*.ckpt")) == ["sr-10.ckpt", "sr-12.ckpt"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -447,6 +447,32 @@ def test_sr_weights_checkpoint_setup_rejects_unknown_monitor(tmp_path: Path):
         ckpt.setup(_make_bare_trainer(), pl_module, stage="fit")
 
 
+@_ignore_gpu_warning
+def test_sr_weights_checkpoint_setup_rejects_unknown_attribute(tmp_path: Path):
+    """A component this module does not have must fail at startup, not at the
+    first save.
+
+    ``attribute`` is read nowhere else, so a typo — or ``discriminator`` on a
+    plain ``SRLightning``, which is a one-line YAML mistake — otherwise survives
+    a whole ``every_n_train_steps`` interval and then dies with a bare
+    ``AttributeError`` from inside the save path.
+    """
+    ckpt = SRWeightsCheckpoint(
+        monitor_metric=None, attribute="discriminator", dirpath=str(tmp_path)
+    )
+    with pytest.raises(MisconfigurationException, match=r"discriminator"):
+        ckpt.setup(_make_bare_trainer(), build_module(), stage="fit")
+
+
+@_ignore_gpu_warning
+def test_sr_weights_checkpoint_setup_accepts_a_present_component(tmp_path: Path):
+    """The refusal above must not reject the configuration ``attribute`` exists for."""
+    ckpt = SRWeightsCheckpoint(
+        monitor_metric=None, attribute="discriminator", dirpath=str(tmp_path)
+    )
+    ckpt.setup(_make_bare_trainer(), build_module_with_component(), stage="fit")  # must not raise
+
+
 def test_sr_weights_checkpoint_save_checkpoint_is_actually_overridden():
     """Cheap static guard: the override must exist as a distinct method, not
     silently inherit ModelCheckpoint's (which would write full, optimizer-bearing

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -103,6 +103,18 @@ def write_weights(tmp_path, **meta_overrides):
     return path, source
 
 
+def init_gan_from(path, **kwargs):
+    """Build a GAN module and run the ``fit`` setup — the hook ``init_from`` loads in.
+
+    The load is deferred out of ``__init__`` so that ``validate``/``test``/
+    ``export``, which all instantiate the model from config, never read the file.
+    Every ``init_from`` assertion therefore has to drive the stage that does.
+    """
+    module = build_gan_module(init_from=str(path), **kwargs)
+    module.setup("fit")
+    return module
+
+
 def clone_params(module):
     return {name: p.detach().clone() for name, p in module.named_parameters()}
 
@@ -677,7 +689,7 @@ def test_init_from_loads_generator_weights_bit_exactly(tmp_path):
     """
     path, source = write_weights(tmp_path)
 
-    gan = build_gan_module(init_from=str(path))
+    gan = init_gan_from(path)
 
     loaded, original = gan.model.state_dict(), source.model.state_dict()
     assert loaded.keys() == original.keys()
@@ -722,7 +734,7 @@ def test_init_from_refuses_a_mismatched_artifact(tmp_path, override, field):
     path, _ = write_weights(tmp_path, **override)
 
     with pytest.raises(ValueError) as excinfo:
-        build_gan_module(init_from=str(path))
+        init_gan_from(path)
 
     message = str(excinfo.value)
     assert [name for name in INIT_FROM_FIELDS if name in message] == [field]
@@ -734,7 +746,7 @@ def test_init_from_accepts_an_artifact_whose_unvalidated_fields_differ(tmp_path)
     says nothing about whether its weights fit this generator."""
     path, _ = write_weights(tmp_path, **{"eval_config.crop_border": 99})
 
-    build_gan_module(init_from=str(path))  # must not raise
+    init_gan_from(path)  # must not raise
 
 
 def test_init_from_rejects_a_ckpt_and_names_the_pt(tmp_path):
@@ -745,7 +757,7 @@ def test_init_from_rejects_a_ckpt_and_names_the_pt(tmp_path):
     torch.save({"state_dict": {}}, path)
 
     with pytest.raises(ValueError) as excinfo:
-        build_gan_module(init_from=str(path))
+        init_gan_from(path)
 
     message = str(excinfo.value)
     assert "sr-42.ckpt" in message
@@ -759,7 +771,98 @@ def test_init_from_refuses_a_pt_with_no_metadata(tmp_path):
     torch.save({"state_dict": build_source_module().model.state_dict()}, path)
 
     with pytest.raises(ValueError, match="meta"):
-        build_gan_module(init_from=str(path))
+        init_gan_from(path)
+
+
+def test_init_from_names_the_component_artifact_it_was_handed(tmp_path):
+    """A ``d-weights-*.pt`` is the likeliest misuse after a ``.ckpt``: the template
+    writes both files into one dirpath.
+
+    It is refused either way — a component's meta has no generator-scoped ``io``
+    section — but "io.scale is None" never tells the user they grabbed the
+    discriminator's weights, which is the whole mistake.
+    """
+    module = build_gan_module()
+    path = tmp_path / "d-weights-10000.pt"
+    torch.save(
+        {
+            "state_dict": module.discriminator.state_dict(),
+            "meta": build_component_metadata(module, "discriminator"),
+        },
+        path,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        init_gan_from(path)
+
+    message = str(excinfo.value)
+    assert "d-weights-10000.pt" in message
+    assert "discriminator" in message, "the message must name the component it was handed"
+    assert "sr-weights" in message, "...and the generator file that should have been used"
+    assert not [name for name in INIT_FROM_FIELDS if name in message], (
+        "a component file is not a field mismatch, and must not be reported as one"
+    )
+
+
+def test_init_from_accepts_a_pt_written_before_kind_existed(tmp_path):
+    """``kind`` is an additive field: the golden 1e6-step artifact the template
+    ships predates it, and keying the component refusal on its *absence* would
+    refuse the one file ``init_from`` is shipped pointing at."""
+    source = build_source_module()
+    meta = build_metadata(source)
+    del meta["kind"]
+    path = tmp_path / "sr-weights.pt"
+    torch.save({"state_dict": source.model.state_dict(), "meta": meta}, path)
+
+    init_gan_from(path)  # must not raise
+
+
+def test_init_from_names_the_cli_null_coercion_trap():
+    """``--...init_from=null`` does not unset it: jsonargparse coerces a null CLI
+    value for a ``str | None`` field to the *string* ``'None'``, which then reaches
+    ``torch.load`` as a filename and dies as a missing file. Name the trap instead —
+    the comment in the template cannot reach someone who has already typed it."""
+    with pytest.raises(ValueError) as excinfo:
+        init_gan_from("None")
+
+    message = str(excinfo.value)
+    assert "null" in message, "the message must name the CLI override that produces it"
+    assert "--config" in message, "...and the overlay that actually works"
+
+
+def test_init_from_is_only_read_when_the_run_is_fitting(tmp_path):
+    """Every subcommand instantiates the model from config — ``--ckpt_path`` does
+    not skip it — so a construction-time load made ``validate``/``test``/``export``
+    depend on an artifact they never use, and die with ``FileNotFoundError`` on
+    every clone, worktree and CI box that lacks it.
+
+    A path that does not exist is the whole proof: the non-fit stages must not
+    touch it, and ``fit`` must.
+    """
+    missing = tmp_path / "absent-sr-weights.pt"
+
+    module = build_gan_module(init_from=str(missing))  # construction must not read it
+    for stage in ("validate", "test", "predict"):
+        module.setup(stage)  # must not raise
+
+    with pytest.raises(FileNotFoundError):
+        module.setup("fit")
+
+
+@_ignore_cpu_fit_warnings
+def test_init_from_is_reached_through_a_real_trainer_fit(tmp_path):
+    """The stage gate must hold for the value Lightning passes — ``trainer.state.fn``,
+    a ``TrainerFn`` enum — not only the plain string a direct ``setup()`` call uses.
+
+    A gate that missed it would skip the MSE initialisation of every real run
+    without a word: the generator would just start from scratch, which is not the
+    paper's recipe and looks like nothing at all. Driving a refusal out through
+    ``trainer.fit`` is the cheap proof that the call site is reached.
+    """
+    path, _ = write_weights(tmp_path, **{"io.scale": 2})
+
+    with pytest.raises(ValueError, match="io.scale"):
+        fit_gan(build_gan_module(init_from=str(path)), n_batches=1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -451,9 +451,11 @@ def test_adversarial_weight_scales_the_generators_gradient():
 def test_global_step_counts_optimizer_steps_not_batches(k, n_batches, expected):
     """global_step counts optimizer steps and this module takes two per batch,
     so it is N + N//k — not the batch count. That is the unit max_steps,
-    val_check_interval and checkpoint filenames use, so a max_steps copied from
-    the SRResNet template trains for half the iterations. (Manual optimization
-    is not the cause: with a single optimizer it still equals the batch count.)
+    checkpoint filenames and every_n_train_steps use, so a max_steps copied from
+    the SRResNet template trains for half the iterations. (val_check_interval is
+    the exception: Lightning counts it in batches. Manual optimization is not the
+    cause of any of it: with a single optimizer global_step still equals the
+    batch count.)
     """
     trainer = fit_gan(build_gan_module(k=k), n_batches=n_batches)
 

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -921,8 +921,10 @@ def test_the_bare_weights_sink_stays_component_scoped(tmp_path):
     ``SRWeightsCheckpoint`` writes one network's weights and describes exactly
     that network; adding this run's whole adversarial setup to a discriminator's
     (or a generator's) ``.pt`` would describe things the file does not contain.
+    Both sinks are checked — the template runs one of each side by side, and the
+    generator's is the distributable artifact ``init_from`` consumes.
 
-    Driven by a real fit, and asserted on the file that fit wrote: the property is
+    Driven by a real fit, and asserted on the files that fit wrote: the property is
     about which metadata builder the save path reaches, so inspecting the builders
     directly cannot show it — neither has ever carried these keys.
     """
@@ -939,11 +941,21 @@ def test_the_bare_weights_sink_stays_component_scoped(tmp_path):
                 every_n_train_steps=1,
                 attribute="discriminator",
                 filename_prefix="d-weights",
-            )
+            ),
+            SRWeightsCheckpoint(
+                monitor_metric=None,
+                dirpath=str(tmp_path),
+                every_n_train_steps=1,
+                attribute="model",
+                filename_prefix="sr-weights",
+            ),
         ],
     )
-    meta = torch.load(next(tmp_path.glob("d-weights-*.pt")), weights_only=True)["meta"]
+    d_meta = torch.load(next(tmp_path.glob("d-weights-*.pt")), weights_only=True)["meta"]
+    g_meta = torch.load(next(tmp_path.glob("sr-weights-*.pt")), weights_only=True)["meta"]
 
-    assert set(meta).isdisjoint({"discriminator", "adversarial"})
-    assert meta["kind"] == "component"
-    assert meta["component"]["name"] == "discriminator"
+    assert set(d_meta).isdisjoint({"discriminator", "adversarial"})
+    assert d_meta["kind"] == "component"
+    assert d_meta["component"]["name"] == "discriminator"
+    assert set(g_meta).isdisjoint({"discriminator", "adversarial"})
+    assert g_meta["kind"] == "sr_model"

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -17,7 +17,7 @@ from sisr.models.base import SRModel
 from sisr.models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
 from sisr.models.srresnet import SRResNet, SRResNetTrainingConfig
 from sisr.processors import RGBSignedOutputProcessor, YChannelProcessor
-from sisr.training import SRCheckpoint, SRGANLightning, SRLightning
+from sisr.training import SRCheckpoint, SRGANLightning, SRLightning, SRWeightsCheckpoint
 from sisr.training.config import SRTrainingConfig
 from sisr.training.metadata import build_component_metadata, build_metadata
 
@@ -906,23 +906,42 @@ def test_checkpoint_carries_both_networks_and_their_optimizers(tmp_path):
     # The base's generator-scoped provenance survives — the generator is still
     # the distributable artifact.
     assert ckpt["sisr_meta"]["model"]["class_path"].endswith("SRResNet")
-    assert not any("vgg" in k.lower() for k in ckpt["state_dict"])
+    # Structural, not a name match: `not any("vgg" in k)` would stay green if the
+    # criterion's frozen backbone were ever renamed, and 20M parameters would land
+    # in every checkpoint unnoticed.
+    assert all(k.startswith(("model.", "discriminator.")) for k in ckpt["state_dict"])
 
 
-def test_the_bare_weights_sink_stays_component_scoped():
+@_ignore_cpu_fit_warnings
+def test_the_bare_weights_sink_stays_component_scoped(tmp_path):
     """``on_save_checkpoint`` is a ``.ckpt`` hook only.
 
     ``SRWeightsCheckpoint`` writes one network's weights and describes exactly
     that network; adding this run's whole adversarial setup to a discriminator's
     (or a generator's) ``.pt`` would describe things the file does not contain.
+
+    Driven by a real fit, and asserted on the file that fit wrote: the property is
+    about which metadata builder the save path reaches, so inspecting the builders
+    directly cannot show it — neither has ever carried these keys.
     """
     module = build_gan_module()
 
-    checkpoint = {"global_step": 7, "epoch": 0}
-    module.on_save_checkpoint(checkpoint)
-
-    assert set(checkpoint["sisr_meta"]) >= {"discriminator", "adversarial"}
-    assert set(build_component_metadata(module, "discriminator")).isdisjoint(
-        {"discriminator", "adversarial"}
+    fit_gan(
+        module,
+        n_batches=2,
+        enable_checkpointing=True,
+        callbacks=[
+            SRWeightsCheckpoint(
+                monitor_metric=None,
+                dirpath=str(tmp_path),
+                every_n_train_steps=1,
+                attribute="discriminator",
+                filename_prefix="d-weights",
+            )
+        ],
     )
-    assert set(build_metadata(module)).isdisjoint({"discriminator", "adversarial"})
+    meta = torch.load(next(tmp_path.glob("d-weights-*.pt")), weights_only=True)["meta"]
+
+    assert set(meta).isdisjoint({"discriminator", "adversarial"})
+    assert meta["kind"] == "component"
+    assert meta["component"]["name"] == "discriminator"

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -12,13 +12,14 @@ import lightning
 import pytest
 import torch
 
-from sisr.losses import AdversarialLoss
+from sisr.losses import AdversarialLoss, VGG19FeatureLoss
 from sisr.models.base import SRModel
 from sisr.models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
-from sisr.models.srresnet import SRResNet
+from sisr.models.srresnet import SRResNet, SRResNetTrainingConfig
 from sisr.processors import RGBSignedOutputProcessor, YChannelProcessor
-from sisr.training import SRGANLightning
+from sisr.training import SRCheckpoint, SRGANLightning, SRLightning
 from sisr.training.config import SRTrainingConfig
+from sisr.training.metadata import build_component_metadata, build_metadata
 
 # Every fit below runs on CPU with a single-worker loader over a handful of
 # batches, which Lightning flags as three PossibleUserWarnings the strict global
@@ -49,6 +50,7 @@ def build_gan_module(
     criterion=None,
     adversarial_weight=SRGANTrainingConfig.adversarial_weight,
     layer_lrs=None,
+    init_from=None,
 ):
     """A minimal but real SRGANLightning — one residual block keeps it CPU-fast."""
     return cls(
@@ -62,6 +64,7 @@ def build_gan_module(
             example_input_shape=(3, 24, 24),
             adversarial_weight=adversarial_weight,
             layer_lrs=layer_lrs,
+            init_from=init_from,
         ),
         eval_config=SRGANEvalConfig(perceptual_metrics=[]),
         optimizer=lambda params: torch.optim.SGD(params, lr=0.1),
@@ -69,6 +72,35 @@ def build_gan_module(
         lr_scheduler=lr_scheduler,
         discriminator_lr_scheduler=discriminator_lr_scheduler,
     )
+
+
+def build_source_module():
+    """The realistic ``init_from`` source: a plain, MSE-trained SRResNet run.
+
+    Its generator and processor match :func:`build_gan_module`'s exactly, so a
+    ``.pt`` written from it is the one artifact ``init_from`` must accept.
+    """
+    return SRLightning(
+        model=SRResNet(scale=4, num_residual_blocks=1),
+        processor=RGBSignedOutputProcessor(),
+        training_config=SRResNetTrainingConfig(),
+    )
+
+
+def write_weights(tmp_path, **meta_overrides):
+    """A generator-weights ``.pt`` whose meta can be corrupted one field at a time.
+
+    Written with the same :func:`~sisr.training.metadata.build_metadata` that
+    ``SRWeightsCheckpoint`` uses, so what is exercised is the real payload shape.
+    """
+    source = build_source_module()
+    meta = build_metadata(source)
+    for dotted, value in meta_overrides.items():
+        section, key = dotted.split(".")
+        meta[section][key] = value
+    path = tmp_path / "sr-weights.pt"
+    torch.save({"state_dict": source.model.state_dict(), "meta": meta}, path)
+    return path, source
 
 
 def clone_params(module):
@@ -103,13 +135,15 @@ def gan_loader(n_batches, hr=96, scale=4):
     )
 
 
-def fit_gan(module, n_batches, callbacks=None, val_batches=0, **trainer_kwargs):
+def fit_gan(
+    module, n_batches, callbacks=None, val_batches=0, enable_checkpointing=False, **trainer_kwargs
+):
     """Run a real Trainer loop over ``module`` and hand back the trainer."""
     trainer = lightning.Trainer(
         max_epochs=1,
         accelerator="cpu",
         logger=False,
-        enable_checkpointing=False,
+        enable_checkpointing=enable_checkpointing,
         enable_progress_bar=False,
         enable_model_summary=False,
         num_sanity_val_steps=0,
@@ -155,6 +189,18 @@ class BackwardGradSpy(SRGANLightning):
     def manual_backward(self, loss, *args, **kwargs):
         self.d_grads_before_backward.append(grad_snapshot(self.discriminator))
         return super().manual_backward(loss, *args, **kwargs)
+
+
+class ProbeStateSpy(SRGANLightning):
+    """Records the module- and generator-level ``training`` flags at probe forward time."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.probe_flags = []
+
+    def _forward_sr(self, *args, **kwargs):
+        self.probe_flags.append((self.training, self.model.training))
+        return super()._forward_sr(*args, **kwargs)
 
 
 class ShrinkingGenerator(SRModel):
@@ -206,14 +252,31 @@ def generator_grads_after_one_seeded_batch(adversarial_weight):
     return {name: p.grad.detach().clone() for name, p in module.model.named_parameters()}
 
 
+def _pair_dataset(hr_size, scale):
+    lr_size = hr_size // scale
+    return torch.utils.data.TensorDataset(
+        torch.rand(1, 3, lr_size, lr_size), torch.rand(1, 3, hr_size, hr_size)
+    )
+
+
 def fake_datamodule(hr_crop_size=96, scale=4):
     """Minimal stand-in exposing the read accessors SRLightning.setup probes."""
-    lr_size = hr_crop_size // scale
     return SimpleNamespace(
-        train_dataset=torch.utils.data.TensorDataset(
-            torch.rand(1, 3, lr_size, lr_size), torch.rand(1, 3, hr_crop_size, hr_crop_size)
-        ),
+        train_dataset=_pair_dataset(hr_crop_size, scale),
         val_dataset=None,
+        test_datasets=None,
+    )
+
+
+def val_only_datamodule(hr_size=128, scale=4):
+    """A ``validate``-style datamodule: no train dataset, and full-image samples.
+
+    ``hr_size`` is deliberately not the discriminator's ``hr_input_size`` —
+    validation images are whole pictures, never the training crop.
+    """
+    return SimpleNamespace(
+        train_dataset=None,
+        val_dataset=_pair_dataset(hr_size, scale),
         test_datasets=None,
     )
 
@@ -531,6 +594,42 @@ def test_the_probe_keys_on_the_hr_crop_the_discriminator_scores():
     module.setup("fit")  # must not raise: the 112x112 patch is cropped to the 96x96 output
 
 
+def test_the_size_check_is_scoped_to_the_train_dataset():
+    """``hr_input_size`` constrains the TRAINING crop, and nothing else.
+
+    ``setup`` probes whichever dataset the live stage instantiated, so a bare
+    ``validate``/``test`` run hands the probe a **full image**. Ungated, that
+    both refuses a perfectly valid run and does a full-resolution generator
+    forward on CPU at setup.
+    """
+    module = build_gan_module(hr_input_size=96)
+    module.trainer = SimpleNamespace(datamodule=val_only_datamodule(hr_size=128))
+
+    module.setup("validate")  # must not raise: 128 != 96 is not a training crop
+
+
+def test_the_probe_forward_runs_with_the_whole_module_in_eval_mode():
+    """``self.model.eval()`` is not enough: the forward selector reads the
+    LightningModule's own ``training`` flag (``self.training and self._compiled
+    is not None``), which ``self.model.eval()`` leaves True. On a compiled run
+    the probe would therefore go through ``self._compiled`` and trigger a dynamo
+    compile at setup — before, and at a different shape from, the deliberate
+    ``on_fit_start`` warm-up that exists to surface toolchain failures at a
+    predictable point.
+
+    The generator's own flag must stay False regardless: a train-mode probe
+    forward folds the sample into its BatchNorm running statistics before
+    training has taken a step.
+    """
+    module = build_gan_module(cls=ProbeStateSpy)
+    module.trainer = SimpleNamespace(datamodule=fake_datamodule(hr_crop_size=96))
+
+    module.setup("fit")
+
+    assert module.probe_flags == [(False, False)], "probe forward ran in training mode"
+    assert module.training and module.model.training, "training mode was not restored"
+
+
 def test_layer_lrs_refused():
     """Inherited through SRResNetTrainingConfig, so YAML can set it — and this
     override never reads it, which would silently give both networks uniform LRs
@@ -553,3 +652,174 @@ def test_a_base_training_config_is_refused():
             discriminator=SRDiscriminator(),
             training_config=SRTrainingConfig(cuda_graph=True),
         )
+
+
+# ---------------------------------------------------------------------------
+# init_from — MSE initialisation of the generator
+# ---------------------------------------------------------------------------
+
+#: Every meta field init_from validates, in the message form it reports them.
+INIT_FROM_FIELDS = (
+    "model.class_path",
+    "model.init_args",
+    "processor.class_path",
+    "io.output_range",
+    "io.scale",
+)
+
+
+def test_init_from_loads_generator_weights_bit_exactly(tmp_path):
+    """Ledig scopes the MSE-init trick to "when training the actual GAN", so a
+    paper-faithful run starts from an MSE-trained SRResNet rather than scratch.
+
+    Bit-exactly, not approximately: the two modules are built independently, so
+    an ignored ``init_from`` leaves two unrelated random initialisations here.
+    """
+    path, source = write_weights(tmp_path)
+
+    gan = build_gan_module(init_from=str(path))
+
+    loaded, original = gan.model.state_dict(), source.model.state_dict()
+    assert loaded.keys() == original.keys()
+    for key, value in original.items():
+        assert torch.equal(loaded[key], value), key
+    # Only the generator: the discriminator is not in that file at all, and the
+    # adversarial half of the run starts from scratch by design.
+    assert not any(k.startswith("discriminator.") for k in loaded)
+
+
+@pytest.mark.parametrize(
+    ("override", "field"),
+    [
+        ({"model.class_path": "sisr.models.srcnn.model.SRCNN"}, "model.class_path"),
+        (
+            {
+                "model.init_args": {
+                    "scale": 4,
+                    "in_out_channels": 3,
+                    "hidden_channel": 64,
+                    "kernel_sizes": [9, 3, 9],
+                    "num_residual_blocks": 16,
+                    "padding": "same",
+                }
+            },
+            "model.init_args",
+        ),
+        ({"processor.class_path": "sisr.processors.rgb.RGBProcessor"}, "processor.class_path"),
+        ({"io.output_range": [0.0, 1.0]}, "io.output_range"),
+        ({"io.scale": 2}, "io.scale"),
+    ],
+)
+def test_init_from_refuses_a_mismatched_artifact(tmp_path, override, field):
+    """Silently initialising from weights trained under a different processor,
+    scale or architecture produces a model that trains and scores without ever
+    erroring — only the numbers are wrong.
+
+    Each field is refused on its own: a single generic "metadata mismatch" would
+    satisfy a substring match on any one field name, so the message is asserted
+    to name the offending field and *only* that one.
+    """
+    path, _ = write_weights(tmp_path, **override)
+
+    with pytest.raises(ValueError) as excinfo:
+        build_gan_module(init_from=str(path))
+
+    message = str(excinfo.value)
+    assert [name for name in INIT_FROM_FIELDS if name in message] == [field]
+
+
+def test_init_from_accepts_an_artifact_whose_unvalidated_fields_differ(tmp_path):
+    """The check must key on the five fields that make weights transferable, not
+    refuse every artifact: a criterion or eval_config recorded by the source run
+    says nothing about whether its weights fit this generator."""
+    path, _ = write_weights(tmp_path, **{"eval_config.crop_border": 99})
+
+    build_gan_module(init_from=str(path))  # must not raise
+
+
+def test_init_from_rejects_a_ckpt_and_names_the_pt(tmp_path):
+    """A ``.ckpt`` holds the whole module under ``model.``-prefixed keys, so a
+    strict load into the bare generator fails with an unreadable key dump —
+    and it carries no ``meta`` to validate against either."""
+    path = tmp_path / "sr-42.ckpt"
+    torch.save({"state_dict": {}}, path)
+
+    with pytest.raises(ValueError) as excinfo:
+        build_gan_module(init_from=str(path))
+
+    message = str(excinfo.value)
+    assert "sr-42.ckpt" in message
+    assert ".pt" in message, "the message must point at the sibling weights file"
+
+
+def test_init_from_refuses_a_pt_with_no_metadata(tmp_path):
+    """Without ``meta`` there is nothing to validate against, so accepting the
+    file would silently reinstate every mismatch the checks above refuse."""
+    path = tmp_path / "sr-weights.pt"
+    torch.save({"state_dict": build_source_module().model.state_dict()}, path)
+
+    with pytest.raises(ValueError, match="meta"):
+        build_gan_module(init_from=str(path))
+
+
+# ---------------------------------------------------------------------------
+# checkpoint provenance
+# ---------------------------------------------------------------------------
+
+
+@_ignore_cpu_fit_warnings
+def test_checkpoint_carries_both_networks_and_their_optimizers(tmp_path):
+    """The adversarial half of a run must be recoverable from its own ``.ckpt``.
+
+    Driven by a real fit with checkpointing on, because everything asserted here
+    is written by Lightning's save path rather than by any one method: the
+    second optimizer's state, the discriminator's parameters, and the two
+    ``sisr_meta`` blocks this module appends.
+
+    The VGG criterion is what makes the final assertion non-vacuous — a
+    perceptual criterion holds its frozen VGG outside the module tree precisely
+    so up to 20M frozen parameters stay out of every checkpoint.
+    """
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        criterion = VGG19FeatureLoss(layer="vgg22", weights=None)
+    module = build_gan_module(criterion=criterion)
+
+    fit_gan(
+        module,
+        n_batches=2,
+        enable_checkpointing=True,
+        callbacks=[SRCheckpoint(monitor_metric=None, dirpath=str(tmp_path), every_n_train_steps=1)],
+    )
+    ckpt = torch.load(next(tmp_path.glob("*.ckpt")), weights_only=False)
+
+    assert any(k.startswith("model.") for k in ckpt["state_dict"])
+    assert any(k.startswith("discriminator.") for k in ckpt["state_dict"])
+    assert len(ckpt["optimizer_states"]) == 2
+    assert ckpt["sisr_meta"]["discriminator"]["class_path"].endswith("SRDiscriminator")
+    assert ckpt["sisr_meta"]["discriminator"]["init_args"]["hr_input_size"] == 96
+    assert ckpt["sisr_meta"]["adversarial"]["loss"].endswith("AdversarialLoss")
+    assert ckpt["sisr_meta"]["adversarial"]["weight"] == pytest.approx(1e-3)
+    assert ckpt["sisr_meta"]["adversarial"]["d_steps_per_g_step"] == 1
+    # The base's generator-scoped provenance survives — the generator is still
+    # the distributable artifact.
+    assert ckpt["sisr_meta"]["model"]["class_path"].endswith("SRResNet")
+    assert not any("vgg" in k.lower() for k in ckpt["state_dict"])
+
+
+def test_the_bare_weights_sink_stays_component_scoped():
+    """``on_save_checkpoint`` is a ``.ckpt`` hook only.
+
+    ``SRWeightsCheckpoint`` writes one network's weights and describes exactly
+    that network; adding this run's whole adversarial setup to a discriminator's
+    (or a generator's) ``.pt`` would describe things the file does not contain.
+    """
+    module = build_gan_module()
+
+    checkpoint = {"global_step": 7, "epoch": 0}
+    module.on_save_checkpoint(checkpoint)
+
+    assert set(checkpoint["sisr_meta"]) >= {"discriminator", "adversarial"}
+    assert set(build_component_metadata(module, "discriminator")).isdisjoint(
+        {"discriminator", "adversarial"}
+    )
+    assert set(build_metadata(module)).isdisjoint({"discriminator", "adversarial"})

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -13,16 +13,24 @@ import pytest
 import torch
 
 from sisr.losses import AdversarialLoss
+from sisr.models.base import SRModel
 from sisr.models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
 from sisr.models.srresnet import SRResNet
 from sisr.processors import RGBSignedOutputProcessor, YChannelProcessor
 from sisr.training import SRGANLightning
+from sisr.training.config import SRTrainingConfig
 
-# Every fit below runs on CPU (matching CI, which has no GPU); Lightning logs a
-# PossibleUserWarning about the idle GPU on this dev box, which the strict global
-# filterwarnings=error would otherwise fail on.
-_ignore_gpu_warning = pytest.mark.filterwarnings(
-    "ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning"
+# Every fit below runs on CPU with a single-worker loader over a handful of
+# batches, which Lightning flags as three PossibleUserWarnings the strict global
+# filterwarnings=error would otherwise fail on. Suppressed by message rather than
+# by category: PossibleUserWarning is also how Lightning reports real
+# misconfigurations, and blanket-ignoring the class hides those too.
+_ignore_cpu_fit_warnings = pytest.mark.filterwarnings(
+    "ignore:GPU available but not used:lightning.pytorch.utilities.warnings.PossibleUserWarning",
+    "ignore:The '.*' does not have many workers:"
+    "lightning.pytorch.utilities.warnings.PossibleUserWarning",
+    "ignore:You defined a `validation_step` but have no `val_dataloader`:"
+    "lightning.pytorch.utilities.warnings.PossibleUserWarning",
 )
 
 
@@ -38,6 +46,9 @@ def build_gan_module(
     lr_scheduler=None,
     discriminator_lr_scheduler=None,
     cls=SRGANLightning,
+    criterion=None,
+    adversarial_weight=SRGANTrainingConfig.adversarial_weight,
+    layer_lrs=None,
 ):
     """A minimal but real SRGANLightning — one residual block keeps it CPU-fast."""
     return cls(
@@ -45,8 +56,13 @@ def build_gan_module(
         processor=RGBSignedOutputProcessor(),
         discriminator=SRDiscriminator(hr_input_size=hr_input_size),
         adversarial_loss=AdversarialLoss(),
-        criterion=torch.nn.MSELoss(),
-        training_config=SRGANTrainingConfig(d_steps_per_g_step=k, example_input_shape=(3, 24, 24)),
+        criterion=torch.nn.MSELoss() if criterion is None else criterion,
+        training_config=SRGANTrainingConfig(
+            d_steps_per_g_step=k,
+            example_input_shape=(3, 24, 24),
+            adversarial_weight=adversarial_weight,
+            layer_lrs=layer_lrs,
+        ),
         eval_config=SRGANEvalConfig(perceptual_metrics=[]),
         optimizer=lambda params: torch.optim.SGD(params, lr=0.1),
         discriminator_optimizer=lambda params: torch.optim.SGD(params, lr=0.1),
@@ -141,6 +157,55 @@ class BackwardGradSpy(SRGANLightning):
         return super().manual_backward(loss, *args, **kwargs)
 
 
+class ShrinkingGenerator(SRModel):
+    """A pre-upsampled generator that emits less than the HR patch it is handed.
+
+    ``shrink`` pixels of it, via one valid-padded conv. Exists to separate the
+    raw HR patch from the crop the discriminator scores, which SRResNet's exact
+    ``scale x lr`` output makes indistinguishable.
+    """
+
+    input_contract = "pre_upsampled"
+
+    def __init__(self, channels=3, shrink=16):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(channels, channels, kernel_size=shrink + 1, padding="valid")
+        self._hparams = {"in_out_channels": channels, "scale": 4, "shrink": shrink}
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class ZeroContentLoss(torch.nn.Module):
+    """A content term that is identically zero, with an identically-zero gradient.
+
+    Still a function of ``sr``, so the generator stays reachable from ``g_loss``
+    and a backward through it is well-formed — it just contributes nothing. That
+    leaves the adversarial term as the only thing that can put a non-zero number
+    into a generator gradient.
+    """
+
+    def forward(self, sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
+        return sr.sum() * 0.0
+
+
+def generator_grads_after_one_seeded_batch(adversarial_weight):
+    """Generator ``.grad`` after one batch with the content term zeroed.
+
+    Seeded either side of construction so the two runs this is called for differ
+    in nothing but ``adversarial_weight``: the discriminator's own step is
+    independent of it, so the generator sees an identical discriminator.
+    """
+    torch.manual_seed(0)
+    module = build_gan_module(
+        k=1, criterion=ZeroContentLoss(), adversarial_weight=adversarial_weight
+    )
+    torch.manual_seed(1)
+    fit_gan(module, n_batches=1)
+    # Nothing clears grads after opt_g.step(), so these are g_loss's.
+    return {name: p.grad.detach().clone() for name, p in module.model.named_parameters()}
+
+
 def fake_datamodule(hr_crop_size=96, scale=4):
     """Minimal stand-in exposing the read accessors SRLightning.setup probes."""
     lr_size = hr_crop_size // scale
@@ -201,7 +266,7 @@ def test_configure_optimizers_returns_the_optimizer_list_first_in_a_fixed_order(
 # ---------------------------------------------------------------------------
 
 
-@_ignore_gpu_warning
+@_ignore_cpu_fit_warnings
 def test_one_step_moves_both_networks_at_k1():
     module = build_gan_module(k=1)
     recorder = ParamRecorder()
@@ -212,7 +277,7 @@ def test_one_step_moves_both_networks_at_k1():
     assert params_changed(recorder.d[0], recorder.d[1]), "discriminator did not update"
 
 
-@_ignore_gpu_warning
+@_ignore_cpu_fit_warnings
 def test_at_k2_the_generator_updates_only_on_every_second_batch():
     """k is spent ACROSS batches (Goodfellow Algorithm 1: each discriminator
     step sees a fresh minibatch), not looped inside one training_step."""
@@ -227,7 +292,7 @@ def test_at_k2_the_generator_updates_only_on_every_second_batch():
     assert params_changed(recorder.d[1], recorder.d[2]), "D must update every batch"
 
 
-@_ignore_gpu_warning
+@_ignore_cpu_fit_warnings
 def test_generator_backward_leaves_the_discriminator_gradients_untouched():
     """The generator's backward passes THROUGH the discriminator to reach the
     generator, and accumulates into D's .grad on the way unless toggled off.
@@ -263,7 +328,50 @@ def test_generator_backward_leaves_the_discriminator_gradients_untouched():
     ), "generator must still receive its gradient through the discriminator"
 
 
-@_ignore_gpu_warning
+@_ignore_cpu_fit_warnings
+def test_the_generator_is_trained_by_the_adversarial_term():
+    """What makes this module adversarial rather than a plain SRResNet run.
+
+    Every other test here passes on the content loss alone, so two edits that
+    silently drop the adversarial objective — dropping the term from ``g_loss``,
+    or scoring ``sr.detach()`` in it, the plausible symmetry with the
+    discriminator's line — would go unnoticed while ``loss/train/adv`` kept
+    being logged.
+
+    Zeroing the content term is what discriminates: the generator's gradient can
+    then only have arrived through the discriminator. The weight is raised off
+    the paper's 1e-3 purely so the resulting SGD update is unambiguous in
+    float32; the gradient assertion is the load-bearing one.
+    """
+    module = build_gan_module(k=1, criterion=ZeroContentLoss(), adversarial_weight=1.0)
+    recorder = ParamRecorder()
+
+    fit_gan(module, n_batches=1, callbacks=[recorder])
+
+    assert any(
+        p.grad is not None and torch.count_nonzero(p.grad) for p in module.model.parameters()
+    ), "with the content term zeroed the generator got no gradient — the adversarial term is inert"
+    assert params_changed(recorder.g[0], recorder.g[1]), "generator did not update"
+
+
+@_ignore_cpu_fit_warnings
+def test_adversarial_weight_scales_the_generators_gradient():
+    """The paper's 1e-3 has to actually multiply the adversarial term.
+
+    Doubling it must double the generator's gradient exactly, since with the
+    content term zeroed that gradient IS ``weight * d(adversarial)/d(theta)``.
+    A dropped or detached adversarial term leaves both runs at zero and fails
+    the non-degeneracy check first.
+    """
+    half = generator_grads_after_one_seeded_batch(0.5)
+    full = generator_grads_after_one_seeded_batch(1.0)
+
+    assert any(torch.count_nonzero(g) for g in full.values()), "no adversarial gradient to scale"
+    for name, grad in full.items():
+        assert torch.allclose(half[name], grad * 0.5, rtol=1e-5, atol=1e-8), name
+
+
+@_ignore_cpu_fit_warnings
 @pytest.mark.parametrize(("k", "n_batches", "expected"), [(1, 20, 40), (2, 20, 30)])
 def test_global_step_counts_optimizer_steps_not_batches(k, n_batches, expected):
     """global_step counts optimizer steps and this module takes two per batch,
@@ -277,7 +385,7 @@ def test_global_step_counts_optimizer_steps_not_batches(k, n_batches, expected):
     assert trainer.global_step == expected
 
 
-@_ignore_gpu_warning
+@_ignore_cpu_fit_warnings
 def test_training_keeps_updating_across_a_validation_boundary():
     """Everything but the optimization surface is inherited, so validation must
     still score and training must still move afterwards. A mid-training
@@ -302,7 +410,7 @@ def test_training_keeps_updating_across_a_validation_boundary():
 # ---------------------------------------------------------------------------
 
 
-@_ignore_gpu_warning
+@_ignore_cpu_fit_warnings
 def test_a_single_lr_scheduler_steps_once_per_batch():
     """With exactly one scheduler configured, LightningModule.lr_schedulers()
     returns the scheduler ITSELF, not a one-element list — iterating the bare
@@ -316,7 +424,7 @@ def test_a_single_lr_scheduler_steps_once_per_batch():
     assert trainer.optimizers[0].param_groups[0]["lr"] == pytest.approx(0.01)
 
 
-@_ignore_gpu_warning
+@_ignore_cpu_fit_warnings
 def test_both_schedulers_step_and_count_milestones_in_batches():
     """Milestones are counted in batches — deliberately a different unit from
     trainer.global_step, which counts this module's two optimizer steps per
@@ -402,3 +510,46 @@ def test_a_matching_discriminator_input_size_passes_the_probe():
     module.trainer = SimpleNamespace(datamodule=fake_datamodule(hr_crop_size=96))
 
     module.setup("fit")  # must not raise
+
+
+def test_the_probe_keys_on_the_hr_crop_the_discriminator_scores():
+    """The discriminator sees extract_target(hr_cropped), not the raw HR patch.
+
+    SRResNet emits exactly scale x lr, which makes the two indistinguishable, so
+    a probe keyed on the raw patch looks correct. A shrinking pre-upsampled
+    generator separates them: it takes a 112x112 patch and emits 96x96, and 96 is
+    the size that reaches the discriminator's shape-fixed dense head.
+    """
+    module = SRGANLightning(
+        model=ShrinkingGenerator(shrink=16),
+        processor=RGBSignedOutputProcessor(),
+        discriminator=SRDiscriminator(hr_input_size=96),
+        training_config=SRGANTrainingConfig(example_input_shape=None),
+    )
+    module.trainer = SimpleNamespace(datamodule=fake_datamodule(hr_crop_size=112, scale=1))
+
+    module.setup("fit")  # must not raise: the 112x112 patch is cropped to the 96x96 output
+
+
+def test_layer_lrs_refused():
+    """Inherited through SRResNetTrainingConfig, so YAML can set it — and this
+    override never reads it, which would silently give both networks uniform LRs
+    where the base raises. The file's only unsignalled misconfiguration."""
+    module = build_gan_module(layer_lrs=[1e-4, 1e-4, 1e-4])
+
+    with pytest.raises(ValueError, match="layer_lrs"):
+        module.configure_optimizers()
+
+
+def test_a_base_training_config_is_refused():
+    """on_fit_start's "the CUDA-graph path is unreachable" argument rests on
+    SRGANTrainingConfig.__post_init__ refusing cuda_graph, which only holds if
+    the config really is that subclass — the type hint alone does not enforce it,
+    and this project has been silently frozen by a live graph before."""
+    with pytest.raises(TypeError, match="SRGANTrainingConfig"):
+        SRGANLightning(
+            model=SRResNet(scale=4, num_residual_blocks=1),
+            processor=RGBSignedOutputProcessor(),
+            discriminator=SRDiscriminator(),
+            training_config=SRTrainingConfig(cuda_graph=True),
+        )

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -1,0 +1,404 @@
+"""SRGANLightning — the two-optimizer alternating training loop.
+
+Every failure mode this file guards is silent: nothing crashes, both loss
+curves keep moving, and the model trains wrongly. So each test drives a real
+``Trainer`` loop and asserts on parameters, gradients or step counts, not on
+whether a call happened.
+"""
+
+from types import SimpleNamespace
+
+import lightning
+import pytest
+import torch
+
+from sisr.losses import AdversarialLoss
+from sisr.models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
+from sisr.models.srresnet import SRResNet
+from sisr.processors import RGBSignedOutputProcessor, YChannelProcessor
+from sisr.training import SRGANLightning
+
+# Every fit below runs on CPU (matching CI, which has no GPU); Lightning logs a
+# PossibleUserWarning about the idle GPU on this dev box, which the strict global
+# filterwarnings=error would otherwise fail on.
+_ignore_gpu_warning = pytest.mark.filterwarnings(
+    "ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning"
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def build_gan_module(
+    k=1,
+    hr_input_size=96,
+    num_residual_blocks=1,
+    lr_scheduler=None,
+    discriminator_lr_scheduler=None,
+    cls=SRGANLightning,
+):
+    """A minimal but real SRGANLightning — one residual block keeps it CPU-fast."""
+    return cls(
+        model=SRResNet(scale=4, num_residual_blocks=num_residual_blocks),
+        processor=RGBSignedOutputProcessor(),
+        discriminator=SRDiscriminator(hr_input_size=hr_input_size),
+        adversarial_loss=AdversarialLoss(),
+        criterion=torch.nn.MSELoss(),
+        training_config=SRGANTrainingConfig(d_steps_per_g_step=k, example_input_shape=(3, 24, 24)),
+        eval_config=SRGANEvalConfig(perceptual_metrics=[]),
+        optimizer=lambda params: torch.optim.SGD(params, lr=0.1),
+        discriminator_optimizer=lambda params: torch.optim.SGD(params, lr=0.1),
+        lr_scheduler=lr_scheduler,
+        discriminator_lr_scheduler=discriminator_lr_scheduler,
+    )
+
+
+def clone_params(module):
+    return {name: p.detach().clone() for name, p in module.named_parameters()}
+
+
+def params_changed(before, after):
+    return any(not torch.equal(before[name], value) for name, value in after.items())
+
+
+def grad_snapshot(module):
+    return {
+        name: (None if p.grad is None else p.grad.detach().clone())
+        for name, p in module.named_parameters()
+    }
+
+
+def same_grad(before, after):
+    if (before is None) != (after is None):
+        return False
+    return before is None or torch.equal(before, after)
+
+
+def gan_loader(n_batches, hr=96, scale=4):
+    """(lr, hr) pairs matching the discriminator's declared input size."""
+    lr_size = hr // scale
+    return torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(
+            torch.rand(n_batches, 3, lr_size, lr_size), torch.rand(n_batches, 3, hr, hr)
+        ),
+        batch_size=1,
+    )
+
+
+def fit_gan(module, n_batches, callbacks=None, val_batches=0, **trainer_kwargs):
+    """Run a real Trainer loop over ``module`` and hand back the trainer."""
+    trainer = lightning.Trainer(
+        max_epochs=1,
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        num_sanity_val_steps=0,
+        callbacks=callbacks or [],
+        **trainer_kwargs,
+    )
+    trainer.fit(
+        module,
+        gan_loader(n_batches),
+        gan_loader(val_batches) if val_batches else None,
+    )
+    return trainer
+
+
+class ParamRecorder(lightning.Callback):
+    """Snapshots both networks' parameters before training and after every batch.
+
+    Index 0 is the pre-training state, index i+1 the state after batch i.
+    """
+
+    def __init__(self):
+        self.g = []
+        self.d = []
+
+    def on_train_start(self, trainer, pl_module):
+        self._record(pl_module)
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        self._record(pl_module)
+
+    def _record(self, pl_module):
+        self.g.append(clone_params(pl_module.model))
+        self.d.append(clone_params(pl_module.discriminator))
+
+
+class BackwardGradSpy(SRGANLightning):
+    """Records the discriminator's gradients immediately before every backward."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.d_grads_before_backward = []
+
+    def manual_backward(self, loss, *args, **kwargs):
+        self.d_grads_before_backward.append(grad_snapshot(self.discriminator))
+        return super().manual_backward(loss, *args, **kwargs)
+
+
+def fake_datamodule(hr_crop_size=96, scale=4):
+    """Minimal stand-in exposing the read accessors SRLightning.setup probes."""
+    lr_size = hr_crop_size // scale
+    return SimpleNamespace(
+        train_dataset=torch.utils.data.TensorDataset(
+            torch.rand(1, 3, lr_size, lr_size), torch.rand(1, 3, hr_crop_size, hr_crop_size)
+        ),
+        val_dataset=None,
+        test_datasets=None,
+    )
+
+
+def multistep(milestone=2):
+    return lambda opt: torch.optim.lr_scheduler.MultiStepLR(opt, milestones=[milestone], gamma=0.1)
+
+
+# ---------------------------------------------------------------------------
+# optimizers
+# ---------------------------------------------------------------------------
+
+
+def test_generator_optimizer_excludes_discriminator_parameters():
+    """The trap: self.parameters() sweeps D into the generator's optimizer,
+    which then MINIMISES the adversarial loss w.r.t. D — training D to lose,
+    with entirely healthy-looking curves and nothing failing."""
+    module = build_gan_module()
+    opt_g, opt_d = module.configure_optimizers()[0]
+
+    g_ids = {id(p) for group in opt_g.param_groups for p in group["params"]}
+    d_ids = {id(p) for p in module.discriminator.parameters()}
+    assert g_ids.isdisjoint(d_ids)
+    # ...and each optimizer owns exactly its own network, so the disjointness
+    # above cannot be satisfied by an under-populated generator optimizer.
+    assert g_ids == {id(p) for p in module.model.parameters()}
+    assert {id(p) for group in opt_d.param_groups for p in group["params"]} == d_ids
+
+
+def test_configure_optimizers_returns_the_optimizer_list_first_in_a_fixed_order():
+    """training_step unpacks self.optimizers() positionally, so the order is
+    part of the contract; the shape stays a (optimizers, schedulers) pair even
+    with no schedulers, so callers never have to branch on it."""
+    module = build_gan_module()
+
+    optimizers, schedulers = module.configure_optimizers()
+
+    assert schedulers == []
+    opt_g, opt_d = optimizers
+    assert {id(p) for group in opt_g.param_groups for p in group["params"]} == {
+        id(p) for p in module.model.parameters()
+    }
+    assert {id(p) for group in opt_d.param_groups for p in group["params"]} == {
+        id(p) for p in module.discriminator.parameters()
+    }
+
+
+# ---------------------------------------------------------------------------
+# the alternating step
+# ---------------------------------------------------------------------------
+
+
+@_ignore_gpu_warning
+def test_one_step_moves_both_networks_at_k1():
+    module = build_gan_module(k=1)
+    recorder = ParamRecorder()
+
+    fit_gan(module, n_batches=1, callbacks=[recorder])
+
+    assert params_changed(recorder.g[0], recorder.g[1]), "generator did not update"
+    assert params_changed(recorder.d[0], recorder.d[1]), "discriminator did not update"
+
+
+@_ignore_gpu_warning
+def test_at_k2_the_generator_updates_only_on_every_second_batch():
+    """k is spent ACROSS batches (Goodfellow Algorithm 1: each discriminator
+    step sees a fresh minibatch), not looped inside one training_step."""
+    module = build_gan_module(k=2)
+    recorder = ParamRecorder()
+
+    fit_gan(module, n_batches=2, callbacks=[recorder])
+
+    assert not params_changed(recorder.g[0], recorder.g[1]), "G must not update on batch 0 at k=2"
+    assert params_changed(recorder.d[0], recorder.d[1]), "D must update every batch"
+    assert params_changed(recorder.g[1], recorder.g[2]), "G must update on batch 1 at k=2"
+    assert params_changed(recorder.d[1], recorder.d[2]), "D must update every batch"
+
+
+@_ignore_gpu_warning
+def test_generator_backward_leaves_the_discriminator_gradients_untouched():
+    """The generator's backward passes THROUGH the discriminator to reach the
+    generator, and accumulates into D's .grad on the way unless toggled off.
+
+    Measured: without toggle_optimizer the generator's backward changes 34 of
+    the discriminator's gradient tensors (e.g. features.0.weight by 0.200085);
+    with it, none. It is currently harmless only because the next batch's
+    opt_d.zero_grad() clears the debris first — an emergent property of the
+    ordering, not a stated invariant, and a live bug the moment anything
+    reorders the steps or accumulates gradients.
+
+    The property is "the generator's backward does not *change* D's gradients",
+    not "D has no gradient afterwards": D legitimately carries the gradient of
+    its own loss at that point, since opt_d.zero_grad() runs *before* the
+    discriminator's backward and nothing clears it afterwards (measured: 74.99
+    on features.0.weight after a correct step). Both halves of the assertion
+    matter — one that only checked D would pass if the generator had silently
+    stopped learning altogether.
+    """
+    module = build_gan_module(k=1, cls=BackwardGradSpy)
+
+    fit_gan(module, n_batches=1)
+
+    assert len(module.d_grads_before_backward) == 2, "expected the D backward, then the G backward"
+    before_generator_backward = module.d_grads_before_backward[1]
+    after = grad_snapshot(module.discriminator)
+    polluted = [
+        name for name, grad in after.items() if not same_grad(before_generator_backward[name], grad)
+    ]
+    assert not polluted, f"generator backward polluted discriminator gradients at {polluted[:3]}"
+    assert any(
+        p.grad is not None and torch.count_nonzero(p.grad) for p in module.model.parameters()
+    ), "generator must still receive its gradient through the discriminator"
+
+
+@_ignore_gpu_warning
+@pytest.mark.parametrize(("k", "n_batches", "expected"), [(1, 20, 40), (2, 20, 30)])
+def test_global_step_counts_optimizer_steps_not_batches(k, n_batches, expected):
+    """global_step counts optimizer steps and this module takes two per batch,
+    so it is N + N//k — not the batch count. That is the unit max_steps,
+    val_check_interval and checkpoint filenames use, so a max_steps copied from
+    the SRResNet template trains for half the iterations. (Manual optimization
+    is not the cause: with a single optimizer it still equals the batch count.)
+    """
+    trainer = fit_gan(build_gan_module(k=k), n_batches=n_batches)
+
+    assert trainer.global_step == expected
+
+
+@_ignore_gpu_warning
+def test_training_keeps_updating_across_a_validation_boundary():
+    """Everything but the optimization surface is inherited, so validation must
+    still score and training must still move afterwards. A mid-training
+    validation run has frozen this project's training before (the CUDA-graph
+    zero_grad trap), and it does so with the loss curve still moving."""
+    module = build_gan_module(k=1)
+    recorder = ParamRecorder()
+
+    trainer = fit_gan(
+        module, n_batches=4, val_batches=1, callbacks=[recorder], val_check_interval=2
+    )
+
+    assert "loss/val" in trainer.callback_metrics
+    assert "psnr/val/RGB" in trainer.callback_metrics
+    # Snapshots are [initial, b0, b1, b2, b3]; validation runs between b1 and b2.
+    assert params_changed(recorder.g[2], recorder.g[3]), "generator froze after validation"
+    assert params_changed(recorder.d[2], recorder.d[3]), "discriminator froze after validation"
+
+
+# ---------------------------------------------------------------------------
+# LR schedulers — manual optimization does not step them
+# ---------------------------------------------------------------------------
+
+
+@_ignore_gpu_warning
+def test_a_single_lr_scheduler_steps_once_per_batch():
+    """With exactly one scheduler configured, LightningModule.lr_schedulers()
+    returns the scheduler ITSELF, not a one-element list — iterating the bare
+    return is a TypeError, so this configuration must be handled explicitly."""
+    module = build_gan_module(lr_scheduler=multistep(milestone=2))
+
+    trainer = fit_gan(module, n_batches=3)
+
+    assert len(trainer.lr_scheduler_configs) == 1
+    assert trainer.lr_scheduler_configs[0].scheduler.last_epoch == 3
+    assert trainer.optimizers[0].param_groups[0]["lr"] == pytest.approx(0.01)
+
+
+@_ignore_gpu_warning
+def test_both_schedulers_step_and_count_milestones_in_batches():
+    """Milestones are counted in batches — deliberately a different unit from
+    trainer.global_step, which counts this module's two optimizer steps per
+    batch. The paper's schedule (1e5 iterations, then 1e5 more) is in batches."""
+    module = build_gan_module(
+        lr_scheduler=multistep(milestone=2), discriminator_lr_scheduler=multistep(milestone=2)
+    )
+
+    trainer = fit_gan(module, n_batches=3)
+
+    assert [c.scheduler.last_epoch for c in trainer.lr_scheduler_configs] == [3, 3]
+    assert [o.param_groups[0]["lr"] for o in trainer.optimizers] == pytest.approx([0.01, 0.01])
+    assert trainer.global_step == 6
+
+
+# ---------------------------------------------------------------------------
+# refusals
+# ---------------------------------------------------------------------------
+
+
+def test_discriminator_channels_must_match_the_processor():
+    """A 1-channel processor with a 3-channel discriminator is otherwise a raw
+    Conv2d shape error on the first step."""
+    with pytest.raises(ValueError, match="in_channels"):
+        SRGANLightning(
+            model=SRResNet(scale=4, in_out_channels=1, num_residual_blocks=1),
+            processor=YChannelProcessor(),
+            discriminator=SRDiscriminator(in_channels=3),
+            training_config=SRGANTrainingConfig(),
+        )
+
+
+def test_unset_components_default_to_the_srgan_paper_ones():
+    """A base SREvalConfig here would silently score SRGAN with wang SSIM,
+    crop_border=0 and no perceptual metric — the only metric family that tracks
+    what an adversarial objective optimises."""
+    module = SRGANLightning(
+        model=SRResNet(scale=4, num_residual_blocks=1),
+        processor=RGBSignedOutputProcessor(),
+        discriminator=SRDiscriminator(),
+    )
+
+    assert isinstance(module.training_config, SRGANTrainingConfig)
+    assert isinstance(module.eval_config, SRGANEvalConfig)
+    assert isinstance(module.adversarial_loss, AdversarialLoss)
+    assert module.eval_config.ssim_impl == "daala"
+    assert module.eval_config.perceptual_metrics == ["lpips", "dists"]
+    assert module.automatic_optimization is False
+
+
+def test_matching_discriminator_channels_are_accepted():
+    """The check must key on the real channel counts, not refuse every pairing."""
+    module = SRGANLightning(
+        model=SRResNet(scale=4, in_out_channels=1, num_residual_blocks=1),
+        processor=YChannelProcessor(),
+        discriminator=SRDiscriminator(in_channels=1),
+        training_config=SRGANTrainingConfig(),
+    )
+
+    assert module.discriminator.hparams["in_channels"] == 1
+
+
+def test_ddp_refused():
+    module = build_gan_module()
+    module.trainer = SimpleNamespace(world_size=2, precision="32-true")
+
+    with pytest.raises(RuntimeError, match="world_size"):
+        module.on_fit_start()
+
+
+def test_discriminator_input_size_checked_against_the_real_crop():
+    """A D/crop mismatch is otherwise a raw Linear shape error deep in step 1."""
+    module = build_gan_module(hr_input_size=128)  # dataset serves 96
+    module.trainer = SimpleNamespace(datamodule=fake_datamodule(hr_crop_size=96))
+
+    with pytest.raises(ValueError, match="hr_input_size"):
+        module.setup("fit")
+
+
+def test_a_matching_discriminator_input_size_passes_the_probe():
+    """The probe must key on the real crop, not refuse every dataset."""
+    module = build_gan_module(hr_input_size=96)
+    module.trainer = SimpleNamespace(datamodule=fake_datamodule(hr_crop_size=96))
+
+    module.setup("fit")  # must not raise

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1718,6 +1718,42 @@ def test_setup_gracefully_reprobes_dataset_already_opened_by_real_training(
 
 
 # ---------------------------------------------------------------------------
+# _extra_probe — subclass hook fed setup()'s already-sampled (lr, hr) pair
+# ---------------------------------------------------------------------------
+
+
+def test_setup_calls_extra_probe_with_the_sampled_pair(tiny_rgb_image_dir: Path, tmp_path: Path):
+    """A subclass hook must receive the exact (lr, hr) pair setup() already
+    sampled from the real train dataset — not just any call. Asserting only
+    "was called" can't tell a correct pair from an empty or wrong one, so
+    this checks the actual shapes and their scale relationship."""
+    seen = {}
+
+    class Probing(SRLightning):
+        def _extra_probe(self, lr, hr, source):
+            seen["lr_shape"] = tuple(lr.shape)
+            seen["hr_shape"] = tuple(hr.shape)
+            seen["source"] = source
+
+    model = SRResNet(scale=2, num_residual_blocks=1)
+    lit = Probing(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRResNetTrainingConfig(scale=2),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")
+
+    assert seen["source"] == "train_dataset"
+    assert seen["hr_shape"][-1] == seen["lr_shape"][-1] * 2
+
+
+# ---------------------------------------------------------------------------
 # cuda_graph — full-step CUDA-graph capture of the training step
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
⛔ **Do not merge yet — 5th of a 6-PR stack.** Based on `feat/srgan-components`; merge the four below it first.

The SRGAN training loop: `SRGANLightning`, generator initialisation from pretrained weights, adversarial provenance, and the shipped template. Verified by a real GPU run.

Reference: Ledig et al., [arXiv:1609.04802](https://arxiv.org/pdf/1609.04802).

## The loop

`SRGANLightning(SRLightning)` with `automatic_optimization = False`. It **inherits `_forward_lr`/`_forward_sr`/`_step`/`validation_step`/metrics/checkpoint metadata unchanged** and overrides only the optimization surface — so training, benchmarking and inference still route through one pipeline.

Discriminator first, then generator (Goodfellow Algorithm 1), so the generator is updated against the critic that just moved. Goodfellow's `k` (`d_steps_per_g_step`, default 1 = Ledig's 1:1) is spent **across batches** — D every batch, G every k-th — so each discriminator step sees a fresh minibatch, as Algorithm 1 specifies. One generator forward per batch, reused: D's backward runs on `sr.detach()`, and G's flows through a second, fresh D forward. No `retain_graph` anywhere.

`toggle_optimizer`/`untoggle_optimizer` are load-bearing, not decoration. The generator's backward must pass *through* the discriminator to reach the generator, and without toggling it accumulates into D's `.grad` on the way — measured: D carries gradient `[1.241, 1.0]` untoggled versus `[None, None]` toggled, with the generator receiving its gradient either way.

## Units, measured

`global_step` counts optimizer steps, and this module takes **two per batch**, so it advances `N + N//k` per N batches. That is unchanged Lightning behaviour, **not** a quirk of manual optimization — measured over 20 batches: automatic + 1 optimizer = 20, **manual + 1 optimizer = 20**, manual + 2 optimizers = 40. Every other architecture here is unaffected.

The template's comment states each knob's real unit, because they differ: `max_steps`, checkpoint filenames and `every_n_train_steps` are in global steps; `val_check_interval`, `log_every_n_steps` and the hand-stepped scheduler milestones are in **batches**. TensorBoard's default x-axis is batches too, so `sr-weights-10000.pt` corresponds to x=5000 — a 2× offset between a curve and the checkpoint pulled off it.

The template ships the paper's **full** two-phase schedule: `max_steps: 400000` = 2×10⁵ generator iterations, with both networks' LR decaying 1e-4 → 1e-5 at batch 100000.

## Refusals

Five, all loud, because each otherwise mistrains or misloads silently: `cuda_graph` (one capture cannot wrap two alternating optimizers), DDP, `layer_lrs`, a discriminator whose `in_channels` disagrees with the processor, and a discriminator whose declared `hr_input_size` disagrees with the real training crop — validated against the *post-crop* size the discriminator actually receives.

`init_from` refuses **per field** — generator `class_path`, generator `init_args`, `processor.class_path`, `io.output_range`, `io.scale` — each naming the offending field, because weights trained under a different processor or scale produce a model that trains and scores without ever erroring. It also names a `.ckpt`, a discriminator's component `.pt`, and the `--…=null`-becomes-`'None'` CLI trap specifically. It loads only when the run is **fitting**, in `setup` — deliberately not `on_fit_start`, because Lightning restores a `--ckpt_path` resume *between* those two hooks, so loading later would overwrite a resumed generator while the discriminator and optimizer state carried on.

## Testing

**898 passed / 0 skipped / 0 failed** with the GPU visible. `ruff check` and `ruff format --check` clean.

The two load-bearing tests were run five times (5/5 green), and three mutations were verified RED with byte-identical reverts:

| Mutation | Caught by |
|---|---|
| `self.parameters()` instead of `self.model.parameters()` | parameter-disjointness |
| `k` guard removed | k=2 alternation |
| `g_loss = content` (adversarial term dropped) | adversarial-term test |

**That third one is why this section exists.** An earlier revision of these tests passed with the adversarial term dropped entirely — the module would have trained a plain SRResNet while still logging `loss/train/adv`, and scored *better* PSNR for it. The guard now uses a content loss that is identically zero, so the discriminator is the only possible source of a generator gradient, plus a check that halving `adversarial_weight` halves that gradient.

## Smoke run — mechanical, not a quality claim

500 batches from the golden 1M-step SRResNet initialisation, on GPU: 39 min 48 s, ~109 ms/batch steady state.

- CUDA-graph refusal fired at construction, verbatim — not a silent skip.
- `loss/train/d` min **0.216**, max 1.969, zero exact zeros — the critic did not win outright.
- Generator moved: **159/159** learnable tensors, ‖Δ‖₂ = 3.44. `num_batches_tracked` went **1000001 → 1000501**, proving both that the golden init loaded and that exactly 500 batches ran.
- All four loss tags present **and moving** (50 distinct values from 50 points each).
- Rolling windows held independently for all three checkpoint callbacks.
- Both `sr-weights-*.pt` (`kind='sr_model'`) and `d-weights-*.pt` (`kind='component'`) written, neither callback's deletion touching the other's files — the first real exercise of two weight checkpoints with different `attribute` values.

**No image-quality claim is made.** Perceptual gains need ~10⁵ iterations; PSNR is *expected* to fall under an adversarial objective. Any metric from this run is labelled not-evidence in the notes.

## Known issue, documented not fixed

The template's shipped dataloader worker counts **OOM host RAM at the first full validation** — a val worker's float64 `imresize` on a 2040 px DIV2K image, with a discriminator and VGG19 also resident. It fires at the first `val_check_interval`, i.e. hours in, not at step 0. The smoke run completed at 4 train / 0 val workers. The template documents this; no value was changed, because the safe counts on a given box are unmeasured and shipping a guess as though measured would be worse than saying so.

## Stack

```
main → CLI subclass mode → perceptual metrics → rolling checkpoints
     → SRGAN components → THIS PR · SRGAN module + template → docs
```

**Do not use "delete branch on merge"** — it races and closes the child PR instead of retargeting it.
