### PR TITLE
refactor: give the two SR checkpointers one shared module

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -616,9 +616,9 @@ def _validate_monitor_metric(
 ) -> None:
     """Raise if ``monitor`` names no logged metric, or is monitored in the wrong direction.
 
-    Shared by :class:`SRCheckpoint` and :class:`SRWeightsCheckpoint`'s ``setup`` —
-    they are siblings under :class:`~lightning.pytorch.callbacks.ModelCheckpoint`,
-    not parent/child, so this check cannot be reused via ``super()`` across them.
+    Implementation behind :meth:`_SRCheckpointBase._validate_monitor`, which is
+    how every caller reaches it — ``label``/``monitor``/``mode`` are all ``self``
+    there. Kept as a module-level function only because the rule is pure.
 
     The direction half exists because both classes default to ``mode='max'``,
     which is right for PSNR/SSIM and exactly inverted for LPIPS/DISTS — the
@@ -764,7 +764,94 @@ class _RollingSaveMixin:
             self._remove_checkpoint(trainer, self._rolling.pop(0))
 
 
-class SRCheckpoint(_RollingSaveMixin, ModelCheckpoint):
+class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
+    """Everything :class:`SRCheckpoint` and :class:`SRWeightsCheckpoint` share.
+
+    They were siblings under ``ModelCheckpoint`` rather than parent and child,
+    which forced the filename construction, the rolling-mode ``save_top_k``
+    rule and the monitor validation to be written twice or reached through a
+    free function taking the caller's identity as an argument. They are two
+    adapters over one module, so that module now exists.
+
+    Subclasses supply defaults and, where they differ, a ``_save_checkpoint``
+    payload. Nothing here decides what a checkpoint *contains*.
+    """
+
+    def __init__(
+        self,
+        monitor_metric: str | None = "psnr/val/RGB",
+        save_top_k: int = 3,
+        dirpath: str | None = None,
+        filename_prefix: str = "sr",
+        mode: str = "max",
+        keep_last: int = 3,
+        **kwargs: Any,
+    ):
+        if monitor_metric is None:
+            # Rolling: no metric in the filename (there is none), and step
+            # must be in it or every save overwrites the last.
+            filename = f"{filename_prefix}-{{step}}"
+            save_top_k = -1
+        else:
+            # '/' is a path separator; a monitor tag carries several.
+            label = monitor_metric.replace("/", "_")
+            filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
+        super().__init__(
+            monitor=monitor_metric,
+            mode=mode,
+            save_top_k=save_top_k,
+            dirpath=dirpath,
+            filename=filename,
+            auto_insert_metric_name=False,
+            **kwargs,
+        )
+        self._init_rolling(keep_last, filename_prefix)
+
+    def _validate_monitor(self, pl_module: lightning.LightningModule) -> None:
+        """Raise if this callback's ``monitor``/``mode`` pair is unloggable or inverted.
+
+        Args:
+            pl_module: The model being trained; must expose ``eval_config``.
+
+        Raises:
+            MisconfigurationException: Per :func:`_validate_monitor_metric`.
+        """
+        _validate_monitor_metric(type(self).__name__, self.monitor, pl_module, mode=self.mode)
+
+    def setup(
+        self,
+        trainer: lightning.Trainer,
+        pl_module: lightning.LightningModule,
+        stage: str,
+    ) -> None:
+        """Validate ``monitor`` against the metrics ``SRLightning`` will log.
+
+        Lightning itself only raises ``MisconfigurationException`` for a
+        missing monitor once the val loop has already run at least once
+        (``ModelCheckpoint._save_topk_checkpoint``, gated on
+        ``val_loop._has_run``) — with a long ``val_check_interval`` that is a
+        late, expensive-to-reach crash. This moves the same failure to startup.
+
+        Args:
+            trainer: The active trainer.
+            pl_module: The model being trained; must expose ``eval_config``.
+            stage: Lightning trainer stage. Only ``"fit"`` is checked — the
+                monitored tags are val-loop metrics, so they are never logged
+                under ``validate``/``test``/``predict`` and demanding them
+                there would reject configs valid for the stage being run.
+
+        Raises:
+            MisconfigurationException: If ``monitor`` does not name a metric
+                ``SRLightning`` will log during ``fit``, or if ``mode``
+                disagrees with that metric's direction.
+        """
+        super().setup(trainer, pl_module, stage)
+        if stage != "fit":
+            return
+        self._validate_monitor(pl_module)
+
+
+class SRCheckpoint(_SRCheckpointBase):
     """Model checkpoint that monitors a super-resolution quality metric.
 
     A thin convenience wrapper around
