### PR TITLE
fix: put benchmark images on the same step axis as every other metric

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -49,6 +49,28 @@ class BenchmarkSample(NamedTuple):
     perceptual: dict[str, float]
 
 
+def _logger_step(trainer: lightning.Trainer) -> int:
+    """Return the step axis Lightning writes ``self.log`` metrics on.
+
+    Deliberately not ``trainer.global_step``, which counts *optimizer* steps: a
+    module under manual optimization with two optimizers (SRGAN steps D and G
+    per batch) advances it twice per batch, so anything logged against it lands
+    at 2x the step of every ``self.log`` scalar. Lightning maintains
+    ``_batches_that_stepped`` for precisely this reason — "increased once per
+    batch disregarding multiple optimizers on purpose for loggers" — and reads
+    it back in ``logger_connector``; its own ``LearningRateMonitor`` and
+    ``DeviceStatsMonitor`` reach for the same private attribute, which is what
+    makes matching them here the correct call rather than a shortcut.
+
+    Args:
+        trainer: The active trainer.
+
+    Returns:
+        The batch-counted step shared by every ``self.log`` metric.
+    """
+    return trainer.fit_loop.epoch_loop._batches_that_stepped
+
+
 class BenchmarkImageLogger(Callback):
     """Logs bicubic|SR|HR image composites and PSNR/SSIM to TensorBoard for held-out sets.
 
@@ -342,6 +364,10 @@ class BenchmarkImageLogger(Callback):
         dataset = source_dataloaders[dataloader_idx].dataset
         batch_size = lr_img.size(0)
         n = pl_module.eval_config.crop_border
+        # Resolved once per batch, and only when something will actually be
+        # emitted — a trainer with no fit loop is legitimate when no TB logger
+        # is attached, and the guard below already skips every emission then.
+        step = _logger_step(trainer) if self._tb_experiment is not None else 0
 
         for i in range(batch_size):
             global_idx = batch_idx * batch_size + i
@@ -384,7 +410,6 @@ class BenchmarkImageLogger(Callback):
                 continue
 
             if self.log_per_image_metrics:
-                step = trainer.global_step
                 for key, psnr_val in psnr_dict.items():
                     tag = f"per_image/{dataset_name}/psnr/{key}/{filename}"
                     self._tb_experiment.add_scalar(tag, psnr_val, global_step=step)
@@ -415,9 +440,7 @@ class BenchmarkImageLogger(Callback):
             strip = torchvision.utils.make_grid(
                 [bicubic, sr_padded, hr_cpu], nrow=3, padding=2, pad_value=0.5
             )
-            self._tb_experiment.add_image(
-                f"{dataset_name}/{filename}", strip, global_step=trainer.global_step
-            )
+            self._tb_experiment.add_image(f"{dataset_name}/{filename}", strip, global_step=step)
 
     def _flush_buffer(self, pl_module: lightning.LightningModule):
         """Log per-set mean PSNR/SSIM/perceptual scores from the buffered samples.

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -67,6 +67,62 @@ def test_benchmark_setup_datamodule_without_test_names_is_safe():
     assert cb.dataset_names == []
 
 
+def _make_step_axis_trainer(global_step: int, batches_that_stepped: int) -> SimpleNamespace:
+    """Trainer stub whose two step axes disagree, as they do under manual optimization.
+
+    SRGAN steps D and G per batch, so ``global_step`` is 2x the batch count while
+    Lightning keeps ``_batches_that_stepped`` batch-counted "disregarding multiple
+    optimizers on purpose for loggers" (``loops/training_epoch_loop.py``). A stub
+    where the two agree passes whichever axis the callback reads, so it observes
+    nothing — the disagreement is the entire point of this fixture.
+    """
+    return SimpleNamespace(
+        global_step=global_step,
+        fit_loop=SimpleNamespace(
+            epoch_loop=SimpleNamespace(_batches_that_stepped=batches_that_stepped)
+        ),
+    )
+
+
+def _make_benchmark_pl_module() -> MagicMock:
+    """Stub module exercising only ``_collect_batch``'s PSNR path."""
+    pl_module = MagicMock()
+    pl_module.eval_config = SimpleNamespace(
+        crop_border=0, psnr_keys=["RGB"], ssim_keys=[], perceptual_keys=[]
+    )
+    pl_module.predict_rgb = MagicMock(return_value=(torch.rand(1, 3, 8, 8), torch.rand(1, 3, 8, 8)))
+    pl_module._build_metric_tensors = MagicMock(side_effect=lambda s, h: {"RGB": (s, h)})
+    return pl_module
+
+
+def test_benchmark_logs_on_the_batch_counted_axis_not_global_step():
+    """Image strips and per-image scalars must share the axis ``self.log`` uses.
+
+    Logging at ``trainer.global_step`` puts every benchmark image at twice the
+    step of the loss curves it is read against, for any module training under
+    manual optimization with two optimizers.
+    """
+    cb = BenchmarkImageLogger(log_per_image_metrics=True)
+    cb._buffer["Set5"] = []
+    cb._tb_experiment = MagicMock()
+    trainer = _make_step_axis_trainer(global_step=400, batches_that_stepped=200)
+    dataloaders = [SimpleNamespace(dataset=SimpleNamespace(img_paths=[Path("baby.png")]))]
+
+    cb._collect_batch(
+        trainer,
+        _make_benchmark_pl_module(),
+        batch=(torch.rand(1, 3, 8, 8), torch.rand(1, 3, 8, 8)),
+        batch_idx=0,
+        dataset_name="Set5",
+        source_dataloaders=dataloaders,
+        dataloader_idx=0,
+        should_log_images=True,
+    )
+
+    assert cb._tb_experiment.add_image.call_args.kwargs["global_step"] == 200
+    assert cb._tb_experiment.add_scalar.call_args.kwargs["global_step"] == 200
+
+
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger._bicubic_to
 # ---------------------------------------------------------------------------
