### PR TITLE
chore: ignore the local agent-skill config directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ templates/*
 # LLM agentic coding artifacts (brainstorming specs, implementation plans).
 docs/superpowers/
 
+# mattpocock-skills engineering-skill config (dev/personal tooling only, not tracked)
+/docs/agents/
+/.scratch/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## What changed

`docs/agents/` and `.scratch/` are now gitignored.

## Why

Both hold local working state rather than project source — personal engineering-skill config, and a per-initiative sprint board. They sit at the repo root rather than under the already-ignored agent-artifact tree, so without this an ordinary `git add .` would commit them.

This matches the existing policy exactly: the ignore rule itself is tracked, the artifacts it covers are not.

## Evidence

Not a code change — no test applies. Verified by `git status` reporting a clean tree with the rule in place, and an untracked `docs/` without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)