### PR TITLE
fix: put diagnostic callbacks on the same step axis as every other metric

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -513,8 +513,11 @@ class GradNormLogger(Callback):
     after the backward pass and logs it as the ``"diag/grad_norm"`` scalar.
 
     Args:
-        log_every_n_steps (int): Compute and log every *n* training steps.
-            Defaults to ``100``.
+        log_every_n_steps (int): Compute and log every *n* **batches**.
+            Defaults to ``100``. The unit is batches, not optimizer steps, so
+            the configured cadence means the same thing under automatic and
+            manual optimization — and matches the axis the emitted scalar is
+            plotted on. See :func:`_logger_step`.
     """
 
     def __init__(self, log_every_n_steps: int = 100):
@@ -533,7 +536,7 @@ class GradNormLogger(Callback):
             trainer: The trainer instance.
             pl_module: The model being trained.
         """
-        if trainer.global_step % self.log_every_n_steps != 0:
+        if _logger_step(trainer) % self.log_every_n_steps != 0:
             return
 
         grad_norms = [p.grad.detach().norm(2) for p in pl_module.parameters() if p.grad is not None]
@@ -550,7 +553,9 @@ class WeightHistogramLogger(Callback):
     Groups by prefix, e.g. ``model.feat``, ``model.mapping``, ``model.recon``.
 
     Args:
-        log_every_n_steps (int): Log histograms every *n* training steps.
+        log_every_n_steps (int): Log histograms every *n* **batches**.
+            The unit is batches, not optimizer steps, matching the axis the
+            histograms are written on — see :func:`_logger_step`.
             Defaults to ``10000``. Histograms dominate event-file size, and
             one is written per tracked parameter on every cadence hit — at
             the templates' 1M-step schedule the old default of ``100`` was
@@ -582,7 +587,8 @@ class WeightHistogramLogger(Callback):
             batch: Unused.
             batch_idx: Unused.
         """
-        if trainer.global_step % self.log_every_n_steps != 0:
+        step = _logger_step(trainer)
+        if step % self.log_every_n_steps != 0:
             return
 
         tb_logger = next(
@@ -602,7 +608,7 @@ class WeightHistogramLogger(Callback):
             if param.requires_grad and name.startswith("model."):
                 parts = name.split(".", 2)
                 tb_name = parts[0] + "." + "/".join(parts[1:])
-                experiment.add_histogram(tb_name, param, global_step=trainer.global_step)
+                experiment.add_histogram(tb_name, param, global_step=step)
 
 
 def _validate_monitor_metric(

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -67,7 +67,9 @@ def test_benchmark_setup_datamodule_without_test_names_is_safe():
     assert cb.dataset_names == []
 
 
-def _make_step_axis_trainer(global_step: int, batches_that_stepped: int) -> SimpleNamespace:
+def _make_step_axis_trainer(
+    global_step: int, batches_that_stepped: int, loggers: list | None = None
+) -> SimpleNamespace:
     """Trainer stub whose two step axes disagree, as they do under manual optimization.
 
     SRGAN steps D and G per batch, so ``global_step`` is 2x the batch count while
@@ -81,6 +83,7 @@ def _make_step_axis_trainer(global_step: int, batches_that_stepped: int) -> Simp
         fit_loop=SimpleNamespace(
             epoch_loop=SimpleNamespace(_batches_that_stepped=batches_that_stepped)
         ),
+        loggers=[] if loggers is None else loggers,
     )
 
 
@@ -222,7 +225,8 @@ def _make_gradnorm_pl_module():
 
 def test_grad_norm_logger_logs_on_cadence():
     cb = GradNormLogger(log_every_n_steps=10)
-    trainer = SimpleNamespace(global_step=10)
+    # batch axis ON cadence, optimizer axis OFF -- the gate must read the former.
+    trainer = _make_step_axis_trainer(global_step=17, batches_that_stepped=10)
     pl_module = _make_gradnorm_pl_module()
     cb.on_after_backward(trainer, pl_module)
     pl_module.log.assert_called_once()
@@ -233,7 +237,8 @@ def test_grad_norm_logger_logs_on_cadence():
 
 def test_grad_norm_logger_skips_off_cadence():
     cb = GradNormLogger(log_every_n_steps=10)
-    trainer = SimpleNamespace(global_step=7)
+    # batch axis OFF cadence, optimizer axis ON.
+    trainer = _make_step_axis_trainer(global_step=20, batches_that_stepped=7)
     pl_module = _make_gradnorm_pl_module()
     cb.on_after_backward(trainer, pl_module)
     pl_module.log.assert_not_called()
