### PR TITLE
refactor: give the scoring path one owner

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -341,10 +341,11 @@ class BenchmarkImageLogger(Callback):
         slices — mirroring the primary-val-loader path in
         ``SRLightning.validation_step`` — so only the scalar ``.item()``
         results ever leave the GPU. SSIM and perceptual scores go through
-        ``pl_module._mean_ssim``/``pl_module._mean_perceptual`` rather than calling
-        ``torchmetrics``/``perceptual_score`` here directly, so this callback
-        cannot silently diverge from ``validation_step`` on which SSIM
-        implementation or perceptual backbone a given ``eval_config`` means. When
+        ``pl_module.scorer`` — the same object ``validation_step`` uses — rather
+        than calling ``torchmetrics``/``perceptual_score`` here directly, so
+        this callback cannot silently diverge from ``validation_step`` on the
+        crop, the reductions, or which SSIM/perceptual backbone a given
+        ``eval_config`` means. When
         *should_log_images* (or
         ``self.log_per_image_metrics``), exactly one host transfer per image
         (``lr_img[i]``/``sr[i]``/``hr_img[i]`` each ``.cpu()`` at most once)
@@ -362,7 +363,6 @@ class BenchmarkImageLogger(Callback):
         # Resolve filenames from the underlying dataset for use as TB tags.
         dataset = source_dataloaders[dataloader_idx].dataset
         batch_size = lr_img.size(0)
-        n = pl_module.eval_config.crop_border
         # Resolved once per batch, and only when something will actually be
         # emitted — a trainer with no fit loop is legitimate when no TB logger
         # is attached, and the guard below already skips every emission then.
@@ -372,37 +372,18 @@ class BenchmarkImageLogger(Callback):
             global_idx = batch_idx * batch_size + i
             filename = dataset.img_paths[global_idx].stem
 
-            sr_metric = sr[i : i + 1]
-            hr_metric = hr_cropped[i : i + 1]
-            if n > 0:
-                sr_metric = sr_metric[..., n:-n, n:-n]
-                hr_metric = hr_metric[..., n:-n, n:-n]
-            # Still a private reach: the colorspace split has no public
-            # seam, and duplicating it here would recreate a divergence
-            # this design removed. Keys now come from eval_config, so this is a value
-            # lookup only — the callback no longer decides *which* keys exist.
-            # Same rationale extends to _mean_psnr and _mean_ssim below: they
-            # are the only places that decide the PSNR reduction and which
-            # implementation eval_config.ssim_impl means, so reaching into them
-            # here (rather than calling torchmetrics directly) keeps this path
-            # and validation_step's unable to disagree on what "psnr/..." and
-            # "ssim/..." tag under the same name. PSNR used to call torchmetrics
-            # directly with the default dim=None, which pools the batch instead
-            # of averaging per-image PSNRs; it agreed only because this loop
+            # One scorer object, shared with validation_step, so the two paths
+            # cannot disagree on the crop, the colorspace split, the PSNR
+            # reduction or which SSIM eval_config.ssim_impl names. This used to
+            # be four separate reaches into private SRLightning methods, each
+            # of which could have been "tidied" independently — PSNR in fact
+            # was, calling torchmetrics with the default dim=None (whole-batch
+            # pooling) and agreeing with validation_step only because this loop
             # slices one image at a time.
-            metric_tensors = pl_module._build_metric_tensors(sr_metric, hr_metric)
-            psnr_dict = {
-                key: pl_module._mean_psnr(*metric_tensors[key]).item()
-                for key in pl_module.eval_config.psnr_keys
-            }
-            ssim_dict = {
-                key: pl_module._mean_ssim(*metric_tensors[key]).item()
-                for key in pl_module.eval_config.ssim_keys
-            }
-            perceptual_dict = {
-                name: pl_module._mean_perceptual(name, sr_metric, hr_metric).item()
-                for name in pl_module.eval_config.perceptual_keys
-            }
+            scores = pl_module.scorer.score(sr[i : i + 1], hr_cropped[i : i + 1])
+            psnr_dict = {key: value.item() for key, value in scores.psnr.items()}
+            ssim_dict = {key: value.item() for key, value in scores.ssim.items()}
+            perceptual_dict = {name: value.item() for name, value in scores.perceptual.items()}
             self._buffer[dataset_name].append(
                 BenchmarkSample(filename, psnr_dict, ssim_dict, perceptual_dict)
             )

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -15,20 +15,17 @@ from typing import Any
 
 import lightning
 import torch
-import torchmetrics.functional
 import torchvision
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 
-from ..colorspace import rgb_to_ycbcr_studio
 from ..losses import SRLoss
 from ..models.base import SRModel
-from ..perceptual import perceptual_score
 from ..processors import SRProcessor
-from ..ssim import daala_ssim
 from .config import SREvalConfig, SRTrainingConfig
 from .cuda_graph import CUDAGraphStep
 from .metadata import build_metadata
