### PR TITLE
fix: refuse to write an artifact that cannot state its own scale

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,19 @@ to the torch hub cache, and TV's `2e-8` presumes the `[-1, 1]` output range that
 | `compile_backend` | A `torch._dynamo` backend name, or unset for eager. |
 | `layer_lrs` | Per-`Conv2d` learning rates; requires every trainable parameter to live in a `Conv2d`. |
 | `init_strategy`, `init_mean`, `init_std` | Weight initialisation. |
-| `scale` | Upscaling factor, for provenance and cross-checks. |
+| `scale` | Upscaling factor. **Required whenever a run writes an artifact and the model has no `scale` of its own.** |
+
+`scale` is stated here for SRCNN and inherited from the network for SRResNet, and that
+asymmetry is real rather than an inconsistency to tidy away. SRResNet upsamples internally, so
+its scale is a property of the network and lives in its hyperparameters. SRCNN is
+resolution-preserving — it refines an input that has *already* been upsampled — so its scale is
+a property of the **data**, and nothing about the network records it.
+
+Set it anyway. Saving an artifact whose scale cannot be resolved from either source is refused
+rather than recorded as null: a file that cannot state its factor is unusable by anyone who did
+not train it, because for a pre-upsampled architecture the factor is exactly what they must
+resize the input by before feeding it. It is deliberately *not* inferred from the datamodule —
+`scale` is not part of the dataset contract, and a predict-only dataset has none at all.
 
 `example_input_shape` is **not** only a TensorBoard-graph dummy. It also shapes the
 `torch.compile` warm-up — a wrong size compiles once and then recompiles on step 1 —

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -95,13 +95,17 @@ class SRTrainingConfig:
 
         scale: The model's upscaling factor, for provenance metadata and
             cross-checking against the model's own ``scale`` hparam (see