@@ -245,7 +250,7 @@ def test_grad_norm_logger_handles_none_grads():
     p = torch.zeros(4, requires_grad=True)
     p.grad = None
     pl_module.parameters = MagicMock(return_value=[p])
-    trainer = SimpleNamespace(global_step=1)
+    trainer = _make_step_axis_trainer(global_step=2, batches_that_stepped=1)
     cb.on_after_backward(trainer, pl_module)
     args, _ = pl_module.log.call_args
     assert args[1] == 0.0
@@ -265,7 +270,7 @@ def test_grad_norm_logger_uses_grad_detach_not_grad_data():
     assert "p.grad.detach()" in src
 
     cb = GradNormLogger(log_every_n_steps=1)
-    trainer = SimpleNamespace(global_step=1)
+    trainer = _make_step_axis_trainer(global_step=2, batches_that_stepped=1)
     pl_module = _make_gradnorm_pl_module()
     cb.on_after_backward(trainer, pl_module)
     args, _ = pl_module.log.call_args
@@ -273,14 +278,102 @@ def test_grad_norm_logger_uses_grad_detach_not_grad_data():
     assert args[1] == pytest.approx(10.0)
 
 
+def test_grad_norm_logger_cadence_counts_batches_not_optimizer_steps():
+    """``log_every_n_steps`` must gate on the axis ``self.log`` writes to.
+
+    ``trainer.global_step`` counts *optimizer* steps, so under manual
+    optimization gating on it makes the configured cadence mean a different
+    number of batches per training paradigm, and leaves ``diag/grad_norm``
+    sampled against one counter while plotted against another.
+
+    Both directions are asserted deliberately: a stub whose two axes agree, or a
+    single direction, passes under a gate reading either axis.
+    """
+    # global_step ON cadence, batch count OFF -> must not fire.
+    cb = GradNormLogger(log_every_n_steps=10)
+    pl_module = _make_gradnorm_pl_module()
+    cb.on_after_backward(_make_step_axis_trainer(global_step=10, batches_that_stepped=7), pl_module)
+    pl_module.log.assert_not_called()
+
+    # global_step OFF cadence, batch count ON -> must fire.
+    cb = GradNormLogger(log_every_n_steps=10)
+    pl_module = _make_gradnorm_pl_module()
+    cb.on_after_backward(
+        _make_step_axis_trainer(global_step=14, batches_that_stepped=10), pl_module
+    )
+    pl_module.log.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # WeightHistogramLogger
 # ---------------------------------------------------------------------------
 
 
+def _make_histogram_probe(tmp_path: Path, monkeypatch):
+    """Real ``TensorBoardLogger`` with ``add_histogram`` spied, plus a stub module.
+
+    A real logger, not a mock: the callback reaches ``tb_logger.experiment``
+    through an ``isinstance`` check on ``trainer.loggers``, so a bare mock would
+    be filtered out and every assertion below would pass vacuously.
+    """
+    import lightning.pytorch.loggers as pl_loggers
+
+    pl_module = MagicMock()
+    pl_module.named_parameters = MagicMock(
+        return_value=[("model.feat.0.weight", torch.nn.Parameter(torch.rand(4, 3, 3, 3)))]
+    )
+    tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
+    add_histogram = MagicMock(wraps=tb_logger.experiment.add_histogram)
+    monkeypatch.setattr(tb_logger.experiment, "add_histogram", add_histogram)
+    return pl_module, tb_logger, add_histogram
+
+
+def test_weight_histogram_logger_cadence_counts_batches_not_optimizer_steps(
+    tmp_path: Path, monkeypatch
+):
+    """Same gate, same reason as the ``GradNormLogger`` case above."""
+    pl_module, tb_logger, add_histogram = _make_histogram_probe(tmp_path, monkeypatch)
+    cb = WeightHistogramLogger(log_every_n_steps=10)
+
+    # global_step ON cadence, batch count OFF -> must not fire.
+    trainer = _make_step_axis_trainer(global_step=10, batches_that_stepped=7)
+    trainer.loggers = [tb_logger]
+    cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
+    add_histogram.assert_not_called()
+
+    # global_step OFF cadence, batch count ON -> must fire.
+    trainer = _make_step_axis_trainer(global_step=14, batches_that_stepped=10)
+    trainer.loggers = [tb_logger]
+    cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
+    add_histogram.assert_called_once()
+    tb_logger.finalize("success")
+
+
+def test_weight_histogram_logger_writes_on_the_batch_counted_axis_not_global_step(
+    tmp_path: Path, monkeypatch
+):
+    """Histograms go to the raw TB experiment, so they must carry the batch axis.
+
+    This is the same defect fixed for benchmark images: writing at
+    ``trainer.global_step`` puts every histogram at twice the step of the loss
+    curves it is read against, for any module under manual optimization with two
+    optimizers.
+    """
+    pl_module, tb_logger, add_histogram = _make_histogram_probe(tmp_path, monkeypatch)
+    cb = WeightHistogramLogger(log_every_n_steps=1)
+
+    trainer = _make_step_axis_trainer(global_step=400, batches_that_stepped=200)
+    trainer.loggers = [tb_logger]
+    cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
+    tb_logger.finalize("success")
+
+    add_histogram.assert_called_once()
+    assert add_histogram.call_args.kwargs["global_step"] == 200
+
+
 def test_weight_histogram_logger_skips_off_cadence():
     cb = WeightHistogramLogger(log_every_n_steps=10)
