### PR TITLE
test: pin the validation scoring path's tags and values under both SSIM conventions

### DIFF
--- a/tests/training/test_scoring_contract.py
+++ b/tests/training/test_scoring_contract.py
@@ -1,0 +1,159 @@
+"""Golden-value contract for the validation scoring path.
+
+Nothing else pins what ``validation_step`` *emits* — the existing metric tests
+each check one property (a reduction, a routing, a key set) but none fixes the
+tag grammar and the numbers together. That makes the scoring path safe to
+"tidy" and silently renumber, which is exactly the hazard trap 2 describes:
+a figure is comparable only to one computed the same way, and nothing here
+would have noticed the difference.
+
+Two deliberate design choices:
+
+* **The model is factored out.** ``_step`` is replaced with fixed tensors, so
+  every number below is a function of the metric math alone — not of torch's
+  RNG, not of weight init, not of a model's forward. A torch upgrade that
+  perturbs convolution output cannot make this file lie.
+* **Both ``ssim_impl`` values are pinned.** ``wang`` and ``daala`` share the
+  ``ssim/...`` tag names, so the *only* thing distinguishing them is the value.
+  Pinning one convention would leave the other free to drift.
+"""
+
+import functools
+
+import pytest
+import torch
+
+from sisr.models.srresnet.model import SRResNet
+from sisr.processors import RGBProcessor
+from sisr.training import SREvalConfig, SRLightning, SRTrainingConfig
+
+# Fixed inputs. Seeded once at module import; regenerating with a different seed
+# invalidates every value below.
+#
+# 🚨 The two images carry DELIBERATELY different error magnitudes. Two equally-wrong
+# images make per-image-mean PSNR and whole-batch-pooled PSNR agree exactly, so a
+# fixture built from plain `torch.rand` pairs pins nothing about the reduction —
+# verified: it lets `dim=(1, 2, 3) -> dim=None` pass untouched. Here the two
+# reductions sit 11.35 dB apart, which is what makes them distinguishable.
+_g = torch.Generator().manual_seed(20260816)
+HR = torch.rand(2, 3, 24, 24, generator=_g)
+_noise = torch.rand(2, 3, 24, 24, generator=_g)
+SR = HR.clone()
+SR[0] = (HR[0] + 0.02 * (_noise[0] - 0.5)).clamp(0, 1)  # barely wrong
+SR[1] = (HR[1] + 0.60 * (_noise[1] - 0.5)).clamp(0, 1)  # badly wrong
+
+# Deliberately broad: every psnr_channels form (aggregate, YCbCr, bare channel),
+# separate_psnr on, and a non-zero crop_border, so the contract covers the whole
+# tag surface rather than the two tags a default config happens to emit.
+PSNR_CHANNELS = ["RGB", "YCbCr", "Y"]
+SSIM_CHANNELS = ["RGB", "Y"]
+CROP_BORDER = 4
+
+# PSNR is independent of ssim_impl by construction; asserting that is the point
+# of scoring it under both rather than sharing one copy.
+GOLDEN: dict[str, dict[str, float]] = {
+    "wang": {
+        "psnr/val/R": 30.38504028,
+        "psnr/val/G": 30.43302727,
+        "psnr/val/B": 30.49940491,
+        "psnr/val/RGB": 30.43884277,
+        "psnr/val/Y": 35.31136703,
+        "psnr/val/Cb": 35.89144135,
+        "psnr/val/Cr": 35.01395416,
+        "psnr/val/YCbCr": 35.38640594,
+        "ssim/val/RGB": 0.9286418557,
+        "ssim/val/Y": 0.9239290357,
+    },
+    "daala": {
+        "psnr/val/R": 30.38504028,
+        "psnr/val/G": 30.43302727,
+        "psnr/val/B": 30.49940491,
+        "psnr/val/RGB": 30.43884277,
+        "psnr/val/Y": 35.31136703,
+        "psnr/val/Cb": 35.89144135,
+        "psnr/val/Cr": 35.01395416,
+        "psnr/val/YCbCr": 35.38640594,
+        "ssim/val/RGB": 0.9231098537,
+        "ssim/val/Y": 0.9885816613,
+    },
+}
+
+
+def score(ssim_impl: str) -> dict[str, float]:
+    """Run ``validation_step`` on fixed tensors and return every logged tag.
+
+    ``_step`` is stubbed rather than mocked at the model level so the crop,
+    the colorspace conversions, both reductions and the tag construction all
+    run for real — those are the parts a scoring-module refactor would move.
+    """
+    eval_config = SREvalConfig(
+        psnr_channels=PSNR_CHANNELS,
+        separate_psnr=True,
+        ssim_channels=SSIM_CHANNELS,
+        ssim_impl=ssim_impl,
+        crop_border=CROP_BORDER,
+    )
+    module = SRLightning(
+        model=SRResNet(scale=4, num_residual_blocks=1),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=4),
+        eval_config=eval_config,
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+    logged: dict[str, float] = {}
+
+    def fake_log(name, value, **kwargs):
+        logged[name] = float(value.detach()) if isinstance(value, torch.Tensor) else float(value)
+
+    module.log = fake_log
+    module._step = lambda batch: (torch.tensor(0.0), None, None, SR.clone(), HR.clone())
+    module.validation_step((torch.rand(2, 3, 6, 6), HR.clone()), 0)
+    return logged
+
+
+@pytest.mark.parametrize("ssim_impl", ["wang", "daala"])
+def test_validation_emits_exactly_the_expected_tags(ssim_impl: str):
+    """The tag set is the contract: no additions, no renames, no silent drops.
+
+    ``psnr/val/{key}`` is constructed in three separate places in the codebase
+    and ``psnr/{set}/{key}`` in a fourth; set equality here is what makes moving
+    them into one owner a refactor rather than a rename.
+    """
+    logged = score(ssim_impl)
+    assert set(logged) == set(GOLDEN[ssim_impl]) | {"loss/val"}
+
+
+@pytest.mark.parametrize("ssim_impl", ["wang", "daala"])
+def test_validation_values_are_pinned(ssim_impl: str):
+    """Every scored number, to 9 significant figures, on fixed inputs."""
+    logged = score(ssim_impl)
+    for tag, expected in GOLDEN[ssim_impl].items():
+        assert logged[tag] == pytest.approx(expected, rel=1e-9), tag
+
+
+def test_psnr_is_identical_across_ssim_impl():
+    """`ssim_impl` must not reach the PSNR path.
+
+    Without this, a refactor that threaded the impl through a shared scorer
+    could perturb PSNR and still satisfy both pinned tables above, because each
+    table was regenerated from the same broken code.
+    """
+    wang, daala = score("wang"), score("daala")
+    psnr_tags = [t for t in wang if t.startswith("psnr/")]
+    assert psnr_tags
+    for tag in psnr_tags:
+        assert wang[tag] == daala[tag], tag
+
+
+def test_the_two_ssim_conventions_genuinely_differ():
+    """Guards the pinning against vacuity.
+
+    If `ssim_impl` silently stopped being honoured, both tables above would
+    still pass once regenerated — they would just be the same numbers twice.
+    Trap 2 in miniature: same tag, different meaning, no way to tell them apart
+    after the fact.
+    """
+    wang, daala = score("wang"), score("daala")
+    for tag in (t for t in wang if t.startswith("ssim/")):
+        assert wang[tag] != pytest.approx(daala[tag], rel=1e-6), tag


