### PR TITLE
fix: report cache and dataset-config failures in terms the operator can act on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Workflow-wide floor. actions: write is NOT here -- it is granted per job, to
+# the ones that actually save an Actions cache, so a job that only checks out
+# and runs a script cannot write to the cache at all.
 permissions:
   contents: read
-  # An explicit permissions block zeroes unlisted scopes; actions: write keeps
-  # Actions-cache saves working (setup-uv enable-cache / setup-python cache: pip).
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,6 +47,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write  # setup-uv enable-cache / setup-python cache: pip
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +83,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write  # setup-uv enable-cache / setup-python cache: pip
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Workflow-wide floor. actions: write is NOT here -- it is granted per job, to
+# the ones that actually save an Actions cache, so a job that only checks out
+# and runs a script cannot write to the cache at all.
 permissions:
   contents: read
-  # An explicit permissions block zeroes unlisted scopes; actions: write keeps
-  # Actions-cache saves working (setup-uv enable-cache / setup-python cache: pip).
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,6 +47,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: write  # setup-uv enable-cache / setup-python cache: pip
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -80,6 +83,9 @@ jobs:
   typecheck:
     runs-on: windows-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write  # setup-uv enable-cache / setup-python cache: pip
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -100,6 +106,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    permissions:
+      contents: read
+      actions: write  # setup-uv enable-cache / setup-python cache: pip
     strategy:
       fail-fast: false
       matrix:
@@ -160,6 +169,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write  # setup-uv enable-cache / setup-python cache: pip
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ notice.
 
 ### Changed
 
+- **`LMDBCache.close()`** releases the read environment and lets the next access reopen
+  it. Closing the object `get_env()` returns left the instance holding a dead handle.
 - **Y-channel metrics are computed in BT.601 studio range**, matching MATLAB and the
   published SR literature. Figures produced before this read systematically low.
 - **SR output is clamped to `[0, 1]` before scoring.**
@@ -89,6 +91,12 @@ notice.
   README.
 - **The LMDB cache could delete another process's in-progress build.** Deletion is now
   restricted to proven corruption; environmental failures raise instead.
+- **A misspelled key inside a dataset spec's `init_args`** reported a bare `TypeError`
+  naming the dataset class but not the config path that produced it. It now names the
+  field, the offending key and the accepted ones.
+- **Publishing a rebuilt cache could fail on a name collision** when an earlier trash
+  sibling from the same process had outlived its best-effort cleanup, and reported it as
+  though the cache were stale.
 - **A cache build could wait on its lock forever.** The timeout only bounded waits on a
   holder confirmed alive. A sentinel whose pid was unreadable, or was this process's own
   after pid recycling, took neither that path nor the abandoned-lock takeover path while

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -7,6 +7,8 @@ only run for the stages that need them. Test sets are surfaced through
 :meth:`test_dataloader` (for ``cli test --ckpt_path`` final eval).
 """
 
+import importlib
+import inspect
 from typing import Any
 
 import lightning
@@ -54,6 +56,68 @@ def _validate_spec(field_name: str, spec: dict[str, Any]) -> None:
     init_args = spec.get("init_args", {})
     if not isinstance(init_args, dict):
         raise ValueError(f"{field_name}.init_args must be a mapping; got {init_args!r}.")
+
+
+def _accepted_init_args(class_path: str) -> list[str] | None:
+    """Returns *class_path*'s accepted keyword argument names, or ``None``.
+
+    Only called on the error path, so importing here costs nothing on a
+    healthy run -- and by then the class has already been imported anyway.
+
+    Args:
+        class_path: Dotted path from the spec.
+
+    Returns:
+        Sorted parameter names, or ``None`` if the class cannot be resolved
+        or inspected (in which case the caller falls back to the raw error).
+    """
+    try:
+        module_name, _, attr = class_path.rpartition(".")
+        cls = getattr(importlib.import_module(module_name), attr)
+        params = inspect.signature(cls).parameters
+    except (ImportError, AttributeError, TypeError, ValueError):
+        return None
+    return sorted(
+        name
+        for name, p in params.items()
+        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD) and name != "self"
+    )
+
+
+def _instantiate_spec(field_name: str, spec: dict[str, Any]) -> Any:
+    """Materialises a dataset spec, naming the field when an init_arg is wrong.
+
+    ``_validate_spec`` catches keys that landed *beside* ``init_args``. A
+    misspelled key *inside* ``init_args`` gets all the way to the dataset
+    constructor instead, and surfaces as a bare ``TypeError`` naming the class
+    but not the config path that produced it -- so the reader is told
+    ``TrainDataset`` is wrong without being told which of several dataset
+    blocks to go and fix.
+
+    Args:
+        field_name: Dotted config path, e.g. ``'data.train_dataset'``.
+        spec: A spec already checked by :func:`_validate_spec`.
+
+    Returns:
+        The instantiated dataset.
+
+    Raises:
+        ValueError: If ``init_args`` holds a key the target does not accept.
+    """
+    try:
+        return instantiate_class((), spec)
+    except TypeError as exc:
+        if "unexpected keyword argument" not in str(exc):
+            raise
+        accepted = _accepted_init_args(spec["class_path"])
+        given = sorted(spec.get("init_args", {}))
+        unknown = [k for k in given if accepted is not None and k not in accepted]
+        detail = f" Unexpected: {unknown}." if unknown else ""
+        options = f" Accepted: {accepted}." if accepted is not None else ""
+        raise ValueError(
+            f"{field_name}.init_args holds a key {spec['class_path']} does not accept."
+            f"{detail}{options} Original error: {exc}"
+        ) from exc
 
 
 class SRDataModule(lightning.LightningDataModule):
@@ -182,15 +246,16 @@ class SRDataModule(lightning.LightningDataModule):
                 which datasets get instantiated.
         """
         if stage in ("fit", None) and self._train_ds is None:
-            self._train_ds = instantiate_class((), self._train_spec)
+            self._train_ds = _instantiate_spec("data.train_dataset", self._train_spec)
         if stage in ("fit", "validate", "test", None) and not self._test_ds and self._test_specs:
             self._test_ds = {
-                name: instantiate_class((), spec) for name, spec in self._test_specs.items()
+                name: _instantiate_spec(f"data.test_datasets.{name}", spec)
+                for name, spec in self._test_specs.items()
             }
         if stage in ("fit", "validate", None) and self._val_ds is None:
-            self._val_ds = instantiate_class((), self._val_spec)
+            self._val_ds = _instantiate_spec("data.val_dataset", self._val_spec)
         if stage in ("predict", None) and self._predict_ds is None and self._predict_spec:
-            self._predict_ds = instantiate_class((), self._predict_spec)
+            self._predict_ds = _instantiate_spec("data.predict_dataset", self._predict_spec)
 
     def train_dataloader(self) -> DataLoader:
         """Build the training DataLoader.

--- a/sisr/training/probe.py
+++ b/sisr/training/probe.py
@@ -111,6 +111,9 @@ class ProbeResult:
                 self._train_lr = self.sample.lr
             else:
                 self._train_lr, _ = _sample_zero(train_ds)
+        # Set on the branch above, both ways: either from an existing sample
+        # taken from train_dataset, or by reading index 0. train_ds being
+        # non-None is what guarantees one of them ran.
         assert self._train_lr is not None
         return train_ds, self._train_lr
 

--- a/sisr/utils/cache.py
+++ b/sisr/utils/cache.py
@@ -15,6 +15,7 @@ torch-free; colorspace math lives in :mod:`sisr.colorspace` for this reason.
 """
 
 import ctypes
+import itertools
 import logging
 import os
 import shutil
@@ -47,6 +48,10 @@ _HEARTBEAT_MAX_INTERVAL = 30.0
 # neither the live-holder path nor the takeover path, and without a cap there
 # it polls forever.
 _LOCK_WAIT_MULTIPLE = 3
+
+#: Distinguishes temp siblings created by the same process for the same cache.
+#: See :meth:`LMDBCache._sibling_tmp_path`.
+_SIBLING_SEQ = itertools.count()
 
 # Windows liveness check: OpenProcess's failure mode must be inspected via
 # GetLastError, which ctypes only tracks reliably through a use_last_error=True
@@ -267,6 +272,16 @@ class LMDBCache:
         lock_timeout: Seconds to wait on a held lock, past which a *dead*
             holder's lock is considered abandoned. A live holder is never
             preempted regardless of this value.