-            :meth:`validate_against`). ``None`` (the default) leaves it
-            unchecked and out of exported metadata — appropriate for
-            architectures like SRCNN where scale is a training-data choice,
-            not a fixed property of the model itself. Deliberately not
-            inferred from ``trainer.datamodule.train_dataset.scale``: that
-            attribute lives outside the ``SRDataset`` contract (``PredictDataset``
-            has none at all), whereas per-paper knobs already live here.
+            :meth:`validate_against`). **Required for any run that writes an
+            artifact** on an architecture carrying no ``scale`` hparam of its
+            own — :func:`~sisr.training.metadata.build_metadata` refuses rather
+            than recording a null. It used to be documented as optional there,
+            which held while the metadata was read only by us; a file handed to
+            a stranger has to state the factor, because for a pre-upsampled
+            architecture it is what they must resize the input by. Still
+            deliberately not inferred from
+            ``trainer.datamodule.train_dataset.scale``: that attribute lives
+            outside the ``SRDataset`` contract (``PredictDataset`` has none at
+            all), whereas per-paper knobs already live here.
 
         compile_backend: Name of a ``torch._dynamo`` backend (e.g.
             ``'cudagraphs'``, ``'inductor'``) to compile the training-mode

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -134,6 +134,10 @@ def build_metadata(
         Contains only ``dict``/``list``/``str``/``int``/``float``/``bool``/``None`` values —
         safe for ``torch.save``/``torch.load(weights_only=True)`` and, per top-level field, for
         JSON-encoding into ONNX ``metadata_props``.
+
+    Raises:
+        ValueError: If the scale cannot be resolved from either
+            ``training_config.scale`` or the model's own hparams.
     """
     model = module.model
     processor = module.processor
@@ -141,6 +145,14 @@ def build_metadata(
     scale = module.training_config.scale
     if scale is None:
         scale = model.hparams.get("scale")
+    if scale is None:
+        raise ValueError(
+            f"Cannot describe a {type(model).__name__} artifact without a scale: "
+            f"training_config.scale is None and the model declares no 'scale' "
+            f"hyperparameter. A reader cannot use the file without it -- for a "
+            f"pre-upsampled architecture the scale is what they must resize the input "
+            f"by before feeding it. Set training_config.scale in your config."
+        )
 
     meta = _envelope("sr_model", global_step, epoch, monitor, monitor_value, batch_step)
     meta["model"] = {

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -26,6 +26,7 @@ model:
       training_config:
         class_path: sisr.models.srcnn.SRCNNTrainingConfig
         init_args:
+          scale: &scale 3
           # Must match the real training input: 1-channel Y at subimg_size.
           example_input_shape: [1, 33, 33]
       # Defaults to ssim_impl: wang, the field standard.
@@ -39,7 +40,7 @@ data:
       img_dir: data/DIV2K_train_HR
       subimg_size: 33
       stride: 14
-      scale: &scale 3
+      scale: *scale
       use_tqdm: true
       cache_dir: .lmdb_cache/DIV2K_train_HR
   val_dataset:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -865,12 +865,20 @@ def _build_srcnn_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path) -> tuple[P
                     },
                 },
                 "processor": {"class_path": "sisr.processors.RGBProcessor"},
+                "training_config": {
+                    "class_path": "sisr.training.SRTrainingConfig",
+                    "init_args": {"scale": 2},
+                },
                 "eval_config": {
                     "class_path": "sisr.training.SREvalConfig",
                     "init_args": {"crop_border": 0},
                 },
             },
         },
+        # Without this the CLI warns "No seed found", which the strict warning
+        # filter makes fatal -- and only when no earlier test has seeded the
+        # process, so the test passed in a full run and failed on its own.
+        "seed_everything": 42,
         "optimizer": {"class_path": "torch.optim.SGD", "init_args": {"lr": 1.0e-4}},
         "data": {
             "train_dataset": {

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -26,7 +26,7 @@ from sisr.training import SRLightning  # noqa: E402
 def _make_srcnn_module(example_input_shape: tuple[int, ...] | None) -> SRLightning:
     """Tiny Y-channel SRCNN — small enough to trace/export quickly."""
     model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(5, 1, 3), padding=0)
-    training_config = SRCNNTrainingConfig(example_input_shape=example_input_shape)
+    training_config = SRCNNTrainingConfig(example_input_shape=example_input_shape, scale=2)
     return SRLightning(model=model, processor=YChannelProcessor(), training_config=training_config)
 
 
@@ -93,7 +93,9 @@ def test_to_onnx_requires_example_input_shape_or_input_sample():
 def test_to_onnx_accepts_explicit_input_sample(tmp_path):
     """An explicit input_sample bypasses the training_config.example_input_shape seam."""
     model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(5, 1, 3), padding=0)
-    module = SRLightning(model=model, processor=YChannelProcessor())
+    module = SRLightning(
+        model=model, processor=YChannelProcessor(), training_config=SRCNNTrainingConfig(scale=2)
+    )
     onnx_path = tmp_path / "model.onnx"
 
     to_onnx(module, onnx_path, input_sample=torch.zeros(1, 1, 24, 24))

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -592,7 +592,7 @@ def build_module(eval_config: SREvalConfig | None = None) -> SRLightning:
     return SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=eval_config or SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -842,6 +842,7 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
     module = SRLightning(
         model=model,
         processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4, momentum=0.9),
     )
@@ -932,6 +933,7 @@ def _run_tiny_fit(
         module = SRLightning(
             model=model,
             processor=RGBProcessor(),
+            training_config=SRTrainingConfig(scale=2),
             eval_config=SREvalConfig(crop_border=0),
             optimizer=functools.partial(torch.optim.SGD, lr=1e-4, momentum=0.9),
         )
@@ -1209,7 +1211,7 @@ def _make_real_pl_module() -> SRLightning:
     return SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -1313,7 +1315,7 @@ def test_collect_batch_metric_values_match_pre_change_host_copy_first_ordering()
     pl_module = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(
             crop_border=3,
             psnr_channels=["RGB", "YCbCr"],
@@ -1387,7 +1389,7 @@ def test_benchmark_logger_uses_module_ssim_impl():
     pl_module = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0, ssim_channels=["Y"], ssim_impl="daala"),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -1768,7 +1770,7 @@ def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
     pl_module = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=2, perceptual_metrics=["lpips"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -1879,7 +1881,7 @@ def test_benchmark_collect_batch_crops_per_eval_config():
     pl_module = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=3),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -1917,7 +1919,7 @@ def test_benchmark_collect_batch_routes_through_processor():
     pl_module = SRLightning(
         model=model,
         processor=YChannelProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0, psnr_channels=["RGB", "YCbCr"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -1957,7 +1959,7 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_fals
     pl_module = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(
             crop_border=0, psnr_channels=["RGB", "YCbCr"], separate_psnr=False
         ),
@@ -1989,7 +1991,7 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_true
     pl_module = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0, psnr_channels=["RGB"], separate_psnr=True),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -2279,7 +2281,7 @@ def test_weights_checkpoint_metadata_records_both_axes_distinguishably(tmp_path:
     module = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=YChannelProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
     )
     trainer = _manual_optimization_trainer(batches=199_999, optimizer_steps=400_000)
@@ -2308,7 +2310,7 @@ def test_full_checkpoint_metadata_records_both_axes_distinguishably():
     module = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=YChannelProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
     )
     checkpoint = {
@@ -2335,7 +2337,7 @@ def test_checkpoint_metadata_batch_step_is_none_when_the_loop_state_is_absent():
     module = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=YChannelProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
     )
     checkpoint: dict = {}

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -35,7 +35,7 @@ def srcnn_rgb_lit() -> SRLightning:
     return SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -48,7 +48,7 @@ def srcnn_y_lit() -> SRLightning:
     return SRLightning(
         model=model,
         processor=YChannelProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0, psnr_channels=["RGB", "YCbCr"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -101,7 +101,7 @@ def test_step_y_path_loss_on_y_only():
     lit = SRLightning(
         model=model,
         processor=YChannelProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         criterion=criterion,
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
@@ -121,7 +121,7 @@ def test_step_ycbcr_path():
     lit = SRLightning(
         model=model,
         processor=YCbCrProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -255,7 +255,7 @@ def test_configure_optimizers_with_lr_scheduler(srcnn_rgb_lit: SRLightning):
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
         lr_scheduler=functools.partial(torch.optim.lr_scheduler.StepLR, step_size=10),
@@ -295,7 +295,7 @@ def test_build_metric_tensors_rgb_only_when_neither_metric_requests_y():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(psnr_channels=["RGB"], ssim_channels=["RGB"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -314,7 +314,7 @@ def test_build_metric_tensors_union_of_psnr_and_ssim_keys():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(psnr_channels=["RGB"], ssim_channels=["RGB", "Y"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -329,7 +329,7 @@ def test_build_metric_tensors_with_separate_psnr_includes_per_channel():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(psnr_channels=["RGB"], separate_psnr=True),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -344,7 +344,7 @@ def test_build_metric_tensors_ycbcr_does_conversion():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(psnr_channels=["YCbCr"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -368,7 +368,7 @@ def test_build_metric_tensors_ycbcr_uses_studio_range_not_full_range():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(psnr_channels=["YCbCr"]),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -454,7 +454,7 @@ def test_base_training_config_skips_reset_parameters():
     SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),  # init_strategy='default' by default
+        training_config=SRTrainingConfig(scale=2),  # init_strategy='default' by default
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -621,7 +621,7 @@ def test_step_calls_processor_extract_and_reconstruct():
     lit = SRLightning(
         model=model,
         processor=processor,
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -643,7 +643,7 @@ def test_step_loss_uses_extract_target_not_extract():
     lit = SRLightning(
         model=model,
         processor=RGBSignedOutputProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -682,7 +682,7 @@ def test_saved_tb_hparams_contain_processor_name():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -753,7 +753,7 @@ def _overshooting_rgb_lit() -> SRLightning:
     return SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -858,7 +858,7 @@ def test_tb_hparams_expand_nested_config_fields():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=7),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -882,7 +882,7 @@ def test_hparams_stay_nested_plain_dicts_for_checkpoint_reload():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=7),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -942,7 +942,7 @@ def test_predict_step_srresnet_upsamples_by_scale():
     lit = SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -987,7 +987,7 @@ def _make_lit_with_ssim_impl(ssim_impl: str) -> SRLightning:
     return SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(crop_border=0, ssim_channels=["Y"], ssim_impl=ssim_impl),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -1238,6 +1238,7 @@ def test_on_save_checkpoint_leaves_monitor_unset():
     lit = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=2),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
     checkpoint = {"global_step": 1, "epoch": 0}
@@ -1355,7 +1356,7 @@ def _srcnn_lit() -> SRLightning:
     return SRLightning(
         model=model,
         processor=RGBProcessor(),
-        training_config=SRTrainingConfig(),
+        training_config=SRTrainingConfig(scale=2),
         eval_config=SREvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -17,7 +17,7 @@ def _make_srcnn_lit() -> SRLightning:
     return SRLightning(
         model=model,
         processor=YChannelProcessor(),
-        training_config=SRCNNTrainingConfig(),
+        training_config=SRCNNTrainingConfig(scale=3),
         eval_config=SRCNNEvalConfig(),
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
@@ -122,13 +122,6 @@ def test_build_metadata_scale_falls_back_to_model_hparams():
     assert meta["io"]["scale"] == 2
 
 
-def test_build_metadata_scale_is_none_when_neither_source_has_it():
-    """SRCNN has no 'scale' hparam and training_config.scale is unset -> None,
-    not a guessed value."""
-    meta = build_metadata(_make_srcnn_lit())
-    assert meta["io"]["scale"] is None
-
-
 def test_metadata_records_ssim_impl():
     """Which SSIM produced a checkpoint's filename must be answerable from the
     artifact alone. eval_config is serialised wholesale, so this rides along —
@@ -217,6 +210,7 @@ def test_metadata_records_the_criterion_identity():
     module = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=RGBSignedOutputProcessor(),
+        training_config=SRTrainingConfig(scale=3),
         criterion=WeightedSumLoss(
             terms={"vgg22": vgg, "tv": TotalVariationLoss()},
             weights={"vgg22": 1.0, "tv": 2.0e-8},
@@ -233,6 +227,7 @@ def test_metadata_criterion_defaults_to_the_class_name_for_a_plain_loss():
     module = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=3),
     )
 
     meta = build_metadata(module)
