### PR TITLE
chore: add mypy static type checking and a py.typed marker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,36 @@ jobs:
       - name: Ruff format check
         run: ruff format --check .
 
+  # Type-checks only the modules [tool.mypy]'s overrides don't blanket-ignore
+  # (Lightning's hook system and jsonargparse's dynamic CLI/subclass
+  # resolution make sisr/training/, sisr/cli.py resist useful static typing
+  # without a large, separate effort). Installs the dev extra rather than a
+  # bare `mypy` so it type-checks against the same third-party stubs/versions
+  # the rest of CI runs against.
+  # windows-latest, not ubuntu-latest: sisr/cache.py's ctypes.WinDLL Windows
+  # liveness check is genuine platform-specific code, guarded by a runtime
+  # sys.platform == "win32" check -- but typeshed's ctypes stubs only expose
+  # WinDLL under that same platform, so mypy raises attr-defined errors for it
+  # when its own --platform is anything else. test-matrix already treats
+  # windows-latest as first-class, so this matches, not adds, a supported OS.
+  typecheck:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # See the lint job for why this pins an exact patch version.
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-suffix: typecheck
+      - name: Install
+        run: uv pip install --system -e ".[dev]"
+      - name: Mypy
+        run: mypy sisr
+
   test-matrix:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,12 @@ described in the [README](README.md#install).
 ```bash
 pytest                                  # full suite
 pytest --cov=sisr --cov-report=term     # with coverage, as CI runs it
+mypy sisr                               # type-check, as CI runs it
 ```
+
+`mypy` only checks the modules `[tool.mypy]`'s overrides don't blanket-ignore — Lightning's
+hook system and jsonargparse's dynamic CLI/subclass resolution make `sisr/training/` and
+`sisr/cli.py` resist useful static typing without a much larger, separate effort.
 
 `tests/` mirrors `sisr/`, so `sisr/training/lightning_module.py` maps to
 `tests/training/test_lightning_module.py`.
@@ -40,9 +45,10 @@ subprocesses where breakpoints never fire. Run with
 
 ## Making a change
 
-Branch off `main`, add tests with your change, run `pytest`, open a PR. Three checks have
-to pass: **test** (pytest + coverage), **build** (`pip install .` and imports work), and
-**lint** (`ruff check` + `ruff format --check`). `main` keeps linear history.
+Branch off `main`, add tests with your change, run `pytest`, open a PR. Four checks have
+to pass: **test** (pytest + coverage), **build** (`pip install .` and imports work),
+**lint** (`ruff check` + `ruff format --check`), and **typecheck** (`mypy sisr`, over the
+modules it doesn't blanket-ignore). `main` keeps linear history.
 
 The path a change takes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,3 +222,10 @@ ignore_errors = true
 # versions in dev's environment: torchvision 0.28, tqdm 4.70).
 module = ["torchvision.*", "tqdm.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# onnx is the optional [export] extra, deliberately not part of the default
+# dev install (see test.yml's onnx-export job) — the typecheck job installs
+# only [dev], so the import is unresolved there regardless of stub coverage.
+module = ["onnx"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,12 @@ dev = [
     "pyyaml>=6",
     "ruff>=0.9",
     "mypy>=1.11",
+    # tests/test_packaging.py builds a real wheel via hatchling's PEP 517
+    # build_wheel() hook to check py.typed actually ships in it, rather than
+    # only asserting the pyproject.toml config that's supposed to include it.
+    # Already a [build-system] requirement; declared again here so it's
+    # present outside pip's ephemeral build-isolation environment too.
+    "hatchling>=1.27",
 ]
 # Opt-in: sisr/export.py gates the actual `import onnx` inside to_onnx(),
 # so plain `pip install .` stays onnx-free. onnxruntime is the CI numeric-parity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     # resolves only transitively (via jsonargparse/lightning), which is fragile.
     "pyyaml>=6",
     "ruff>=0.9",
+    "mypy>=1.11",
 ]
 # Opt-in: sisr/export.py gates the actual `import onnx` inside to_onnx(),
 # so plain `pip install .` stays onnx-free. onnxruntime is the CI numeric-parity
@@ -181,3 +182,37 @@ convention = "google"
 # Test *names* are the documentation here; writing hundreds of docstrings to
 # satisfy a linter is churn, not clarity.
 "tests/**" = ["D"]
+
+[tool.mypy]
+# Checks that the "modern type hints" style rule (PEP 585/604) is a checked
+# promise, not just convention. Runs over the whole `sisr` package; the
+# overrides below blanket-ignore the modules whose dynamism (Lightning's hook
+# system, jsonargparse's dynamic CLI/subclass resolution) resists useful
+# static typing without a large, separate effort. The mypy CI job is green
+# only because of those overrides -- it is not exercising those modules.
+python_version = "3.12"
+# Pinned rather than left to infer from the host: sisr/cache.py's Windows
+# liveness check uses ctypes.WinDLL, which typeshed only exposes under this
+# platform. Without pinning it, the exact same code type-checks clean on a
+# Windows dev machine and fails with attr-defined errors on Linux/macOS one
+# -- see the typecheck CI job (windows-latest) for the other half of this.
+platform = "win32"
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+disallow_untyped_defs = true
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+# Lightning's hook system (dynamic **kwargs call signatures, callback
+# protocol) and jsonargparse's dynamic CLI/subclass resolution (dotted
+# overrides, class_path dispatch) make these fight a type checker rather than
+# benefit from one. Ignored wholesale rather than annotated around.
+module = ["sisr.training.*", "sisr.cli"]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+# Neither ships inline types or a py.typed marker (checked against the
+# versions in dev's environment: torchvision 0.28, tqdm 4.70).
+module = ["torchvision.*", "tqdm.*"]
+ignore_missing_imports = true

--- a/sisr/cache.py
+++ b/sisr/cache.py
@@ -73,6 +73,7 @@ def _pid_alive_windows(pid: int) -> bool:
     STILL_ACTIVE = 259
     ERROR_ACCESS_DENIED = 5
 
+    assert _kernel32 is not None  # only called when sys.platform == "win32"
     handle = _kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not handle:
         return ctypes.get_last_error() == ERROR_ACCESS_DENIED
@@ -190,7 +191,7 @@ class LMDBCacheBuildContext:
         with ProcessPoolExecutor(max_workers=num_workers) as executor:
             pending: set[Future] = set()
 
-            def _submit():
+            def _submit() -> None:
                 nonlocal next_submit
                 if next_submit < n_items:
                     args = (items[next_submit],)
@@ -639,6 +640,7 @@ class LMDBCache:
         """
         if self._heartbeat_stop is None:
             return
+        assert self._heartbeat_thread is not None  # set together in _start_heartbeat
         self._heartbeat_stop.set()
         try:
             self._heartbeat_thread.join(timeout=1.0)

--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -14,7 +14,7 @@ torch-free :mod:`~sisr.datasets.hr_cache`, because it subclasses
 """
 
 import abc
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -99,8 +99,13 @@ class SRDataset(torch.utils.data.Dataset, abc.ABC):
         """Return the number of items the dataset serves."""
 
     @abc.abstractmethod
-    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return the ``(lr_tensor, hr_tensor)`` pair at ``idx``."""
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor] | torch.Tensor:
+        """Return the ``(lr_tensor, hr_tensor)`` pair at ``idx``.
+
+        Paired train/validation datasets return the tuple; prediction-only
+        datasets (no ground-truth HR to pair with) return a lone LR tensor —
+        see :class:`~sisr.datasets.predict.PredictDataset`.
+        """
 
 
 class HRCachedTrainDataset(SRDataset):
@@ -179,7 +184,11 @@ class HRCachedTrainDataset(SRDataset):
             sizes.append((h, w))
         return sizes
 
-    def _parallel_build_hr(self, ctx: LMDBCacheBuildContext, process_fn) -> None:
+    def _parallel_build_hr(
+        self,
+        ctx: LMDBCacheBuildContext,
+        process_fn: Callable[[Path, int], list[tuple[str, bytes]]],
+    ) -> None:
         """Runs the shared HR-decode build over :attr:`img_paths`.
 
         *process_fn* is passed in rather than imported here so each

--- a/sisr/losses/composite.py
+++ b/sisr/losses/composite.py
@@ -96,6 +96,7 @@ class WeightedSumLoss(SRLoss):
             else:
                 prior.copy_(value)
             total = contribution if total is None else total + contribution
+        assert total is not None  # __init__ requires terms to be non-empty
         return total
 
     def describe(self) -> str:

--- a/sisr/losses/vgg.py
+++ b/sisr/losses/vgg.py
@@ -121,6 +121,14 @@ class _VGGFeatureLoss(SRLoss):
     #: Name of the ``torchvision.models`` builder for this depth.
     MODEL_NAME: ClassVar[str]
 
+    # Declared here so attribute access resolves to these types instead of
+    # falling back to nn.Module.__getattr__'s `Tensor | Module` union: `_vgg`
+    # is assigned via object.__setattr__ (see __init__) and `_mean`/`_std` via
+    # register_buffer, neither of which mypy can see as a normal `self.x = ...`.
+    _vgg: torch.nn.Module
+    _mean: torch.Tensor
+    _std: torch.Tensor
+
     def __init__(
         self,
         layer: str = "vgg22",

--- a/sisr/models/base.py
+++ b/sisr/models/base.py
@@ -1,7 +1,7 @@
 """Abstract base class for single-image super-resolution architectures."""
 
 import abc
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 import torch
 import torch.nn as nn
@@ -36,7 +36,7 @@ class SRModel(nn.Module, abc.ABC):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the model on input ``x`` and return the SR output tensor."""
 
-    def reset_parameters(self, **kwargs) -> None:
+    def reset_parameters(self, **kwargs: Any) -> None:
         """Optional paper-style weight init. Default: no-op (kwargs ignored).
 
         Subclasses may declare specific kwargs (e.g. ``SRCNN``'s ``mean`` /

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -4,7 +4,7 @@ Reference: Image Super-Resolution Using Deep Convolutional Networks
 (https://arxiv.org/pdf/1501.00092).
 """
 
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 import torch
 
@@ -75,7 +75,9 @@ class SRCNN(SRModel):
             num_filters[-1], num_channels, kernel_size=kernel_sizes[-1], padding=padding
         )
 
-    def _check_architecture(self, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...]):
+    def _check_architecture(
+        self, num_filters: tuple[int, ...], kernel_sizes: tuple[int, ...]
+    ) -> None:
         """Validates num_filters/kernel_sizes are same-length positive-int tuples."""
         for i, name in zip(
             [num_filters, kernel_sizes], ["num_filters", "kernel_sizes"], strict=False
@@ -104,17 +106,21 @@ class SRCNN(SRModel):
                 f"Got num_filters={num_filters} and kernel_sizes={kernel_sizes}."
             )
 
-    def reset_parameters(self, mean: float = 0.0, std: float = 0.001):
+    def reset_parameters(self, mean: float = 0.0, std: float = 0.001, **kwargs: Any) -> None:
         """Gaussian weight init + zero biases, per the SRCNN paper (https://arxiv.org/pdf/1501.00092).
 
         Args:
             mean: Mean of the weight-init normal distribution.
             std: Standard deviation of the weight-init normal distribution.
+            **kwargs: Unused; absorbed so callers can invoke this
+                polymorphically across architectures (see
+                :meth:`SRModel.reset_parameters`).
         """
         for module in self.modules():
             if isinstance(module, torch.nn.Conv2d):
                 torch.nn.init.normal_(module.weight, mean=mean, std=std)
-                torch.nn.init.constant_(module.bias, 0.0)
+                if module.bias is not None:
+                    torch.nn.init.constant_(module.bias, 0.0)
 
     def forward(
         self,

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -157,14 +157,14 @@ class SRResNet(SRModel):
             hidden_channel, in_out_channels, kernel_size=kernel_sizes[2], padding=padding
         )
 
-    def _check_scale(self, scale: int):
+    def _check_scale(self, scale: int) -> None:
         """Validates that scale is a positive power of 2."""
         if not isinstance(scale, int) or scale < 1:
             raise ValueError(f"scale must be a positive integer. Got {scale}.")
         if (scale & (scale - 1)) != 0:
             raise ValueError(f"scale must be a power of 2. Got {scale}.")
 
-    def _check_architecture(self, kernel_sizes: tuple[int, ...], num_residual_blocks: int):
+    def _check_architecture(self, kernel_sizes: tuple[int, ...], num_residual_blocks: int) -> None:
         """Validates kernel_sizes (length-3, positive ints) and num_residual_blocks (positive)."""
         if not isinstance(kernel_sizes, tuple):
             raise ValueError(f"kernel_sizes must be a tuple. Got {type(kernel_sizes)}.")

--- a/sisr/perceptual.py
+++ b/sisr/perceptual.py
@@ -25,7 +25,22 @@ the module tree: an ``nn.Module`` attribute would put ~230 MB of AlexNet (or
 ~528 MB of VGG16) into every ``state_dict`` this project writes.
 """
 
+from typing import Protocol, runtime_checkable
+
 import torch
+
+
+@runtime_checkable
+class _ResettableMetric(Protocol):
+    """Structural type for the "lpips" branch's net.
+
+    Whatever ``_lpips_metric_cls`` returns (the real torchmetrics class, or a
+    test double standing in for it) is matched by shape rather than base
+    class, so the seam stays swappable.
+    """
+
+    def reset(self) -> None: ...
+
 
 #: Metric name -> is-lower-better. Consumed by the checkpoint-monitor direction
 #: check: PSNR/SSIM are higher-better and SRCheckpoint defaults to mode='max',
@@ -146,6 +161,7 @@ def perceptual_score(
             # The metric object is reused, so its accumulators must not be: LPIPS
             # keeps a list state and would retain one tensor per call for the whole
             # run. Only the per-call value returned above is ever read.
+            assert isinstance(net, _ResettableMetric)  # the "lpips" branch of _cached_net
             net.reset()
             return score
         # require_grad=False matches what the functional path passes for the

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -2,7 +2,10 @@
 
 import re
 import tomllib
+import zipfile
 from pathlib import Path
+
+import hatchling.build
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
@@ -56,3 +59,17 @@ def test_perceptual_extra_declares_lpips():
     pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
     extras = pyproject["project"]["optional-dependencies"]
     assert any(dep.startswith("lpips") for dep in extras["perceptual"])
+
+
+def test_wheel_ships_py_typed(tmp_path):
+    """sisr/py.typed (PEP 561) makes the package's type annotations a checked
+    promise to consumers of the wheel, not just an internal convention.
+
+    Builds a real wheel via hatchling's PEP 517 build_wheel() hook rather than
+    only reading pyproject.toml's config, so a future include/exclude rule
+    that silently drops the marker is caught here instead of in a user's
+    environment.
+    """
+    wheel_name = hatchling.build.build_wheel(str(tmp_path))
+    with zipfile.ZipFile(tmp_path / wheel_name) as wheel:
+        assert "sisr/py.typed" in wheel.namelist()


### PR DESCRIPTION
## What

Adds `mypy` static type checking, gated in CI, plus a PEP 561 `sisr/py.typed` marker.

## Checked now

`mypy sisr` (see `[tool.mypy]` in `pyproject.toml`) actually type-checks:

- `sisr/colorspace.py`, `sisr/ssim.py`, `sisr/imresize.py`, `sisr/cache.py`
- `sisr/losses/` (whole package)
- `sisr/datasets/` (whole package)
- `sisr/processors/` (whole package)
- `sisr/export.py`, `sisr/perceptual.py`
- the model network-definition files (`sisr/models/base.py`, `sisr/models/*/model.py`, `sisr/models/srgan/discriminator.py`) and, since they turned out to be plain, statically-shaped dataclasses rather than jsonargparse-dynamic wiring, the model `config.py` files too (`sisr/models/srcnn/config.py`, `sisr/models/srresnet/config.py`, `sisr/models/srgan/config.py`)

## Ignored, and why

`[[tool.mypy.overrides]]` blanket-ignores (`ignore_errors = true`):

- `sisr.training.*` (the whole subpackage) — Lightning's hook system
- `sisr.cli` — jsonargparse's dynamic CLI/subclass resolution

Both make static typing resist useful checking without a much larger, separate effort — per the agreed scope for this pass.

Also `ignore_missing_imports = true` for `torchvision.*` and `tqdm.*`, neither of which ships a `py.typed` marker or inline types.

## Real fixes made (no suppressions needed)

mypy raised 20 real errors across 9 files in the checked set; all were fixed for real — no `# type: ignore` was needed anywhere:

- Missing return/parameter type annotations (`sisr/cache.py`, `sisr/models/base.py`, `sisr/models/srcnn/model.py`, `sisr/models/srresnet/model.py`, `sisr/datasets/base.py`)
- Two narrow `assert`s in `sisr/cache.py` making explicit an invariant the code already relied on at runtime (`_kernel32` is only `None` off-Windows; `_heartbeat_thread` is always set alongside `_heartbeat_stop`)
- `sisr/losses/vgg.py`: class-level type annotations for attributes set via `object.__setattr__`/`register_buffer`, which otherwise fall back to `nn.Module.__getattr__`'s `Tensor | Module` union
- `sisr/losses/composite.py`: an `assert` making explicit that the accumulator loop always runs at least once (enforced by the constructor's non-empty-terms check)
- `sisr/datasets/base.py` + `sisr/datasets/predict.py`: widened `SRDataset.__getitem__`'s abstract return type to `tuple[Tensor, Tensor] | Tensor` — `PredictDataset` genuinely has no HR pair to return (real inference images, no ground truth), so the narrower base signature was actually wrong, not just under-annotated
- `sisr/models/srcnn/model.py`: `reset_parameters` now takes `**kwargs: Any` (matching the base class's documented polymorphic-call contract) and guards `Conv2d.bias` being `None`
- `sisr/perceptual.py`: added a `@runtime_checkable` structural `Protocol` (`_ResettableMetric`) instead of asserting against `torchmetrics.Metric` directly — the latter would have broken the test suite's duck-typed stand-in for the LPIPS backbone

Also pinned `platform = "win32"` in `[tool.mypy]`: `sisr/cache.py`'s Windows liveness check uses `ctypes.WinDLL`, which typeshed only exposes under that platform, so the exact same code type-checks clean on Windows and fails with `attr-defined` on Linux/macOS without the pin. The new `typecheck` CI job accordingly runs on `windows-latest` (already a supported leg via `test-matrix`), not `ubuntu-latest`.

## Packaging

- `sisr/py.typed` added (empty PEP 561 marker).
- Verified hatchling's existing `packages = ["sisr"]` wheel config already includes it — built a real wheel locally and inspected its contents rather than assuming.
- `tests/test_packaging.py::test_wheel_ships_py_typed` now asserts this directly: it builds a wheel via hatchling's PEP 517 `build_wheel()` hook and checks `sisr/py.typed` is actually in it, not just that the config that's supposed to produce it looks right.

## Acceptance evidence

- `mypy sisr` — clean, 0 errors, 44 source files checked.
- `ruff check .` and `ruff format --check .` — clean.
- Full test suite (`pytest`, this data-less worktree): **800 passed, 3 skipped** (skips are the pre-existing data-gated byte-equality tests, not new).
- Wheel built locally via `hatchling.build.build_wheel()` and confirmed to contain `sisr/py.typed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
