### PR TITLE
docs: document the compiled bf16 path, and why it is not the default

### DIFF
--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -135,10 +135,37 @@ trainer:
   # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
   # above, hence it lives here rather than as a custom key.
   benchmark: true
-  # bf16-mixed measured as a REGRESSION at this batch size (0.72x SRResNet b16,
-  # full power) -- autocast's cast-churn doesn't saturate the SMs at b16, so this
-  # is not just "stay in fp32 for paper comparability", it is currently slower.
+  # bf16-mixed on its own is a REGRESSION at this batch size, measured twice on
+  # two platforms (0.72x on Windows; 41.0 vs 35.5 ms/step eager on Linux, 0.87x).
+  # Autocast's cast-churn doesn't saturate the SMs at b16, so this is not merely
+  # "stay in fp32 for paper comparability" -- alone, it is slower.
   # Crossover measured at b32 (bf16+fused wins) -- revisit only if batch_size rises.
+  #
+  # It is a different story COMBINED WITH torch.compile's inductor backend, which
+  # fuses those casts into the kernels. Measured on Linux, SRResNet b16 96x96 x4,
+  # 350 steady batches per cell, both sweep orderings:
+  #
+  #   cuda_graph fp32 (below)            25.7 ms/step
+  #   eager fp32                         35.5
+  #   eager bf16                         41.0   <- bf16 alone loses
+  #   inductor reduce-overhead fp32      26.3   <- does NOT beat cuda_graph
+  #   inductor reduce-overhead bf16      16.0   <- 1.60x over cuda_graph
+  #
+  # So the opt-in path is BOTH settings together, and only together:
+  #   precision: bf16-mixed
+  #   model.training_config.compile_backend: inductor   (with cuda_graph off --
+  #     the two are mutually exclusive; inductor brings its own cudagraph trees)
+  #
+  # !! Before using it for anything you intend to compare against a paper: the
+  # cuda_graph path is verified bit-identical to eager, and bf16-mixed is not.
+  # The 1.60x is a numerics trade whose PSNR/SSIM cost has NOT been measured.
+  # Throughput was all that matrix established. Stay in fp32 for reproduction
+  # runs until a fidelity comparison exists.
+  #
+  # Inductor also needs a C COMPILER at runtime, not just the triton package --
+  # it shells out to build each kernel. `pip install triton` alone is not enough;
+  # a box with no toolchain fails at the first compiled step with
+  # "RuntimeError: Failed to find C compiler".
   # precision: bf16-mixed
   accelerator: cuda
   devices: [0]

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -151,6 +151,13 @@ trainer:
   #   inductor reduce-overhead fp32      26.3   <- does NOT beat cuda_graph
   #   inductor reduce-overhead bf16      16.0   <- 1.60x over cuda_graph
   #
+  # !! Those two rows are NOT scope-matched, so read the fp32 one narrowly.
+  # cuda_graph captures the WHOLE training step (zero_grad, forward, loss,
+  # backward); compile_backend wraps the MODEL ONLY -- loss, backward and the
+  # optimizer stay eager. So "inductor fp32 loses" means "compiling the model
+  # alone does not beat capturing the whole step", not "inductor cannot beat
+  # graph capture". The bf16 win above is achieved despite that same handicap.
+  #
   # So the opt-in path is BOTH settings together, and only together:
   #   precision: bf16-mixed
   #   model.training_config.compile_backend: inductor   (with cuda_graph off --


### PR DESCRIPTION
Comment-only change to `templates/config.srresnet.template.yaml`. No settings changed, nothing enabled.

## Why

The template currently says `bf16-mixed` is a regression. That is still true **alone** — re-measured on a second platform at 41.0 vs 35.5 ms/step eager (0.87×) — but it is now misleading, because combined with `torch.compile`'s inductor backend the same setting is by far the fastest configuration measured on this hardware.

## The matrix behind it

SRResNet golden geometry (b16, 96×96 HR, ×4), real DIV2K-800, 500 batches per cell with the first 150 discarded (n=350 steady), every cell run in **both** sweep orderings with a fresh process, AC + Best-performance asserted before each of the 12 runs:

| cell | ms/step | vs graph capture |
|---|---|---|
| `cuda_graph` fp32 (current default) | 25.66 | — |
| eager fp32 | 35.53 | 1.38× slower |
| eager bf16 | 41.03 | 1.60× slower |
| inductor `reduce-overhead` fp32 | 26.33 | 2.6% slower |
| inductor `max-autotune` fp32 | 27.62 | 7.1% slower |
| **inductor `reduce-overhead` bf16** | **16.04** | **1.60× faster** |
| inductor `max-autotune` bf16 | 16.98 | 1.51× faster |

Three things worth pulling out:

- **fp32 compilation does not beat graph capture.** Capture already removed the launch overhead the fp32 win would have come from.
- **bf16 alone loses; only the combination wins.** The "autocast cast-churn" explanation had been inherited from an earlier measurement on the other platform and never checked locally. The eager-bf16 cell was added specifically to test it, and it holds.
- **`max-autotune` lost to `reduce-overhead` in both precisions** on this GPU, and torch says why in its own warning: `Not enough SMs to use max_autotune_gemm mode`. That mode is *untested* here, not bad — worth re-checking on a larger GPU.

## Why it is documented and not adopted

`cuda_graph` is verified bit-identical to eager. `bf16-mixed` is not, by construction. **No PSNR/SSIM was measured under bf16** — that matrix was throughput only. Since the project's headline claim is reproducing Ledig to ~0.01 dB PSNR-Y, a 1.60× speedup at unmeasured fidelity cost is a trade rather than a free win, so the comment tells you to stay in fp32 for anything you intend to compare against a paper. The missing measurement is tracked separately.

## Also warned

Inductor needs a **C compiler at runtime**, not just the `triton` package — it shells out to build each kernel. A box with the package and no toolchain fails at the first compiled step with `RuntimeError: Failed to find C compiler`, which is exactly how this surfaced.

## Verification

- Suite green: 802 passed / 5 skipped in the worktree (data-less, so the byte-equality and real-image SSIM cases skip; the main checkout runs 923/2 with data). `ruff check` + `format --check` clean.
- File still decodes under cp1252 — jsonargparse opens configs with the platform encoding, so a non-ASCII byte here is a hard launch failure. All 30 added lines are ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)