@@ -248,6 +243,7 @@ def test_metadata_stays_weights_only_loadable_with_a_criterion_block(tmp_path):
     module = SRLightning(
         model=SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same"),
         processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=3),
     )
     path = tmp_path / "meta.pt"
     torch.save({"meta": build_metadata(module)}, path)
@@ -356,3 +352,23 @@ def test_component_metadata_is_weights_only_safe(tmp_path):
     loaded = torch.load(path, weights_only=True)
 
     assert loaded["meta"] == meta
+
+
+def test_build_metadata_refuses_an_artifact_that_cannot_state_its_scale():
+    """Fails if a saved artifact can record ``io.scale: None``.
+
+    A pre-upsampled architecture carries no ``scale`` hparam, so with
+    ``training_config.scale`` unset the factor is unrecoverable from the file.
+    That is the one thing a consumer of such a model must know -- it is what they
+    have to resize the input by before feeding it -- so writing the artifact at
+    all is worse than refusing.
+    """
+    module = SRLightning(
+        model=SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0),
+        processor=YChannelProcessor(),
+    )
+    assert module.training_config.scale is None
+    assert "scale" not in module.model.hparams
+
+    with pytest.raises(ValueError, match="without a scale"):
+        build_metadata(module)


### PR DESCRIPTION
Closes #164. Third in the stack.

