### PR TITLE
docs: document SRGAN training and the perceptual metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ notice.
 
 - **SRResNet** and **SRCNN**, both fully wired — model, dataset pipeline, config
   dataclasses, and an experiment template each.
+- **SRGAN** (`sisr/models/srgan/`, `sisr/training/gan_module.py`) — the SRResNet
+  generator trained adversarially against an `SRDiscriminator` critic. `SRGANLightning`
+  drives both optimizers under manual optimization, `AdversarialLoss` supplies the
+  non-saturating objective over the critic's logits, and the shipped template reproduces
+  SRGAN-VGG54. The generator initialises from an MSE-trained SRResNet's bare weights, the
+  paper's recipe, and refuses any weights file whose architecture, processor, output
+  range or scale disagrees with the run loading it. `trainer.global_step` counts
+  optimizer steps, so it advances twice per batch here and nowhere else — see the README.
+- **Subclass-mode CLI** — the top-level `model:` block may now name its Lightning module
+  with `class_path`/`init_args`, which is how a config selects `SRGANLightning` instead
+  of `SRLightning`. Existing configs that set `model:` fields directly keep resolving
+  against the default `SRLightning`; the shipped templates were re-nested to match the
+  new form.
+- **Perceptual metrics** (`sisr/perceptual.py`) — LPIPS and DISTS, selected by
+  `SREvalConfig.perceptual_metrics` and logged as `lpips/val` / `dists/val` and per
+  benchmark set. Empty by default, so every existing architecture logs exactly the tags
+  it logged before. They exist because an adversarial objective makes PSNR and SSIM worse
+  by design; neither substitutes for the paper's MOS study. `lpips_net` selects the LPIPS
+  backbone, and a figure is comparable only to one computed under the same backbone.
+- **`[perceptual]` extra** — `pip install '.[perceptual]'` for LPIPS, which torchmetrics
+  gates on the `lpips` package. DISTS needs nothing beyond torchvision and ships in core.
+- **Rolling last-N checkpoints** — `SRCheckpoint` and `SRWeightsCheckpoint` with
+  `monitor_metric: null` keep the last `keep_last` saves by step, which Lightning cannot
+  express through `save_top_k` alone. A metric-monitored "best" is the wrong artifact for
+  an adversarial run. When a monitor *is* set, its direction is now validated too, so a
+  lower-is-better metric left at the default `mode='max'` is refused at setup instead of
+  keeping the worst model of the run.
 - **`sisr` console script** over a single `LightningCLI` entrypoint, with `fit`, `test`,
   `predict` and `export` subcommands. One self-contained YAML drives an experiment.
 - **Pluggable losses** (`sisr/losses/`): `CharbonnierLoss`, `TotalVariationLoss`,
@@ -29,7 +56,9 @@ notice.
 - **Provenance metadata** (`sisr/training/metadata.py`) — one builder feeding checkpoints,
   bare weight files, and ONNX exports, so the three cannot drift.
 - **`SRWeightsCheckpoint`** — distributable optimizer-free `.pt` weights, roughly a third
-  the size of a full checkpoint.
+  the size of a full checkpoint. `attribute` picks which component gets saved, with
+  matching provenance, so a GAN run can hand out the generator and retain the critic in
+  separate files.
 - **Opt-in full-step CUDA-graph capture** (`SRTrainingConfig.cuda_graph`), which refuses
   configurations it cannot capture soundly rather than capturing them anyway.
 - **LR-only prediction path** — `PredictDataset`, `predict_step`, and `SRPredictionWriter`.
@@ -46,6 +75,8 @@ notice.
   stride needs no rebuild, and caching a dataset for one architecture serves the other.
 - **Colorspace is chosen by composing an `SRProcessor`**, replacing a config string field.
 - **Google-style docstrings are enforced** via ruff's pydocstyle rules.
+- **`torchmetrics>=1.9` floor** (was `>=1.4`) — the version DISTS was verified present in
+  on this project. Lowering it means testing the lower version, not guessing.
 
 ### Fixed
 