+
+    Raises:
+        RuntimeError: If no valid cache exists and *build_fn* is ``None``; if
+            an existing cache cannot be opened for a reason that is not
+            corruption (see :meth:`_try_load`, which refuses to rebuild
+            destructively over it); or if a finished build cannot be moved
+            into place (see :meth:`_publish`).
+        TimeoutError: If another process's build lock could not be obtained
+            within ``_LOCK_WAIT_MULTIPLE * lock_timeout`` (see
+            :meth:`_acquire_lock`).
     """
 
     def __init__(
@@ -331,6 +346,21 @@ class LMDBCache:
         if self._env is None:
             self._env = lmdb.open(str(self._lmdb_path), readonly=True, lock=False)
         return self._env
+
+    def close(self) -> None:
+        """Closes the read environment, if one is open, and forgets the handle.
+
+        Closing the object returned by :meth:`get_env` directly leaves this
+        instance holding a closed handle that :meth:`get_env` will hand out
+        again, so every later read fails on a dead environment. Going through
+        here instead makes the next :meth:`get_env` reopen cleanly.
+
+        Idempotent, and safe to call on a cache whose environment was never
+        opened.
+        """
+        if self._env is not None:
+            self._env.close()
+            self._env = None
 
     def get(self, key: str) -> bytes | None:
         """Reads a single value from the cache.
@@ -436,7 +466,11 @@ class LMDBCache:
                 pass
             return False
         except (lmdb.Error, OSError) as exc:
-            if strict:
+            # A concurrent _publish renames this directory aside between the
+            # exists() check above and the open here. That is not a failure to
+            # report -- there is simply nothing to load -- so re-check before
+            # raising, or a routine publish surfaces as a scary open error.
+            if strict and self._lmdb_path.exists():
                 raise RuntimeError(
                     f"Cannot open the existing cache at {self._lmdb_path}: {exc}. This is "
                     "not corruption: most likely another handle to this cache is already "
@@ -628,6 +662,16 @@ class LMDBCache:
         check's own false negatives (e.g. a pid query blocked or denied for
         a transient reason) with an independent liveness signal.
 
+        The interval is a quarter of *timeout*, but clamped, and the clamp is
+        what a test has to watch. Below a ``lock_timeout`` of
+        ``4 * _HEARTBEAT_MIN_INTERVAL`` the floor wins and the interval stops
+        shrinking with the timeout; at or under ``_HEARTBEAT_MIN_INTERVAL``
+        the heartbeat can no longer refresh faster than the sentinel goes
+        stale. A test that pairs one process's long ``lock_timeout`` against
+        another's very short one is then asserting nothing -- the lock reads
+        as stale on the first check regardless of whether the heartbeat works
+        -- so keep the short side comfortably above that floor.
+
         Args:
             timeout: The caller's ``lock_timeout``; the refresh interval is
                 a small fraction of it, bounded to a sane range.
@@ -745,9 +789,7 @@ class LMDBCache:
         """
         self._sweep_stale_siblings()
 
-        tmp_path = self._lmdb_path.with_name(f"{self._lmdb_path.name}.build.{os.getpid()}.tmp")
-        if tmp_path.exists():
-            shutil.rmtree(tmp_path)  # leftover of an earlier crashed attempt, same pid: ours
+        tmp_path = self._sibling_tmp_path("build")
 
         env = lmdb.open(str(tmp_path), map_size=map_size)
         try:
@@ -766,6 +808,31 @@ class LMDBCache:
 
         self._publish(tmp_path)
         self._length = length
+
+    def _sibling_tmp_path(self, kind: str) -> Path:
+        """Builds a unique ``<name>.<kind>.<seq>.<pid>.tmp`` sibling path.
+
+        The pid stays last so :meth:`_pid_from_sibling_name` can still read it
+        and :meth:`_sweep_stale_siblings` can still tell a dead owner's leftover
+        from a live one's. The sequence number in front of it is what makes the
+        name unique *within* this process: a trash sibling whose cleanup lost
+        the race against a lingering reader is still on disk when the next
+        publish runs, and reusing the name would make ``os.replace`` fail onto
+        the non-empty leftover -- reporting a stale-cache error for what is
+        only a naming collision.
+
+        Args:
+            kind: ``'build'`` or ``'trash'``.
+
+        Returns:
+            A sibling path that does not currently exist.
+        """
+        while True:
+            candidate = self._lmdb_path.with_name(
+                f"{self._lmdb_path.name}.{kind}.{next(_SIBLING_SEQ)}.{os.getpid()}.tmp"
+            )
+            if not candidate.exists():
+                return candidate
 
     def _publish(self, tmp_path: Path) -> None:
         """Atomically moves a finished build from *tmp_path* into :attr:`_lmdb_path`.
