### PR TITLE
fix: keep a config's subclass when a dotted CLI override sets one of its fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,11 @@ dependencies = [
     # those, not just the functional entry points.
     # Lowering it means testing the lower version, not guessing.
     "torchmetrics>=1.9",
-    "jsonargparse[signatures]>=4.27",
+    # sisr/cli.py calls set_parsing_settings(subclasses_enabled=...) so a dotted CLI
+    # override of a dataclass config field keeps the architecture's subclass. That
+    # keyword does not exist below 4.50, and 4.50 is the version it was verified on
+    # here. Lowering it means testing the lower version, not guessing.
+    "jsonargparse[signatures]>=4.50",
     "lmdb>=1.4",
     "pillow>=10",
     "numpy>=1.26",

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -35,11 +35,12 @@ from pathlib import Path
 from typing import Any, Literal
 
 import torch
+from jsonargparse import set_parsing_settings
 from lightning.pytorch import Trainer
 from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCLI
 
 from .export import to_onnx
-from .training import SRDataModule, SRLightning
+from .training import SRDataModule, SREvalConfig, SRLightning, SRTrainingConfig
 
 # Checkpoints saved before SRLightning.__init__ stopped flattening self.hparams for
 # TensorBoard display (see its docstring) stored ONLY these two dataclasses' fields —
@@ -171,6 +172,16 @@ class SRLightningCLI(LightningCLI):
                 f"for every subcommand at construction. Subclass _ExportTrainer, or add "
                 f"an `export` method with the same signature."
             )
+        # Must precede super().__init__(), which builds every subcommand's parser.
+        # jsonargparse treats a pure dataclass as a *closed* type by default (its
+        # `is_pure_dataclass` selector), so a dotted override such as
+        # --model.init_args.eval_config.crop_border=0 arrives as a NestedArg and
+        # rebuilds the whole field from the bare annotation, discarding the
+        # architecture's subclass and every subclass-only default with it. Naming
+        # the two base classes re-enables subclasses for all their descendants;
+        # disabling the selector by name instead would change parsing for every
+        # dataclass-typed field in Lightning and jsonargparse too.
+        set_parsing_settings(subclasses_enabled=[SREvalConfig, SRTrainingConfig])
         super().__init__(*args, trainer_class=trainer_class, **kwargs)
 
     def parse_arguments(self, parser: LightningArgumentParser, args: ArgsType) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -376,27 +376,29 @@ def test_srgan_template_ships_a_real_init_from_path():
 
 
 @_ignore_random_vgg
-def test_dotted_override_reverts_eval_config_but_not_training_config(tmp_path: Path):
-    """Characterisation: a dotted CLI override of one nested field is not neutral.
+def test_dotted_override_keeps_the_config_subclass(tmp_path: Path):
+    """A dotted CLI override sets its field and changes nothing else.
 
-    jsonargparse rebuilds the whole subclass field from its *bare annotation*
-    when a dotted override touches it, so the outcome depends on how the
-    module's ``__init__`` types that argument:
+    jsonargparse treats a pure dataclass as a *closed* type by default, which
+    made a dotted override rebuild the whole field from its **bare annotation**.
+    The outcome then depended on how the module's ``__init__`` typed the
+    argument, which is not a distinction any user could predict:
 
     * ``training_config`` is annotated ``SRGANTrainingConfig | None`` — the bare
-      annotation already **is** the subclass, so nothing is lost.
+      annotation already **is** the subclass, so nothing was lost.
     * ``eval_config`` is annotated ``SREvalConfig | None`` on the base module, so
-      overriding any field on it silently drops back to the base class and every
-      subclass-only default with it: ``perceptual_metrics`` empties (the only
-      metric family an adversarial run can be judged by) and ``ssim_impl`` flips
-      from ``'daala'`` to ``'wang'``, renumbering SSIM against a different
-      convention. Nothing is logged.
+      overriding any field on it dropped back to the base class and took every
+      subclass-only default with it: ``perceptual_metrics`` emptied (the only
+      metric family an adversarial run can be judged by) and ``ssim_impl``
+      flipped ``'daala'`` → ``'wang'``, renumbering SSIM against a different
+      convention with nothing logged.
 