## The defect

Built exactly as the shipped SRCNN template builds it, an artifact recorded no scale:

```
Snapshot @ 8c56324
SRCNN     io: {'scale': None, 'input': 'pre_upsampled', ...}
SRResNet  io: {'scale': 4,    'input': 'native_lr',     ...}
```

SRCNN is resolution-preserving, so scale is a property of the **data**, not the network — there is
no hyperparameter to fall back on. `SRTrainingConfig.scale` exists and no template set it.

## This changes a documented position, deliberately

The field's docstring said `None` "leaves it unchecked and out of exported metadata — **appropriate**
for architectures like SRCNN". That reasoning held while we were the only readers. It stops holding
for a file handed to someone else: for a pre-upsampled architecture the scale is precisely what they
must resize the input by, so a file that cannot state it is unusable. It also leaves any
artifact-naming scheme with nothing to read.

**What is preserved:** the scale is still *not* inferred from the datamodule. That refusal had a real
reason — `scale` is outside the `SRDataset` contract and `PredictDataset` has none — and it stands.
It is stated in the config, which is where per-paper knobs already live.

## Side effect worth having

The template's YAML anchor moves into the model block, which settles an inconsistency: the other two
templates already anchor scale there, and SRCNN anchored it on the dataset only because it had
nowhere else to put it.

## Verification

- RED first: `DID NOT RAISE ValueError` on pre-fix code.
- ~30 test modules were building artifacts with an unresolvable scale and now declare one.
- **Two tests whose subject *is* the scale-absent case keep it** — I reverted my own over-broad edit
  on both.
- One test asserted the removed behaviour directly and is replaced by its inverse.
- Full suite: 935 passed, 2 skipped.

## Also fixed in passing

A latent order dependence: a CLI test config had no seed, so the "No seed found" warning — fatal
under the strict filter — fired only when no earlier test had seeded the process. It **passed in a
full run and failed alone**.

## Risk

Not LOW. Refusing a previously-accepted value is a contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)