### PR TITLE
test: make distributed code paths provable on a single-GPU machine

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 """Shared pytest fixtures for the sisr test suite."""
 
+from collections.abc import Callable
 from pathlib import Path
 
+import lightning
 import numpy as np
 import pytest
 import torch
@@ -31,3 +33,44 @@ def tiny_rgb_image_dir(tmp_path: Path) -> Path:
 def rgb_batch() -> torch.Tensor:
     """Random ``(B=2, C=3, H=8, W=8)`` RGB tensor in ``[0, 1]``."""
     return torch.rand(2, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+
+
+@pytest.fixture
+def two_process_trainer() -> Callable[..., lightning.Trainer]:
+    """Factory for a real two-process trainer, over gloo, on CPU.
+
+    Nothing else in the suite runs more than one process, so without this every
+    rank-sensitive code path ships unproven. Two processes is enough: the whole
+    class of defect here is "this happens once per process when it should happen
+    once", and that is already visible at a world size of two.
+
+    ``ddp_spawn`` rather than ``ddp`` because ``ddp`` re-executes the entry
+    script, which under pytest means re-running the whole test command. The
+    launcher differs from production; the semantics under test — sampler
+    splitting, metric reduction, rank identity — are the strategy's, and are the
+    same either way.
+
+    **What this cannot prove:** anything NCCL-specific, device placement on real
+    GPUs, or throughput. Those need genuine multi-GPU hardware, which containers
+    do not supply — they share the host's devices.
+
+    Returns:
+        A callable taking ``Trainer`` keyword overrides and returning a trainer
+        configured for two CPU processes.
+    """
+
+    def _make(**overrides: object) -> lightning.Trainer:
+        settings: dict[str, object] = {
+            "accelerator": "cpu",
+            "devices": 2,
+            "strategy": "ddp_spawn",
+            "logger": False,
+            "enable_checkpointing": False,
+            "enable_progress_bar": False,
+            "enable_model_summary": False,
+            "num_sanity_val_steps": 0,
+        }
+        settings.update(overrides)
+        return lightning.Trainer(**settings)  # type: ignore[arg-type]
+
+    return _make

--- a/tests/training/test_distributed.py
+++ b/tests/training/test_distributed.py
@@ -1,0 +1,87 @@
+"""Proof that the two-process test harness works, and what it can show.
+
+Every distributed defect in this codebase is of one shape: something that must
+happen once per *run* happens once per *process*. Catching that needs more than
+one process, and nothing else in the suite starts one. These tests establish the
+harness and pin the mechanism the rank-sensitive tests elsewhere depend on;
+they assert nothing about ``sisr`` itself.
+"""
+
+from collections.abc import Callable
+
+import lightning
+import pytest
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+# Defined at module scope because ddp_spawn pickles the module across to each
+# worker process; a locally-defined class cannot make that trip.
+
+
+class _RankProbe(lightning.LightningModule):
+    """Logs its own rank index twice, reduced and unreduced.
+
+    With two processes the two logged values differ by construction: rank 0
+    contributes 0.0 and rank 1 contributes 1.0. A reduced mean is therefore
+    0.5 and an unreduced one is whatever the reporting process happened to
+    hold, which makes the difference between the two impossible to miss.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer = torch.nn.Linear(4, 4)
+
+    def training_step(self, batch: list[torch.Tensor], batch_idx: int) -> torch.Tensor:
+        (x,) = batch
+        return self.layer(x).square().mean()
+
+    def validation_step(self, batch: list[torch.Tensor], batch_idx: int) -> None:
+        rank = torch.tensor(float(self.trainer.global_rank))
+        self.log("probe/unreduced", rank, sync_dist=False)
+        self.log("probe/reduced", rank, sync_dist=True)
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        return torch.optim.SGD(self.parameters(), lr=0.1)
+
+
+def _loaders() -> tuple[DataLoader, DataLoader]:
+    data = TensorDataset(torch.randn(8, 4, generator=torch.Generator().manual_seed(0)))
+    return DataLoader(data, batch_size=2), DataLoader(data, batch_size=2)
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_harness_starts_two_real_processes(
+    two_process_trainer: Callable[..., lightning.Trainer],
+) -> None:
+    """Fails if the harness silently degrades to a single process.
+
+    A one-process run passes every rank assertion trivially, so a harness that
+    quietly falls back would turn every test built on it green and meaningless.
+    """
+    trainer = two_process_trainer(max_steps=2, limit_val_batches=1)
+    train_loader, val_loader = _loaders()
+    trainer.fit(_RankProbe(), train_loader, val_loader)
+
+    assert trainer.world_size == 2
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_sync_dist_reduces_across_processes_and_its_absence_does_not(
+    two_process_trainer: Callable[..., lightning.Trainer],
+) -> None:
+    """Pins the mechanism every rank-correctness test in this suite relies on.
+
+    ``sync_dist=True`` must produce the mean over both processes; without it the
+    logged value is one process's own, presented as though it were global. That
+    second case is the live defect shape for validation metrics, so it is
+    asserted rather than merely described.
+    """
+    trainer = two_process_trainer(max_steps=2, limit_val_batches=1)
+    train_loader, val_loader = _loaders()
+    trainer.fit(_RankProbe(), train_loader, val_loader)
+
+    metrics = {key: float(value) for key, value in trainer.callback_metrics.items()}
+    # mean(0.0, 1.0) -- only reachable if both processes contributed.
+    assert metrics["probe/reduced"] == pytest.approx(0.5)
+    # The reporting process's own rank index, never the mean.
+    assert metrics["probe/unreduced"] == pytest.approx(0.0)


### PR DESCRIPTION
Closes #166. Second in the stack, on top of #168.

## Why it comes first

Nothing in the suite ran more than one process, so every rank-sensitive change in this arc would
have shipped unproven — which the standing fix criteria do not allow. With this in place, a rank
guard can be proven *at the moment it is written*.

## What it does

A fixture starting a real two-process trainer over **gloo on CPU**. No second GPU involved.

`ddp_spawn` rather than `ddp`: `ddp` re-executes the entry script, which under pytest means
re-running the whole test command. The launcher differs from production; the semantics under test —
sampler splitting, metric reduction, rank identity — belong to the strategy and are identical.

## The mechanism test asserts both directions

```
probe/reduced    = 0.5   # sync_dist=True  -> mean over both processes
probe/unreduced  = 0.0   # sync_dist=False -> the reporting process's own value
```

The second line is the live defect shape for validation metrics (#118), so it is asserted rather
than described.

## What it cannot prove

NCCL behaviour, device placement on real GPUs, throughput. Those need genuine multi-GPU hardware —
containers do not substitute, since they share the host's devices.

## Verification

- **Stable across five consecutive runs**, per the convention that one green run is not evidence
  for a new test.
- Costs ~23s of suite time.
- Test-only: no `sisr/` code changed.

## Risk

LOW. Touches no seam, no contract, no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)