-    **The second half is a known open defect, not desired behaviour.** It is
-    pinned here so a jsonargparse release that changes the merge — in either
-    direction — shows up as a failing test rather than as a silently different
-    experiment. The same annotation-dependence governs the checkpoint-reload
-    merge in ``_parse_ckpt_path``.
+    ``SRLightningCLI.__init__`` now re-enables subclasses for both config
+    families, so both halves behave the same way. Each half is asserted on a
+    field the base class either lacks or defaults differently — that, not the
+    overridden value, is what says no rebuild happened. A jsonargparse release
+    that changes the merge in either direction fails this test rather than
+    silently producing a differently-scored experiment.
     """
     from sisr.models.srgan import SRGANEvalConfig, SRGANTrainingConfig
     from sisr.training import SREvalConfig
@@ -431,12 +433,40 @@ def test_dotted_override_reverts_eval_config_but_not_training_config(tmp_path: P
     assert kept.training_config.init_from == str(tmp_path / "absent.pt")
     assert kept.training_config.example_input_shape == (3, 24, 24)
 
-    reverted = _resolve(*args, "--model.init_args.eval_config.crop_border=0").model
-    assert not isinstance(reverted.eval_config, SRGANEvalConfig)
-    assert type(reverted.eval_config) is SREvalConfig
-    assert reverted.eval_config.crop_border == 0
-    assert reverted.eval_config.perceptual_metrics == []
-    assert reverted.eval_config.ssim_impl == "wang"
+    kept_eval = _resolve(*args, "--model.init_args.eval_config.crop_border=0").model
+    assert isinstance(kept_eval.eval_config, SRGANEvalConfig)
+    assert type(kept_eval.eval_config) is not SREvalConfig
+    assert kept_eval.eval_config.crop_border == 0
+    # Both are subclass-only defaults the override never names: on the base class
+    # they are [] and 'wang', so their survival is what says no rebuild happened.
+    assert kept_eval.eval_config.perceptual_metrics == ["lpips", "dists"]
+    assert kept_eval.eval_config.ssim_impl == "daala"
+
+
+def test_dotted_override_keeps_a_base_annotated_training_config_subclass():
+    """The ``training_config`` half of the same fix, on a template that can see it.
+
+    SRGAN annotates ``training_config`` with its own subclass, so rebuilding the
+    field from the annotation is a no-op there and that template cannot tell
+    whether the fix applies to ``SRTrainingConfig`` at all. ``SRLightning``
+    annotates it ``SRTrainingConfig | None``, and the SRResNet template fills it
+    with ``SRResNetTrainingConfig``, so this is the configuration where the
+    second entry in ``subclasses_enabled`` is load-bearing.
+
+    ``scale`` and ``init_strategy`` exist only on the subclass — on a rebuilt
+    base ``SRTrainingConfig`` the attribute access itself would raise.
+    """
+    from sisr.models.srresnet import SRResNetTrainingConfig
+
+    m = _resolve(
+        "--config",
+        str(SRRESNET_TEMPLATE),
+        "--model.init_args.training_config.example_input_shape=[3,32,32]",
+    ).model
+    assert isinstance(m.training_config, SRResNetTrainingConfig)
+    assert m.training_config.example_input_shape == (3, 32, 32)
+    assert m.training_config.scale == 4
+    assert m.training_config.init_strategy == "default"
 
 
 def test_composite_criterion_resolves_through_the_real_cli(tmp_path: Path):


### PR DESCRIPTION
## What changed

A dotted CLI override of one field on a config dataclass now sets that field
and changes nothing else. Previously it silently reverted every *other* field
on that config to the base class.

## Why

`--model.init_args.eval_config.crop_border=0` set `crop_border` and, with
nothing logged, also reverted:

- SRResNet's `ssim_impl` from `daala` back to `wang` -- renumbering SSIM under
  a different convention, so the run's numbers stop being comparable to the
  ones it is supposed to be compared against
- SRGAN's `perceptual_metrics` to empty -- removing the only metric family an
  adversarial run can be judged by, since PSNR and SSIM get worse by design

Whether it happened at all depended on how the module's `__init__` annotated
the argument: `SRGANLightning` types `training_config` as its own subclass, so
that one survived, while `eval_config` is typed as the base on `SRLightning`,
so that one did not. That is not a distinction any user could predict from the
config they wrote.

Root cause: jsonargparse registers `is_pure_dataclass` as a subclasses-disabled
selector by default, so these config dataclasses were treated as *closed*
types. A dotted override arrives as a `NestedArg`, which then rebuilds the
whole field from the bare annotation and discards the subclass identity that
had been threaded through correctly.

The CLI now re-enables subclasses for both config families before the parsers
are built. Naming the two base classes covers every architecture's subclass;
dropping the selector by name would have changed parsing for every
dataclass-typed field in Lightning and jsonargparse too.

The dependency floor moves to the first release carrying `subclasses_enabled`,
and to the version this was verified on.

## Evidence

**Bug fix** -- the tests that catch it:

- `tests/test_cli.py::test_dotted_override_keeps_the_config_subclass`
- `tests/test_cli.py::test_dotted_override_keeps_a_base_annotated_training_config_subclass`

Both confirmed **RED** against the unfixed code and **GREEN** after, by
reverting only `sisr/cli.py` and re-running:

| | unfixed | fixed |
| --- | --- | --- |
| `type(eval_config)` | `SREvalConfig` | `SRGANEvalConfig` |
| `ssim_impl` | `wang` | `daala` |
| `perceptual_metrics` | `[]` | `['lpips', 'dists']` |
| `crop_border` (the override) | 0 | 0 |

The first test replaces the characterisation test that pinned the old
behaviour -- replaced, not deleted, so the thing that flips is visible in the
diff.

The second test exists because the first cannot observe half the fix: SRGAN
annotates `training_config` with its own subclass, so no SRGAN config can tell
whether `SRTrainingConfig` is covered. It uses the SRResNet template, where
`SRLightning` annotates the base and `scale` / `init_strategy` exist only on
the subclass -- on a rebuilt base the attribute access itself would raise.

Full suite: **918 passed, 0 skipped, 0 failed**. `--print_config` output is
byte-identical for both shipped templates, so no emitted config changes shape.

## Checklist

- [x] `pytest` passes locally, and I have said which tests **skipped** (a skip is not a pass)
- [x] `ruff check` and `ruff format --check` are clean
- [x] Commit subjects use a Conventional Commit type and describe the **effect**
- [x] Docs changes are in their own `docs:` commit, not mixed into a code commit
- [x] Breaking changes carry `!` and a `BREAKING CHANGE:` footer
- [x] No internal tracker identifiers in the code or commit messages

## Merge strategy

- [x] **Squash** -- single-purpose PR