@@ -800,9 +867,7 @@ class LMDBCache:
         """
         trash_path = None
         if self._lmdb_path.exists():
-            trash_path = self._lmdb_path.with_name(
-                f"{self._lmdb_path.name}.trash.{os.getpid()}.tmp"
-            )
+            trash_path = self._sibling_tmp_path("trash")
             try:
                 os.replace(self._lmdb_path, trash_path)
             except OSError as exc:

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from torch.utils.data import DataLoader
 
 from sisr.training import SRDataModule
+from sisr.training.datamodule import _accepted_init_args
 
 
 def _make_dm(image_dir: Path, *, with_train: bool = True) -> SRDataModule:
@@ -448,3 +450,71 @@ def test_train_dataset_built_from_class_path_spec(tiny_rgb_image_dir: Path):
     assert isinstance(dm._train_ds, TrainDataset)
     assert isinstance(dm._val_ds, ValidationDataset)
     assert isinstance(dm._test_ds["Set5"], ValidationDataset)
+
+
+def test_unknown_init_args_key_names_the_config_field_and_the_valid_keys(tmp_path):
+    """_validate_spec catches keys that land *beside* init_args. A misspelled
+    key *inside* it reaches the dataset constructor instead and surfaces as a
+    bare TypeError naming the class but not the config path — which of several
+    dataset blocks is wrong is exactly what the reader needs."""
+    dm = SRDataModule(
+        train_dataset={
+            "class_path": "sisr.datasets.srresnet.ValidationDataset",
+            "init_args": {"img_dir": str(tmp_path), "scale": 2, "crops_per_imag": 8},
+        },
+        val_dataset={
+            "class_path": "sisr.datasets.srresnet.ValidationDataset",
+            "init_args": {"img_dir": str(tmp_path), "scale": 2},
+        },
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        dm.setup(stage="fit")
+
+    message = str(excinfo.value)
+    assert "data.train_dataset.init_args" in message, "must name the offending config field"
+    assert "crops_per_imag" in message, "must name the key that was not accepted"
+    assert "img_dir" in message, "must list what the target does accept"
+    assert isinstance(excinfo.value.__cause__, TypeError), "the original error must be preserved"
+
+
+def test_an_unrelated_type_error_from_a_dataset_constructor_is_not_reworded(tmp_path):
+    """Only the unexpected-keyword case is translated. A TypeError raised by
+    the constructor's own logic must propagate untouched, or a real bug gets
+    reported as a config mistake."""
+
+    def _boom(*args, **kwargs):
+        raise TypeError("something else entirely")
+
+    with patch("sisr.training.datamodule.instantiate_class", side_effect=_boom):
+        dm = SRDataModule(
+            train_dataset={"class_path": "sisr.datasets.srresnet.ValidationDataset"},
+            val_dataset={"class_path": "sisr.datasets.srresnet.ValidationDataset"},
+        )
+        with pytest.raises(TypeError, match="something else entirely"):
+            dm.setup(stage="fit")
+
+
+def test_non_mapping_init_args_is_refused_by_name(tmp_path):
+    """init_args typed as anything but a mapping cannot be splatted into the
+    constructor, so it is caught at validation rather than at instantiation."""
+    with pytest.raises(ValueError, match=r"data\.train_dataset\.init_args must be a mapping"):
+        SRDataModule(
+            train_dataset={
+                "class_path": "sisr.datasets.srresnet.ValidationDataset",
+                "init_args": ["img_dir", str(tmp_path)],
+            },
+            val_dataset={"class_path": "sisr.datasets.srresnet.ValidationDataset"},
+        )
+
+
+@pytest.mark.parametrize(
+    "class_path",
+    ["sisr.datasets.srresnet.NoSuchDataset", "no_such_module.Thing", "not-a-dotted-path"],
+)
+def test_accepted_init_args_gives_up_quietly_on_an_unresolvable_class(class_path):
+    """The accepted-keys lookup is a courtesy on the error path. If the class
+    cannot be resolved or inspected it must return None so the caller still
+    reports the original constructor error, rather than replacing a real
+    failure with an import error raised while composing the message."""
+    assert _accepted_init_args(class_path) is None

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -399,6 +399,21 @@ def test_flatten_hparams_handles_nested():
     }
 
 
+def test_flatten_hparams_stringifies_a_value_of_no_other_kind():
+    """The catch-all is the only thing standing between an unusual config
+    field and a crash while writing the TensorBoard HParams tab.
+
+    No shipped config reaches it today -- every field is a primitive, a list,
+    a dict or a class -- which is why it sat uncovered. It is reachable by any
+    architecture whose config holds something else (a Path, an enum), so it is
+    a live safety net rather than dead code, and it is cheaper to pin than to
+    remove and rediscover.
+    """
+    flat = SRLightning._flatten_hparams({"where": Path("/tmp/x"), "nested": {"k": Path("y")}})
+
+    assert flat == {"where": str(Path("/tmp/x")), "nested/k": str(Path("y"))}
+
+
 # ---------------------------------------------------------------------------
 # init strategy
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,22 @@ import pytest
 from sisr.utils.cache import LMDBCache, LMDBCacheBuildContext
 
 _MAP_SIZE = 16 * 1024 * 1024  # 16 MiB — plenty for tiny test caches
+
+
+@contextmanager
+def _live_child():
+    """Yields the pid of a process that is certainly alive and certainly not ours.
+
+    Tests that need a "confirmed live holder" must own that process: the parent
+    pid is not a safe stand-in, since nothing stops it exiting mid-test, and
+    Windows does not reparent orphans the way POSIX does.
+    """
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        yield proc.pid
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
 
 
 def _make_build_fn(n: int, value_prefix: bytes = b"v"):
@@ -828,22 +845,27 @@ def test_acquire_lock_raises_timeout_error_on_confirmed_live_holder_past_hard_ca
     notice and intervene."""
     name, checksum = "hardcap", "hc1"
     lock_path = tmp_path / f"{name}_{checksum[:16]}.build.lock"