@@ -806,35 +893,6 @@ class SRCheckpoint(_RollingSaveMixin, ModelCheckpoint):
             :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
     """
 
-    def __init__(
-        self,
-        monitor_metric: str | None = "psnr/val/RGB",
-        save_top_k: int = 3,
-        dirpath: str | None = None,
-        filename_prefix: str = "sr",
-        mode: str = "max",
-        keep_last: int = 3,
-        **kwargs: Any,
-    ):
-        if monitor_metric is None:
-            # Rolling: no metric in the filename (there is none), and step
-            # must be in it or every save overwrites the last.
-            filename = f"{filename_prefix}-{{step}}"
-            save_top_k = -1
-        else:
-            label = monitor_metric.replace("/", "_")
-            filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
-        super().__init__(
-            monitor=monitor_metric,
-            mode=mode,
-            save_top_k=save_top_k,
-            dirpath=dirpath,
-            filename=filename,
-            auto_insert_metric_name=False,
-            **kwargs,
-        )
-        self._init_rolling(keep_last, filename_prefix)
-
     def _save_checkpoint(self, trainer: lightning.Trainer, filepath: str) -> None:
         """Save via :class:`~lightning.pytorch.callbacks.ModelCheckpoint`, then enforce rolling.
 
@@ -847,46 +905,8 @@ class SRCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         # docstring for why a rolling window can't be expressed via save_top_k alone.
         self._enforce_rolling_window(trainer, filepath)
 
-    def setup(
-        self,
-        trainer: lightning.Trainer,
-        pl_module: lightning.LightningModule,
-        stage: str,
-    ) -> None:
-        """Validate ``monitor`` against the metrics ``SRLightning`` will log.
 
-        Lightning itself only raises ``MisconfigurationException`` for a
-        missing monitor once the val loop has already run at least once
-        (``ModelCheckpoint._save_topk_checkpoint``, gated on
-        ``val_loop._has_run``) — with a long ``val_check_interval`` that is a
-        late, expensive-to-reach crash. This moves the same failure to
-        startup by checking ``monitor`` against ``pl_module.eval_config.psnr_keys``
-        / ``ssim_keys`` (the same seams ``SRLightning`` logs val PSNR/SSIM
-        from) up front, before any training happens.
-
-        Args:
-            trainer: The active trainer.
-            pl_module: The model being trained; must expose ``eval_config``
-                (an :class:`SREvalConfig`).
-            stage: Lightning trainer stage. Only ``"fit"`` is checked — the
-                monitored tags are val-loop metrics, so they are never logged
-                under ``validate``/``test``/``predict`` and demanding them
-                there would reject configs that are perfectly valid for the
-                stage actually being run.
-
-        Raises:
-            MisconfigurationException: If ``monitor`` does not name a
-                metric ``SRLightning`` will log during ``fit``, or if
-                ``mode`` disagrees with that metric's direction (PSNR/SSIM
-                are higher-is-better; LPIPS/DISTS are lower-is-better).
-        """
-        super().setup(trainer, pl_module, stage)
-        if stage != "fit":
-            return
-        _validate_monitor_metric("SRCheckpoint", self.monitor, pl_module, mode=self.mode)
-
-
-class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
+class SRWeightsCheckpoint(_SRCheckpointBase):
     """Model checkpoint that saves bare, optimizer-free weights as ``.pt`` files.
 
     A distributable sibling to :class:`SRCheckpoint`: that class produces resumable
@@ -952,22 +972,15 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         attribute: str = "model",
         **kwargs: Any,
     ):
-        if monitor_metric is None:
-            filename = f"{filename_prefix}-{{step}}"
-            save_top_k = -1
-        else:
-            label = monitor_metric.replace("/", "_")
-            filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
         super().__init__(
-            monitor=monitor_metric,
-            mode=mode,
+            monitor_metric=monitor_metric,
             save_top_k=save_top_k,
             dirpath=dirpath,
-            filename=filename,
-            auto_insert_metric_name=False,
+            filename_prefix=filename_prefix,
+            mode=mode,
+            keep_last=keep_last,
             **kwargs,
         )
-        self._init_rolling(keep_last, filename_prefix)
         self.attribute = attribute
 
     @property
@@ -1034,7 +1047,6 @@ class SRWeightsCheckpoint(_RollingSaveMixin, ModelCheckpoint):
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
             return
-        _validate_monitor_metric("SRWeightsCheckpoint", self.monitor, pl_module, mode=self.mode)
         if not hasattr(pl_module, self.attribute):
             raise MisconfigurationException(
                 f"`SRWeightsCheckpoint(attribute={self.attribute!r})` has nothing to save: "

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -27,7 +27,7 @@ from sisr.training import (
     SRWeightsCheckpoint,
     WeightHistogramLogger,
 )
-from sisr.training.callbacks import BenchmarkSample, _validate_monitor_metric
+from sisr.training.callbacks import BenchmarkSample
 
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
@@ -519,12 +519,12 @@ def test_srcheckpoint_setup_error_lists_valid_metrics(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# _validate_monitor_metric direction check (LPIPS/DISTS are lower-is-better)
+# _SRCheckpointBase._validate_monitor direction check (LPIPS/DISTS are lower-is-better)
 # ---------------------------------------------------------------------------
 
 
 def build_module(eval_config: SREvalConfig | None = None) -> SRLightning:
-    """Real SRLightning exposing only the `eval_config` `_validate_monitor_metric` reads."""
+    """Real SRLightning exposing only the `eval_config` `_validate_monitor` reads."""
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     return SRLightning(
         model=model,
@@ -537,7 +537,7 @@ def build_module(eval_config: SREvalConfig | None = None) -> SRLightning:
 
 def test_perceptual_monitor_is_accepted():
     module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips"]))
-    _validate_monitor_metric("SRCheckpoint", "lpips/val", module, mode="min")  # must not raise
+    SRCheckpoint(monitor_metric="lpips/val", mode="min")._validate_monitor(module)  # no raise
 
 
 def test_lower_is_better_metric_rejects_mode_max():
@@ -548,13 +548,30 @@ def test_lower_is_better_metric_rejects_mode_max():
     """
     module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips"]))
     with pytest.raises(MisconfigurationException, match="lower-is-better"):
