### PR TITLE
fix: bound every wait on a cache build lock, not just the live-holder one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ notice.
   README.
 - **The LMDB cache could delete another process's in-progress build.** Deletion is now
   restricted to proven corruption; environmental failures raise instead.
+- **A cache build could wait on its lock forever.** The timeout only bounded waits on a
+  holder confirmed alive. A sentinel whose pid was unreadable, or was this process's own
+  after pid recycling, took neither that path nor the abandoned-lock takeover path while
+  a heartbeat kept it looking fresh — so the waiter polled with no error, no progress and
+  no further log line. Every wait path is now bounded by the same cap.
 - **SRCNN's paper weight-init std** corrected to the published `0.001`.
 - **`example_input_shape` pointed at the wrong size**, defeating compile warm-up and
   misreporting FLOPs.

--- a/sisr/utils/cache.py
+++ b/sisr/utils/cache.py
@@ -41,9 +41,12 @@ _CORRUPTION_ERRORS = (lmdb.CorruptedError, lmdb.InvalidError, lmdb.VersionMismat
 _HEARTBEAT_MIN_INTERVAL = 0.01
 _HEARTBEAT_MAX_INTERVAL = 30.0
 
-# How many multiples of lock_timeout to wait on a confirmed-live holder
-# before giving up and raising -- bounds an otherwise-unbounded wait.
-_LIVE_HOLDER_WAIT_MULTIPLE = 3
+# How many multiples of lock_timeout to wait for a lock before giving up and
+# raising. Bounds *every* wait path, not just the confirmed-live-holder one: a
+# sentinel whose pid is unreadable, or is our own after pid recycling, takes
+# neither the live-holder path nor the takeover path, and without a cap there
+# it polls forever.
+_LOCK_WAIT_MULTIPLE = 3
 
 # Windows liveness check: OpenProcess's failure mode must be inspected via
 # GetLastError, which ctypes only tracks reliably through a use_last_error=True
@@ -516,7 +519,7 @@ class LMDBCache:
         :meth:`_start_heartbeat`) has gone stale for longer than *timeout*
         — i.e. it crashed without releasing the lock. Waiting on a
         confirmed-*live* holder is itself capped at
-        ``_LIVE_HOLDER_WAIT_MULTIPLE * timeout``: past that this raises
+        ``_LOCK_WAIT_MULTIPLE * timeout``: past that this raises
         rather than blocking forever, so a genuinely stuck wait surfaces
         instead of hanging silently.
 
@@ -537,8 +540,9 @@ class LMDBCache:
             :attr:`_length` in that case.
 
         Raises:
-            TimeoutError: If a confirmed-live holder still has not finished
-                after ``_LIVE_HOLDER_WAIT_MULTIPLE * timeout`` seconds.
+            TimeoutError: If the lock has not been obtained after
+                ``_LOCK_WAIT_MULTIPLE * timeout`` seconds, whether the holder
+                is confirmed alive or cannot be confirmed either way.
         """
         if self._claim_sentinel():
             return True
@@ -546,19 +550,23 @@ class LMDBCache:
         own_pid = os.getpid()
         start = time.monotonic()
         next_log_at = start + timeout
-        hard_deadline = start + timeout * _LIVE_HOLDER_WAIT_MULTIPLE
+        hard_deadline = start + timeout * _LOCK_WAIT_MULTIPLE
         while True:
             if self._try_load(checksum):
                 return False
 
+            # Evaluated once per pass so every branch below is bounded by it --
+            # including any added later. Only the message differs by branch.
+            now = time.monotonic()
+            expired = now > hard_deadline
+
             holder_pid = self._read_lock_pid()
             if holder_pid is not None and holder_pid != own_pid and _pid_alive(holder_pid):
-                now = time.monotonic()
-                if now > hard_deadline:
+                if expired:
                     raise TimeoutError(
                         f"Build lock {self._lock_path()} has been held by live pid "
-                        f"{holder_pid} for over {timeout * _LIVE_HOLDER_WAIT_MULTIPLE:.1f}s "
-                        f"({_LIVE_HOLDER_WAIT_MULTIPLE}x lock_timeout). Refusing to wait "
+                        f"{holder_pid} for over {timeout * _LOCK_WAIT_MULTIPLE:.1f}s "
+                        f"({_LOCK_WAIT_MULTIPLE}x lock_timeout). Refusing to wait "
                         f"indefinitely. If that process is confirmed gone, remove "
                         f"{self._lock_path()} manually and retry."
                     )
@@ -575,6 +583,21 @@ class LMDBCache:
                 continue
 
             if not self._lock_is_stale(timeout):
+                if expired:
+                    whose = (
+                        "unreadable"
+                        if holder_pid is None
+                        else f"{holder_pid}, which is dead or our own"
+                    )
+                    raise TimeoutError(
+                        f"Build lock {self._lock_path()} is held by a process this one "
+                        f"cannot confirm is alive -- its recorded pid is {whose} -- yet "
+                        f"its heartbeat keeps the sentinel fresh, so it never looks "
+                        f"abandoned either. Waited over "
+                        f"{timeout * _LOCK_WAIT_MULTIPLE:.1f}s ({_LOCK_WAIT_MULTIPLE}x "
+                        f"lock_timeout). Refusing to wait indefinitely. If no build is "
+                        f"really running, remove {self._lock_path()} manually and retry."
+                    )
                 time.sleep(poll_interval)
                 continue
 
@@ -636,7 +659,7 @@ class LMDBCache:
         started". That would mask the original ``start()`` error *and* skip
         :meth:`_release_lock` on the next line (this runs inside a
         ``finally``), leaving a live-pid sentinel that stalls every other
-        waiter for up to ``_LIVE_HOLDER_WAIT_MULTIPLE * lock_timeout``.
+        waiter for up to ``_LOCK_WAIT_MULTIPLE * lock_timeout``.
         """
         if self._heartbeat_stop is None:
             return

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -846,6 +846,60 @@ def test_acquire_lock_raises_timeout_error_on_confirmed_live_holder_past_hard_ca
         )
 
 
