### PR TITLE
chore: make type checking a gate and narrow what it exempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ notice.
 
 ### Changed
 
+- **Type checking is a required status check**, and the package ships a `py.typed`
+  marker, so the annotations are a checked promise to downstream users rather than an
+  internal convention. The modules exempted from it are now named one by one instead
+  of matched by a glob that silently swallowed every module added beside them.
 - **`LMDBCache.close()`** releases the read environment and lets the next access reopen
   it. Closing the object `get_env()` returns left the instance holding a dead handle.
 - **Y-channel metrics are computed in BT.601 studio range**, matching MATLAB and the

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@
 [![build](https://github.com/YeapJieShen/single-image-super-resolution/actions/workflows/build.yml/badge.svg)](https://github.com/YeapJieShen/single-image-super-resolution/actions/workflows/build.yml)
 [![coverage](https://codecov.io/gh/YeapJieShen/single-image-super-resolution/branch/main/graph/badge.svg)](https://app.codecov.io/gh/YeapJieShen/single-image-super-resolution)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![mypy](https://img.shields.io/badge/mypy-checked-blue)](https://mypy-lang.org/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 
-That `test` badge isn't decorative: `test` is a required status check, so a pull
-request cannot merge without the full suite passing.
+Those badges aren't decorative. `test`, `build`, `lint` and `typecheck` are all
+**required status checks**, so a pull request cannot merge unless the full suite
+passes on Linux and Windows across Python 3.12 and 3.13, the wheel and the editable
+install both work, `ruff` is clean, and the package type-checks. The package also
+ships a `py.typed` marker, so those annotations reach you rather than stopping at
+the repository boundary.
 
 Reproduce single-image super-resolution papers without rewriting a training loop each
 time. Every architecture runs through one `LightningCLI` entrypoint, and an experiment is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,13 @@ check_untyped_defs = true
 # protocol) and jsonargparse's dynamic CLI/subclass resolution (dotted
 # overrides, class_path dispatch) make these fight a type checker rather than
 # benefit from one. Ignored wholesale rather than annotated around.
-module = ["sisr.training.*", "sisr.cli"]
+module = [
+    "sisr.training.callbacks",
+    "sisr.training.datamodule",
+    "sisr.training.gan_module",
+    "sisr.training.lightning_module",
+    "sisr.cli",
+]
 ignore_errors = true
 
 [[tool.mypy.overrides]]

--- a/sisr/training/__init__.py
+++ b/sisr/training/__init__.py
@@ -4,6 +4,8 @@ Re-exports are flat so experiment YAMLs can use short class paths like
 ``sisr.training.SRLightning`` instead of ``sisr.training.lightning_module.SRLightning``.
 """
 
+from typing import Any
+
 from .callbacks import (
     BenchmarkImageLogger,
     GradNormLogger,
@@ -31,7 +33,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """Resolve ``SRGANLightning`` on first access, not at package import.
 
     Every other re-export above is a plain import; this one cannot be. Each

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,108 @@
+"""The static-typing gate: that it runs, that it bites, and what it covers."""
+
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+#: Modules whose dynamism (Lightning's hook system, jsonargparse's subclass
+#: resolution) makes them fight a type checker rather than benefit from one.
+#: Narrowing this list is the point; widening it needs a reason in the diff.
+EXPECTED_IGNORED = {
+    "sisr.cli",
+    "sisr.training.callbacks",
+    "sisr.training.datamodule",
+    "sisr.training.gan_module",
+    "sisr.training.lightning_module",
+}
+
+
+def _ignored_modules() -> set[str]:
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    return {
+        module
+        for override in config["tool"]["mypy"]["overrides"]
+        if override.get("ignore_errors")
+        for module in override["module"]
+    }
+
+
+def test_type_check_exemptions_are_named_one_by_one():
+    """A glob like `sisr.training.*` silently swallows every module added to the
+    package afterwards, including ones that would check clean. Listing them
+    individually makes each exemption a visible line in a diff."""
+    ignored = _ignored_modules()
+
+    assert not [m for m in ignored if "*" in m], (
+        f"exemptions must name modules, not globs: {sorted(ignored)}"
+    )
+    assert ignored == EXPECTED_IGNORED, (
+        "the exemption list changed; if that is deliberate, update EXPECTED_IGNORED "
+        "in this test in the same commit so it stays a decision rather than a drift"
+    )
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["sisr.metrics.scoring", "sisr.training.config", "sisr.training.metadata"],
+)
+def test_modules_that_should_be_checked_are_not_exempt(module):
+    """These sit next to exempt ones and would be easy to sweep back under a
+    glob. `sisr.metrics.scoring` in particular was exempt purely because it used
+    to live under `sisr/training/`."""
+    assert module not in _ignored_modules()
+
+
+@pytest.mark.skipif(shutil.which("mypy") is None, reason="mypy is not installed")
+def test_the_gate_rejects_a_deliberate_violation(tmp_path):
+    """A gate that has never been seen to fail is not known to be a gate.
+
+    Runs the checker under this project's own config against a file that
+    violates it, and requires the specific error rather than merely a non-zero
+    exit -- which a crash, a bad path or an unreadable config would also give.
+    """
+    offender = tmp_path / "offender.py"
+    offender.write_text(
+        '"""Deliberately mistyped module."""\n\n\ndef f() -> int:\n    return "not an int"\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", "--config-file", str(PYPROJECT), str(offender)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode != 0, f"the checker accepted a bad return type:\n{result.stdout}"
+    assert "return-value" in result.stdout, (
+        f"expected a return-value error, got:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.skipif(shutil.which("mypy") is None, reason="mypy is not installed")
+def test_the_gate_accepts_the_same_module_once_corrected():
+    """The counterpart to the test above: an error that fires on everything is
+    not a gate either."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        good = Path(tmp) / "good.py"
+        good.write_text(
+            '"""Correctly typed module."""\n\n\ndef f() -> int:\n    return 1\n',
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "mypy", "--config-file", str(PYPROJECT), str(good)],
+            capture_output=True,
+            text=True,
+            cwd=tmp,
+        )
+
+    assert result.returncode == 0, f"the checker rejected a clean module:\n{result.stdout}"


### PR DESCRIPTION
Closes #116. Closes #132.

Stacked on #155 → #154 → #153 → #152 — **merge bottom-up.**

## What was already true

Worth stating, because it changes what this PR is: `mypy` already ran in CI,
`sisr/py.typed` already existed, and a test already built a real wheel to prove the
marker ships. #132 was already satisfied verbatim — the `test` badge and the line
about it were both in the README.

## What was actually missing

**The gate was not a gate.** `typecheck` was not among the required status checks
— only `test`, `build` and `lint` were — so it could fail and a pull request would
still merge.

**The exemption was a glob.** `sisr.training.*` swallowed every module added to
that package regardless of whether it would check clean. `scoring.py` was exempt
purely because of where it used to live; #153 moved it, and it immediately started
checking and immediately found a real widening.

## What changed

- `typecheck` **added to the required status checks** on `main-protection`.
  Verified against the server afterwards: `test, build, lint, typecheck`,
  enforcement `active`.
- The exemption list **names five modules individually** instead of matching a
  glob, so `sisr.training.config`, `.metadata` and `.probe` are now checked, and a
  new exemption is a visible line in a diff. The five that remain
  (`cli`, `callbacks`, `datamodule`, `gan_module`, `lightning_module`) are the ones
  where Lightning's hook system and jsonargparse's subclass resolution genuinely
  fight a checker.
- One real annotation gap surfaced and was fixed: the package's lazy
  `__getattr__` resolver, previously hidden by the glob.
- **README** names all four gates and what each covers, and states that `py.typed`
  ships — closing #132 with something load-bearing rather than closing it empty.

## Evidence

**The newly-covered modules are genuinely checked, not silently skipped.** I
injected a deliberate error into each and confirmed the checker reports it:

| module | result |
| --- | --- |
| `sisr.metrics.scoring` | CHECKED |
| `sisr.training.config` | CHECKED |
| `sisr.training.metadata` | CHECKED |
| `sisr.training.probe` | CHECKED |

**The gate is proven to bite, permanently.** `tests/test_typing.py` runs the
checker under this project's own config against a deliberate violation and requires
the specific `return-value` error — not merely a non-zero exit, which a crash, a bad
path or an unreadable config would also produce. It also runs it against a *clean*
module, because an error that fires on everything is not a gate either. And it pins
the exemption list, failing if a glob reappears or the list changes without the test
changing with it.

**Suite** — `933 passed, 2 skipped` of 935 collected, 3m21s. The 2 skips are the
Windows-only cache liveness paths, as on `main`. No data-gated test skipped.
`ruff check`, `ruff format --check`, `mypy sisr` all clean.

## Follow-up, filed separately

Removing the five remaining exemptions is real work with an unknown floor, so it is
its own issue rather than a silent omission here.

## Checklist

- [x] `pytest` passes locally; skips named above (a skip is not a pass)
- [x] `ruff check` and `ruff format --check` are clean
- [x] A deliberate violation is proven to fail the gate
- [x] Docs changes are in their own `docs:` commit
- [x] No internal tracker identifiers in the code or commit messages

## Merge strategy

- [x] **Rebase** — carries both a code and a docs commit

> **Part of stack #160** (`#152 -> #153 -> #154 -> #155 -> #156 -> #159`). Merge **bottom-up**.
> These PRs were first opened by chaining bases by hand, which gave correct ancestry but no
> GitHub stack object and so no CI above #152. They were retro-linked with `gh stack link`,
> and every PR in the stack now runs full CI despite its base still being a feature branch.
> A `cancelled` check here is a duplicate-trigger artifact, not a failure -- the push and the
> stack event both fire and `cancel-in-progress` kills the first.