-    other_pid = os.getppid()  # genuinely alive, and guaranteed not to equal our own pid
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-    os.write(fd, str(other_pid).encode())
-    os.close(fd)
 
-    with pytest.raises(TimeoutError, match="Refusing to wait indefinitely"):
-        LMDBCache(
-            cache_dir=tmp_path,
-            name=name,
-            checksum=checksum,
-            length=1,
-            map_size=_MAP_SIZE,
-            build_fn=_make_build_fn(1),
-            lock_poll_interval=0.02,
-            lock_timeout=0.05,
-        )
+    # A child we own, not os.getppid(). The parent's liveness is not ours to
+    # guarantee: POSIX reparents an orphan to init, but Windows does not, so a
+    # parent that exits leaves getppid() naming a dead -- or recycled -- pid,
+    # and this test's whole premise is that the holder is *confirmed alive*.
+    with _live_child() as other_pid:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.write(fd, str(other_pid).encode())
+        os.close(fd)
+
+        with pytest.raises(TimeoutError, match="Refusing to wait indefinitely"):
+            LMDBCache(
+                cache_dir=tmp_path,
+                name=name,
+                checksum=checksum,
+                length=1,
+                map_size=_MAP_SIZE,
+                build_fn=_make_build_fn(1),
+                lock_poll_interval=0.02,
+                lock_timeout=0.05,
+            )
 
 
 def test_acquire_lock_is_bounded_when_the_holder_pid_cannot_be_read(tmp_path: Path):
@@ -1186,3 +1208,154 @@ def test_build_invokes_sibling_sweep_automatically(tmp_path: Path):
     )
 
     assert not leftover.exists()
