### PR TITLE
docs: give the config surface a reference page and cut the templates back to config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Workflow-wide floor. actions: write is NOT here -- it is granted per job, to
-# the ones that actually save an Actions cache, so a job that only checks out
-# and runs a script cannot write to the cache at all.
+# Floor only: actions: write is granted per job, to the ones that save a cache.
 permissions:
   contents: read
 
@@ -18,9 +16,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Cheap gate: skips the expensive matrices below on a doc-only PR. Deliberately
-  # an allowlist, not a denylist — anything not explicitly listed here (including
-  # this workflow file itself) is treated as code and runs the full matrix.
+  # Allowlist, not denylist: anything unlisted is treated as code. See docs/configuration.md.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -66,18 +62,12 @@ jobs:
         run: pip install .
       - name: Smoke import
         run: python -c "import sisr; from sisr.cli import main; print('sisr', sisr.__version__, '- main:', main)"
-      # Ports the old tests/test_cli.py::test_cli_help_lists_subcommands subprocess
-      # smoke here: it cost ~10s of the pytest suite re-importing torch +
-      # lightning just to print --help, and this job already installs the wheel and
-      # smoke-imports it, so it's the natural home for a packaging-level check.
+      # Lives here, not in pytest: this job already has the wheel installed.
       - name: CLI entry point lists subcommands
         run: |
           python -c "import subprocess; out = subprocess.run(['sisr', '--help'], capture_output=True, text=True, check=True).stdout; missing = [s for s in ('fit', 'validate', 'test', 'predict') if s not in out]; assert not missing, f'sisr --help missing subcommands: {missing}'"
 
-  # Cheap single-leg guard for the *editable* install path (PEP 660): test.yml
-  # moved to uv, so nothing else in CI exercises `pip install -e`, yet
-  # CONTRIBUTING.md gives contributors who skip uv exactly that command. One
-  # OS/Python leg is enough — this checks build-backend behaviour, not the matrix.
+  # The only leg exercising `pip install -e`, which CONTRIBUTING.md still gives.
   editable-install:
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -98,9 +88,7 @@ jobs:
       - name: Smoke import
         run: python -c "import sisr; from sisr.cli import main; print('sisr', sisr.__version__, '- main:', main)"
 
-  # Stable required-check context: green only if every build-matrix leg and the
-  # editable-install check passed, or were skipped because `changes` found a
-  # doc-only PR (see the equivalent gate in test.yml).
+  # Stable required-check context: matrix legs are not fixed contexts themselves.
   build:
     needs: [build-matrix, editable-install]
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Workflow-wide floor. actions: write is NOT here -- it is granted per job, to
-# the ones that actually save an Actions cache, so a job that only checks out
-# and runs a script cannot write to the cache at all.
+# Floor only: actions: write is granted per job, to the ones that save a cache.
 permissions:
   contents: read
 
@@ -18,11 +16,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Cheap gate: skips the expensive matrices below on a doc-only PR. Deliberately
-  # an allowlist, not a denylist — anything not explicitly listed here (including
-  # this workflow file itself) is treated as code and runs the full matrix.
-  # lint stays ungated: it's a single cheap job, not a matrix, and isn't part of
-  # the `test` required-check's own dependency chain.
+  # Allowlist, not denylist: anything unlisted is treated as code. See docs/configuration.md.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -55,8 +49,7 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      # setup-uv stopped publishing moving major/minor tags at v8.0.0 as supply-chain
-      # hardening, so this pins an exact patch unlike the @v4/@v5 actions above.
+      # setup-uv publishes no moving major tag since v8.0.0, so this pins an exact patch.
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
@@ -68,18 +61,7 @@ jobs:
       - name: Ruff format check
         run: ruff format --check .
 
-  # Type-checks only the modules [tool.mypy]'s overrides don't blanket-ignore
-  # (Lightning's hook system and jsonargparse's dynamic CLI/subclass
-  # resolution make sisr/training/, sisr/cli.py resist useful static typing
-  # without a large, separate effort). Installs the dev extra rather than a
-  # bare `mypy` so it type-checks against the same third-party stubs/versions
-  # the rest of CI runs against.
-  # windows-latest, not ubuntu-latest: sisr/utils/cache.py's ctypes.WinDLL Windows
-  # liveness check is genuine platform-specific code, guarded by a runtime
-  # sys.platform == "win32" check -- but typeshed's ctypes stubs only expose
-  # WinDLL under that same platform, so mypy raises attr-defined errors for it
-  # when its own --platform is anything else. test-matrix already treats
-  # windows-latest as first-class, so this matches, not adds, a supported OS.
+  # windows-latest is required: typeshed only exposes ctypes.WinDLL there.
   typecheck:
     runs-on: windows-latest
     timeout-minutes: 10
@@ -129,19 +111,7 @@ jobs:
           cache-dependency-glob: pyproject.toml
       - name: Install
         run: uv pip install --system -e ".[dev]"
-      # -n 2, deliberately low: every xdist worker is a fresh interpreter that
-      # cold-imports the whole torch + lightning stack (~10s; torch 3.7s, plus scipy
-      # and sympy via torchmetrics/torchvision), while the suite's own compute is only
-      # ~20s. Past a couple of workers the added startup costs more than the
-      # parallelism wins back. Measured 2026-07-30, 8-core/16-thread Windows:
-      # -n 0 44.0s, -n 2 38.3s, -n 4 38.3s, -n 8 47.1s (-n auto = 16 is far worse).
-      # Re-measure before raising this — "more workers" is not free here, and the
-      # break-even moves whenever the import cost or the suite's compute changes.
-      # GitHub runners have fewer cores than the machine above, so -n 8 (this
-      # workflow's previous setting) already sits past the break-even point measured
-      # as slower than serial there; -n 2 is the safer choice here too.
-      # --dist=loadscope keeps same-module tests on one worker so module-scoped
-      # fixtures (e.g. the shared SRCNN LMDB cache) build once instead of once per worker.
+      # -n 2 is measured, not shy: more workers cost more in cold imports than they win.
       - name: Run tests with coverage
         run: pytest -n 2 --dist=loadscope --cov=sisr --cov-report=xml --cov-report=term --cov-fail-under=90
       - name: Upload coverage to Codecov
@@ -159,11 +129,7 @@ jobs:
           path: coverage.xml
           retention-days: 14
 
-  # Numeric-parity check for the opt-in ONNX export: torch eager vs.
-  # onnxruntime CPU (GitHub runners have no GPU), both architectures. Single
-  # OS/Python leg — a correctness check on one code path, not a compatibility
-  # matrix. Installs the `export` extra explicitly since test-matrix's `.[dev]`
-  # deliberately excludes it (onnx/onnxruntime stay opt-in for contributors).
+  # Numeric parity for the opt-in ONNX export: torch eager vs onnxruntime CPU.
   onnx-export:
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -186,9 +152,7 @@ jobs:
       - name: ONNX export parity tests
         run: pytest tests/test_export.py tests/test_cli.py -k export -v
 
-  # Stable required-check context: green only if every matrix leg passed, or
-  # were skipped because `changes` found a doc-only PR (legs report as
-  # "test-matrix (os, ver)", which are not fixed contexts).
+  # Stable required-check context: matrix legs are not fixed contexts themselves.
   test:
     needs: [test-matrix, onnx-export]
     if: always()

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ pip install .
 
 Bring your own HR images. Training and benchmark sets are downloaded separately and are
 not distributed here. Copy a template out of [`templates/`](templates/) and point its
