### PR TITLE
fix: name a compiler package conda-forge still ships in the daala regenerator

### DIFF
--- a/tests/reference/gen_daala_ssim_expected.py
+++ b/tests/reference/gen_daala_ssim_expected.py
@@ -1,7 +1,8 @@
 """Regenerate ``daala_ssim_expected.json`` from the real daala C reference.
 
-Developer-only: needs a C compiler in the ``sisr`` env (see the plan). The test
-suite and CI read the committed JSON and never run this.
+Developer-only: needs a C compiler in the ``sisr`` env -- see :func:`build` for the
+drivers tried and how to install one. The test suite and CI read the committed JSON
+and never run this.
 
 Usage (from the repo root, PowerShell, with the ``sisr`` conda env activated --
 activation puts the env's ``Library\\bin``, hence the compiler, on PATH):
@@ -28,16 +29,15 @@ HERE = Path(__file__).resolve().parent
 
 def build(workdir: Path) -> Path:
     """Compile the vendored reference and return the executable path."""
-    # conda-forge's Windows gcc/clang packages only ship a target-prefixed
-    # driver (e.g. x86_64-w64-mingw32-gcc.exe) -- no plain gcc/clang alias --
-    # so that name is tried too, after the plain ones.
+    # conda-forge's `gcc` ships a plain gcc.exe on Windows, but `gcc_win-64` alone
+    # ships only the target-prefixed driver (x86_64-w64-mingw32-gcc.exe), so that
+    # name is tried too, after the plain ones.
     cc = shutil.which("gcc") or shutil.which("clang") or shutil.which("x86_64-w64-mingw32-gcc")
     if cc is None:
         sys.exit(
-            "No C compiler on PATH. If m2w64-gcc is already installed in the sisr env, "
-            "activate that env (or add its Library\\bin to PATH) so "
-            "x86_64-w64-mingw32-gcc.exe resolves. Otherwise install it: "
-            "conda install -n sisr -c conda-forge m2w64-gcc"
+            "No C compiler on PATH. If gcc is already installed in the sisr env, "
+            "activate that env (or add its Library\\bin to PATH) so gcc.exe "
+            "resolves. Otherwise install it: conda install -n sisr -c conda-forge gcc"
         )
     exe = workdir / ("daala_ssim.exe" if sys.platform == "win32" else "daala_ssim")
     subprocess.run(


### PR DESCRIPTION
## What changed

The daala-SSIM reference regenerator now names a compiler package conda-forge
still ships. Its no-compiler error told the developer to install `m2w64-gcc`.

## Why

conda-forge retired that package. At version 15 it ships three activation
scripts and no compiler, its only dependency is the real toolchain, and it
prints an obsolescence notice on every `conda activate`. Following the advice
produced a broken environment and a confusing message on every shell.

The comment above it had drifted the other way: it claimed conda-forge's
Windows packages ship *no* plain `gcc` alias, so only the target-prefixed
driver could be found. Verified false on the current toolchain -- `gcc.exe`
and `cc.exe` are both present and `shutil.which("gcc")` resolves directly.
The prefixed fallback is still worth keeping, but for a `gcc_win-64`-only
environment, not because no plain alias exists anywhere.

Developer-only path: the suite and CI read the committed JSON and never
compile.

## Evidence

No test: a string asserting its own text documents nothing. The meaningful
check is that the script still works under the toolchain it now advertises.

Re-ran the regenerator end to end on this box:

- `133 cases (14 synthetic, 119 real)` written
- `git diff` on `tests/reference/daala_ssim_expected.json` **empty** -- every
  case reproduced byte-identically
- exercises the `shutil.which` chain that this diff touches

Also grepped the repo for the stale value, per the lesson from the last
doc-drift fix: both occurrences were in this one file, and both are fixed.

## Checklist

- [x] `pytest` passes locally, and I have said which tests **skipped** (a skip is not a pass)
- [x] `ruff check` and `ruff format --check` are clean
- [x] Commit subjects use a Conventional Commit type and describe the **effect**
- [x] Docs changes are in their own `docs:` commit, not mixed into a code commit
- [x] Breaking changes carry `!` and a `BREAKING CHANGE:` footer
- [x] No internal tracker identifiers in the code or commit messages

## Merge strategy

- [x] **Squash** -- single-purpose PR