+
+
+# ---------------------------------------------------------------------------
+# Follow-ups from the post-merge review batch
+# ---------------------------------------------------------------------------
+
+
+def test_strict_load_treats_a_concurrent_rename_aside_as_absent(tmp_path: Path):
+    """_publish moves an existing cache aside with os.replace rather than
+    deleting it. That rename can land between _try_load's exists() check and
+    its lmdb.open, and the open then fails for a perfectly benign reason.
+
+    Strict mode must re-check and report "nothing to load" rather than raising
+    the environmental-failure error, whose text tells the operator to go
+    investigate an OS-level conflict that does not exist.
+    """
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="race",
+        checksum="r1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+
+    def rename_aside_then_fail(*args, **kwargs):
+        os.replace(cache.path, cache.path.with_name(cache.path.name + ".gone"))
+        raise lmdb.Error("environment already open in this process")
+
+    with patch("sisr.utils.cache.lmdb.open", side_effect=rename_aside_then_fail):
+        assert cache._try_load("r1", strict=True) is False
+
+
+def test_strict_load_still_raises_when_the_directory_is_really_there(tmp_path: Path):
+    """The re-check above must not weaken the guard it sits in: a directory
+    that is still present after a failed open is the destructive-rebuild case
+    strict mode exists to refuse."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="present",
+        checksum="p1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+
+    with (
+        patch("sisr.utils.cache.lmdb.open", side_effect=lmdb.Error("already open")),
+        pytest.raises(RuntimeError) as excinfo,
+    ):
+        cache._try_load("p1", strict=True)
+
+    assert "Refusing to silently rebuild" in str(excinfo.value)
+    # The underlying failure is the actionable half -- "already open in this
+    # process" and a Windows sharing violation need different responses.
+    assert isinstance(excinfo.value.__cause__, lmdb.Error)
+
+
+def test_sibling_tmp_paths_are_unique_within_one_process(tmp_path: Path):
+    """A trash sibling whose cleanup lost the race against a lingering reader
+    is still on disk when this process publishes again. Reusing the name would
+    make os.replace fail onto the non-empty leftover and report a stale-cache
+    error for what is only a naming collision."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="uniq",
+        checksum="u1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    first = cache._sibling_tmp_path("trash")
+    first.mkdir()
+    second = cache._sibling_tmp_path("trash")
+
+    assert first != second, "a surviving leftover must not be handed out twice"
+    assert not second.exists()
+    # The pid stays last so the stale-sibling sweep can still read it.
+    assert LMDBCache._pid_from_sibling_name(first.name) == os.getpid()
+    assert LMDBCache._pid_from_sibling_name(second.name) == os.getpid()
+
+
+def test_publish_succeeds_when_an_earlier_trash_sibling_survives(tmp_path: Path):
+    """The cleanup of a trash sibling is best-effort: a lingering reader can
+    leave it on disk. Publishing again from the same process must still work.
+
+    Before the per-attempt sequence, the second publish derived the identical
+    <lmdb>.trash.<pid>.tmp name, and os.replace onto that non-empty leftover
+    fails -- surfacing as "cannot move the stale cache aside", which sends the
+    operator looking for a corrupt cache when the only problem is a name
+    collision. _publish is driven directly here to isolate that mechanism.
+    """
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="survivor",
+        checksum="s1",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1, value_prefix=b"old"),
+    )
+    stranded = cache.path.with_name(f"{cache.path.name}.trash.{os.getpid()}.tmp")
+    stranded.mkdir()
+    (stranded / "data.mdb").write_bytes(b"not empty")
+
+    tmp_build_dir = cache.path.with_name(f"{cache.path.name}.staged.tmp")
+    tmp_env = lmdb.open(str(tmp_build_dir), map_size=_MAP_SIZE)
+    with tmp_env.begin(write=True) as txn:
+        txn.put(b"key_0", b"new0")
+        txn.put(b"__checksum__", b"s1")
+        txn.put(b"__length__", b"1")
+    tmp_env.close()
+
+    cache._publish(tmp_build_dir)  # must not raise
+
+    cache.close()
+    assert cache.get("key_0") == b"new0", "the freshly published build must be live"
+
+
+def test_close_lets_the_environment_be_reopened(tmp_path: Path):
+    """Closing the object get_env() returns leaves this instance holding a dead
+    handle that get_env() hands straight back, so every later read fails. The
+    close() seam exists so callers stop reaching through to do that."""
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="closable",
+        checksum="c1",
+        length=2,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(2),
+    )
+    assert cache.get("key_0") == b"v0"
+
+    cache.close()
+    assert cache._env is None
+    cache.close()  # idempotent
+
+    assert cache.get("key_0") == b"v0", "get_env must reopen after close()"
+
+
+def test_close_is_safe_before_the_environment_is_ever_opened(tmp_path: Path):
+    cache = LMDBCache(
+        cache_dir=tmp_path,
+        name="unopened",
+        checksum="u2",
+        length=1,
+        map_size=_MAP_SIZE,
+        build_fn=_make_build_fn(1),
+    )
+    cache.close()
+    cache.close()
+    assert cache._env is None


