### PR TITLE
fix: bound the per-image gather in imresize so validation stops exhausting host RAM

### DIFF
--- a/sisr/imresize.py
+++ b/sisr/imresize.py
@@ -67,6 +67,12 @@ import numpy as np
 
 _KERNEL_WIDTH = 4.0  # bicubic support width; MATLAB's a=-0.5 coefficient (OpenCV uses a=-0.75)
 
+# Cap on one gather's float64 footprint in _resize_axis -- see its docstring. Sized
+# well above any training crop (a 96x96 crop at scale 4 gathers 0.84 MiB, so the
+# training path never splits) and well below a full-image validation gather (286.88
+# MiB for a 1536x2040 DIV2K image at the same scale).
+_GATHER_CHUNK_BYTES = 64 << 20
+
 
 def _cubic(x: np.ndarray) -> np.ndarray:
     """MATLAB's bicubic convolution kernel (Keys' family, a=-0.5)."""
@@ -152,6 +158,16 @@ def _resize_axis(
     the multiply and reduction, measured 1.77x per axis pass with
     bit-identical output.
 
+    ``gathered`` itself is then built in slices of the *free* axis (the one not
+    being resized) rather than whole. Whole, it is
+    ``(out_length, num_taps, free_length, C)`` float64 -- 286.88 MiB for a
+    1536x2040 DIV2K image at scale 4, per DataLoader worker per image, which is
+    what exhausted host RAM at the first full-image validation of a run using the
+    shipped worker counts. The contraction runs over the tap axis alone, so every
+    output element's summation is unchanged by where the free axis is cut: the
+    result is byte-identical, not merely close, and is asserted that way in
+    ``tests/test_imresize.py``.
+
     Args:
         image: uint8 array, ``(H, W, C)``.
         axis: ``0`` to resize height, ``1`` to resize width.
@@ -161,12 +177,37 @@ def _resize_axis(
     Returns:
         uint8 array with *axis* resized to ``out_length``.
     """
-    if axis == 0:
-        gathered = image[indices].astype(np.float64)  # (out_h, num_taps, W, C)
-        out = np.einsum("ij,ijkl->ikl", weights, gathered, optimize=True)
+    out_length, num_taps = weights.shape
+    channels = image.shape[2]
+    free_length = image.shape[1 if axis == 0 else 0]
+    step = max(1, _GATHER_CHUNK_BYTES // (out_length * num_taps * channels * 8))
+
+    def contract(start: int, stop: int) -> np.ndarray:
+        if axis == 0:
+            gathered = image[indices, start:stop].astype(np.float64)  # (out_h, taps, w, C)
+            return np.einsum("ij,ijkl->ikl", weights, gathered, optimize=True)
+        gathered = image[start:stop][:, indices].astype(np.float64)  # (h, out_w, taps, C)
+        return np.einsum("jk,ijkl->ijl", weights, gathered, optimize=True)
+
+    if step >= free_length:
+        # One slice covers the image, so skip the output buffer and the copy into
+        # it -- neither is free. Every training crop lands here (0.84 MiB gathered
+        # at 96x96, scale 4), and this branch is what keeps the cap off the hot
+        # path: without it the crop case measured +10.6% for a split it never does.
+        out = contract(0, free_length)
     else:
-        gathered = image[:, indices].astype(np.float64)  # (H, out_w, num_taps, C)
-        out = np.einsum("jk,ijkl->ijl", weights, gathered, optimize=True)
+        if axis == 0:
+            shape = (out_length, free_length, channels)
+        else:
+            shape = (free_length, out_length, channels)
+        out = np.empty(shape, dtype=np.float64)
+        for start in range(0, free_length, step):
+            stop = min(start + step, free_length)
+            if axis == 0:
+                out[:, start:stop] = contract(start, stop)
+            else:
+                out[start:stop] = contract(start, stop)
+
     return _round_half_away_from_zero(np.clip(out, 0.0, 255.0)).astype(np.uint8)
 
 

--- a/tests/test_imresize.py
+++ b/tests/test_imresize.py
@@ -234,6 +234,55 @@ def test_resize_axis_einsum_matches_naive_multiply_then_sum(in_h, in_w, out_h, o
     )
 
 
+@pytest.mark.parametrize("axis", [0, 1])
+def test_resize_axis_gather_chunking_is_byte_identical_and_really_splits(axis, monkeypatch):
+    """Slicing the gather along the free axis must not move a single byte.
+
+    ``_resize_axis`` caps one gather's float64 footprint at
+    ``_GATHER_CHUNK_BYTES`` and walks the free axis in slices, because the
+    un-split gather is 286.88 MiB for a full-size DIV2K validation image and that
+    allocation is what exhausted host RAM at a run's first validation. The
+    contraction runs over the tap axis alone, so the split is arithmetically
+    inert.
+
+    Both halves are load-bearing. The equality alone would pass vacuously under a
+    cap that never splits — which is exactly the configuration the training path
+    runs in — so the observed gather sizes are asserted too: more than one, and
+    every one within the cap.
+    """
+    import sisr.imresize as imresize
+
+    rng = np.random.default_rng(20260809 + axis)
+    img = rng.integers(0, 256, size=(40, 53, 3), dtype=np.uint8)
+    in_length = img.shape[axis]
+    out_length = in_length // 3
+    free_length = img.shape[1 if axis == 0 else 0]
+    weights, indices = _contributions(in_length, out_length, out_length / in_length)
+    bytes_per_column = out_length * weights.shape[1] * img.shape[2] * 8
+
+    sizes: list[int] = []
+    real_einsum = np.einsum
+
+    def spy_einsum(subscripts, *operands, **kwargs):
+        sizes.append(operands[1].nbytes)  # the gathered taps
+        return real_einsum(subscripts, *operands, **kwargs)
+
+    monkeypatch.setattr(imresize.np, "einsum", spy_einsum)
+
+    monkeypatch.setattr(imresize, "_GATHER_CHUNK_BYTES", free_length * bytes_per_column)
+    whole = _resize_axis(img, axis, weights, indices)
+    assert len(sizes) == 1, "the unsplit reference itself split -- cap chosen too small"
+
+    for columns in (3, 1):
+        sizes.clear()
+        cap = columns * bytes_per_column
+        monkeypatch.setattr(imresize, "_GATHER_CHUNK_BYTES", cap)
+        split = _resize_axis(img, axis, weights, indices)
+        assert len(sizes) == -(-free_length // columns), "the cap did not split the gather"
+        assert max(sizes) <= cap
+        assert np.array_equal(whole, split)
+
+
 def test_matlab_imresize_constant_image_is_invariant():
     """Weights always sum to 1, so resizing a constant-value image at any
     scale must reproduce that exact constant everywhere (up or down)."""


### PR DESCRIPTION
## What changed

`imresize` now builds its gathered-taps array in slices of the free axis
instead of whole, bounding one image's transient float64 allocation at 64 MiB.

## Why

`_resize_axis` materialised the entire gather at once:
`(out_length, num_taps, free_length, C)` in float64. For a 1536x2040 DIV2K
image at scale 4 that is **286.88 MiB**, per DataLoader worker, per image.

Training never saw it -- a 96x96 crop gathers 0.84 MiB, 341x smaller -- so it
first appeared at a run's first *full-image* validation and killed the run
there, hours in rather than at step 0. The failure was
`numpy._ArrayMemoryError: Unable to allocate 287. MiB for an array with shape
(384, 16, 2040, 3)`, which is exactly this array.

The contraction runs over the tap axis alone, so where the free axis is cut
cannot change any output element's summation. A single slice short-circuits to
the previous code path, which is what keeps the cap off the training path.

## Evidence

**Touches `sisr/imresize.py`** -- byte-equality re-proven:

- `resize()` output **byte-identical** to the previous implementation on 12
  real DIV2K validation images (`np.array_equal` on the final uint8, not a
  tolerance)
- Identical across cap sizes 1 / 4 / 16 / 64 / 256 / 1024 MiB, so the slicing
  boundary is inert rather than incidentally harmless at one setting
- The MATLAB reference byte-equality tests pass (data present on this box, so
  they ran rather than skipped)

**Bug fix** -- the test that catches it:

- `tests/test_imresize.py::test_resize_axis_gather_chunking_is_byte_identical_and_really_splits`
  (both axes)
- It asserts the split output equals the unsplit output **and** that the split
  actually happened -- observed gather sizes are more than one and each within
  the cap. Without the second half the first would pass vacuously under a cap
  that never splits, which is exactly the configuration the training path runs
  in.

**Performance** -- before/after on real data:

| | before | after |
| --- | --- | --- |
| peak gather (exact array size) | 286.9 MiB | **64.0 MiB** |
| full-image validation resize | 157.6 ms | 170.6 ms (+8.2%) |
| 96x96 training crop | 680.1 us | 671.9 us (no measurable change) |

- Medians of 5 isolated runs per variant; warm-up excluded. Within-variant
  spread under 0.7%.
- Measured on: this branch vs `main`'s `imresize.py` extracted verbatim by git,
  real DIV2K validation images, **AC Best-performance overlay**, one variant per
  fresh process, each pinned to a single core.
- The pinning and process isolation are not ceremony: timing both variants in
  one process made whichever ran *second* slower by -15.8% one ordering and
  +37.1% the other, and this CPU is hybrid, so a fresh process landing on a P-
  vs E-core splits a sub-millisecond timing almost exactly 2x. Three earlier
  attempts at this table were wrong before that protocol was adopted.
- The +8.2% is confined to full-image validation (~1.3 s per 100-image pass).
  The training path short-circuits and is unchanged.

**Scope, stated honestly:** this removes the allocation that raised the error,
and a run using the shipped worker counts now completes where it previously
died. But it is ~2.5% of that run's total host-memory demand. The dominant
term is the number of spawned workers, so this bounds a spike rather than
making a marginal configuration safe.

## Checklist

- [x] `pytest` passes locally, and I have said which tests **skipped** (a skip is not a pass)
- [x] `ruff check` and `ruff format --check` are clean
- [x] Commit subjects use a Conventional Commit type and describe the **effect**
- [x] Docs changes are in their own `docs:` commit, not mixed into a code commit
- [x] Breaking changes carry `!` and a `BREAKING CHANGE:` footer
- [x] No internal tracker identifiers in the code or commit messages

## Merge strategy

- [x] **Squash** -- single-purpose PR