-    trainer = SimpleNamespace(global_step=7, loggers=[])
+    trainer = _make_step_axis_trainer(global_step=20, batches_that_stepped=7)
     pl_module = MagicMock()
     cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
     pl_module.named_parameters.assert_not_called()
@@ -288,7 +381,7 @@ def test_weight_histogram_logger_skips_off_cadence():
 
 def test_weight_histogram_logger_skips_when_no_tb_logger():
     cb = WeightHistogramLogger(log_every_n_steps=1)
-    trainer = SimpleNamespace(global_step=1, loggers=[])
+    trainer = _make_step_axis_trainer(global_step=2, batches_that_stepped=1)
     pl_module = MagicMock()
     cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
     pl_module.named_parameters.assert_not_called()
@@ -1664,7 +1757,7 @@ def test_weight_histogram_logger_calls_add_histogram_for_model_params_only(
     add_histogram = MagicMock(wraps=experiment.add_histogram)
     monkeypatch.setattr(experiment, "add_histogram", add_histogram)
 
-    trainer = SimpleNamespace(global_step=1, loggers=[tb_logger])
+    trainer = _make_step_axis_trainer(global_step=2, batches_that_stepped=1, loggers=[tb_logger])
     cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
     tb_logger.finalize("success")
 


### PR DESCRIPTION
## What

`GradNormLogger` and `WeightHistogramLogger` gated `log_every_n_steps` on `trainer.global_step`, which counts **optimizer** steps. Under manual optimization (the adversarial module steps D and G per batch) that is 2× the batch count, so:

- the configured cadence meant a different number of batches depending on the training paradigm, and
- `GradNormLogger` sampled against one counter while emitting through `self.log`, which plots on the other.

`WeightHistogramLogger` carried a second, sharper instance: it stamped `add_histogram` on the **raw** TensorBoard experiment with `global_step`, so its histograms would land at twice the step of the loss curves they are read against. That is the same defect #101 fixed for benchmark images, at a site #101 never touched.

Both now read `_logger_step`, the helper #101 introduced.

## The unit is batches

Deliberate choice, not a typo fix. Batches mean `log_every_n_steps` says one thing regardless of paradigm and matches the axis the metric is plotted on. The alternative — optimizer steps — has a real argument (a grad-norm trace arguably wants per-optimizer-step resolution under adversarial training) but costs a config value whose meaning changes per model. Accepted cost: under a two-optimizer paradigm the trace samples half as often per optimizer step.

## Evidence

Three tests, each **proven RED against pre-fix `main`** before the fix landed:

- `test_grad_norm_logger_cadence_counts_batches_not_optimizer_steps`
- `test_weight_histogram_logger_cadence_counts_batches_not_optimizer_steps`
- `test_weight_histogram_logger_writes_on_the_batch_counted_axis_not_global_step` — fails as `assert 400 == 200`, the same signature #101's own proof used

Each cadence test asserts **both** directions (batch-axis on / optimizer-axis off, and the reverse); a stub whose two axes agree, or a single direction, passes under a gate reading either axis. The histogram probe uses a real `TensorBoardLogger` rather than a mock, because the callback finds it through an `isinstance` check that would filter a mock out and make every assertion pass vacuously.

Additionally verified by **isolated mutation**: reverting only the `add_histogram` axis while leaving the gate fixed kills exactly the axis test and leaves the two cadence tests green.

Seven pre-existing tests had trainer stubs carrying only `global_step`; they now use the shared two-axis fixture, with values chosen so the axes disagree rather than agree.

## Verification

- Full suite with real data: **923 passed / 2 skipped** (920 before; the 2 skips are the Windows-only cache liveness paths). New tests re-run 5× for stability.
- `ruff check` + `ruff format --check` clean; `mypy sisr` clean.

## Blast radius

None to existing data. `GradNormLogger` is wired only in the SRCNN/SRResNet templates, where automatic optimization makes `global_step` equal the batch count; `WeightHistogramLogger` is wired in no template. The bug was latent on every shipped config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)