-        _validate_monitor_metric("SRCheckpoint", "lpips/val", module, mode="max")
+        SRCheckpoint(monitor_metric="lpips/val", mode="max")._validate_monitor(module)
 
 
 def test_psnr_monitor_still_requires_mode_max():
     module = build_module(eval_config=SREvalConfig())
     with pytest.raises(MisconfigurationException, match="higher-is-better"):
-        _validate_monitor_metric("SRCheckpoint", "psnr/val/RGB", module, mode="min")
+        SRCheckpoint(monitor_metric="psnr/val/RGB", mode="min")._validate_monitor(module)
+
+
+@pytest.mark.parametrize("cls", [SRCheckpoint, SRWeightsCheckpoint])
+def test_monitor_error_names_the_actual_callback_class(cls):
+    """The misconfiguration message must name the class that was misconfigured.
+
+    The label used to be a hard-coded literal at each call site; it is now
+    derived from ``type(self).__name__`` so the two cannot drift. Nothing
+    pinned it, so deriving it wrongly — or reverting to a literal on the base,
+    which would name every subclass identically — was invisible to the suite.
+    Both classes are asserted because a single-class check passes under a
+    hard-coded literal that happens to match that one class.
+    """
+    module = build_module()
+    cb = cls(monitor_metric="not/a/metric", mode="max")
+    with pytest.raises(MisconfigurationException, match=cls.__name__):
+        cb._validate_monitor(module)
 
 
 # ---------------------------------------------------------------------------
@@ -897,7 +914,7 @@ def test_rolling_mode_needs_no_monitor_validation(tmp_path: Path):
     regardless of monitor. `_make_bare_trainer()` (used by every other
     `.setup()` test in this file) is a real, unfitted Trainer that clears
     that machinery without running an actual loop, isolating this test to
-    what it actually claims: that `_validate_monitor_metric` doesn't fire.
+    what it actually claims: that `_validate_monitor` doesn't fire.
     """
     cb = SRCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
     cb.setup(trainer=_make_bare_trainer(), pl_module=build_module(), stage="fit")  # must not raise


### PR DESCRIPTION
From the architecture review — the only candidate rated **LOW risk**, which under the standing unattended-session rule is the only one an agent may implement rather than propose. The other five are filed as proposals.

## Problem

`SRCheckpoint` and `SRWeightsCheckpoint` were siblings under `ModelCheckpoint` rather than parent and child. One concept — "an SR checkpointer: monitored-or-rolling, sanitised filename, validated monitor" — was therefore spread across a free function, a mixin, and two classes:

- The filename construction and the rolling-mode `save_top_k = -1` rule were written **twice**, verbatim.
- `_validate_monitor_metric` took **four** arguments to perform one check, one of which (`label`) existed solely so the error could name its caller — a value both callers already knew about themselves.
- Both docstrings stated the same justification: *"siblings … not parent/child, so this cannot be reused via `super()`"*. That is a consequence of the chosen shape, not a reason for it — `SRWeightsCheckpoint._save_checkpoint` never calls `super()._save_checkpoint`, so inheriting pulls in none of the full-payload write it exists to avoid.

## Change

One `_SRCheckpointBase` owns construction, the rolling rule, the window bookkeeping and monitor validation. Each subclass keeps only its defaults and, where they differ, its payload override. Two adapters over one module.

The validation call goes from four arguments to one, and the caller's name is now derived via `type(self).__name__` rather than passed as a literal, so the message and the class cannot drift.

## Behaviour is unchanged

Same filenames, same rolling rule, same `state_key`, same YAML `class_path`/`init_args` surface. No seam moves; the metric path is untouched.

## Verified by mutation, not by reading

- **Removing the rolling-mode `save_top_k = -1` rule kills 18 tests** — that invariant is well guarded.
- **Deriving the class name killed nothing.** No test pinned the class name in a message users actually read, and this change alters how that name is produced. That gap is closed here by a new test, parametrised over **both** classes — a single-class check still passes when the name is hard-coded to that one class, and I confirmed the mutation fails on the `SRWeightsCheckpoint` arm specifically.

Tests that were parametrised over both classes purely to exercise duplicated code now target the base once.

## Checks

- Full suite: **804 passed / 5 skipped** in the worktree (data-less, so the byte-equality and real-image SSIM cases skip; `--collect-only` is 807 vs the main checkout's 925 — the difference is entirely `test_ssim.py` cases parametrised over image sets that aren't present).
- `ruff check` + `format --check` clean; `mypy sisr` clean, 44 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)