### PR TITLE
[temporary] verify doc-only CI skip gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,5 @@ notice.
   (GHSA-53q9-r3pm-6pq6 / CVE-2025-32434). See [SECURITY.md](SECURITY.md).
 
 [Unreleased]: https://github.com/YeapJieShen/single-image-super-resolution/commits/main
+
+<!-- verification-only: confirms the doc-only CI skip gate; this branch is temporary and will be deleted. -->


### PR DESCRIPTION
Temporary PR to verify the doc-only skip gate added in #98. Base is the feature branch, head is a single trivial CHANGELOG.md-only commit. Will be closed and the branch deleted once the matrix-skip / summary-green behavior is confirmed.