@@ -53,6 +84,14 @@ notice.
   `zero_grad(set_to_none=True)` severed a live CUDA graph's gradient tensors from the
   optimizer, so weights stopped updating while the reported loss kept moving.
 - **`--ckpt_path` could not reload any checkpoint this project had ever saved.**
+- **`--ckpt_path` rebuilt an architecture's `eval_config` as the base class**, so every
+  default the subclass had overridden reverted on reload — a resumed SRResNet run could
+  monitor a different SSIM convention than a fresh run from the same YAML. The
+  checkpoint's stored fields are now merged onto the class the config already selected,
+  so subclass identity and subclass-only defaults both survive, including from
+  checkpoints saved before a field existed. A dotted *command-line* override of such a
+  field still reverts the object to its base class — a separate, open defect; see the
+  README.
 - **The LMDB cache could delete another process's in-progress build.** Deletion is now
   restricted to proven corruption; environmental failures raise instead.
 - **SRCNN's paper weight-init std** corrected to the published `0.001`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ means writing a network and a config dataclass, not a new Lightning module. See
 |---|---|---|---|
 | SRCNN | [Dong et al. 2015](https://arxiv.org/pdf/1501.00092) | pre-upsampled to HR size | none, same-resolution refinement |
 | SRResNet | [Ledig et al. 2017](https://arxiv.org/pdf/1609.04802) | true low-resolution | ×scale sub-pixel convolution |
+| SRGAN | [Ledig et al. 2017](https://arxiv.org/pdf/1609.04802) | true low-resolution | ×scale sub-pixel convolution |
+
+SRGAN's network *is* SRResNet — only how it is trained differs. See [SRGAN](#srgan).
 
 ## Losses
 
@@ -83,8 +86,9 @@ class of ours:
 
 ```yaml
 model:
-  criterion:
-    class_path: torch.nn.L1Loss
+  init_args:
+    criterion:
+      class_path: torch.nn.L1Loss
 ```
 
 | Class | What it is |
@@ -102,17 +106,18 @@ Combining them logs each term separately as `loss/train/{name}` and
 
 ```yaml
 model:
-  criterion:
-    class_path: sisr.losses.WeightedSumLoss
-    init_args:
-      terms:
-        vgg22:
-          class_path: sisr.losses.VGG19FeatureLoss
-          init_args:
-            layer: vgg22
-        tv:
-          class_path: sisr.losses.TotalVariationLoss
-      weights: {vgg22: 1.0, tv: 2.0e-8}
+  init_args:
+    criterion:
+      class_path: sisr.losses.WeightedSumLoss
+      init_args:
+        terms:
+          vgg22:
+            class_path: sisr.losses.VGG19FeatureLoss
+            init_args:
+              layer: vgg22
+          tv:
+            class_path: sisr.losses.TotalVariationLoss
+        weights: {vgg22: 1.0, tv: 2.0e-8}
 ```
 
 That is Ledig et al.'s SRResNet-VGG22 recipe: a VGG22 content loss plus total
@@ -137,6 +142,69 @@ and it refuses a 3-channel non-RGB processor (`YCbCrProcessor`) unless you set
 trains on features that mean nothing. The frozen VGG is deliberately excluded
 from checkpoints, so a `.ckpt` trained under one criterion loads into a module
 configured with another.
+
+## SRGAN
+
+[`templates/config.srgan.template.yaml`](templates/config.srgan.template.yaml)
+reproduces **SRGAN-VGG54**, the paper's headline variant: the SRResNet generator, a
+VGG19 `φ_{5,4}` content loss, and `sisr.losses.AdversarialLoss` (non-saturating, over
+the critic's logits) weighted `1e-3`, alternating one `sisr.models.srgan.SRDiscriminator`
+update per generator update. `sisr.training.SRGANLightning` owns both optimizers under
+manual optimization; the YAML selects it by `class_path` on the top-level `model:` block,
+which is what that block's `class_path`/`init_args` nesting is for.
+
+```bash
+pip install '.[perceptual]'   # LPIPS. DISTS needs no extra.
+sisr fit --config templates/config.srgan.template.yaml
+```
+
+**The generator starts from an MSE-trained SRResNet.** Ledig et al. scope the
+MSE-initialisation trick to "when training the actual GAN", so a paper-faithful run
+points `training_config.init_from` at a finished SRResNet run's bare-weights `.pt` —
+never the sibling `.ckpt`, which holds the whole LightningModule. That file's own
+provenance metadata is checked against this run's generator, processor, output range and
+scale, and refused on any mismatch: weights trained under a different one produce a model
+that trains and scores without ever erroring. Set `init_from: null` in the YAML to train
+from scratch, which is not the paper's recipe (`--...init_from=null` on the command line
+does not work — jsonargparse coerces it to the string `'None'`).
+
+**`global_step` runs ahead of the batch count here, and only here.** It counts optimizer
+steps, and this module takes two per batch, so after `N` batches it reads `N + N // k` —
+twice `N` at the default `k = 1`. This is unchanged Lightning behaviour, not a quirk of
+manual optimization: manual optimization with a *single* optimizer still gives
+`global_step == batches`, measured. No other architecture here is affected. Two knobs
+that read alike are in different units, so check which before copying a number between
+templates:
+
+| Counted in global steps | Counted in batches |
+|---|---|
+| `trainer.max_steps`, `every_n_train_steps`, the `{step}` in checkpoint filenames | `val_check_interval`, `log_every_n_steps`, LR-scheduler milestones |
+
+TensorBoard's default x-axis is the batch counter, so a curve and the checkpoint pulled
+off it are a factor of 2 apart.
+
+**PSNR and SSIM get worse by design.** An adversarial objective buys perceptual detail by
+spending distortion, which is what those two measure. The template's checkpoints are
+therefore rolling rather than monitored — `monitor_metric: null` with `keep_last: 3`
+keeps the last three saves by step — because a `save_top_k` on `psnr/val/RGB` or
+`ssim/val/RGB` selects the *least* adversarial state of the run, typically one from its
+first few thousand steps. `SRWeightsCheckpoint` does the same for distributable weights,
+once per network via `attribute: model` and `attribute: discriminator`.
+
+**Perceptual metrics are what track the objective instead.** `SRGANEvalConfig` adds
+`lpips` and `dists` on top of SRResNet's scoring, logged as `lpips/val` and `dists/val`
+during validation and as `lpips/{set}` / `dists/{set}` per benchmark set. Both are
+lower-is-better, so a checkpoint monitoring one needs `mode: min`; `SRCheckpoint` refuses
+the wrong direction at setup rather than quietly keeping the worst model of the run.
+
+**MOS is not reproduced.** Ledig et al.'s headline result is a human mean-opinion-score
+study, and nothing here stands in for one. LPIPS and DISTS correlate with human judgement
+better than PSNR does — that is the entire claim being made for them, not that they are a
+substitute.
+
+The template also records a host-RAM OOM in the validation dataloader workers, hit at the
+first validation rather than at step 0; read the comment beside its
+`val_dataloader_kwargs` before choosing worker counts.
 
 ## Comparability
 
@@ -177,73 +245,72 @@ both are pinned:
   SRResNet SSIM figure is comparable to Ledig et al. and **not** to Wang-based tables
   (the EDSR/RCAN/SwinIR/BasicSR lineage); always say which convention a number came
   from.
+- **An LPIPS figure is comparable only to one computed under the same backbone**, and
+  the discipline is the same as SSIM's. `SREvalConfig.lpips_net` selects `'alex'` (the
+  default, and what the SR literature usually reports), `'vgg'` or `'squeeze'`; these
+  are three different learned networks, not three reductions of one number, so they do
+  not agree on the same image. As with `ssim_impl`, the tag (`lpips/val`) and the
+  checkpoint filename carry the bare value and nothing about how it was produced — the
+  backbone is recorded in `hparams` and in every artifact's `sisr_meta`. DISTS has no
+  such knob.
 
-## `--ckpt_path` silently drops subclass-only `eval_config` defaults
+## Config overrides and subclass defaults
 
-Checkpoints saved before `ssim_impl` existed do not pick up its new default when
-reloaded — and the mechanism is not "the checkpoint overrides the CLI"; it is more
-structural than that. `SRLightning` saves `eval_config` in `hparams` as
-`dataclasses.asdict(self.eval_config)` — a bare dict with no `class_path`
-([`sisr/training/lightning_module.py`](sisr/training/lightning_module.py)).
-`SRLightningCLI._parse_ckpt_path` rebuilds that dict via `_reconstruct_ckpt_hparams`
-and hands it to jsonargparse as the `model.eval_config` value
-([`sisr/cli.py`](sisr/cli.py)). Because the dict carries no class identity,
-jsonargparse instantiates the field's **annotation type** — the base `SREvalConfig`
-— never the subclass (`SRResNetEvalConfig`) that actually produced the value, and it
-does this whether or not a CLI override was also given, since the replacement runs
-after argument parsing. Keys the dict happens to carry survive as explicit values;
-any key it is missing falls back to `SREvalConfig`'s own default, not the subclass's.
-A checkpoint saved before `ssim_impl` existed simply has no such key, so nothing
-"overrides" anything — the field falls to the base default, `wang`. `crop_border=4`
-and `psnr_channels=['RGB', 'Y']` survive reload only because `dataclasses.asdict`
-happened to record them explicitly at save time, not because the subclass identity
-is preserved.
+**`--ckpt_path` preserves subclass identity.** `SRLightning` saves `eval_config` in
+`hparams` as `dataclasses.asdict(self.eval_config)` — a bare dict with no `class_path`
+([`sisr/training/lightning_module.py`](sisr/training/lightning_module.py)) —
+and `SRLightningCLI._parse_ckpt_path` merges that dict, through the *subcommand's own*
+parser, onto the class `--config` has already selected
+([`sisr/cli.py`](sisr/cli.py)). The stored keys land as `init_args` overrides on
+`SRResNetEvalConfig`; every key the dict does not mention keeps the subclass's own
+default, not the base class's. So a checkpoint saved before `ssim_impl` existed still
+reloads as an `SRResNetEvalConfig` scoring `daala`, and `crop_border=4` /
+`psnr_channels=['RGB', 'Y']` survive because the class does, not because
+`dataclasses.asdict` happened to record them. This holds on every subcommand that
+accepts `--ckpt_path`, `fit` resume included, and is locked by
+`test_ckpt_path_preserves_eval_config_subclass_identity` in
+[`tests/test_cli.py`](tests/test_cli.py), which asserts both the reloaded object's class
+and a subclass-only default absent from the checkpoint's stored dict. Earlier versions
+of this README described patching a copy of a checkpoint's `hyper_parameters` before
+re-scoring; that recipe existed for this failure only, and is obsolete.
 
-**This generalises past `ssim_impl`.** Any `SREvalConfig` field an architecture
-subclass overrides is equally at risk the moment a checkpoint predates that field, on
-**every** subcommand that accepts `--ckpt_path` — `fit` resume included, not just
-`validate`/`test`. That makes resume the more damaging case: resuming a pre-change
-SRResNet run from an old checkpoint trains and checkpoints on `wang` `ssim/val/RGB`
-for the rest of the run, while a fresh `fit` from the identical YAML uses `daala` —
-two runs of "the same config" whose monitored metric means different things,
-distinguishable only by reading `hparams`, not by anything in the logs or filenames.
-This behaviour is locked in (deliberately not fixed) by
-`test_ckpt_path_loses_subclass_only_eval_defaults` in
-[`tests/test_cli.py`](tests/test_cli.py) — read it for the exact mechanics, including
-why a CLI override alongside `--ckpt_path` doesn't help.
-
-For example:
+**A dotted command-line override still resets the config it touches.** This is a
+separate defect with a separate cause — no checkpoint is involved, and it is not fixed.
+Setting one field of a subclass-typed config from the CLI applies that field but
+rebuilds the object as its bare annotation type, so every *other* default the subclass
+had overridden silently reverts with it:
 
 ```bash
-sisr validate --config my.yaml --ckpt_path old.ckpt --model.eval_config.ssim_impl=daala
+sisr validate --config templates/config.srresnet.template.yaml \
+              --model.init_args.eval_config.ssim_impl=wang
 ```
 
-silently scores with `wang`: the emitted config confirms `wang`, and the SSIM values
-come back bit-identical to a pre-upgrade run. This is a one-time migration issue per
-field, not an ongoing bug — a checkpoint written after a given field was added
-carries it explicitly and restores it correctly; it is only checkpoints predating
-that field that fall back.
+resolves `eval_config` to the base `SREvalConfig`. `ssim_impl` is `wang` as asked, but
+`crop_border` drops `4` → `0` and `psnr_channels` drops `['RGB', 'Y']` → `['RGB']`, and
+nothing in the logs says so. The same happens to `training_config`, and to any field
+whose annotation has subclasses. Naming the class in a separate argument does not help;
+the dotted override that follows resets it again.
 
-Workaround: patch a **copy** of the checkpoint and re-score (or resume) from the
-copy. Handle both hparams formats the codebase supports — current checkpoints nest
-`eval_config` as a dict, but checkpoints from before `SRLightning` stopped
-flattening `self.hparams` store `'/'`-joined keys instead (e.g.
-`"eval_config/ssim_impl"`; see `_reconstruct_ckpt_hparams` in
-[`sisr/cli.py`](sisr/cli.py) and the legacy-flattened-checkpoint test in
-[`tests/test_cli.py`](tests/test_cli.py)) — and old checkpoints are exactly the
-population this section targets:
+Two forms do work. Set the field in YAML — in the config itself, or in an overlay passed
+as a second `--config`:
 
-```python
-import torch
-
-ckpt = torch.load("old.ckpt", weights_only=True, map_location="cpu")
-hp = ckpt["hyper_parameters"]
-if "eval_config" in hp and isinstance(hp["eval_config"], dict):
-    hp["eval_config"]["ssim_impl"] = "daala"  # current nested format
-else:
-    hp["eval_config/ssim_impl"] = "daala"  # legacy '/'-flattened format
-torch.save(ckpt, "old_daala.ckpt")
+```yaml
+model:
+  init_args:
+    eval_config:
+      init_args:
+        ssim_impl: wang
 ```
+
+or pass the whole object as one JSON argument, `class_path` included:
+
+```bash
+sisr validate --config templates/config.srresnet.template.yaml \
+  --model.init_args.eval_config='{"class_path": "sisr.models.srresnet.SRResNetEvalConfig", "init_args": {"ssim_impl": "wang"}}'
+```
+
+`--print_config` tells the two apart at a glance: the resolved `eval_config` shows a
+`class_path` when the subclass survived, and a bare key/value mapping when it did not.
 
 ## ONNX export
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ before running it:
 - **TV's `2e-8` presumes a `[-1, 1]` model output range**, i.e.
   `RGBSignedOutputProcessor`. Under a `[0, 1]` processor the same image has half
   the total variation, so the effective weight differs by 2×.
-- **A perceptual run scores worse PSNR by design.** The shipped templates already
-  checkpoint on both `psnr/val/RGB` and `ssim/val/RGB` — under a perceptual
-  criterion the PSNR-monitored "best" no longer tracks the training objective, so
-  decide which monitored checkpoint you actually want.
+- **A perceptual run scores worse PSNR by design.** The shipped non-adversarial
+  templates (SRCNN, SRResNet) already checkpoint on both `psnr/val/RGB` and
+  `ssim/val/RGB` — under a perceptual criterion the PSNR-monitored "best" no longer
+  tracks the training objective, so decide which monitored checkpoint you actually
+  want. (SRGAN's template is deliberately monitor-free instead — see [SRGAN](#srgan).)
 
 A VGG loss normalises with RGB ImageNet statistics, so it refuses a 1-channel
 processor (SRCNN's `YChannelProcessor`) unless you set `grayscale_to_rgb: true`,
@@ -166,11 +167,18 @@ provenance metadata is checked against this run's generator, processor, output r
 scale, and refused on any mismatch: weights trained under a different one produce a model
 that trains and scores without ever erroring. Set `init_from: null` in the YAML to train
 from scratch, which is not the paper's recipe (`--...init_from=null` on the command line
-does not work — jsonargparse coerces it to the string `'None'`).
+does not work — jsonargparse coerces it to the string `'None'`). YAML is also the safer
+place for any other `training_config` field, for the reason covered under
+[Config overrides and subclass defaults](#config-overrides-and-subclass-defaults):
+`training_config` is a dataclass-typed field, and here it also carries
+`adversarial_weight` and `d_steps_per_g_step`, so a dotted CLI override of one field
+reverts the rest. `SRGANLightning` rejects the reverted base config at construction, so
+this fails loudly rather than silently — but it fails.
 
 **`global_step` runs ahead of the batch count here, and only here.** It counts optimizer
-steps, and this module takes two per batch, so after `N` batches it reads `N + N // k` —
-twice `N` at the default `k = 1`. This is unchanged Lightning behaviour, not a quirk of
+steps, and this module takes one discriminator step every batch plus one generator step
+every `k`-th batch, so after `N` batches it reads `N + N // k` — twice `N` at the default
+`k = 1`. This is unchanged Lightning behaviour, not a quirk of
 manual optimization: manual optimization with a *single* optimizer still gives
 `global_step == batches`, measured. No other architecture here is affected. Two knobs
 that read alike are in different units, so check which before copying a number between
@@ -179,6 +187,10 @@ templates:
 | Counted in global steps | Counted in batches |
 |---|---|
 | `trainer.max_steps`, `every_n_train_steps`, the `{step}` in checkpoint filenames | `val_check_interval`, `log_every_n_steps`, LR-scheduler milestones |
+
+`every_n_train_steps` needs an even value to fire at its stated cadence, since
+`global_step` only takes even values here — an odd one fires at twice its nominal
+period (mechanics in the template's comment).
 
 TensorBoard's default x-axis is the batch counter, so a curve and the checkpoint pulled
 off it are a factor of 2 apart.
@@ -287,9 +299,11 @@ sisr validate --config templates/config.srresnet.template.yaml \
 
 resolves `eval_config` to the base `SREvalConfig`. `ssim_impl` is `wang` as asked, but
 `crop_border` drops `4` → `0` and `psnr_channels` drops `['RGB', 'Y']` → `['RGB']`, and
-nothing in the logs says so. The same happens to `training_config`, and to any field
-whose annotation has subclasses. Naming the class in a separate argument does not help;
-the dotted override that follows resets it again.
+nothing in the logs says so. The same happens to `training_config` — these two
+dataclass-typed config fields are the affected shape, not subclass-typed fields
+generally: `model` itself has subclasses (`SRResNet` among them) and survives a dotted
+override of one of its own scalar fields with every other value intact. Naming the class
+in a separate argument does not help; the dotted override that follows resets it again.
 
 Two forms do work. Set the field in YAML — in the config itself, or in an overlay passed
 as a second `--config`:

--- a/README.md
+++ b/README.md
@@ -167,13 +167,19 @@ provenance metadata is checked against this run's generator, processor, output r
 scale, and refused on any mismatch: weights trained under a different one produce a model
 that trains and scores without ever erroring. Set `init_from: null` in the YAML to train
 from scratch, which is not the paper's recipe (`--...init_from=null` on the command line
-does not work — jsonargparse coerces it to the string `'None'`). YAML is also the safer
-place for any other `training_config` field, for the reason covered under
-[Config overrides and subclass defaults](#config-overrides-and-subclass-defaults):
-`training_config` is a dataclass-typed field, and here it also carries
-`adversarial_weight` and `d_steps_per_g_step`, so a dotted CLI override of one field
-reverts the rest. `SRGANLightning` rejects the reverted base config at construction, so
-this fails loudly rather than silently — but it fails.
+does not work — jsonargparse coerces it to the string `'None'`). A dotted CLI override
+of one field is safe on `training_config` here but not on `eval_config`, and the
+difference is the annotation each argument carries, not the field. `SRGANLightning`
+types `training_config` as `SRGANTrainingConfig | None`, so the bare-annotation rebuild
+described under
+[Config overrides and subclass defaults](#config-overrides-and-subclass-defaults) lands
+back on the subclass itself — overriding `adversarial_weight` or `d_steps_per_g_step`
+alone costs nothing. `eval_config` is still typed at the base `SREvalConfig | None`,
+exactly as it is on `SRLightning`, so a dotted override of one of its fields reverts the
+rest: `perceptual_metrics` empties — silently removing the only metric family that
+tracks an adversarial objective — and `ssim_impl` flips from `daala` to `wang`, with
+nothing logged. YAML, or the whole-object JSON override from that section, is what to
+use for any `eval_config` field here.
 
 **`global_step` runs ahead of the batch count here, and only here.** It counts optimizer
 steps, and this module takes one discriminator step every batch plus one generator step


### PR DESCRIPTION
⛔ **Do not merge yet — top of a 6-PR stack.** Doc-only; merge the five below it first.

Documents the SRGAN training path and the perceptual metrics, and **revises** the section describing the checkpoint-reload defect that the bottom of this stack fixes.

## The revision matters more than the addition

`README.md` documented — as live behaviour — that `--ckpt_path` rebuilds `eval_config` as the base class and silently drops every default an architecture subclass overrode. **That is fixed**, so the warning, its escalation, and the patch-a-copy-of-the-checkpoint workaround recipe are **deleted**, not softened. A warning that contradicts the code is worse than none.

**The residual is described precisely, because there is one.** A dotted CLI override of a dataclass-typed config field — `--model.init_args.eval_config.ssim_impl=wang`, **no `--ckpt_path` involved** — still applies the value while reverting the object to the base class, so every *other* subclass default reverts with it. Different cause, still open. Scoped to `eval_config`/`training_config`: subclass-typed fields such as `model` merge correctly, verified by counterexample. Two working forms are documented, and `--print_config` distinguishes them (a surviving subclass prints a `class_path`; a reverted one prints a bare mapping).

## Not a breaking change

The subclass-mode CLI was checked rather than assumed: both pre-change templates were instantiated under the new CLI, and jsonargparse treats a `class_path`-less `model:` mapping as `init_args` for the default model class, so **existing configs keep resolving** — subclassed eval configs and all. The old dotted CLI form still parses too. The CHANGELOG says so instead of carrying a false migration warning.

## What else is documented

SRGAN-VGG54 as the reproduced variant; the MSE-trained-SRResNet initialisation and why the paper scopes it to the GAN; the `global_step` accounting (`N + N//k` from two optimizer steps per batch — unchanged Lightning behaviour, **not** a manual-optimization quirk, and no other architecture affected) with each knob's real unit; that PSNR and SSIM get worse **by design**, which is why rolling last-N checkpoints exist; `pip install '.[perceptual]'` for LPIPS while DISTS needs no extra; and that a LPIPS figure compares only within one `lpips_net`, in the same voice as the existing SSIM-convention warning.

**MOS is not reproduced.** Ledig's headline result is a human study. LPIPS and DISTS correlate with it better than PSNR does, and that is the whole claim — they are not a substitute, and the README says so plainly.

No number from the arc's smoke run appears anywhere: 500 batches is a mechanical check, not evidence of quality.