@@ -1215,7 +1271,14 @@ def test_benchmark_collect_batch_emits_add_image_and_add_scalar(tmp_path: Path, 
     cb = BenchmarkImageLogger(
         dataset_names=["Set5"], log_every_n_val_runs=1, log_per_image_metrics=True
     )
-    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    trainer = SimpleNamespace(
+        datamodule=None,
+        loggers=[tb_logger],
+        # Two axes, deliberately unequal: emission must follow the batch-counted
+        # one, so a stub where they agree could not observe a regression here.
+        global_step=42,
+        fit_loop=SimpleNamespace(epoch_loop=SimpleNamespace(_batches_that_stepped=21)),
+    )
     cb.setup(trainer, pl_module=None, stage="fit")
     pl_module = _make_real_pl_module()  # SRCNN + RGBProcessor: LR/SR/HR all 16x16
     cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
@@ -1263,7 +1326,14 @@ def test_benchmark_collect_batch_default_omits_per_image_scalars_but_keeps_image
 
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
     assert cb.log_per_image_metrics is False
-    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    trainer = SimpleNamespace(
+        datamodule=None,
+        loggers=[tb_logger],
+        # Two axes, deliberately unequal: emission must follow the batch-counted
+        # one, so a stub where they agree could not observe a regression here.
+        global_step=42,
+        fit_loop=SimpleNamespace(epoch_loop=SimpleNamespace(_batches_that_stepped=21)),
+    )
     cb.setup(trainer, pl_module=None, stage="fit")
     pl_module = _make_real_pl_module()
     cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
@@ -1303,7 +1373,14 @@ def test_benchmark_collect_batch_log_per_image_metrics_decoupled_from_image_stri
     cb = BenchmarkImageLogger(
         dataset_names=["Set5"], log_every_n_val_runs=99, log_per_image_metrics=True
     )
-    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    trainer = SimpleNamespace(
+        datamodule=None,
+        loggers=[tb_logger],
+        # Two axes, deliberately unequal: emission must follow the batch-counted
+        # one, so a stub where they agree could not observe a regression here.
+        global_step=42,
+        fit_loop=SimpleNamespace(epoch_loop=SimpleNamespace(_batches_that_stepped=21)),
+    )
     cb.setup(trainer, pl_module=None, stage="fit")
     pl_module = _make_real_pl_module()
     cb.on_validation_epoch_start(trainer=trainer, pl_module=pl_module)
@@ -1350,7 +1427,14 @@ def test_benchmark_collect_batch_image_strip_first_panel_is_bicubic_at_hr_size(
 
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
-    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    trainer = SimpleNamespace(
+        datamodule=None,
+        loggers=[tb_logger],
+        # Two axes, deliberately unequal: emission must follow the batch-counted
+        # one, so a stub where they agree could not observe a regression here.
+        global_step=42,
+        fit_loop=SimpleNamespace(epoch_loop=SimpleNamespace(_batches_that_stepped=21)),
+    )
     cb.setup(trainer, pl_module=None, stage="fit")
 
     pl_module = _make_real_pl_module()
@@ -1400,7 +1484,14 @@ def test_benchmark_collect_batch_image_strip_upsamples_lr_to_hr_size(tmp_path: P
     monkeypatch.setattr(experiment, "add_image", add_image)
 
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
-    trainer = SimpleNamespace(datamodule=None, loggers=[tb_logger], global_step=42)
+    trainer = SimpleNamespace(
+        datamodule=None,
+        loggers=[tb_logger],
+        # Two axes, deliberately unequal: emission must follow the batch-counted
+        # one, so a stub where they agree could not observe a regression here.
+        global_step=42,
+        fit_loop=SimpleNamespace(epoch_loop=SimpleNamespace(_batches_that_stepped=21)),
+    )
     cb.setup(trainer, pl_module=None, stage="fit")
 
     pl_module = _make_real_pl_module()


### PR DESCRIPTION
## What changed

Benchmark image strips and per-image PSNR/SSIM now log on the same step axis as every other metric, instead of one that runs at 2x under adversarial training.

## Why

`BenchmarkImageLogger` wrote straight to the TensorBoard experiment at `trainer.global_step`, which counts **optimizer** steps. A module under manual optimization with two optimizers advances it twice per batch, so every benchmark tag sat at twice the step of the loss and metric curves it is read against — silently misaligning the visual evidence from the scalars.

Everything logged via `self.log` uses `trainer.fit_loop.epoch_loop._batches_that_stepped`, which Lightning keeps batch-counted deliberately ("increased once per batch disregarding multiple optimizers on purpose for loggers") and which stock `LearningRateMonitor` / `DeviceStatsMonitor` read the same way. Both emission sites now route through a `_logger_step` helper.

The two axes coincide under automatic optimization, which is why this stayed invisible until a run used two optimizers.

## Evidence

**Bug fix** — the test that catches it:

- Test: `tests/training/test_callbacks.py::test_benchmark_logs_on_the_batch_counted_axis_not_global_step`
- Confirmed **RED** against the unfixed code (`assert 400 == 200` on the image strip's step), **GREEN** after.
- The stub injects a trainer whose two axes **disagree** (400 vs 21/200). A stub where they agree passes with or without the fix and documents nothing — the five existing emission-path tests were given unequal axes for the same reason.

Full suite: **922 passed**, `ruff check` + `ruff format --check` clean, `mypy sisr` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)