### PR DESCRIPTION
## Why

The validation scoring path builds `psnr/val/{key}` in three separate places and `psnr/{set}/{key}` in a fourth, and nothing pins the result as a whole. Existing tests each cover one property — a reduction, a routing, a key set — so the path can be moved and every published figure silently renumbered without a single failure.

That is trap 2 in its most expensive form: a figure is comparable only to one computed the same way, and nothing here would notice the difference after the fact.

This is the safety net that has to exist **before** the scoring path is refactored, not after.

## What

One new test module pinning, under **both** SSIM conventions:

- the exact tag set emitted by `validation_step` — no additions, renames, or silent drops
- every scored value to 9 significant figures
- that `ssim_impl` does not reach the PSNR path
- that the two conventions genuinely differ, so the pinning cannot go vacuous

## Two design choices

**The model is factored out.** `_step` is stubbed with fixed tensors, so every pinned number is a function of the metric math alone — not torch's RNG, not weight init, not a model's forward. A torch upgrade that perturbs convolution output cannot make this file lie.

**The fixture's two images are deliberately unequal.** An earlier version used plain `torch.rand` pairs; because two equally-wrong images make per-image-mean and batch-pooled PSNR agree exactly, that version was verified to let the reduction change pass **untouched**. It pinned nothing about the reduction it was written to protect. The two reductions now sit 11.35 dB apart. This is the same blind spot that already cost one test in this repo.

## Mutation evidence

Each applied to `main`, measured, then reverted:

| mutation | result |
|---|---|
| drop the `crop_border` slice | 2 failed |
| rename the psnr tag | 4 failed |
| reduction `dim=(1,2,3)` → `None` | 2 failed |
| drop the studio-range conversion | 2 failed |
| ignore `ssim_impl` (always wang) | 2 failed |
| swap the ssim tag family to psnr | 5 failed |

Flipping the `ssim_impl` **default** correctly survives — the tests parametrise it explicitly, so the default is a separate concern.

Tests only; no production code touched. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)