### PR DESCRIPTION
Closes #127.

Stacked on #154 → #153 → #152 — **merge bottom-up.**

## What changed

The whole checklist, as one PR. They share a shape: the code already refused the
bad state, but named it in a way that sent the reader somewhere else.

### Cache locking

- [x] **Strict load re-checks existence before raising.** `_publish` moves an
  existing cache aside with `os.replace`, and that rename can land between
  `_try_load`'s `exists()` check and its `lmdb.open`. The benign case was reported
  as an OS-level conflict to go investigate.
- [x] **Same-pid trash collision.** Temp siblings now carry a per-attempt sequence
  *ahead of* the pid, so the pid stays parseable by the stale-sibling sweep. Trash
  cleanup is best-effort, so a leftover from this same process could still be on
  disk at the next publish; reusing the name made `os.replace` fail onto it and
  reported it as a stale cache.
- [x] **Missing exception types in `Raises:`.** `LMDBCache.__init__` now documents
  the `RuntimeError` and `TimeoutError` that reach callers. Audited against the
  source rather than by eye: 4 `RuntimeError` and 2 `TimeoutError` raise sites,
  all reachable from `__init__`, all now documented — and nothing documented that
  is not raised.
- [x] **Heartbeat interval vs staleness threshold recorded.** Below a
  `lock_timeout` of `4 * _HEARTBEAT_MIN_INTERVAL` the clamp wins and the heartbeat
  can no longer outrun staleness, making a mixed-timeout assertion vacuous. The
  shortest `lock_timeout` any test uses is `0.05`, against a floor of `0.04` — so
  nothing is vacuous today, which is exactly why it needed writing down.
- [x] **`close()` seam.** Callers stop closing the object `get_env()` returns and
  leaving the instance holding a dead handle it hands straight back.
- [x] **`getppid` fragility.** The live-holder test now owns the process it calls
  alive. POSIX reparents an orphan to init, Windows does not — so a parent that
  exits leaves `getppid()` naming a dead or recycled pid, under a test whose whole
  premise is a *confirmed alive* holder.

### Config validation

- [x] **Stray keys inside `init_args`.** Now names the config field, the offending
  key and the accepted ones. Previously a bare `TypeError` naming the dataset
  class — which does not say which of several dataset blocks to fix. Only the
  unexpected-keyword case is translated; a `TypeError` from the constructor's own
  logic propagates untouched, with a test pinning that.
- [ ] **"Pin the cause in the environment-is-none assertion" — not done; I could
  not identify it.** No assertion in the tree matches that description: there is no
  `environment is None` assertion, and searches for bare asserts, `__cause__`
  assertions and the environment-open tests turned up nothing that fits. I did the
  nearest defensible things rather than guess at a target — pinned `__cause__` in
  the strict-load test, and gave the one bare assertion in the probe the reason it
  was missing — but **the original item should be re-stated or dropped**, not
  assumed handled.

### CUDA graphs

- [x] **Nothing survived.** #152 removed the capture path, its config field, its
  four Lightning hooks and all 43 of its tests. Re-checked against the tree: no
  `cuda_graph` reference remains in any tracked file. The bullet closes empty.

### CI hygiene