+def test_acquire_lock_is_bounded_when_the_holder_pid_cannot_be_read(tmp_path: Path):
+    """The hard cap must cover the *not-stale* branch too, not only the
+    confirmed-live one.
+
+    A sentinel whose pid is unreadable (truncated, or caught mid-write) takes
+    neither the live-holder path -- that requires a readable pid -- nor the
+    takeover path, because a still-running heartbeat keeps its mtime fresh so
+    it never looks stale. Without a cap on this branch the waiter polls
+    forever: no error, no progress, no log line after the first, which is the
+    hardest failure to attribute after the fact. It must raise instead.
+
+    time.sleep is replaced rather than shortened so an unbounded loop fails
+    fast here instead of hanging the suite; the counter is what distinguishes
+    "raised late" from "never raised at all".
+    """
+    name, checksum = "unreadablepid", "up1"
+    lock_path = tmp_path / f"{name}_{checksum[:16]}.build.lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    os.write(fd, b"not-a-pid")  # _read_lock_pid() -> None
+    os.close(fd)
+
+    spins = 0
+    spin_cap = 60  # ~1.2s of real waiting; the 3x hard cap lands near spin 8
+    real_sleep = time.sleep  # captured before the patch, which rebinds time.sleep
+
+    class _SpunForever(Exception):
+        pass
+
+    def heartbeat_then_sleep(interval: float) -> None:
+        nonlocal spins
+        spins += 1
+        if spins > spin_cap:
+            raise _SpunForever(f"polled {spins} times without raising TimeoutError")
+        lock_path.touch()  # a live holder's heartbeat: never stale
+        real_sleep(interval)
+
+    with (
+        patch("sisr.utils.cache.time.sleep", heartbeat_then_sleep),
+        pytest.raises(TimeoutError, match="Refusing to wait indefinitely"),
+    ):
+        LMDBCache(
+            cache_dir=tmp_path,
+            name=name,
+            checksum=checksum,
+            length=1,
+            map_size=_MAP_SIZE,
+            build_fn=_make_build_fn(1),
+            lock_poll_interval=0.02,
+            lock_timeout=0.05,
+        )
+
+    assert spins <= spin_cap, "cap was never enforced"
+
+
 def test_acquire_lock_toctou_reread_skips_unlink_if_pid_changed(tmp_path: Path):
     """Immediately before unlinking a dead+stale sentinel to take over, the
     pid is re-read; if it changed (another waiter already reclaimed a fresh


### PR DESCRIPTION
Closes #128.

Stacked on #153, which is stacked on #152 — **merge bottom-up: #152, then #153, then this.**

## What changed

The build lock's hard cap now bounds **every** wait path, not only the one where
the holder's pid is confirmed alive.

## Why

A sentinel whose pid is **unreadable** — truncated, or read mid-write — or whose
pid is **this process's own after recycling** takes neither the live-holder path
(that branch requires a readable pid that is not ours) nor the abandoned-lock
takeover path, because a still-running heartbeat keeps its mtime fresh so it never
looks stale.

The waiter then polls forever. No exception, no progress, and no log line after
the first — which is the failure shape hardest to notice while it happens and
hardest to attribute afterwards. That is why this was split out of the follow-up
batch: the rest of that batch is hygiene, and this one hangs a build worker.

## How it is fixed

The deadline is evaluated **once per pass** and applies to every branch, rather
than being repeated inside the one branch that had it. A new wait path added later
inherits the cap instead of silently missing it — which is exactly how this branch
came to miss it. The two messages differ only in what they can honestly say about
the holder.

`_LIVE_HOLDER_WAIT_MULTIPLE` is renamed `_LOCK_WAIT_MULTIPLE`: it no longer bounds
only live holders, and a constant whose name understates its scope is how the next
branch gets missed.

## Evidence

**Test proven RED before the fix, GREEN after** — the acceptance criterion.

Against the unfixed code:

```
_SpunForever: polled 61 times without raising TimeoutError
1 failed in 1.34s
```

After the fix: `1 passed`.

The test replaces `time.sleep` rather than shortening it, so an unbounded loop
fails fast here instead of hanging the suite, and the **counter** is what
distinguishes "raised late" from "never raised at all" — a plain `pytest.raises`
would report the same failure for a hang and for a slow raise.

> One note on process, since it changes what the evidence is worth: my first
> version of this test appeared to go red for the right reason but did not. Patching
> `sisr.utils.cache.time.sleep` rebinds `sleep` on the real `time` module, so the
> fake recursed into itself, never actually slept, and the wall clock never reached
> the deadline. The red above is from the corrected test, re-run against the unfixed
> code.

**Suite** — `914 passed, 2 skipped` of 916 collected, 3m22s. The 2 skips are the
Windows-only cache liveness paths, as on `main`. No data-gated test skipped.
`ruff check`, `ruff format --check`, `mypy sisr` all clean.

## Checklist

- [x] `pytest` passes locally; skips named above (a skip is not a pass)
- [x] Test confirmed **RED** against the unfixed code, **GREEN** after
- [x] `ruff check` and `ruff format --check` are clean
- [x] Docs changes are in their own `docs:` commit
- [x] No internal tracker identifiers in the code or commit messages

## Merge strategy

- [x] **Rebase** — carries both a code and a docs commit

> **Part of stack #160** (`#152 -> #153 -> #154 -> #155 -> #156 -> #159`). Merge **bottom-up**.
> These PRs were first opened by chaining bases by hand, which gave correct ancestry but no
> GitHub stack object and so no CI above #152. They were retro-linked with `gh stack link`,
> and every PR in the stack now runs full CI despite its base still being a feature branch.
> A `cancelled` check here is a duplicate-trigger artifact, not a failure -- the push and the
> stack event both fire and `cancel-in-progress` kills the first.