-dataset paths at wherever yours live.
+dataset paths at wherever yours live. Every setting a template exposes is explained in
+[`docs/configuration.md`](docs/configuration.md).
 
 ```bash
 # check the config resolves before committing to a run

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,393 @@
+# Configuration reference
+
+One YAML file describes one experiment. Every architecture runs through the same
+`LightningCLI` entrypoint, so the file is the only thing that changes:
+
+```bash
+sisr fit -c templates/config.srresnet.template.yaml
+```
+
+Copy a template out of [`templates/`](../templates/) and point its dataset paths at
+wherever your images live. This page explains the settings; the templates stay
+close to bare YAML so they read as configuration rather than as prose.
+
+> **Config files must stay ASCII.** jsonargparse opens them with the platform
+> encoding, so a non-ASCII character is a hard `UnicodeDecodeError` at launch.
+
+---
+
+## Top-level keys
+
+| Key | What it does |
+| --- | --- |
+| `seed_everything` | Seeds Python, NumPy and torch. |
+| `matmul_precision` | Sets `torch.set_float32_matmul_precision`. |
+| `optimizer` | The optimizer. For SRGAN this is the **generator's**. |
+| `lr_scheduler` | Optional schedule. For SRGAN this is the **generator's**. |
+| `model` | The Lightning module and everything it wraps. |
+| `data` | Datasets and dataloader settings. |
+| `trainer` | Schedule, precision, callbacks, loggers. |
+
+### `matmul_precision`
+
+`high` enables TF32 matmul on Ampere and later. Measured a **no-op on this repo's
+conv stacks** — convolutions run through cuDNN, whose `allow_tf32` already defaults
+to true. It is kept for matmul-heavy architectures added later.
+
+---
+
+## The `model` block
+
+`model.class_path` selects the Lightning module: `sisr.training.SRLightning` for
+ordinary supervised training, `sisr.training.SRGANLightning` for adversarial.
+Everything else nests under `model.init_args`.
+
+### `model` (the network) and `processor`
+
+The processor is the colorspace adapter between the data and the network:
+
+| Processor | Model sees | Used by |
+| --- | --- | --- |
+| `RGBProcessor` | RGB in `[0, 1]` | pre-2026-08-02 SRResNet runs |
+| `RGBSignedOutputProcessor` | LR `[0, 1]` in, HR/target `[-1, 1]` | SRResNet, SRGAN |
+| `YChannelProcessor` | Y channel only | SRCNN |
+
+`RGBSignedOutputProcessor` is the range Ledig et al. use (§3.2). **Changing the
+processor renumbers what the network is trained on**, and under SRGAN it also
+changes the space the discriminator scores in.
+
+### `criterion`
+
+Unset means `torch.nn.MSELoss`, which is what both papers' baselines use. Any
+`nn.Module` taking `(pred, target)` works, so L1 needs no project class:
+
+```yaml
+criterion: {class_path: torch.nn.L1Loss}
+criterion: {class_path: sisr.losses.CharbonnierLoss}
+```
+
+**Ledig et al.'s SRResNet-VGG22**, faithfully: a VGG22 content loss plus total
+variation at `2e-8`, with **no pixel term**, trained from scratch on the schedule
+the template already configures. The MSE-initialisation trick in the paper applies
+to the SRGAN variants, not to this one.
+
+```yaml
+criterion:
+  class_path: sisr.losses.WeightedSumLoss
+  init_args:
+    terms:
+      vgg22:
+        class_path: sisr.losses.VGG19FeatureLoss
+        init_args: {layer: vgg22}
+      tv:
+        class_path: sisr.losses.TotalVariationLoss
+    weights: {vgg22: 1.0, tv: 2.0e-8}
+```
+
+Two caveats before running it: the first use downloads **~548 MB of VGG19 weights**
+to the torch hub cache, and TV's `2e-8` presumes the `[-1, 1]` output range that
+`RGBSignedOutputProcessor` provides.
+
+**Choosing `layer` (φ<sub>i,j</sub>)**: blocks 1–2 have 2 convs at both depths
+(`vgg11`–`vgg22`); blocks 3–5 have 4 on VGG19 (up to `vgg54`) or 3 on VGG16 (up to
+`vgg53`). `before_activation: true` selects ESRGAN's pre-ReLU features.
+
+> A perceptual run scores **worse PSNR by design**. The templates checkpoint on
+> `ssim/val/RGB` as well as PSNR, so the PSNR-monitored "best" stops tracking the
+> training objective — decide which monitored checkpoint you actually want.
+
+### `training_config`
+
+| Field | Notes |
+| --- | --- |
+| `example_input_shape` | Must match the real training input. |
+| `compile_backend` | A `torch._dynamo` backend name, or unset for eager. |
+| `layer_lrs` | Per-`Conv2d` learning rates; requires every trainable parameter to live in a `Conv2d`. |
+| `init_strategy`, `init_mean`, `init_std` | Weight initialisation. |
+| `scale` | Upscaling factor, for provenance and cross-checks. |
+
+`example_input_shape` is **not** only a TensorBoard-graph dummy. It also shapes the
+`torch.compile` warm-up — a wrong size compiles once and then recompiles on step 1 —
+and it drives `ModelSummary`'s FLOPs count.
+
+### `eval_config` and the two SSIM conventions
+
+**A metric figure is only comparable to one computed the same way.** SSIM has two
+live conventions here, and `ssim_impl` switches between them:
+
+| `ssim_impl` | Method | Comparable to |
+| --- | --- | --- |
+| `daala` | σ scales with image height | Ledig et al.'s SRResNet/SRGAN paper |
+| `wang` | fixed 11×11 gaussian, σ 1.5 | torchmetrics, MATLAB, BasicSR, EDSR/RCAN/SwinIR |
+
+`SRResNetEvalConfig` and `SRGANEvalConfig` default to **`daala`**, because that is
+what their paper used. `SRCNNEvalConfig` defaults to **`wang`**, the field standard.
+Override explicitly when you need the other:
+
+```yaml
+eval_config:
+  class_path: sisr.models.srresnet.SRResNetEvalConfig
+  init_args: {ssim_impl: wang}
+```
+
+Other fields: `crop_border`, `psnr_channels`, `ssim_channels`, `separate_psnr`,
+`perceptual_metrics` (`lpips` needs the `[perceptual]` extra; `dists` ships in core),
+and `lpips_net` — a LPIPS figure is only comparable under the same backbone.
+
+---
+
+## The `data` block
+
+Datasets are `{class_path, init_args}` specs, instantiated lazily so an expensive
+constructor only runs for the stages that need it.
+
+**LR is derived at load** via a MATLAB-compatible antialiased bicubic resize
+([`sisr/utils/imresize.py`](../sisr/utils/imresize.py)), byte-exact against MATLAB's
+own `imresize`, which is what makes these numbers comparable to published ones.
+
+`test_datasets` are surfaced through both `val_dataloader` (so they are scored during
+`fit` for monitoring) and `test_dataloader` (for `sisr test --ckpt_path`).
+
+> A dotted CLI override cannot reach inside a dataset spec's `init_args` — the field
+> is an opaque dict to jsonargparse, so the override lands as a stray sibling key.
+> The datamodule refuses that rather than silently ignoring it. Edit the YAML.
+
+### Dataloader workers
+
+**Workers are load-bearing on real data**, because deriving LR per sample is a real
+cost and `num_workers=0` hits a hard serial floor. The one-time worker spawn cost
+amortizes to nothing over a full run.
+
+Measured on real DIV2K, steady state:
+
+| Config | `num_workers=0` | `num_workers=16` |
+| --- | --- | --- |
+| SRResNet, batch 16 | 56.0 ms/step | 40.1 ms/step |
+| SRCNN, batch 64 | 79.3 ms/step | 14.9 ms/step |
+
+> **The SRGAN template is more exposed than the others on the same data path.** A
+> resident discriminator plus a VGG19 feature extractor consume RAM the SRResNet
+> template does not need. The template's counts (16 train / 2 val) have **OOM'd host
+> RAM on a 16-worker box** — a val worker's float64 resize of a full-size DIV2K image
+> raised `numpy._ArrayMemoryError` at the *first validation*, not at step 0. A smoke
+> run only completed at 4 train / 0 val workers. Safe counts on any given box are
+> unmeasured; lower these if you OOM.
+
+---
+
+## The `trainer` block
+
+### `benchmark`
+
+cuDNN autotunes a convolution algorithm per input shape and caches it — free here,
+since every training step feeds the same fixed crop shape. Lightning ties this key to
+`deterministic`, which is why it lives in the trainer block rather than as a custom key.
+
+### Precision and compilation
+
+The templates train **eager fp32**, which is bit-identical by definition and what a
+paper reproduction needs.
+
+**`bf16-mixed` on its own is a regression, not a speed-up**, measured twice on two
+platforms (0.72× on Windows; 41.0 vs 35.5 ms/step eager on Linux, 0.87×). Autocast's
+cast-churn does not saturate the SMs at these batch sizes. Crossover was measured at
+batch 32, where bf16 with a fused optimizer wins — revisit only if `batch_size` rises.
+
+It is a different story combined with `torch.compile`'s inductor backend, which fuses
+those casts into the kernels. That is an opt-in path and it is **both settings
+together**:
+
+```yaml
+trainer:
+  precision: bf16-mixed
+model:
+  init_args:
+    training_config:
+      init_args:
+        compile_backend: inductor
+```
+
+Two things to know before using it for anything you intend to compare against a paper:
+
+- **The PSNR/SSIM cost of bf16 has not been measured.** Stay in fp32 for reproduction
+  runs until a fidelity comparison exists.
+- **Inductor needs a C compiler at runtime**, not just the `triton` package — it shells
+  out to build each kernel. A box with no toolchain fails at the first compiled step
+  with `RuntimeError: Failed to find C compiler`.
+
+### 🚨 Step axis: two counters, different units
+
+`trainer.global_step` counts **optimizer steps**. Every `self.log` metric instead
+lands on Lightning's `_batches_that_stepped`, which counts **batches**.
+
+For `SRLightning` the two differ only by one. **For `SRGANLightning` they differ by a
+factor of two**, because it takes two optimizer steps per batch (one discriminator,
+one generator) under manual optimization. This is unchanged Lightning behaviour, not a
+quirk of manual optimization — measured, manual optimization with a *single* optimizer
+still gives `global_step == batches`.
+
+So the units differ, and you must read this before changing any of them:
+
+| In **global steps** | In **batches** |
+| --- | --- |
+| `max_steps` | `val_check_interval` |
+| checkpoint filenames | `log_every_n_steps` |
+| `every_n_train_steps` | hand-stepped LR scheduler `milestones` |
+
+`_batches_that_stepped` is also the **default x-axis every logged metric is plotted
+against**. Under SRGAN, TensorBoard therefore shows the run in batches while checkpoint
+filenames carry global steps — `sr-weights-10000.pt` is the state at TensorBoard
+x=5000, not x=10000.
+
+One further trap: `every_n_train_steps`' condition is checked once per batch, so an
+**even** value halves the batch cadence (10000 → every 5000 batches) while an odd one
+does not (5 → still every 5).
+
+### Callbacks
+
+| Callback | Purpose |
+| --- | --- |
+| `BenchmarkImageLogger` | Writes benchmark-set image strips each val run. |
+| `SRCheckpoint` | Resumable `.ckpt`. |
+| `SRWeightsCheckpoint` | Distributable, optimizer-free `.pt` weights — roughly a third the size, and safe to hand out without leaking optimizer state. `attribute` picks which component is saved. |
+| `GradNormLogger` | Logs `diag/grad_norm`. |
+| `LearningRateMonitor` | Lightning's, logging per step. |
+
+Set `monitor_metric` for a metric-monitored top-k, or `monitor_metric: null` with
+`keep_last` for rolling last-N saves by step. **A monitor's direction is validated at
+setup**, so a lower-is-better metric left at the default `mode: max` is refused rather
+than quietly keeping the worst model of the run.
+
+Throughput diagnostics are left commented out in the templates because they add
+per-step logging overhead. `DeviceStatsMonitor` works as-is; `ThroughputMonitor`
+additionally needs a `batch_size_fn`, since batches are `(lr, hr)` tuples rather than
+plain tensors, and no project-side helper exists yet.
+
+---
+
+## SRGAN specifics
+
+### Two optimizers
+
+The top-level `optimizer:` and `lr_scheduler:` are the **generator's**. The
+discriminator's are nested under `model.init_args` as `discriminator_optimizer` and
+`discriminator_lr_scheduler`.
+
+That asymmetry is deliberate. A second top-level key would need another
+`parser.add_optimizer_args(link_to=...)` in the CLI, and that link targets an argument
+`SRLightning` does not have — adding it would break every non-GAN config. Nesting keeps
+the second optimizer local to the only module that has one.
+
+**Both schedulers use the same milestones**, so the two networks decay together. Ledig
+et al. describe the SRGAN networks as a whole ("1e5 update iterations at 1e-4 and
+another 1e5 at 1e-5"); leaving the discriminator's unset would hold the critic at 1e-4
+through the whole second phase while the generator it scores drops to 1e-5 — 10× faster,
+and a standard way to saturate the generator's adversarial gradient.
+
+`SRGANLightning` steps its schedulers by hand in `on_train_batch_end`, because manual
+optimization does not step them. **Milestones are therefore counted in batches.**
+
+### `init_from`
+
+Ledig et al. scope the MSE-initialisation trick to "when training the actual GAN", so a
+paper-faithful run starts from an MSE-trained SRResNet. Point `init_from` at a **bare
+weights `.pt`**, never the sibling `.ckpt` — a `.ckpt` holds the whole LightningModule.
+
+The generator's architecture, processor, output range and scale are all checked against
+the file's own metadata and **refused on any mismatch**: weights trained under a
+different one produce a model that trains and scores without ever erroring.
+
+Set it to `null` *in the file* (or a `--config` overlay) to train from scratch, which is
+not the paper's recipe. `--...init_from=null` on the command line does **not** work:
+jsonargparse coerces it to the string `'None'`.
+
+### The discriminator's input size
+
+`SRDiscriminator`'s dense head fixes the accepted input size, so `hr_input_size` must
+equal the HR crop the training data serves. The template anchors
+`data.train_dataset.init_args.hr_crop_size` to that same value with a YAML anchor, and
+the setup probe re-checks it against a real sample before the first step. A mismatch is
+otherwise a raw `Linear` shape error.
+
+### One device only
+
+`SRGANLightning` refuses `world_size > 1`. Manual optimization opts out of Lightning's
+gradient synchronisation, so the two networks would train out of sync across ranks with
+nothing failing.
+
+### Checkpointing an adversarial run
+
+The primary artifacts are **rolling and monitor-free**. PSNR and SSIM get worse by
+design under an adversarial objective, so a top-k on either would keep the *least*
+adversarial state of the run — typically one from the first few thousand steps.
+
+Weights are saved for **both** networks. The generator's is what gets handed out and
+what `init_from` consumes; the discriminator's is kept so the critic can be restored by
+hand, though nothing shipped consumes it today. Distinct `filename_prefix` values keep
+each callback's rolling deletion off the other's files in a shared directory.
+
+A perceptual monitor does track the objective, but `lpips`/`dists` are lower-is-better,
+so `mode` **must** be `min`.
+
+**`GradNormLogger` is deliberately absent from the SRGAN template.** Measured: its
+`on_after_backward` hook fires twice per batch, once per network's backward, and
+`pl_module.parameters()` spans both networks (58 tensors = 24 generator + 34
+discriminator). The single `diag/grad_norm` scalar therefore mixes the two and alternates
+between two different meanings. Log per-network norms by hand if you need them.
+
+---
+
+## Project configuration
+
+Notes on `pyproject.toml` and CI that are easy to change without realising what they
+were for.
+
+### Dependency floors
+
+- **`torch>=2.6` is a security floor, not a convenience one.** `torch.load(weights_only=True)`
+  is this project's entire load-time safety contract for third-party `.ckpt`/`.pt` files,
+  and GHSA-53q9-r3pm-6pq6 / CVE-2025-32434 lets that check be bypassed for arbitrary code
+  execution on torch ≤ 2.5.1. Do not lower it.
+- `torchmetrics>=1.9`, `jsonargparse>=4.50` — the versions the relevant APIs were verified
+  present in here. Lowering either means testing the lower version, not guessing.
+
+### Extras
+
+`export` (onnx/onnxruntime) and `perceptual` (lpips) are opt-in. DISTS needs only
+torchvision and ships in core, so the `perceptual` extra buys exactly one metric.
+
+### Test and lint settings
+
+- `--import-mode=importlib` avoids duplicate-basename collisions across test subdirectories.
+  It does **not** add the repo root to `sys.path`, hence the explicit `pythonpath = ["."]` —
+  without it, a bare `pytest` from a git worktree would resolve `tests.reference` from a
+  different checkout while the sibling expectations stay worktree-local, silently mixing two
+  trees.
+- `line-length = 100` matches the code as written: 88 would reflow ~157 lines, 100 only ~53.
+- Test parallelism is a CI-only concern, and `-n 2` there is deliberate rather than shy —
+  every xdist worker is a fresh interpreter that cold-imports the whole torch + lightning
+  stack (~10 s) while the suite's own compute is only ~20 s, so past a couple of workers
+  the startup costs more than the parallelism wins back.
+
+### CI
+
+Four checks are **required** for a pull request to merge: `test`, `build`, `lint` and
+`typecheck`.
+
+- **`typecheck` runs on `windows-latest`, which is not arbitrary.** The cache's liveness
+  check uses `ctypes.WinDLL`, genuine platform-specific code guarded at runtime by
+  `sys.platform == "win32"` — but typeshed only exposes `WinDLL` under that platform, so
+  mypy raises `attr-defined` errors for it anywhere else.
+- `actions: write` is granted **per job**, only to the ones that save an Actions cache, so
+  the gate jobs cannot write to it at all.
+- **Action pinning follows the risk, not a blanket rule.** Third-party actions
+  (`dorny/paths-filter`, `codecov/codecov-action`) are pinned to a commit SHA, because a
+  tag is mutable and those are the ones worth hardening. First-party `actions/*` stay on
+  version tags, and Dependabot keeps them current. `astral-sh/setup-uv` pins an exact
+  patch rather than a major tag only because it stopped publishing moving major tags at
+  v8.0.0 — not as extra hardening.
+- The `changes` job is an **allowlist**, not a denylist: anything not explicitly listed as
+  documentation is treated as code and runs the full matrix.
+- `codecov/patch` is expected to fail and is not a required check — it reports on paths that
+  cannot execute on CPU-only runners. The real coverage gate is `--cov-fail-under=90` inside
+  `test`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,23 +35,13 @@ classifiers = [
 ]
 
 dependencies = [
-    # 2.6 excludes the torch.load(weights_only=True) unpickler bypass fixed in
-    # 2.6.0 (GHSA-53q9-r3pm-6pq6 / CVE-2025-32434) — that flag is this project's
-    # entire load-time safety contract for third-party .ckpt/.pt files.
+    # SECURITY FLOOR (CVE-2025-32434) -- do not lower. See docs/configuration.md.
     "torch>=2.6",
     "torchvision>=0.21",
     "lightning>=2.4",
-    # 1.9 is the version DISTS was verified present in on this project.
-    # sisr/metrics/perceptual.py caches the backbones directly
-    # (torchmetrics.functional.image.dists.DISTSNetwork and
-    # torchmetrics.image.lpip.LearnedPerceptualImagePatchSimilarity.net), so the
-    # pin covers those, not just the functional entry points.
-    # Lowering it means testing the lower version, not guessing.
+    # DISTS was verified present at 1.9; the pin covers the cached backbones too.
     "torchmetrics>=1.9",
-    # sisr/cli.py calls set_parsing_settings(subclasses_enabled=...) so a dotted CLI
-    # override of a dataclass config field keeps the architecture's subclass. That
-    # keyword does not exist below 4.50, and 4.50 is the version it was verified on
-    # here. Lowering it means testing the lower version, not guessing.
+    # set_parsing_settings(subclasses_enabled=...) does not exist below 4.50.
     "jsonargparse[signatures]>=4.50",
     "lmdb>=1.4",
     "pillow>=10",
@@ -66,33 +56,19 @@ dev = [
     "pytest-cov>=5",
     # Parallelizes the suite (CI-only, see test.yml's `-n 2`); execnet is pulled in transitively.
     "pytest-xdist>=3.6",
-    # tests/test_cli.py parses/emits config YAML directly; PyYAML otherwise
-    # resolves only transitively (via jsonargparse/lightning), which is fragile.
+    # Explicit: the tests import yaml directly, not transitively.
     "pyyaml>=6",
     "ruff>=0.9",
     "mypy>=1.11",
-    # tests/test_packaging.py builds a real wheel via hatchling's PEP 517
-    # build_wheel() hook to check py.typed actually ships in it, rather than
-    # only asserting the pyproject.toml config that's supposed to include it.
-    # Already a [build-system] requirement; declared again here so it's
-    # present outside pip's ephemeral build-isolation environment too.
+    # Declared again outside build-isolation: the packaging test builds a real wheel.
     "hatchling>=1.27",
 ]
-# Opt-in: sisr/export.py gates the actual `import onnx` inside to_onnx(),
-# so plain `pip install .` stays onnx-free. onnxruntime is the CI numeric-parity
-# check's target (CPU build — GitHub runners have no GPU); it also lets users
-# verify an export locally without a separate inference framework. Deliberately
-# NOT paired with onnxscript: that would pull in torch's newer torch.export-based
-# exporter, so to_onnx() pins dynamo=False (the legacy TorchScript exporter) and
-# stays on this pair.
+# Opt-in, and deliberately without onnxscript: to_onnx() pins dynamo=False.
 export = [
     "onnx>=1.16",
     "onnxruntime>=1.19",
 ]
-# LPIPS only. torchmetrics implements both LPIPS and DISTS, but gates LPIPS on
-# the `lpips` package (_LPIPS_AVAILABLE) while DISTS needs only torchvision,
-# already a core dep — so DISTS ships in core and this extra buys exactly one
-# metric. Optional because it is a scoring convention, not a training need.
+# LPIPS only: DISTS needs only torchvision and ships in core.
 perceptual = ["lpips>=0.1"]
 
 [project.scripts]
@@ -111,69 +87,25 @@ packages = ["sisr"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-# --import-mode=importlib avoids duplicate-basename collisions across test
-# subdirs (e.g. tests/models/srcnn/test_model.py vs
-# tests/models/srresnet/test_model.py) without requiring __init__.py files.
-# No -n/--dist here: parallelism is a CI-only concern, not a local default, so a
-# bare `pytest` in a dev shell runs serial. See test.yml's test-matrix job for the
-# worker-count rationale and measurements.
+# importlib mode avoids duplicate-basename collisions; parallelism is CI-only.
 addopts = "-ra --strict-markers --import-mode=importlib"
-# importlib import-mode does NOT add the repo root to sys.path — tests/metrics/test_ssim.py's
-# `from tests.reference....` (and any `import sisr`) only resolves today because the
-# editable install's .pth file happens to put it there. A non-editable install (`pip
-# install .`) plus bare pytest fails at collection; bare pytest from a git worktree
-# (this project's PR workflow) would resolve `tests.reference` from a DIFFERENT
-# checkout's sys.path entry while the sibling EXPECTED_PATH stays worktree-local,
-# silently mixing two trees. Explicit pythonpath removes the dependency on install mode.
+# Required: without it a worktree run can mix two checkouts. See docs/configuration.md.
 pythonpath = ["."]
 filterwarnings = [
     "error",
-    # Lightning 2.6.5 constructs torch 2.12's deprecated pytree `LeafSpec` at
-    # lightning/pytorch/utilities/_pytree.py:21, so any real Trainer loop emits a
-    # FutureWarning: "`isinstance(treespec, LeafSpec)` is deprecated, use
-    # `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.".
-    # Scoped to the lightning namespace + dated 2026-07-12; drop this once lightning
-    # stops calling torch's deprecated pytree API (track the next lightning/torch bump).
-    # Upstream: https://github.com/Lightning-AI/pytorch-lightning (pytree LeafSpec deprecation)
+    # Lightning calls torch's deprecated pytree API; drop this once it stops.
     "ignore::FutureWarning:lightning.*",
-    # Manual optimization (SRGANLightning) + every_n_train_steps: Lightning warns
-    # that the saved state is post-optimization. That is exactly the state we
-    # want — a checkpoint should hold the weights the step produced.
+    # Post-optimization state is exactly what a checkpoint should hold.
     "ignore:Using ModelCheckpoint with manual optimization:UserWarning",
 ]
 
 [tool.ruff]
-# Ruff owns lint + format for this project. line-length 100 matches the
-# code as written: 88 would reflow ~157 lines across every file, 100 only ~53
-# (mostly docstrings the formatter can't wrap). It governs both E501 and the
-# formatter's wrap width. target-version pins syntax so UP never rewrites below
-# our requires-python floor. Formatter runs with defaults (double quotes, which
-# already dominate the tree).
+# line-length 100 matches the code as written; 88 would reflow ~157 lines.
 target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-# E,F: pycodestyle errors + pyflakes (unused imports/vars, undefined names).
-# I: import sorting. UP: pyupgrade (modern syntax for the py312 floor).
-# B: flake8-bugbear (likely-bug patterns, e.g. zip() without strict=).
-# UP038 (non-pep604-isinstance) was hand-applied when UP was first selected, then
-# deprecated in ruff 0.12.0 and *removed* in 0.16.0 — so it no longer fires and there
-# is nothing to suppress. Do not add it to `ignore`: ruff warns "rules have been
-# removed and ignoring them has no effect" on every run, which is noise in a required
-# check. The isinstance(x, A | B) style it enforced is now convention, not lint.
-# D: pydocstyle — makes "Google-style docstrings on public API" (a stated
-# project non-negotiable) enforceable instead of review-only. D105 (undocumented
-# magic method) is ignored because dunder semantics are defined by the language,
-# not by us. D107 (undocumented __init__) is ignored because Google style documents
-# constructor args in the *class* docstring, which this repo already does —
-# requiring an __init__ docstring too would push against the very convention being
-# enforced.
-# Limitation worth knowing: D417 (missing Args entry) fires only on *partially*
-# documented functions, not undocumented ones — a docstring with its whole Args:
-# section deleted passes with D fully enabled (verified empirically with a
-# two-function probe; preview DOC rules were silent on it too). So this catches
-# half-documented functions and formatting drift, not the wholesale Args: deletion
-# that motivated adding it. That guardrail stays human review.
+# Do NOT add the removed UP038 to `ignore`: ruff then warns on every run.
 select = ["E", "F", "I", "UP", "B", "D"]
 ignore = ["D105", "D107"]
 
@@ -182,27 +114,14 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 # Re-export hubs import names purely to surface them under short class paths.
-# Names in __all__ are already treated as used; this documents the intent and
-# covers any future __init__.py that omits __all__.
 "__init__.py" = ["F401"]
-# Tests carry ~400 D violations, ~135 of them D103 (undocumented public function).
-# Test *names* are the documentation here; writing hundreds of docstrings to
-# satisfy a linter is churn, not clarity.
+# Test names are the documentation here.
 "tests/**" = ["D"]
 
 [tool.mypy]
-# Checks that the "modern type hints" style rule (PEP 585/604) is a checked
-# promise, not just convention. Runs over the whole `sisr` package; the
-# overrides below blanket-ignore the modules whose dynamism (Lightning's hook
-# system, jsonargparse's dynamic CLI/subclass resolution) resists useful
-# static typing without a large, separate effort. The mypy CI job is green
-# only because of those overrides -- it is not exercising those modules.
+# A required status check; tests/test_typing.py pins the exemption list below.
 python_version = "3.12"
-# Pinned rather than left to infer from the host: sisr/utils/cache.py's Windows
-# liveness check uses ctypes.WinDLL, which typeshed only exposes under this
-# platform. Without pinning it, the exact same code type-checks clean on a
-# Windows dev machine and fails with attr-defined errors on Linux/macOS one
-# -- see the typecheck CI job (windows-latest) for the other half of this.
+# Pinned, not inferred: ctypes.WinDLL is only in typeshed under this platform.
 platform = "win32"
 warn_unused_configs = true
 warn_unused_ignores = true
@@ -211,10 +130,7 @@ disallow_untyped_defs = true
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-# Lightning's hook system (dynamic **kwargs call signatures, callback
-# protocol) and jsonargparse's dynamic CLI/subclass resolution (dotted
-# overrides, class_path dispatch) make these fight a type checker rather than
-# benefit from one. Ignored wholesale rather than annotated around.
+# Lightning's hook system and jsonargparse's subclass resolution fight a checker.
 module = [
     "sisr.training.callbacks",
     "sisr.training.datamodule",
@@ -225,14 +141,11 @@ module = [
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-# Neither ships inline types or a py.typed marker (checked against the
-# versions in dev's environment: torchvision 0.28, tqdm 4.70).
+# Neither ships inline types or a py.typed marker.
 module = ["torchvision.*", "tqdm.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-# onnx is the optional [export] extra, deliberately not part of the default
-# dev install (see test.yml's onnx-export job) — the typecheck job installs
-# only [dev], so the import is unresolved there regardless of stub coverage.
+# The optional [export] extra: unresolved in a [dev]-only install by design.
 module = ["onnx"]
 ignore_missing_imports = true

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -1,7 +1,8 @@
+# SRCNN -- Dong et al., pre-upsampled LR, Y-channel only.
+# Settings are explained in docs/configuration.md. Config files must stay ASCII.
 seed_everything: 42
 
-# TF32 matmul on Ampere+ GPUs. Measured no-op on this repo's conv stacks: conv runs
-# through cuDNN, whose allow_tf32 already defaults True — kept for matmul-heavy archs.
+# No-op on this repo's conv stacks; kept for matmul-heavy architectures.
 matmul_precision: high
 
 optimizer:
@@ -16,7 +17,7 @@ model:
       model:
         class_path: sisr.models.srcnn.SRCNN
         init_args:
-          num_channels: 1                    # Y-channel only (was 3 — latent bug fix)
+          num_channels: 1                    # Y channel only
           num_filters: [64, 32]
           kernel_sizes: [9, 1, 5]
           padding: 0
@@ -25,24 +26,13 @@ model:
       training_config:
         class_path: sisr.models.srcnn.SRCNNTrainingConfig
         init_args:
-          # Must match the real training input: 1-channel Y at subimg_size x subimg_size.
-          # No longer only a TensorBoard-graph dummy -- it also shapes the compile warm-up
-          # (a wrong size compiles once then recompiles on step 1) and ModelSummary's FLOPs.
+          # Must match the real training input: 1-channel Y at subimg_size.
           example_input_shape: [1, 33, 33]
-      # No init_args: the dataclass default leaves ssim_impl at wang -- the field
-      # standard fixed 11x11 gaussian (sigma 1.5), what torchmetrics/MATLAB/BasicSR
-      # compute and what most SR papers report (SRResNet's paper is the exception --
-      # see the daala note in its template). Override with:
-      #   eval_config:
-      #     class_path: sisr.models.srcnn.SRCNNEvalConfig
-      #     init_args:
-      #       ssim_impl: daala
+      # Defaults to ssim_impl: wang, the field standard.
       eval_config:
         class_path: sisr.models.srcnn.SRCNNEvalConfig
 
 data:
-  # LR is derived via MATLAB-compatible antialiased bicubic resizing (see
-  # sisr/utils/imresize.py), comparable to published paper numbers.
   train_dataset:
     class_path: sisr.datasets.srcnn.TrainDataset
     init_args:
@@ -75,10 +65,7 @@ data:
         scale: *scale
   train_dataloader_kwargs:
     batch_size: 64             # not specified by the paper; this project's choice
-    # Workers are load-bearing on real data: per-sample LR derivation measured
-    # ~1.1 ms, so batch 64 is a ~69 ms hard serial floor at num_workers=0 (real
-    # DIV2K steady-state: 79.3 ms/step at w0 vs 14.9 ms/step at w16 -- 0.19x).
-    # The ~2-minute one-time spawn cost amortizes to nothing over a full run.
+    # Load-bearing on real data: num_workers=0 hits a hard serial floor.
     num_workers: 16
     pin_memory: true
     persistent_workers: true
@@ -89,25 +76,16 @@ data:
 
 trainer:
   max_epochs: -1
-  # Paper gives 8e8 backprops, not steps; reading that as per-sample updates (the
-  # mini-batch reading implies implausible iters/sec on 2014 hardware) puts
-  # 1e7 steps * batch 64 = 6.4e8, ~0.8x the paper's figure. Approximation, not a quote.
+  # ~0.8x the paper's 8e8 backprops, read as per-sample updates. An approximation.
   max_steps: 10000000
-  # 20 validation cycles over the run (max_steps / val_check_interval) — matches the
-  # logging budget. Revisit this if max_steps changes, or event files balloon.
-  val_check_interval: 500000
+  val_check_interval: 500000   # 20 validation cycles over the run
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
   log_every_n_steps: 1000
   deterministic: false
-  # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
-  # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
-  # above, hence it lives here rather than as a custom key.
+  # Free here: every training step feeds the same fixed crop shape.
   benchmark: true
-  # bf16-mixed measured as a REGRESSION on this project's other architecture
-  # (0.72x SRResNet b16, full power) -- autocast's cast-churn doesn't saturate
-  # the SMs at these batch sizes. Crossover measured at b32 (bf16+fused wins) --
-  # revisit only if batch_size rises well past this template's 64.
+  # bf16-mixed measured as a REGRESSION at these batch sizes. See the docs.
   # precision: bf16-mixed
   accelerator: cuda
   devices: [0]
@@ -125,9 +103,7 @@ trainer:
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
-    # Distributable, optimizer-free weights (.pt) alongside the resumable .ckpt files
-    # above — same monitors/top-k, so every checkpointed best also ships a bare-weights
-    # counterpart safe to hand out without leaking optimizer state.
+    # Distributable, optimizer-free weights alongside the resumable .ckpt files.
     - class_path: sisr.training.SRWeightsCheckpoint
       init_args:
         monitor_metric: psnr/val/RGB
@@ -142,14 +118,6 @@ trainer:
     - class_path: sisr.training.GradNormLogger
       init_args:
         log_every_n_steps: 5000
-    # Throughput/hardware diagnostics — extra per-step logging overhead, so commented
-    # out by default. DeviceStatsMonitor works as-is; ThroughputMonitor additionally
-    # needs a batch_size_fn (batches are (lr, hr) tuples, not plain tensors — no
-    # project-side helper exists yet).
-    # - class_path: lightning.pytorch.callbacks.DeviceStatsMonitor
-    # - class_path: lightning.pytorch.callbacks.ThroughputMonitor
-    #   init_args:
-    #     batch_size_fn: sisr.training.callbacks.batch_size  # example path; add if needed
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -1,26 +1,18 @@
+# SRGAN-VGG54 -- Ledig et al.'s adversarial variant, generator initialised from MSE.
+# Settings are explained in docs/configuration.md, which covers the two-optimizer
+# layout and the global-step vs batch units below. Config files must stay ASCII.
 seed_everything: 42
 
-# TF32 matmul on Ampere+ GPUs. Measured no-op on this repo's conv stacks: conv runs
-# through cuDNN, whose allow_tf32 already defaults True — kept for matmul-heavy archs.
+# No-op on this repo's conv stacks; kept for matmul-heavy architectures.
 matmul_precision: high
 
-# The GENERATOR's optimizer. Linked into model.init_args.optimizer by SRLightningCLI.
-# The discriminator's is nested under model.init_args below — see the comment there.
+# The GENERATOR's optimizer; the discriminator's is nested under model.init_args.
 optimizer:
   class_path: torch.optim.Adam
   init_args:
     lr: 1.0e-4
 
-# The generator's LR schedule, and the paper's second training phase: Ledig et al.
-# decay 1e-4 -> 1e-5 after 1e5 generator iterations, then train 1e5 more. The
-# discriminator_lr_scheduler nested under model.init_args below mirrors this
-# block exactly, so both networks decay together — Ledig's sentence describes
-# the SRGAN networks as a whole, not the generator alone, and a critic left at
-# 1e-4 for the whole second phase while the generator drops to 1e-5 is a
-# standard way to saturate the generator's adversarial gradient.
-# SRGANLightning steps its schedulers by hand in on_train_batch_end (manual
-# optimization does not step them), so milestones are counted in BATCHES — at the
-# default k=1 one batch is one generator iteration.
+# The generator's schedule. The discriminator's mirrors it so both decay together.
 lr_scheduler:
   class_path: torch.optim.lr_scheduler.MultiStepLR
   init_args:
@@ -31,7 +23,6 @@ model:
   class_path: sisr.training.SRGANLightning
   init_args:
       # The generator: the same SRResNet the baseline template trains, unchanged.
-      # Only how it is trained differs.
       model:
         class_path: sisr.models.srresnet.SRResNet
         init_args:
@@ -41,96 +32,48 @@ model:
           kernel_sizes: [9, 3, 9]
           num_residual_blocks: 16
           padding: same
+      # The discriminator scores the generator's output in THIS space.
       processor:
-        # Paper's range (Ledig et al. §3.2): LR [0,1] in, HR/target [-1,1]. The
-        # discriminator scores the generator's output in THIS space, so changing
-        # the processor renumbers what the critic is trained on.
         class_path: sisr.processors.RGBSignedOutputProcessor
-      # The generator's CONTENT loss. The adversarial term is added on top by
-      # SRGANLightning, weighted by training_config.adversarial_weight.
-      # phi_{5,4} is SRGAN-VGG54, the paper's headline variant. NO total-variation
-      # term: Ledig et al. scope TV at 2e-8 to SRResNet-VGG22, not to the GAN
-      # variants, and adding one here is not the published recipe.
-      # First use downloads ~548 MB of VGG19 weights to the torch hub cache.
+      # CONTENT loss only. First use downloads ~548 MB of VGG19 weights.
       criterion:
         class_path: sisr.losses.VGG19FeatureLoss
         init_args:
           layer: vgg54
-      # The critic. Its dense head fixes the accepted input size, so hr_input_size
-      # must equal the HR crop the training data serves — data.train_dataset.
-      # hr_crop_size below is anchored to this very value, and SRGANLightning's
-      # setup probe re-checks it against a real sample before the first step.
+      # Must equal the HR crop the data serves; hr_crop_size below is anchored to it.
       discriminator:
         class_path: sisr.models.srgan.SRDiscriminator
         init_args:
           hr_input_size: &hr_crop 96
-      # Nested under model.init_args rather than being a second top-level key
-      # alongside optimizer:. A top-level one would need a second
-      # parser.add_optimizer_args(link_to=...) in SRLightningCLI, and that link
-      # targets an argument SRLightning does not have — it would break every
-      # non-GAN config the moment it were added. Nesting keeps the second
-      # optimizer local to the only module that has one.
       discriminator_optimizer:
         class_path: torch.optim.Adam
         init_args:
           lr: 1.0e-4
-      # Same shape as the top-level lr_scheduler:, also nested, and set to the
-      # same milestone/gamma so both networks decay together. Ledig et al.'s
-      # sentence ("All SRGAN variants were trained with 1e5 update iterations
-      # at a learning rate of 1e-4 and another 1e5 iterations at a lower rate
-      # of 1e-5") describes the SRGAN networks as a whole; leaving this unset
-      # would hold the critic at 1e-4 for the entire second phase while the
-      # generator it scores drops to 1e-5 — 10x faster, a standard way to
-      # saturate the generator's adversarial gradient.
       discriminator_lr_scheduler:
         class_path: torch.optim.lr_scheduler.MultiStepLR
         init_args:
           milestones: [100000]   # BATCHES, not global steps
           gamma: 0.1
-      # adversarial_loss: unset means sisr.losses.AdversarialLoss — the
-      # non-saturating objective over the discriminator's LOGITS. Do not pair it
-      # with a sigmoid-terminated critic; SRDiscriminator deliberately emits logits.
+      # adversarial_loss unset means sisr.losses.AdversarialLoss, over LOGITS.
       training_config:
         class_path: sisr.models.srgan.SRGANTrainingConfig
         init_args:
-          # Ledig et al. scope the MSE-initialisation trick to "when training the
-          # actual GAN", so a paper-faithful run starts from an MSE-trained
-          # SRResNet — this repo's golden 1e6-step baseline. Bare weights (.pt),
-          # never the sibling .ckpt: a .ckpt holds the whole LightningModule.
-          # The generator's architecture, processor, output range and scale are
-          # all checked against the file's own metadata and refused on any
-          # mismatch — loading weights trained under a different one produces a
-          # model that trains and scores without ever erroring.
-          # Set to null HERE (or in a --config overlay) to train the GAN from
-          # scratch -- not the paper's recipe. --...init_from=null on the command
-          # line does not work: jsonargparse coerces it to the string 'None',
-          # which SRGANLightning refuses by name rather than hunting for a file.
+          # Bare weights (.pt), never the sibling .ckpt. Mismatches are refused.
           init_from: "experiments/SRResNet/golden/checkpoints/sr-weights-1000000-psnr_val_RGB=28.8635.pt"
-          # Matches the real training input: RGB at hr_crop_size / scale. Not only a
-          # TensorBoard-graph dummy -- it also shapes the compile warm-up (a wrong size
-          # compiles once then recompiles on step 1) and ModelSummary's FLOPs.
+          # Must match the real training input: RGB at hr_crop_size / scale.
           example_input_shape: [3, 24, 24]
-          # adversarial_weight: 1.0e-3 (paper) and d_steps_per_g_step: 1
-          # (Goodfellow's k, Ledig's 1:1 alternation) are the dataclass defaults.
-      # No init_args: the dataclass already adds lpips + dists on top of the
-      # SRResNet scoring (crop_border 4, PSNR on RGB+Y, daala SSIM). An adversarial
-      # objective makes PSNR and SSIM WORSE by design, so the perceptual pair is
-      # the only metric family that tracks what this run is actually optimising.
-      # 'lpips' needs the [perceptual] extra installed.
+          # adversarial_weight 1.0e-3 and d_steps_per_g_step 1 are the defaults.
+      # Defaults add lpips + dists; 'lpips' needs the [perceptual] extra.
       eval_config:
         class_path: sisr.models.srgan.SRGANEvalConfig
 
 data:
-  # LR is derived via MATLAB-compatible antialiased bicubic resizing (see
-  # sisr/utils/imresize.py), comparable to published paper numbers.
   train_dataset:
     class_path: sisr.datasets.srresnet.TrainDataset
     init_args:
       img_dir: data/DIV2K_train_HR
       scale: *scale
-      # Anchored to the discriminator's hr_input_size above: the critic scores
-      # this exact crop, and a mismatch is a raw Linear shape error otherwise.
-      hr_crop_size: *hr_crop
+      hr_crop_size: *hr_crop   # anchored to the discriminator's hr_input_size
       crops_per_image: 1
       use_tqdm: true
       cache_dir: .lmdb_cache/DIV2K_train_HR
@@ -157,90 +100,41 @@ data:
         scale: *scale
   train_dataloader_kwargs:
     batch_size: 16
-    # Workers are load-bearing on real data: per-sample LR derivation is a real
-    # cost, and num_workers=0 hits a hard serial floor (real DIV2K steady-state:
-    # 56.0 ms/step at w0 vs 40.1 ms/step at w16 -- 0.72x). The ~2-minute one-time
-    # spawn cost amortizes to nothing over a full run.
-    # These counts OOM'd host RAM on a 16-worker box -- see the note beside
-    # val_dataloader_kwargs below.
+    # !! These counts have OOM'd host RAM on a 16-worker box. Lower them if you do.
     num_workers: 16
     pin_memory: true
     persistent_workers: true
   val_dataloader_kwargs:
     batch_size: 1
-    # These worker counts (16 train, 2 val) OOM'd host RAM on a 16-worker box: a
-    # val worker's float64 imresize on a full-size DIV2K image (2040px wide)
-    # raised numpy._ArrayMemoryError, at the FIRST validation, not step 0. This
-    # module is more exposed than the SRResNet template on the same data path --
-    # a resident discriminator plus a VGG19 feature extractor eat the RAM the
-    # SRResNet template doesn't need. A smoke run only got through at 4 train /
-    # 0 val workers; the safe counts on any given box are unmeasured -- lower
-    # these if you OOM.
     num_workers: 2
     persistent_workers: true
 
 trainer:
   max_epochs: -1
-  # global_step counts optimizer steps, and this module takes TWO per batch (one
-  # discriminator, one generator), so it advances N + N//k per N batches -- 2x at
-  # the default k=1. That is unchanged Lightning behaviour, not a quirk of manual
-  # optimization: measured, manual optimization with a SINGLE optimizer still
-  # gives global_step == batches. Every other architecture here is unaffected.
-  # The units differ, so read this before changing any of them. max_steps,
-  # checkpoint filenames and every_n_train_steps are in GLOBAL STEPS;
-  # val_check_interval, log_every_n_steps and the hand-stepped LR scheduler's
-  # milestones are in BATCHES (Lightning keys val_check_interval on
-  # total_batch_idx whenever check_val_every_n_epoch is null, as it is below;
-  # log_every_n_steps tests the same _batches_that_stepped counter unconditionally
-  # -- logger_connector.py:59,64). every_n_train_steps' own condition is checked
-  # once per batch, so an EVEN value halves the batch cadence (10000 -> every
-  # 5000 batches) while an odd one does not (5 -> still every 5).
-  # _batches_that_stepped is also the DEFAULT X-AXIS every logged metric is
-  # plotted against, so TensorBoard shows this run in batches while checkpoint
-  # filenames carry global_step: sr-weights-10000.pt is the state at
-  # TensorBoard x=5000, not x=10000 -- a 2x offset between a curve and the
-  # checkpoint pulled off it.
-  # 400000 here = the paper's 2e5 generator iterations (1e5 at 1e-4 + 1e5 at 1e-5).
-  max_steps: 400000
-  # 5000 batches = every 10000 global steps: the checkpoint cadence below.
-  val_check_interval: 5000
+  # !! GLOBAL STEPS; val_check_interval and log_every_n_steps are BATCHES. See the docs.
+  max_steps: 400000            # the paper's 2e5 generator iterations
+  val_check_interval: 5000     # batches = every 10000 global steps
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
-  # BATCHES too -- see the units comment above.
-  log_every_n_steps: 1000
+  log_every_n_steps: 1000      # batches
   deterministic: false
-  # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
-  # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
-  # above, hence it lives here rather than as a custom key.
+  # Free here: every training step feeds the same fixed crop shape.
   benchmark: true
   accelerator: cuda
-  # One device only. SRGANLightning refuses world_size > 1: manual optimization
-  # opts out of Lightning's gradient synchronisation, so the two networks would
-  # train out of sync across ranks with nothing failing.
-  devices: [0]
+  devices: [0]                 # SRGANLightning refuses world_size > 1
   enable_progress_bar: true
   enable_model_summary: true
   callbacks:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
         log_every_n_val_runs: 1
-    # Primary artifacts: rolling, monitor-free. PSNR and SSIM get WORSE by design
-    # under an adversarial objective, so top-k on either would keep the LEAST
-    # adversarial state of the run (typically one from the first few thousand
-    # steps). Rolling keeps the last `keep_last` saves by step instead.
-    # every_n_train_steps is in GLOBAL steps -- see the max_steps comment above:
-    # 10000 is even, so it fires every 5000 batches.
+    # Rolling and monitor-free: a PSNR/SSIM top-k would keep the least adversarial state.
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: null
         keep_last: 3
         every_n_train_steps: 10000
-    # Distributable, optimizer-free weights (.pt) for BOTH networks. The generator's
-    # is what gets handed out, and is what init_from above consumes. The
-    # discriminator's is kept so the critic can be restored by hand, or by a
-    # future run that accepts one -- nothing shipped consumes a d-weights-*.pt
-    # today; there is no init_discriminator_from. Distinct filename_prefix keeps
-    # each callback's rolling deletion off the other's files in a shared dirpath.
+    # Both networks. The generator's is what init_from consumes.
     - class_path: sisr.training.SRWeightsCheckpoint
       init_args:
         monitor_metric: null
@@ -255,31 +149,10 @@ trainer:
         every_n_train_steps: 10000
         attribute: discriminator
         filename_prefix: d-weights
-    # --- Metric-monitored alternatives, for reference. NOT enabled. ---
-    # A PSNR- or SSIM-monitored "best" tracks the least adversarial model here,
-    # which is the opposite of what this run is for. A perceptual monitor tracks
-    # the objective, but lpips/dists are lower-is-better: mode MUST be min, or
-    # the callback silently keeps the worst checkpoint of the run (SRCheckpoint
-    # refuses the wrong direction at setup rather than letting that happen).
-    # - class_path: sisr.training.SRCheckpoint
-    #   init_args:
-    #     monitor_metric: lpips/val
-    #     mode: min
-    #     save_top_k: 3
-    # - class_path: sisr.training.SRWeightsCheckpoint
-    #   init_args:
-    #     monitor_metric: lpips/val
-    #     mode: min
-    #     save_top_k: 3
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-    # GradNormLogger is deliberately absent. Measured on this module: its
-    # on_after_backward hook fires TWICE per batch (once per network's backward),
-    # and pl_module.parameters() spans both networks (58 tensors = 24 generator +
-    # 34 discriminator), so the single diag/grad_norm scalar it logs mixes the two
-    # and alternates between two different meanings. Log per-network norms by hand
-    # if you need them.
+    # GradNormLogger is deliberately absent: one scalar would mix both networks.
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -1,7 +1,8 @@
+# SRResNet -- Ledig et al.'s MSE-trained baseline.
+# Settings are explained in docs/configuration.md. Config files must stay ASCII.
 seed_everything: 42
 
-# TF32 matmul on Ampere+ GPUs. Measured no-op on this repo's conv stacks: conv runs
-# through cuDNN, whose allow_tf32 already defaults True — kept for matmul-heavy archs.
+# No-op on this repo's conv stacks; kept for matmul-heavy architectures.
 matmul_precision: high
 
 optimizer:
@@ -21,62 +22,20 @@ model:
           kernel_sizes: [9, 3, 9]
           num_residual_blocks: 16
           padding: same
+      # Paper's range (Ledig et al. sec. 3.2): LR [0,1] in, HR/target [-1,1].
       processor:
-        # Paper's range (Ledig et al. §3.2): LR [0,1] in, HR/target [-1,1].
-        # Use RGBProcessor instead to reproduce pre-2026-08-02 runs.
         class_path: sisr.processors.RGBSignedOutputProcessor
-      # Loss. Unset means torch.nn.MSELoss, which is what both papers' baselines use.
-      # Any nn.Module taking (pred, target) works, so L1 needs no sisr class:
-      #   criterion: {class_path: torch.nn.L1Loss}
-      #   criterion: {class_path: sisr.losses.CharbonnierLoss}
-      #
-      # Ledig et al.'s SRResNet-VGG22, faithfully: a VGG22 content loss plus total
-      # variation at 2e-8, with NO pixel term, trained from scratch on the schedule
-      # already configured below (1e6 steps at lr 1e-4). The MSE-initialisation trick
-      # in the paper applies to the SRGAN variants, not to this one.
-      # Two caveats before running it: the first use downloads ~548 MB of VGG19
-      # weights to the torch hub cache, and TV's 2e-8 presumes the [-1, 1] output
-      # range that RGBSignedOutputProcessor above provides.
-      # criterion:
-      #   class_path: sisr.losses.WeightedSumLoss
-      #   init_args:
-      #     terms:
-      #       vgg22:
-      #         class_path: sisr.losses.VGG19FeatureLoss
-      #         init_args:
-      #           layer: vgg22
-      #       tv:
-      #         class_path: sisr.losses.TotalVariationLoss
-      #     weights: {vgg22: 1.0, tv: 2.0e-8}
-      #
-      # phi_{i,j}: blocks 1-2 have 2 convs on both depths (vgg11-vgg22); blocks 3-5
-      # have 4 on VGG19 (up to vgg54) or 3 on VGG16 (up to vgg53). before_activation:
-      # true selects ESRGAN's pre-ReLU features. A perceptual run scores WORSE PSNR
-      # by design; the callbacks below already checkpoint on ssim/val/RGB too, so
-      # the PSNR-monitored "best" no longer tracks the training objective -- decide
-      # which monitored checkpoint you actually want.
+      # criterion unset means torch.nn.MSELoss, the paper's baseline objective.
       training_config:
         class_path: sisr.models.srresnet.SRResNetTrainingConfig
         init_args:
-          # Matches the real training input: RGB at hr_crop_size / scale. Not only a
-          # TensorBoard-graph dummy -- it also shapes the compile warm-up (a wrong size
-          # compiles once then recompiles on step 1) and ModelSummary's FLOPs.
+          # Must match the real training input: RGB at hr_crop_size / scale.
           example_input_shape: [3, 24, 24]
-      # No init_args: the dataclass default already sets ssim_impl: daala, the
-      # convention Ledig et al.'s paper actually used (sigma scales with image height,
-      # not Wang's fixed 11x11 -- see sisr/metrics/ssim.py). That makes this run's SSIM
-      # comparable to the paper and NOT to the Wang-based numbers the rest of the SR
-      # literature reports (EDSR/RCAN/SwinIR/BasicSR lineage). Override with:
-      #   eval_config:
-      #     class_path: sisr.models.srresnet.SRResNetEvalConfig
-      #     init_args:
-      #       ssim_impl: wang
+      # Defaults to ssim_impl: daala, the convention this paper used.
       eval_config:
         class_path: sisr.models.srresnet.SRResNetEvalConfig
 
 data:
-  # LR is derived via MATLAB-compatible antialiased bicubic resizing (see
-  # sisr/utils/imresize.py), comparable to published paper numbers.
   train_dataset:
     class_path: sisr.datasets.srresnet.TrainDataset
     init_args:
@@ -109,10 +68,7 @@ data:
         scale: *scale
   train_dataloader_kwargs:
     batch_size: 16
-    # Workers are load-bearing on real data: per-sample LR derivation is a real
-    # cost, and num_workers=0 hits a hard serial floor (real DIV2K steady-state:
-    # 56.0 ms/step at w0 vs 40.1 ms/step at w16 -- 0.72x). The ~2-minute one-time
-    # spawn cost amortizes to nothing over a full run.
+    # Load-bearing on real data: num_workers=0 hits a hard serial floor.
     num_workers: 16
     pin_memory: true
     persistent_workers: true
@@ -129,15 +85,9 @@ trainer:
   num_sanity_val_steps: -1
   log_every_n_steps: 1000
   deterministic: false
-  # cuDNN autotunes a conv algorithm per input shape and caches it — free here since
-  # every step feeds the same fixed crop shape. Lightning ties this to `deterministic`
-  # above, hence it lives here rather than as a custom key.
+  # Free here: every training step feeds the same fixed crop shape.
   benchmark: true
-  # This config trains eager fp32 -- bit-identical by definition, which is what a
-  # paper reproduction needs. bf16-mixed alone is slower here, not faster; pairing
-  # it with model.training_config.compile_backend: inductor is the opt-in fast path
-  # (inductor additionally needs a C compiler at runtime, not just triton), and its
-  # PSNR/SSIM cost has not been measured.
+  # Trains eager fp32. bf16-mixed alone is SLOWER; see docs/configuration.md.
   # precision: bf16-mixed
   accelerator: cuda
   devices: [0]
@@ -155,9 +105,7 @@ trainer:
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
-    # Distributable, optimizer-free weights (.pt) alongside the resumable .ckpt files
-    # above — same monitors/top-k, so every checkpointed best also ships a bare-weights
-    # counterpart safe to hand out without leaking optimizer state.
+    # Distributable, optimizer-free weights alongside the resumable .ckpt files.
     - class_path: sisr.training.SRWeightsCheckpoint
       init_args:
         monitor_metric: psnr/val/RGB
@@ -172,14 +120,6 @@ trainer:
     - class_path: sisr.training.GradNormLogger
       init_args:
         log_every_n_steps: 5000
-    # Throughput/hardware diagnostics — extra per-step logging overhead, so commented
-    # out by default. DeviceStatsMonitor works as-is; ThroughputMonitor additionally
-    # needs a batch_size_fn (batches are (lr, hr) tuples, not plain tensors — no
-    # project-side helper exists yet).
-    # - class_path: lightning.pytorch.callbacks.DeviceStatsMonitor
-    # - class_path: lightning.pytorch.callbacks.ThroughputMonitor
-    #   init_args:
-    #     batch_size_fn: sisr.training.callbacks.batch_size  # example path; add if needed
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:


### PR DESCRIPTION
Closes #158.

Top of the stack: #156 → #155 → #154 → #153 → #152 — **merge bottom-up.**

## What changed

The tracked config surface was roughly half prose. `docs/configuration.md` now owns
the explanations, and every comment block in those files is one line.

| file | comment lines before | after |
| --- | ---: | ---: |
| `templates/config.srgan.template.yaml` | 148 | 24 |
| `pyproject.toml` | 108 | 22 |
| `templates/config.srresnet.template.yaml` | 72 | 13 |
| `templates/config.srcnn.template.yaml` | 43 | 11 |
| `.github/workflows/test.yml` | 45 | 8 |
| `.github/workflows/build.yml` | 17 | 7 |
| **total** | **433** | **78** |

## Why

Two separate problems, and only one of them is aesthetic.

**A measured number has exactly one owner.** Restating a throughput figure or a
platform result beside a config key creates a second copy that ages independently.
That is not hypothetical here: until #152 the SRResNet template's headline
throughput row described the graph-capture path, which by then was being deleted.

**Config that is half changelog is hard to read as config.** Someone opening a
template to see how an experiment is wired had to read past decision history to
find the settings.

`sisr/` is deliberately out of scope — 3.6% comment density, and only a handful of
lines cite a measurement.

## What survived, and where it went

Not everything long was noise. These moved rather than went:

- The `torch>=2.6` floor's **CVE rationale** — a security constraint, kept as a
  one-line `SECURITY FLOOR` marker in `pyproject.toml` and explained in full in the doc.
- **bf16-mixed is a regression, not a speed-up** at these batch sizes, and only wins
  paired with inductor — the thing most likely to be rediscovered the expensive way.
- The **global-step vs batch** units under SRGAN, including that an even
  `every_n_train_steps` halves the batch cadence while an odd one does not.
- Why **`typecheck` runs on `windows-latest`**, which looks arbitrary and is not.
- Settings only valid **together** (`precision` + `compile_backend`) or **anchored**
  to each other (`hr_input_size` ↔ `hr_crop_size`).
- Why **`GradNormLogger` is absent** from the SRGAN template.

## The templates are now strictly ASCII — they were not before

Worth flagging, since the project treats this as a hard rule: jsonargparse opens
config files with the platform encoding, so anything outside it is a launch-time
`UnicodeDecodeError`. All three templates already contained non-ASCII (em dashes, a
section sign) — 6, 7 and 12 lines. Those survived only because cp1252 happens to
decode them; they would not have survived a stricter platform encoding, and an emoji
in the same position would have failed outright. All three are pure ASCII now.

## Evidence

**Behaviour unchanged by construction, and checked** — each file parsed before and
after and the structures compared:

| file | result |
| --- | --- |
| all three templates | parse identical to their previous versions |
| `pyproject.toml` | parses identical |
| both workflows | parse identical, jobs and per-job permissions intact |

**All three templates still resolve through the CLI** (`--print_config`).

**The stripped SRResNet template still trains** — a real fit, 120 steps across two
validation boundaries:

- `psnr/val/RGB` 19.296 → 22.025 dB
- `loss/train` 0.1064 → 0.0392
- 4 checkpoints written

**Suite** — `933 passed, 2 skipped` of 935 collected, 3m31s. The 2 skips are the
Windows-only cache liveness paths, as on `main`. No data-gated test skipped.
`ruff check`, `ruff format --check`, `mypy sisr` all clean.

**Every markdown link checked**, including the new doc's `../`-relative ones.

## Checklist

- [x] `pytest` passes locally; skips named above (a skip is not a pass)
- [x] `ruff check` and `ruff format --check` are clean
- [x] No internal tracker identifiers in the code or commit messages
- [x] Doc-only change, in a single `docs:` commit

## Merge strategy

- [x] **Squash** — single-purpose, one `docs:` commit

> **Part of stack #160** (`#152 -> #153 -> #154 -> #155 -> #156 -> #159`). Merge **bottom-up**.
> These PRs were first opened by chaining bases by hand, which gave correct ancestry but no
> GitHub stack object and so no CI above #152. They were retro-linked with `gh stack link`,
> and every PR in the stack now runs full CI despite its base still being a feature branch.
> A `cancelled` check here is a duplicate-trigger artifact, not a failure -- the push and the
> stack event both fire and `cancel-in-progress` kills the first.