- [x] **Write permissions scoped per job.** `actions: write` was workflow-wide;
  it now sits only on the jobs that actually save a cache. The gate jobs
  (`build`, `test`) and the `changes` filters cannot write to the cache at all.

  **Verified against real runs, not by reading the expression** — the concern with
  scoping this is silently losing cache saves, so both halves were checked in the logs:

  | | result |
  | --- | --- |
  | caching job (`build-matrix`) token | `Actions: write, Contents: read, Metadata: read` |
  | gate job (`build`) token | `Contents: read, Metadata: read` |
  | `setup-uv` cache | `uv cache saved with key: setup-uv-2-...-lint` |
  | `setup-python` pip cache | `Cache saved with the key: setup-python-...` |

  One job does log `Failed to save: Unable to reserve cache ... another job may be
  creating this cache`. That is `editable-install` racing `build-matrix` for the *same*
  key — the sibling wrote it, and it is not a permissions error (that would be a 403).
  It reproduces identically on the pre-change workflow, so it is not caused by this.

- [ ] **SHA-pinning the tag-pinned actions — declined, not done.** The batch listed it as
  *optional hardening* and it is being left out on purpose. Dependabot already tracks
  these, and the repository already draws the line where the risk is: **third-party
  actions pinned by SHA** (`dorny/paths-filter`, `codecov/codecov-action`), **first-party
  `actions/*` on tags**. Pinning everything would have overridden that convention rather
  than followed it, for no real gain.

  `astral-sh/setup-uv` keeps its exact-patch tag, which exists because it stopped
  publishing moving major tags at v8.0.0 — a compatibility pin, not hardening.

  > **On #112:** with this reverted, nothing here touches the `uses:` lines any more, so
  > that Dependabot bump is independent. There is still one trivial conflict, because the
  > top of this stack rewords the comment directly above one of those lines — verified by
  > simulating the merge. **Cheapest order: land this stack first**, then Dependabot
  > rebases #112 itself (no `rebase-strategy` is set, so it defaults to `auto`) and its
  > change reduces to a clean one-line bump.

### Dead code

- [x] **The "unreachable" branch is not unreachable.** Found it by coverage rather
  than by eye — it was the single uncovered line in the module: the `str(obj)`
  catch-all in `_flatten_hparams`. Any config field holding something other than a
  primitive, list, dict or class reaches it; no *shipped* config does today, which
  is why it read as dead. It is a live safety net standing between an unusual field
  and a crash while writing the HParams tab, so I pinned it with a test rather than
  deleting it. `lightning_module.py` is now at **100%** statement coverage.

## Evidence

**Suite** — `927 passed, 2 skipped` of 929 collected, 3m24s. Up 13 tests. The 2
skips are the Windows-only cache liveness paths, as on `main`. No data-gated test
skipped. `ruff check`, `ruff format --check`, `mypy sisr` all clean.

**Every behavioural fix proven RED first**, against the pre-fix code:

| fix | failure before |
| --- | --- |
| strict load vs rename-aside | `RuntimeError: Cannot open the existing cache … the OS-level conflict needs investigating` |
| trash sibling collision | `RuntimeError: Cannot move the stale cache … Investigate and remove it manually` |
| unknown `init_args` key | raw `TypeError` from lightning's `cli.py`, no config path |
| `close()` seam | `AttributeError: 'LMDBCache' object has no attribute 'close'` |

The first two tests were rewritten so their red is about the behaviour under test
rather than about a new method being absent — the first drafts leaned on
`close()`, which confounds the proof.

## Checklist

- [x] `pytest` passes locally; skips named above (a skip is not a pass)
- [x] `ruff check` and `ruff format --check` are clean
- [x] Docs changes are in their own `docs:` commit
- [x] No internal tracker identifiers in the code or commit messages

## Merge strategy

- [x] **Rebase** — carries both a code and a docs commit

> **Part of stack #160** (`#152 -> #153 -> #154 -> #155 -> #156 -> #159`). Merge **bottom-up**.
> These PRs were first opened by chaining bases by hand, which gave correct ancestry but no
> GitHub stack object and so no CI above #152. They were retro-linked with `gh stack link`,
> and every PR in the stack now runs full CI despite its base still being a feature branch.
> A `cancelled` check here is a duplicate-trigger artifact, not a failure -- the push and the
> stack event both fire and `cancel-in-progress` kills the first.


