### PR TITLE
ci: skip build/test matrices on doc-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,33 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Cheap gate: skips the expensive matrices below on a doc-only PR. Deliberately
+  # an allowlist, not a denylist — anything not explicitly listed here (including
+  # this workflow file itself) is treated as code and runs the full matrix.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        id: filter
+        with:
+          predicate-quantifier: some-with-excludes
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+
   build-matrix:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -50,6 +76,8 @@ jobs:
   # CONTRIBUTING.md gives contributors who skip uv exactly that command. One
   # OS/Python leg is enough — this checks build-backend behaviour, not the matrix.
   editable-install:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -65,13 +93,14 @@ jobs:
         run: python -c "import sisr; from sisr.cli import main; print('sisr', sisr.__version__, '- main:', main)"
 
   # Stable required-check context: green only if every build-matrix leg and the
-  # editable-install check passed (see the equivalent gate in test.yml).
+  # editable-install check passed, or were skipped because `changes` found a
+  # doc-only PR (see the equivalent gate in test.yml).
   build:
     needs: [build-matrix, editable-install]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Require all matrix legs to pass
+      - name: Require all matrix legs to pass or be skipped (doc-only PR)
         run: |
-          [ "${{ needs.build-matrix.result }}" = "success" ]
-          [ "${{ needs.editable-install.result }}" = "success" ]
+          [ "${{ needs.build-matrix.result }}" = "success" ] || [ "${{ needs.build-matrix.result }}" = "skipped" ]
+          [ "${{ needs.editable-install.result }}" = "success" ] || [ "${{ needs.editable-install.result }}" = "skipped" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,32 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Cheap gate: skips the expensive matrices below on a doc-only PR. Deliberately
+  # an allowlist, not a denylist — anything not explicitly listed here (including
+  # this workflow file itself) is treated as code and runs the full matrix.
+  # lint stays ungated: it's a single cheap job, not a matrix, and isn't part of
+  # the `test` required-check's own dependency chain.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        id: filter
+        with:
+          predicate-quantifier: some-with-excludes
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -40,6 +66,8 @@ jobs:
         run: ruff format --check .
 
   test-matrix:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
@@ -98,6 +126,8 @@ jobs:
   # matrix. Installs the `export` extra explicitly since test-matrix's `.[dev]`
   # deliberately excludes it (onnx/onnxruntime stay opt-in for contributors).
   onnx-export:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -114,14 +144,15 @@ jobs:
       - name: ONNX export parity tests
         run: pytest tests/test_export.py tests/test_cli.py -k export -v
 
-  # Stable required-check context: green only if every matrix leg passed
-  # (legs report as "test-matrix (os, ver)", which are not fixed contexts).
+  # Stable required-check context: green only if every matrix leg passed, or
+  # were skipped because `changes` found a doc-only PR (legs report as
+  # "test-matrix (os, ver)", which are not fixed contexts).
   test:
     needs: [test-matrix, onnx-export]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Require all matrix legs to pass
+      - name: Require all matrix legs to pass or be skipped (doc-only PR)
         run: |
-          [ "${{ needs.test-matrix.result }}" = "success" ]
-          [ "${{ needs.onnx-export.result }}" = "success" ]
+          [ "${{ needs.test-matrix.result }}" = "success" ] || [ "${{ needs.test-matrix.result }}" = "skipped" ]
+          [ "${{ needs.onnx-export.result }}" = "success" ] || [ "${{ needs.onnx-export.result }}" = "skipped" ]


### PR DESCRIPTION
## What

Skips the expensive build/test matrices on doc-only PRs, without letting a
required status check ever go unreported.

- Adds a `changes` job to both `build.yml` and `test.yml` using
  `dorny/paths-filter` (pinned by commit SHA). It flags `code == 'true'`
  whenever a changed file falls outside a docs allowlist: `**/*.md`,
  `docs/**`, `LICENSE`. Everything else — including `.github/workflows/**`,
  `pyproject.toml`, and `templates/*.yaml` — counts as code.
- Gates the expensive jobs behind `if: needs.changes.outputs.code == 'true'`:
  `build-matrix`, `editable-install` (in `build.yml`) and `test-matrix`,
  `onnx-export` (in `test.yml`). `lint` stays ungated (cheap, single job, and
  not part of the `test` summary job's dependency chain).
- The workflow-level `on:` triggers are untouched — both workflows still fire
  on every PR, so the required `test`/`build` contexts always report.
- Fixes a bug this change would otherwise expose: the `build`/`test` summary
  jobs already run unconditionally (`if: always()`), but their pass/fail
  assertion only accepted a `success` result per dependency. A skipped matrix
  (now possible under the new gate) would have flipped the required check red
  on a doc-only PR. Both assertions now accept `success` **or** `skipped`.

## Why an allowlist, not a denylist

`*.md`, `docs/**`, and `LICENSE` are the only paths confirmed doc-only.
Everything else is treated as code, including paths that look docs-adjacent
but aren't: `templates/*.yaml` is exercised by `tests/test_cli.py`, and
`pyproject.toml` carries both the dependency spec and pytest config.

## Verification

This PR itself touches `.github/workflows/**`, which is deliberately never
doc-only-classified — so its own CI run legitimately runs everything (see
below) and can't by itself demonstrate the skip path.

**1. This PR's own run (code path, unaffected):** every job ran and passed,
including all four matrix legs on both workflows plus `lint`,
`editable-install`, and `onnx-export`. `changes` correctly evaluated
`code == 'true'` since the diff touches `.github/workflows/**`.

**2. Doc-only skip path, proven via a temporary stacked PR:** a throwaway
branch (`ci/verify-doc-only-skip`) was created on top of this feature branch
with a single commit that only appends a line to `CHANGELOG.md`, and a
temporary PR (`#99`) was opened with **this feature branch as its base**
(not `main`) and that throwaway branch as its head. Because the PR's base
already carried this change, `dorny/paths-filter`'s GitHub-API-based diff
(which resolves the real PR base from the event context, not a hardcoded
`main` — confirmed in the job log: *"Fetching list of changed files for
PR#99 ... Detected 1 changed files ... CHANGELOG.md"*) correctly saw a
doc-only diff. Observed job statuses on PR #99:

| Job | Result |
|---|---|
| `changes` (both workflows) | success |
| `build-matrix` (all 4 legs) | **skipped** |
| `editable-install` | **skipped** |
| `test-matrix` (all 4 legs) | **skipped** |
| `onnx-export` | **skipped** |
| `lint` | success (ungated, as designed) |
| **`build`** (required check) | **success** |
| **`test`** (required check) | **success** |

Note: the workflows' `pull_request` trigger only matches `branches: [main]`,
and a `pull_request` event evaluates from the merge-commit context of its
*actual* base branch — so a PR whose base isn't `main` needed that base
branch to (temporarily) also match the trigger before GitHub would run the
workflow at all. This was done with a temporary commit on this branch widening
`branches: [main]` to `branches: [main, ci/skip-doc-only-matrices]`, pushed,
used only to let PR #99 fire, then immediately reverted via a hard reset back
to the prior commit before this PR was left for review — this PR's tip
(`901bf1240da036748eb90f5c451371e0a5f6e065`) has never carried that widening.
The widening commit lived only on the throwaway side of the test and never
appeared in the base↔head diff paths-filter evaluated, so it didn't
contaminate the doc-only signal being tested.

PR #99 was then closed and its branch (`ci/verify-doc-only-skip`) deleted —
it was verification-only and was never intended to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