+from .scoring import SRScorer, metric_tag
 
 
 class SRLightning(lightning.LightningModule):
@@ -94,6 +91,10 @@ class SRLightning(lightning.LightningModule):
         self.processor = processor
         self.training_config = training_config or SRTrainingConfig()
         self.eval_config = eval_config or SREvalConfig()
+        # The scoring path's one owner: crop, colorspace split, both
+        # reductions and the tag grammar. BenchmarkImageLogger uses this
+        # same object, so the two paths cannot disagree.
+        self.scorer = SRScorer(self.eval_config)
         self.criterion = criterion if criterion is not None else torch.nn.MSELoss()
         self.optimizer = optimizer
         self.lr_scheduler = lr_scheduler
@@ -467,98 +468,6 @@ class SRLightning(lightning.LightningModule):
             _recurse(v, k)
 
         return result
-
-    def _build_metric_tensors(
-        self, sr: torch.Tensor, hr: torch.Tensor
-    ) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
-        """Pre-computes (sr, hr) tensor pairs for every tracked PSNR/SSIM key.
-
-        Shared by both metric families (over the union of ``psnr_keys`` and
-        ``ssim_keys``) so a requested colorspace conversion happens at most
-        once per call regardless of how many metrics consume it. ``Y`` /
-        ``Cb`` / ``Cr`` / ``YCbCr`` are converted via ``rgb_to_ycbcr_studio`` —
-        BT.601 studio range, the literature's PSNR/SSIM convention — not the
-        full-range ``rgb_to_ycbcr`` the processors train in (see
-        ``sisr.colorspace`` module docstring). ``RGB``/``R``/``G``/``B`` are
-        untouched either way.
-        """
-        keys = set(self.eval_config.psnr_keys) | set(self.eval_config.ssim_keys)
-        tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
-
-        if keys & {"RGB", "R", "G", "B"}:
-            tensors["RGB"] = (sr, hr)
-            tensors["R"] = (sr[:, 0:1], hr[:, 0:1])
-            tensors["G"] = (sr[:, 1:2], hr[:, 1:2])
-            tensors["B"] = (sr[:, 2:3], hr[:, 2:3])
-
-        if keys & {"YCbCr", "Y", "Cb", "Cr"}:
-            sr_ycc = rgb_to_ycbcr_studio(sr)
-            hr_ycc = rgb_to_ycbcr_studio(hr)
-            tensors["YCbCr"] = (sr_ycc, hr_ycc)
-            tensors["Y"] = (sr_ycc[:, 0:1], hr_ycc[:, 0:1])
-            tensors["Cb"] = (sr_ycc[:, 1:2], hr_ycc[:, 1:2])
-            tensors["Cr"] = (sr_ycc[:, 2:3], hr_ycc[:, 2:3])
-
-        return tensors
-
-    @staticmethod
-    def _mean_psnr(sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
-        """Mean of the per-image PSNRs across the batch (SR-standard reduction).
-
-        Scores each image independently (``dim=(1, 2, 3)``) before the batch
-        mean, so the result is invariant to the val ``batch_size``. This differs
-        from pooling the whole batch into one PSNR — the deviation a stateful
-        ``PeakSignalNoiseRatio`` with default ``dim`` would introduce.
-        """
-        return torchmetrics.functional.image.peak_signal_noise_ratio(
-            sr, hr, data_range=1.0, dim=(1, 2, 3), reduction="elementwise_mean"
-        )
-
-    def _mean_ssim(self, sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
-        """Mean SSIM under the configured implementation.
-
-        The single decision point for which SSIM this project computes —
-        consumed by :meth:`validation_step` and by
-        :class:`~sisr.training.callbacks.BenchmarkImageLogger`, so the
-        validation and benchmark paths cannot report different metrics under
-        the same tag (the two call sites used to each call ``torchmetrics``
-        independently, and only one learning about a new implementation would
-        have silently split them). Not a ``staticmethod`` (unlike
-        :meth:`_mean_psnr`) because it reads ``self.eval_config.ssim_impl``.
-
-        Args:
-            sr: Reconstruction, ``(B, C, H, W)`` float in ``[0, 1]``.
-            hr: Reference, same shape.
-
-        Returns:
-            0-dim tensor. Both implementations reduce per-image then mean over
-            the batch.
-        """
-        if self.eval_config.ssim_impl == "daala":
-            return daala_ssim(sr, hr)
-        return torchmetrics.functional.image.structural_similarity_index_measure(
-            sr, hr, data_range=1.0
-        )
-
-    def _mean_perceptual(self, name: str, sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
-        """Mean perceptual score under the configured backbone.
-
-        The single decision point for which perceptual metric this project
-        computes, mirroring :meth:`_mean_ssim` — consumed by
-        :meth:`validation_step` and by
-        :class:`~sisr.training.callbacks.BenchmarkImageLogger`, so the
-        validation and benchmark paths cannot report different quantities under
-        the same tag.
-
-        Args:
-            name: ``'lpips'`` or ``'dists'``.
-            sr: Reconstruction, ``(B, 3, H, W)`` RGB float in ``[0, 1]``.
-            hr: Reference, same shape.
-
-        Returns:
-            0-dim tensor.
-        """
-        return perceptual_score(name, sr, hr, lpips_net=self.eval_config.lpips_net)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the wrapped SR model on ``x`` and return its raw output.
@@ -948,41 +857,23 @@ class SRLightning(lightning.LightningModule):
 
         loss, lr_img, hr_img, sr, hr_cropped = self._step(batch)
 
-        n = self.eval_config.crop_border
-        if n > 0:
-            sr = sr[..., n:-n, n:-n]
-            hr_cropped = hr_cropped[..., n:-n, n:-n]
-
-        metric_tensors = self._build_metric_tensors(sr, hr_cropped)
+        scores = self.scorer.score(sr, hr_cropped)
 
         # add_dataloader_idx=False keeps metric names clean — needed because the
         # primary val loader is at idx 0 of a list that also contains test loaders.
         self.log("loss/val", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
         self._log_loss_terms("val")
-        primary_psnr = self.eval_config.psnr_channels[0]
-        for key in self.eval_config.psnr_keys:
-            sr_t, hr_t = metric_tensors[key]
+        # prog_bar is a display choice, so it stays with the caller rather than
+        # moving into the scorer — the scorer decides values, not presentation.
+        prog_bar_tags = {
+            metric_tag("psnr", "val", self.eval_config.psnr_channels[0]),
+            metric_tag("ssim", "val", self.eval_config.ssim_channels[0]),
+        }
+        for tag, value in scores.tagged("val").items():
             self.log(
-                f"psnr/val/{key}",
-                self._mean_psnr(sr_t, hr_t),
-                prog_bar=(key == primary_psnr),
-                on_step=False,
-                add_dataloader_idx=False,
-            )
-        primary_ssim = self.eval_config.ssim_channels[0]
-        for key in self.eval_config.ssim_keys:
-            sr_t, hr_t = metric_tensors[key]
-            self.log(
-                f"ssim/val/{key}",
-                self._mean_ssim(sr_t, hr_t),
-                prog_bar=(key == primary_ssim),
-                on_step=False,
-                add_dataloader_idx=False,
-            )
-        for name in self.eval_config.perceptual_keys:
-            self.log(
-                f"{name}/val",
-                self._mean_perceptual(name, sr, hr_cropped),
+                tag,
+                value,
+                prog_bar=(tag in prog_bar_tags),
                 on_step=False,
                 add_dataloader_idx=False,
             )

--- a/sisr/training/scoring.py
+++ b/sisr/training/scoring.py
@@ -1,0 +1,246 @@
+"""One owner for "score an aligned ``(sr_rgb, hr_rgb)`` pair under an ``SREvalConfig``".
+
+Before this module the answer to "how does this project score a reconstruction?"
+was spread across two files and reachable only through private methods.
+``SRLightning`` exposed ``_build_metric_tensors`` / ``_mean_psnr`` /
+``_mean_ssim`` / ``_mean_perceptual`` as a de-facto interface and
+``BenchmarkImageLogger`` reached through all four — its own comment conceded
+the reach, saying "the colorspace split has no public seam". Four separate
+decisions had no single home:
+
+* the **crop-border slice**, written once in ``validation_step`` and again in
+  ``BenchmarkImageLogger._collect_batch``;
+* the **colorspace split** into scored key tensors;
+* the **PSNR reduction** — per-image then batch mean, never batch-pooled;
+* which SSIM ``ssim_impl`` names.
+
+And the **tag grammar** ``{family}/{scope}/{key}`` was rebuilt from f-strings in
+four places, so nothing stopped ``psnr/val/Y`` and ``psnr/Set5/Y`` drifting apart.
+
+Everything above now lives here, and the grammar has exactly one implementation
+in :func:`metric_tag`. Callers supply the *scope* — ``"val"`` for the validation
+loop, a dataset name for the benchmark loop — and nothing else.
+
+This module deliberately depends on ``SREvalConfig`` and tensors only: no
+``SRLightning``, no ``Trainer``, no datamodule. Scoring is testable on two
+tensors and a config.
+"""
+
+import torch
+import torchmetrics.functional.image
+
+from ..colorspace import rgb_to_ycbcr_studio
+from ..perceptual import perceptual_score
+from ..ssim import daala_ssim
+from .config import SREvalConfig
+
+__all__ = ["SRScorer", "Scores", "metric_tag"]
+
+
+def metric_tag(family: str, scope: str, key: str) -> str:
+    """Build a metric tag: ``{family}/{scope}/{key}``.
+
+    The single implementation of the tag grammar. ``psnr/val/Y`` and
+    ``psnr/Set5/Y`` differ only in ``scope``, so routing both through here is
+    what stops the validation and benchmark hierarchies drifting apart.
+
+    Args:
+        family: Metric family — ``'psnr'``, ``'ssim'``, or a perceptual name.
+        scope: ``'val'`` for the validation loop, else a benchmark dataset name.
+        key: Colorspace or channel key, e.g. ``'RGB'`` or ``'Y'``.
+
+    Returns:
+        The TensorBoard tag.
+    """
+    return f"{family}/{scope}/{key}"
+
+
+class Scores:
+    """Metric values for one scored pair, before any tag prefixing.
+
+    Attributes:
+        psnr: ``key -> value``, over ``eval_config.psnr_keys``.
+        ssim: ``key -> value``, over ``eval_config.ssim_keys``.
+        perceptual: ``name -> value``, over ``eval_config.perceptual_keys``.
+    """
+
+    __slots__ = ("psnr", "ssim", "perceptual")
+
+    def __init__(
+        self,
+        psnr: dict[str, torch.Tensor],
+        ssim: dict[str, torch.Tensor],
+        perceptual: dict[str, torch.Tensor],
+    ) -> None:
+        self.psnr = psnr
+        self.ssim = ssim
+        self.perceptual = perceptual
+
+    def tagged(self, scope: str) -> dict[str, torch.Tensor]:
+        """Flatten to ``tag -> value`` under ``scope``.
+
+        Perceptual metrics carry no colorspace key, so they tag as
+        ``{name}/{scope}`` rather than ``{family}/{scope}/{key}`` — the shape
+        already published and therefore preserved here.
+
+        Args:
+            scope: ``'val'`` or a benchmark dataset name.
+
+        Returns:
+            Every metric under its full tag.
+        """
+        tags = {metric_tag("psnr", scope, k): v for k, v in self.psnr.items()}
+        tags |= {metric_tag("ssim", scope, k): v for k, v in self.ssim.items()}
+        tags |= {f"{name}/{scope}": v for name, v in self.perceptual.items()}
+        return tags
+
+
+class SRScorer:
+    """Scores aligned ``(sr_rgb, hr_rgb)`` pairs under one ``SREvalConfig``.
+
+    Built from the config alone, so it can be constructed and exercised without
+    a Lightning module, a trainer or a datamodule.
+
+    Args:
+        eval_config: The evaluation settings to score under.
+    """
+
+    def __init__(self, eval_config: SREvalConfig) -> None:
+        self.eval_config = eval_config
+
+    def crop(self, *tensors: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        """Apply ``crop_border`` to each tensor, or pass them through unchanged.
+
+        The single implementation of the border slice. Both scoring paths took
+        their own copy of this before; a divergence between them would have
+        silently changed what every published figure was computed on.
+
+        Args:
+            *tensors: ``(B, C, H, W)`` tensors to crop identically.
+
+        Returns:
+            The cropped tensors, in the order given.
+        """
+        n = self.eval_config.crop_border
+        if n <= 0:
+            return tensors
+        return tuple(t[..., n:-n, n:-n] for t in tensors)
+
+    def metric_tensors(
+        self, sr: torch.Tensor, hr: torch.Tensor
+    ) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+        """Pre-compute ``(sr, hr)`` pairs for every tracked PSNR/SSIM key.
+
+        Computed over the union of ``psnr_keys`` and ``ssim_keys`` so a
+        requested colorspace conversion happens at most once per call regardless
+        of how many metrics consume it. ``Y`` / ``Cb`` / ``Cr`` / ``YCbCr`` go
+        through ``rgb_to_ycbcr_studio`` — BT.601 **studio** range, the
+        literature's PSNR/SSIM convention — not the full-range ``rgb_to_ycbcr``
+        the processors train in (see :mod:`sisr.colorspace`). ``RGB``/``R``/
+        ``G``/``B`` are untouched either way.
+
+        Args:
+            sr: Reconstruction, ``(B, 3, H, W)`` RGB float in ``[0, 1]``.
+            hr: Reference, same shape.
+
+        Returns:
+            ``key -> (sr_key, hr_key)``.
+        """
+        keys = set(self.eval_config.psnr_keys) | set(self.eval_config.ssim_keys)
+        tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+
+        if keys & {"RGB", "R", "G", "B"}:
+            tensors["RGB"] = (sr, hr)
+            tensors["R"] = (sr[:, 0:1], hr[:, 0:1])
+            tensors["G"] = (sr[:, 1:2], hr[:, 1:2])
+            tensors["B"] = (sr[:, 2:3], hr[:, 2:3])
+
+        if keys & {"YCbCr", "Y", "Cb", "Cr"}:
+            sr_ycc = rgb_to_ycbcr_studio(sr)
+            hr_ycc = rgb_to_ycbcr_studio(hr)
+            tensors["YCbCr"] = (sr_ycc, hr_ycc)
+            tensors["Y"] = (sr_ycc[:, 0:1], hr_ycc[:, 0:1])
+            tensors["Cb"] = (sr_ycc[:, 1:2], hr_ycc[:, 1:2])
+            tensors["Cr"] = (sr_ycc[:, 2:3], hr_ycc[:, 2:3])
+
+        return tensors
+
+    @staticmethod
+    def psnr(sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
+        """Mean of the per-image PSNRs across the batch (SR-standard reduction).
+
+        Scores each image independently (``dim=(1, 2, 3)``) before the batch
+        mean, so the result is invariant to the val ``batch_size``. This differs
+        from pooling the whole batch into one PSNR — the deviation a stateful
+        ``PeakSignalNoiseRatio`` with default ``dim`` would introduce. The two
+        agree only when every image in the batch is equally wrong, which is why
+        a batch-of-one caller cannot detect the difference.
+
+        Args:
+            sr: Reconstruction, ``(B, C, H, W)``.
+            hr: Reference, same shape.
+
+        Returns:
+            0-dim tensor.
+        """
+        return torchmetrics.functional.image.peak_signal_noise_ratio(
+            sr, hr, data_range=1.0, dim=(1, 2, 3), reduction="elementwise_mean"
+        )
+
+    def ssim(self, sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
+        """Mean SSIM under the configured implementation.
+
+        The single decision point for what ``ssim_impl`` names. Both
+        implementations reduce per-image then mean over the batch.
+
+        Args:
+            sr: Reconstruction, ``(B, C, H, W)`` float in ``[0, 1]``.
+            hr: Reference, same shape.
+
+        Returns:
+            0-dim tensor.
+        """
+        if self.eval_config.ssim_impl == "daala":
+            return daala_ssim(sr, hr)
+        return torchmetrics.functional.image.structural_similarity_index_measure(
+            sr, hr, data_range=1.0
+        )
+
+    def perceptual(self, name: str, sr: torch.Tensor, hr: torch.Tensor) -> torch.Tensor:
+        """Mean perceptual score under the configured backbone.
+
+        Args:
+            name: ``'lpips'`` or ``'dists'``.
+            sr: Reconstruction, ``(B, 3, H, W)`` RGB float in ``[0, 1]``.
+            hr: Reference, same shape.
+
+        Returns:
+            0-dim tensor.
+        """
+        return perceptual_score(name, sr, hr, lpips_net=self.eval_config.lpips_net)
+
+    def score(self, sr_rgb: torch.Tensor, hr_rgb: torch.Tensor, *, crop: bool = True) -> Scores:
+        """Score one aligned pair across every metric the config requests.
+
+        Args:
+            sr_rgb: Reconstruction, ``(B, 3, H, W)`` RGB float in ``[0, 1]``.
+            hr_rgb: Reference, same shape.
+            crop: Apply ``crop_border`` first. Pass ``False`` only when the
+                caller has already cropped — scoring an uncropped pair silently
+                changes every number.
+
+        Returns:
+            The metric values, untagged.
+        """
+        if crop:
+            sr_rgb, hr_rgb = self.crop(sr_rgb, hr_rgb)
+
+        tensors = self.metric_tensors(sr_rgb, hr_rgb)
+        return Scores(
+            psnr={k: self.psnr(*tensors[k]) for k in self.eval_config.psnr_keys},
+            ssim={k: self.ssim(*tensors[k]) for k in self.eval_config.ssim_keys},
+            perceptual={
+                name: self.perceptual(name, sr_rgb, hr_rgb)
+                for name in self.eval_config.perceptual_keys
+            },
+        )

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -28,6 +28,7 @@ from sisr.training import (
     WeightHistogramLogger,
 )
 from sisr.training.callbacks import BenchmarkSample
+from sisr.training.scoring import SRScorer
 
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
@@ -88,13 +89,17 @@ def _make_step_axis_trainer(
 
 
 def _make_benchmark_pl_module() -> MagicMock:
-    """Stub module exercising only ``_collect_batch``'s PSNR path."""
+    """Stub module exercising only ``_collect_batch``'s PSNR path.
+
+    Carries a **real** :class:`SRScorer` over a real ``SREvalConfig`` rather
+    than a mocked one: the scorer is the thing under test at this seam, and
+    stubbing it would let the callback stop scoring entirely without failing.
+    """
     pl_module = MagicMock()
-    pl_module.eval_config = SimpleNamespace(
-        crop_border=0, psnr_keys=["RGB"], ssim_keys=[], perceptual_keys=[]
-    )
+    eval_config = SREvalConfig(crop_border=0, psnr_channels=["RGB"], ssim_channels=[])
+    pl_module.eval_config = eval_config
     pl_module.predict_rgb = MagicMock(return_value=(torch.rand(1, 3, 8, 8), torch.rand(1, 3, 8, 8)))
-    pl_module._build_metric_tensors = MagicMock(side_effect=lambda s, h: {"RGB": (s, h)})
+    pl_module.scorer = SRScorer(eval_config)
     return pl_module
 
 
@@ -129,7 +134,7 @@ def test_benchmark_logs_on_the_batch_counted_axis_not_global_step():
 def test_benchmark_psnr_routes_through_the_module_not_torchmetrics_directly():
     """The benchmark path must score PSNR with the same reduction as validation.
 
-    ``SRLightning._mean_psnr`` uses ``dim=(1,2,3)`` — per-image PSNR then batch
+    ``SRScorer.psnr`` uses ``dim=(1,2,3)`` — per-image PSNR then batch
     mean — and documents that reduction as deliberate. ``_collect_batch`` used
     to call ``torchmetrics`` directly with the default ``dim=None``, which pools
     the whole batch into one PSNR. The two agree today only because this path
@@ -138,7 +143,7 @@ def test_benchmark_psnr_routes_through_the_module_not_torchmetrics_directly():
     silently changed every ``psnr/{set}/{key}`` number.
 
     Asserted through the emitted value rather than by spying on the call: a
-    stub ``_mean_psnr`` returns a sentinel, and the buffered sample must carry
+    stub ``SRScorer.psnr`` returns a sentinel, and the buffered sample must carry
     it. A callback computing its own PSNR cannot produce the sentinel, so this
     goes red against the direct-torchmetrics version without caring *how* the
     module is reached.
@@ -146,7 +151,7 @@ def test_benchmark_psnr_routes_through_the_module_not_torchmetrics_directly():
     cb = BenchmarkImageLogger()
     cb._buffer["Set5"] = []
     pl_module = _make_benchmark_pl_module()
-    pl_module._mean_psnr = MagicMock(return_value=torch.tensor(42.0))
+    pl_module.scorer.psnr = MagicMock(return_value=torch.tensor(42.0))
     dataloaders = [SimpleNamespace(dataset=SimpleNamespace(img_paths=[Path("baby.png")]))]
 
     cb._collect_batch(
@@ -1320,7 +1325,7 @@ def test_collect_batch_metric_values_match_pre_change_host_copy_first_ordering()
         hr_old = hr_cropped[i].unsqueeze(0).cpu()
         sr_old = sr_old[..., n:-n, n:-n]
         hr_old = hr_old[..., n:-n, n:-n]
-        metric_tensors_old = pl_module._build_metric_tensors(sr_old, hr_old)
+        metric_tensors_old = pl_module.scorer.metric_tensors(sr_old, hr_old)
         psnr_old = {
             key: torchmetrics.functional.image.peak_signal_noise_ratio(
                 *metric_tensors_old[key], data_range=1.0
@@ -1337,7 +1342,7 @@ def test_collect_batch_metric_values_match_pre_change_host_copy_first_ordering()
         # Shipped ordering: crop the per-image slice directly, no intervening copy.
         sr_new = sr[i : i + 1][..., n:-n, n:-n]
         hr_new = hr_cropped[i : i + 1][..., n:-n, n:-n]
-        metric_tensors_new = pl_module._build_metric_tensors(sr_new, hr_new)
+        metric_tensors_new = pl_module.scorer.metric_tensors(sr_new, hr_new)
         psnr_new = {
             key: torchmetrics.functional.image.peak_signal_noise_ratio(
                 *metric_tensors_new[key], data_range=1.0
@@ -1390,7 +1395,7 @@ def test_benchmark_logger_uses_module_ssim_impl():
 
     with torch.no_grad():
         sr, hr_cropped = pl_module.predict_rgb(lr_img, hr_img)
-    metric_tensors = pl_module._build_metric_tensors(sr, hr_cropped)
+    metric_tensors = pl_module.scorer.metric_tensors(sr, hr_cropped)
     expected = sisr.ssim.daala_ssim(*metric_tensors["Y"]).item()
 
     sample = cb._buffer["Set5"][0]
@@ -1733,7 +1738,7 @@ def test_benchmark_test_epoch_end_logs_means():
 
 def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
     """_collect_batch must pass the per-image, border-cropped SR/HR pair into
-    pl_module._mean_perceptual (mocked here at its perceptual_score seam, so no
+    pl_module.scorer.perceptual (mocked here at its perceptual_score seam, so no
     real LPIPS/DISTS weights load) -- not the un-cropped batch-level tensors or
     anything else in scope. The mock's return depends on sr/hr
     (``sr.sum() - hr.sum()``) rather than being a constant, so a wrong tensor
@@ -1741,7 +1746,7 @@ def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
     non-zero crop_border also means a wrong (un-cropped) pair differs in shape,
     not just content."""
     monkeypatch.setattr(
-        "sisr.training.lightning_module.perceptual_score",
+        "sisr.training.scoring.perceptual_score",
         lambda name, sr, hr, lpips_net: sr.sum() - hr.sum(),
     )
     cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -25,6 +25,7 @@ from sisr.processors import (
 )
 from sisr.training import SRDataModule, SREvalConfig, SRLightning, SRTrainingConfig
 from sisr.training.cuda_graph import CUDAGraphStep
+from sisr.training.scoring import SRScorer
 
 # ---------------------------------------------------------------------------
 # fixtures
@@ -304,7 +305,7 @@ def test_build_metric_tensors_rgb_only_when_neither_metric_requests_y():
     )
     sr = torch.rand(1, 3, 4, 4)
     hr = torch.rand(1, 3, 4, 4)
-    tensors = lit._build_metric_tensors(sr, hr)
+    tensors = lit.scorer.metric_tensors(sr, hr)
     assert set(tensors) == {"RGB", "R", "G", "B"}
 
 
@@ -323,7 +324,7 @@ def test_build_metric_tensors_union_of_psnr_and_ssim_keys():
     )
     sr = torch.rand(1, 3, 4, 4)
     hr = torch.rand(1, 3, 4, 4)
-    tensors = lit._build_metric_tensors(sr, hr)
+    tensors = lit.scorer.metric_tensors(sr, hr)
     assert "Y" in tensors
 
 
@@ -338,7 +339,7 @@ def test_build_metric_tensors_with_separate_psnr_includes_per_channel():
     )
     sr = torch.rand(1, 3, 4, 4)
     hr = torch.rand(1, 3, 4, 4)
-    tensors = lit._build_metric_tensors(sr, hr)
+    tensors = lit.scorer.metric_tensors(sr, hr)
     assert {"R", "G", "B", "RGB"} <= set(tensors)
 
 
@@ -353,7 +354,7 @@ def test_build_metric_tensors_ycbcr_does_conversion():
     )
     sr = torch.rand(1, 3, 4, 4)
     hr = torch.rand(1, 3, 4, 4)
-    tensors = lit._build_metric_tensors(sr, hr)
+    tensors = lit.scorer.metric_tensors(sr, hr)
     assert "YCbCr" in tensors
     sr_ycc, hr_ycc = tensors["YCbCr"]
     # YCbCr first channel (Y) must differ from input R-channel — verifies
@@ -377,7 +378,7 @@ def test_build_metric_tensors_ycbcr_uses_studio_range_not_full_range():
     )
     sr = torch.rand(1, 3, 4, 4, generator=torch.Generator().manual_seed(3))
     hr = torch.rand(1, 3, 4, 4, generator=torch.Generator().manual_seed(4))
-    tensors = lit._build_metric_tensors(sr, hr)
+    tensors = lit.scorer.metric_tensors(sr, hr)
     sr_ycc, hr_ycc = tensors["YCbCr"]
     torch.testing.assert_close(sr_ycc, rgb_to_ycbcr_studio(sr))
     torch.testing.assert_close(hr_ycc, rgb_to_ycbcr_studio(hr))
@@ -785,9 +786,9 @@ def test_step_psnr_matches_hand_clamped_reference_not_raw_output():
     sr_model_out, _ = lit._forward_lr(lr)
     _, _, _, sr_rgb, hr_cropped = lit._step((lr, hr))
 
-    scored_psnr = SRLightning._mean_psnr(sr_rgb, hr_cropped)
-    hand_clamped_psnr = SRLightning._mean_psnr(sr_model_out.clamp(0.0, 1.0), hr_cropped)
-    unclamped_psnr = SRLightning._mean_psnr(sr_model_out, hr_cropped)
+    scored_psnr = SRScorer.psnr(sr_rgb, hr_cropped)
+    hand_clamped_psnr = SRScorer.psnr(sr_model_out.clamp(0.0, 1.0), hr_cropped)
+    unclamped_psnr = SRScorer.psnr(sr_model_out, hr_cropped)
 
     torch.testing.assert_close(scored_psnr, hand_clamped_psnr)
     assert not torch.allclose(scored_psnr, unclamped_psnr)
@@ -964,7 +965,7 @@ def test_val_psnr_is_per_image_mean_not_batch_pooled():
     ).mean()
     pooled = psnr_fn(sr, hr, data_range=1.0)  # dim=None -> pools the batch
 
-    batch_val = SRLightning._mean_psnr(sr, hr)
+    batch_val = SRScorer.psnr(sr, hr)
     assert torch.allclose(batch_val, per_image, atol=1e-5)
     assert not torch.allclose(batch_val, pooled, atol=1e-3)
 
@@ -992,10 +993,10 @@ def test_mean_ssim_dispatches_on_eval_config():
     wang = _make_lit_with_ssim_impl("wang")
     daala = _make_lit_with_ssim_impl("daala")
 
-    assert daala._mean_ssim(sr, hr).item() == pytest.approx(
+    assert daala.scorer.ssim(sr, hr).item() == pytest.approx(
         sisr.ssim.daala_ssim(sr, hr).item(), rel=1e-12
     )
-    assert wang._mean_ssim(sr, hr).item() != pytest.approx(daala._mean_ssim(sr, hr).item())
+    assert wang.scorer.ssim(sr, hr).item() != pytest.approx(daala.scorer.ssim(sr, hr).item())
 
 
 def test_mean_ssim_uses_daala_through_real_srresnet_eval_config():
@@ -1008,7 +1009,7 @@ def test_mean_ssim_uses_daala_through_real_srresnet_eval_config():
     construction rather than a bespoke one.
 
     torch.manual_seed seeds SRResNet's weight init for reproducibility, even
-    though _mean_ssim never runs the model forward — sr/hr are independent
+    though SRScorer.ssim never runs the model forward — sr/hr are independent
     inputs — so nothing here is actually seed-sensitive, but a prior task's
     unseeded model was flagged in review and this follows the same discipline.
     """
@@ -1029,7 +1030,7 @@ def test_mean_ssim_uses_daala_through_real_srresnet_eval_config():
     sr = torch.rand(1, 3, 64, 64, generator=torch.Generator().manual_seed(2))
     hr = torch.rand(1, 3, 64, 64, generator=torch.Generator().manual_seed(3))
 
-    result = lit._mean_ssim(sr, hr)
+    result = lit.scorer.ssim(sr, hr)
 
     assert result.item() == pytest.approx(sisr.ssim.daala_ssim(sr, hr).item(), rel=1e-12)
     wang_result = structural_similarity_index_measure(sr, hr, data_range=1.0)
@@ -2260,7 +2261,7 @@ def capture_logged_metrics(module: SRLightning) -> dict[str, float]:
 def test_validation_logs_perceptual_tags(monkeypatch):
     """Requested perceptual metrics reach TensorBoard under their own tag family."""
     monkeypatch.setattr(
-        "sisr.training.lightning_module.perceptual_score",
+        "sisr.training.scoring.perceptual_score",
         lambda name, sr, hr, lpips_net: torch.tensor(0.5 if name == "lpips" else 0.25),
     )
     module = build_module(eval_config=SREvalConfig(perceptual_metrics=["lpips", "dists"]))


### PR DESCRIPTION
> **Stacked on #107** — base is `test/pin-metric-tags`, not `main`. Review #107 first; this PR's diff is only the refactor.

## Why

There was no module answering *"score an aligned `(sr_rgb, hr_rgb)` pair under this eval config"*. `SRLightning` exposed four private methods as a de-facto interface and `BenchmarkImageLogger` reached through all of them. The callback's own comment conceded it:

> Still a private reach: the colorspace split has no public seam, and duplicating it here would recreate a divergence this design removed.

Four decisions had no single home — the **crop-border slice** (written twice), the **colorspace split**, the **PSNR reduction**, and which SSIM `ssim_impl` names. The tag grammar `{family}/{scope}/{key}` was rebuilt from f-strings in **four** places, so nothing stopped `psnr/val/Y` and `psnr/Set5/Y` drifting apart.

This is INIT.46 candidate 1, and its first symptom already shipped as its own fix (#106) — the benchmark path had in fact been "tidied" into a different PSNR reduction, and agreed with validation only because it slices one image at a time.

## What

New `sisr/training/scoring.py`:

- `SRScorer` — built from an `SREvalConfig` **alone**. No `SRLightning`, no `Trainer`, no datamodule, so scoring is testable on two tensors and a config.
- `metric_tag(family, scope, key)` — the grammar's only implementation. Callers supply the scope (`"val"`, or a dataset name) and nothing else.
- `Scores` — the values, untagged, with `.tagged(scope)` to flatten.

Clean break, no shims: the four private methods are **gone**, and both call sites share one scorer object. Callers keep what is genuinely theirs — `prog_bar` is a display choice, so it stays in `validation_step`.

## Evidence that behaviour is unchanged

This is the part that matters for a path carrying the flagship claim, and it is verified rather than asserted:

**The golden-value contract from #107 passes with identical values before and after.** It pins every emitted tag and every number to 9 significant figures under **both** `ssim_impl` values — including the PSNR reduction, which its fixture is specifically built to detect. That is the whole reason #107 landed first.

Existing coverage also holds unchanged, including `test_collect_batch_metric_values_match_pre_change_host_copy_first_ordering`, which pins the benchmark path's values from before an earlier change.

## Test changes

Mechanical — the same assertions retargeted from the private methods to the scorer. One is a genuine improvement: the benchmark stub module now carries a **real** `SRScorer` over a real `SREvalConfig` instead of a mocked one, because stubbing the scorer would let the callback stop scoring entirely without failing.

## Verification status

`ruff` and `mypy sisr` clean. Affected suites green (237 passed across `test_callbacks.py`, `test_lightning_module.py`, `test_scoring_contract.py`).

**The full suite has not been run against this branch yet** — a GPU screen is running and the standing convention here is not to run the suite beside one. It will be run once the screen finishes and the result posted as a comment before this is ready to merge.

## Not done here

Candidate 6 (`metadata.py`'s read side) stays deliberately held — one adapter is a hypothetical seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)