### PR TITLE
feat!: give the distributable artifact an owner, and make it safetensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ sisr fit --config templates/config.srgan.template.yaml
 
 **The generator starts from an MSE-trained SRResNet.** Ledig et al. scope the
 MSE-initialisation trick to "when training the actual GAN", so a paper-faithful run
-points `training_config.init_from` at a finished SRResNet run's bare-weights `.pt` —
+points `training_config.init_from` at a finished SRResNet run's bare-weights
+`.safetensors` —
 never the sibling `.ckpt`, which holds the whole LightningModule. That file's own
 provenance metadata is checked against this run's generator, processor, output range and
 scale, and refused on any mismatch: weights trained under a different one produce a model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,13 +243,44 @@ So the units differ, and you must read this before changing any of them:
 | In **global steps** | In **batches** |
 | --- | --- |
 | `max_steps` | `val_check_interval` |
-| checkpoint filenames | `log_every_n_steps` |
-| `every_n_train_steps` | hand-stepped LR scheduler `milestones` |
+| `every_n_train_steps` | `log_every_n_steps` |
+| | checkpoint filenames and metadata |
+| | hand-stepped LR scheduler `milestones` |
 
 `_batches_that_stepped` is also the **default x-axis every logged metric is plotted
-against**. Under SRGAN, TensorBoard therefore shows the run in batches while checkpoint
-filenames carry global steps — `sr-weights-10000.pt` is the state at TensorBoard
-x=5000, not x=10000.
+against**, which is why checkpoints are stamped with it: a saved file exists to be
+located on a curve, and one named in optimizer steps cannot be. So
+`sr-weights-10000.safetensors` is the state at TensorBoard x=10000 under every
+paradigm. The artifact's own metadata records **both** counters under distinct names —
+`global_step` keeps meaning the optimizer count, `batch_step` is the axis above — so a
+reader that only knows the older field still reads a true value.
+
+Note the asymmetry in the table: `every_n_train_steps` is Lightning's own and counts
+optimizer steps, while the filename it produces counts batches. Under SRGAN that means
+a cadence of 10000 writes a file named for batch 5000.
+
+### The distributable artifact
+
+`SRWeightsCheckpoint` writes **safetensors**, and it is the only format it writes — the
+`.pt` form no longer exists. The resumable `.ckpt` is unaffected: Lightning owns that
+file, and it carries optimizer moments, loop state and hyperparameters that a flat
+tensor map cannot represent.
+
+The reason is not that our own loading was unsafe. Every `torch.load` here passes
+`weights_only=True` and the torch floor is pinned for it. The exposure is a *consumer*
+opening a published file with that turned off, or on an older torch; safetensors removes
+it by construction. Note the consequence: **this makes the file you hand out
+pickle-free, not the repository** — a `.ckpt` is still a pickle.
+
+Provenance travels in the file's header, one entry per top-level field rather than one
+opaque blob, so anything that can open the artifact gets a readable table. The ONNX
+export writes the same fields the same way.
+
+Mismatches are checked on read. Fields that change what the output *means* — the
+processor and the output range — are refused, because being wrong about either produces
+a plausible image and no error. Library-version drift is warned about and loaded, since
+it cannot change what the tensors mean and refusing would expire every artifact on the
+next dependency bump.
 
 One further trap: `every_n_train_steps`' condition is checked once per batch, so an
 **even** value halves the batch cadence (10000 → every 5000 batches) while an odd one
@@ -261,7 +292,7 @@ does not (5 → still every 5).
 | --- | --- |
 | `BenchmarkImageLogger` | Writes benchmark-set image strips each val run. |
 | `SRCheckpoint` | Resumable `.ckpt`. |
-| `SRWeightsCheckpoint` | Distributable, optimizer-free `.pt` weights — roughly a third the size, and safe to hand out without leaking optimizer state. `attribute` picks which component is saved. |
+| `SRWeightsCheckpoint` | Distributable, optimizer-free `.safetensors` weights — roughly a third the size, and safe to hand out without leaking optimizer state. `attribute` picks which component is saved. |
 | `GradNormLogger` | Logs `diag/grad_norm`. |
 | `LearningRateMonitor` | Lightning's, logging per step. |
 
@@ -303,7 +334,7 @@ optimization does not step them. **Milestones are therefore counted in batches.*
 
 Ledig et al. scope the MSE-initialisation trick to "when training the actual GAN", so a
 paper-faithful run starts from an MSE-trained SRResNet. Point `init_from` at a **bare
-weights `.pt`**, never the sibling `.ckpt` — a `.ckpt` holds the whole LightningModule.
+weights `.safetensors`**, never the sibling `.ckpt` — a `.ckpt` holds the whole LightningModule.
 
 The generator's architecture, processor, output range and scale are all checked against
 the file's own metadata and **refused on any mismatch**: weights trained under a
@@ -357,7 +388,7 @@ were for.
 ### Dependency floors
 
 - **`torch>=2.6` is a security floor, not a convenience one.** `torch.load(weights_only=True)`
-  is this project's entire load-time safety contract for third-party `.ckpt`/`.pt` files,
+  is this project's load-time safety contract for `.ckpt` files, which stay pickles,
   and GHSA-53q9-r3pm-6pq6 / CVE-2025-32434 lets that check be bypassed for arbitrary code
   execution on torch ≤ 2.5.1. Do not lower it.
 - `torchmetrics>=1.9`, `jsonargparse>=4.50` — the versions the relevant APIs were verified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
     "torchmetrics>=1.9",
     # set_parsing_settings(subclasses_enabled=...) does not exist below 4.50.
     "jsonargparse[signatures]>=4.50",
+    # The distributable weights format. Core, not an extra: it is what every run
+    # writes, so it cannot be conditional on an optional install.
+    "safetensors>=0.4",
     "lmdb>=1.4",
     "pillow>=10",
     "numpy>=1.26",

--- a/sisr/artifacts.py
+++ b/sisr/artifacts.py
@@ -1,0 +1,177 @@
+"""The distributable weights artifact: one owner for writing, reading and checking it.
+
+A run produces two kinds of file. The resumable ``.ckpt`` belongs to Lightning —
+it carries optimizer moments, loop state and hyperparameters, and stays exactly
+as it is. This module owns the other one: the bare, optimizer-free weights file
+that gets handed to somebody else.
+
+**Why it exists.** The payload used to be written in one place and its shape
+re-derived by hand in three readers, one of which checked nothing at all. The
+format was `torch.save`, decided at the write site. Adding a second format meant
+editing four files, and the readers had no way to agree with each other.
+
+**Why safetensors.** Not because our own readers were unsafe — every
+``torch.load`` here already passes ``weights_only=True`` and the torch floor is
+pinned for it. The exposure is a *consumer* loading a published file with that
+turned off, or on an older torch. safetensors removes it by construction rather
+than by mitigation, and it is what the surrounding ecosystem reads.
+
+**The header is flat.** safetensors metadata is ``str -> str``, so the nested
+provenance block is written one entry per top-level field, with non-strings
+JSON-encoded. Deliberately not a single blob: per-field survives inspection by
+anything that can open the file, which is most of the value. The ONNX sink made
+the same call for the same reason and now shares this encoder.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import load_file, save_file
+
+#: Extension for every artifact this module writes.
+SUFFIX = ".safetensors"
+
+#: Fields whose disagreement changes what the model's output *means*, rather than
+#: merely describing the run that produced it. Getting one of these wrong yields a
+#: plausible image and no error, which is the failure this validation exists for.
+MEANING_FIELDS: tuple[tuple[str, str], ...] = (
+    ("processor", "class_path"),
+    ("io", "output_range"),
+)
+
+
+def encode_metadata(meta: dict[str, Any]) -> dict[str, str]:
+    """Flatten a provenance block into a ``str -> str`` header.
+
+    Args:
+        meta: A block from :func:`~sisr.training.metadata.build_metadata` or
+            :func:`~sisr.training.metadata.build_component_metadata`.
+
+    Returns:
+        One entry per top-level field. String values are stored as-is so they
+        stay readable; everything else is JSON-encoded.
+    """
+    return {k: v if isinstance(v, str) else json.dumps(v) for k, v in meta.items()}
+
+
+def decode_metadata(header: dict[str, str] | None) -> dict[str, Any]:
+    """Rebuild a provenance block from a flat header.
+
+    Args:
+        header: The header as stored, or ``None`` for a file carrying none.
+
+    Returns:
+        The nested block. A value that is not valid JSON is returned as the
+        string it is, which is what keeps the plain-string fields round-tripping.
+    """
+    out: dict[str, Any] = {}
+    for key, value in (header or {}).items():
+        try:
+            out[key] = json.loads(value)
+        except json.JSONDecodeError:
+            out[key] = value
+    return out
+
+
+def save(path: str | PathLike, tensors: dict[str, torch.Tensor], meta: dict[str, Any]) -> None:
+    """Write one component's weights plus its provenance.
+
+    Args:
+        path: Destination. The caller owns the filename.
+        tensors: A component's ``state_dict()``.
+        meta: Provenance to carry in the header.
+    """
+    # safetensors stores raw buffers and so refuses a view; a state_dict is free
+    # to hand back non-contiguous tensors.
+    save_file(
+        {k: v.detach().contiguous() for k, v in tensors.items()},
+        str(path),
+        metadata=encode_metadata(meta),
+    )
+
+
+def load(path: str | PathLike) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
+    """Read an artifact written by :func:`save`.
+
+    Args:
+        path: The file to read.
+
+    Returns:
+        ``(tensors, meta)``.
+
+    Raises:
+        ValueError: If the file carries no provenance. Loading weights whose
+            provenance is unknown is what every check downstream exists to
+            prevent, so an unlabelled file is refused rather than guessed at.
+    """
+    from safetensors import safe_open
+
+    path = Path(path)
+    with safe_open(str(path), framework="pt") as handle:
+        meta = decode_metadata(handle.metadata())
+    if not meta:
+        raise ValueError(
+            f"{path.name!r} carries no sisr provenance header, so nothing can be checked "
+            f"about it -- not the architecture, the processor, the output range, or the "
+            f"upscaling factor. Weights that load into a mismatched model train and score "
+            f"without erroring; only the numbers are wrong. Point at a file this project "
+            f"wrote."
+        )
+    return load_file(str(path)), meta
+
+
+def require_compatible(
+    found: dict[str, Any],
+    expected: dict[str, Any],
+    *,
+    fields: tuple[tuple[str, str], ...] = MEANING_FIELDS,
+    source: str = "artifact",
+) -> None:
+    """Refuse a mismatch that changes meaning; warn about one that only describes.
+
+    Args:
+        found: Provenance read from the file.
+        expected: Provenance describing the run that wants to use it.
+        fields: ``(section, key)`` pairs to refuse on. Defaults to
+            :data:`MEANING_FIELDS`; a caller with more to lose passes more.
+        source: Name used in messages, normally the filename.
+
+    Raises:
+        ValueError: If any of ``fields`` disagrees.
+    """
+    for section, key in fields:
+        want = expected.get(section, {}).get(key)
+        got = found.get(section, {}).get(key)
+        if got == want:
+            continue
+        raise ValueError(
+            f"{source} was written by a run whose {section}.{key} is {got!r}, but this "
+            f"run's is {want!r}. Weights used under a different architecture, processor, "
+            f"output range or upscaling factor train and score without ever erroring -- "
+            f"only the numbers are wrong. Point at a matching artifact, or align this "
+            f"run's config with the one that produced it."
+        )
+
+    # Version drift cannot change what the tensors mean, so it is said once and
+    # not enforced -- refusing here would make every artifact expire on upgrade.
+    found_versions = found.get("versions", {})
+    expected_versions = expected.get("versions", {})
+    drifted = {
+        name: (found_versions.get(name), value)
+        for name, value in expected_versions.items()
+        if found_versions.get(name) != value
+    }
+    if drifted:
+        detail = ", ".join(f"{n}: {was} -> {now}" for n, (was, now) in sorted(drifted.items()))
+        warnings.warn(
+            f"{source} was written under different library versions ({detail}). The "
+            f"tensors are loaded as-is; this is provenance drift, not a mismatch.",
+            UserWarning,
+            stacklevel=2,
+        )

--- a/sisr/export.py
+++ b/sisr/export.py
@@ -33,12 +33,13 @@ actually invoked.
 
 from __future__ import annotations
 
-import json
 import warnings
 from os import PathLike
 from typing import TYPE_CHECKING
 
 import torch
+
+from . import artifacts
 
 if TYPE_CHECKING:
     from .training import SRLightning
@@ -217,8 +218,8 @@ def _write_metadata_props(
         monitor_value=monitor_value,
     )
     onnx_model = onnx.load(str(file_path))
-    for key, value in meta.items():
+    for key, value in artifacts.encode_metadata(meta).items():
         entry = onnx_model.metadata_props.add()
         entry.key = key
-        entry.value = value if isinstance(value, str) else json.dumps(value)
+        entry.value = value
     onnx.save(onnx_model, str(file_path))

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -7,7 +7,7 @@ N val cycles) and ``cli test`` (one-shot final eval).
 training signals; :class:`SRCheckpoint` is a thin
 :class:`~lightning.pytorch.callbacks.ModelCheckpoint` preset for SR metrics;
 :class:`SRWeightsCheckpoint` is a sibling preset that saves bare, optimizer-free
-``.pt`` weights instead; :class:`SRPredictionWriter` writes ``cli predict``
+safetensors weights instead; :class:`SRPredictionWriter` writes ``cli predict``
 output to disk as PNGs.
 """
 
@@ -24,6 +24,7 @@ import torchvision
 from lightning.pytorch.callbacks import BasePredictionWriter, Callback, ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
+from .. import artifacts
 from ..metrics.perceptual import PERCEPTUAL_METRICS
 from .metadata import build_component_metadata, build_metadata
 
@@ -953,7 +954,7 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
             :class:`~lightning.pytorch.callbacks.ModelCheckpoint`.
     """
 
-    FILE_EXTENSION = ".pt"
+    FILE_EXTENSION = artifacts.SUFFIX
 
     def __init__(
         self,
@@ -1100,7 +1101,14 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
                 monitor=self.monitor,
                 monitor_value=monitor_value,
             )
-        torch.save({"state_dict": component.state_dict(), "meta": meta}, filepath)
+        # Rank-gated to match what ModelCheckpoint's own save path gets for free:
+        # it writes through Strategy.save_checkpoint, which gates on is_global_zero,
+        # and this override replaces exactly that method. Without the gate every
+        # process writes the same path at once. The bookkeeping below stays
+        # unconditional, as it is in the base implementation, and the rolling
+        # window's deletes are gated inside Strategy.remove_checkpoint already.
+        if trainer.is_global_zero:
+            artifacts.save(filepath, component.state_dict(), meta)
 
         self._last_global_step_saved = trainer.global_step
         self._last_checkpoint_saved = filepath

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -20,6 +20,7 @@ import torch
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 
+from .. import artifacts
 from ..losses import AdversarialLoss
 from ..models.base import SRModel
 from ..models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
@@ -199,7 +200,7 @@ class SRGANLightning(SRLightning):
             self._init_generator_from(self.training_config.init_from)
 
     def _init_generator_from(self, init_from: str) -> None:
-        """Initialise the **generator only** from a bare-weights ``.pt``.
+        """Initialise the **generator only** from a bare-weights artifact.
 
         Ledig et al. scope the MSE-initialisation trick to "when training the
         actual GAN", so a paper-faithful SRGAN run starts from an MSE-trained
@@ -212,14 +213,14 @@ class SRGANLightning(SRLightning):
         the numbers are wrong, which is indistinguishable from a bad run.
 
         Args:
-            init_from: Path to a ``.pt`` written by
+            init_from: Path to a ``.safetensors`` written by
                 :class:`~sisr.training.callbacks.SRWeightsCheckpoint` with
-                ``attribute='model'`` — a ``{'state_dict', 'meta'}`` payload.
+                ``attribute='model'``.
 
         Raises:
             ValueError: If ``init_from`` is the string ``'None'`` a CLI
                 ``=null`` collapses to; if it names a ``.ckpt`` or another
-                network's component ``.pt``; if the payload carries no ``meta``
+                network's component file; if the payload carries no ``meta``
                 to validate against; or if any of :data:`_INIT_FROM_FIELDS`
                 disagrees with this run.
             RuntimeError: From ``load_state_dict(strict=True)`` if the metadata
@@ -237,26 +238,16 @@ class SRGANLightning(SRLightning):
         path = Path(init_from)
         if path.suffix == ".ckpt":
             raise ValueError(
-                f"init_from expects a bare-weights .pt, but got the resumable checkpoint "
+                f"init_from expects a bare-weights artifact, but got the resumable checkpoint "
                 f"{path.name!r}. A .ckpt holds the whole LightningModule under "
                 f"'model.'-prefixed keys (plus optimizer state, and no per-network "
                 f"provenance to validate), so loading it into the bare generator is an "
                 f"unreadable key dump at best. Point init_from at the sibling "
-                f"sr-weights-*.pt that SRWeightsCheckpoint writes alongside it, or resume "
+                f"sr-weights file that SRWeightsCheckpoint writes alongside it, or resume "
                 f"the whole run with --ckpt_path instead."
             )
 
-        payload = torch.load(path, weights_only=True, map_location="cpu")
-        meta = payload.get("meta") if isinstance(payload, dict) else None
-        if meta is None or "state_dict" not in payload:
-            raise ValueError(
-                f"init_from={path.name!r} is not a sisr weights file: it has no "
-                f"'state_dict'/'meta' pair. Without the meta block none of the checks "
-                f"that decide whether these weights mean anything in this run "
-                f"(architecture, processor, output range, upscaling factor) can run, so "
-                f"accepting it would reinstate exactly the silent mistraining they exist "
-                f"to prevent."
-            )
+        tensors, meta = artifacts.load(path)
 
         # Only when 'kind' is present: it is an additive field, and the golden
         # artifact the template ships predates it. Absent means generator.
@@ -268,25 +259,19 @@ class SRGANLightning(SRLightning):
                 f"the SRGAN template writes both kinds into one dirpath. Its metadata "
                 f"describes only that component, so none of the generator checks "
                 f"(architecture, processor, output range, upscaling factor) can run "
-                f"against it. Point init_from at the sr-weights-*.pt sibling."
+                f"against it. Point init_from at the sr-weights sibling."
             )
 
-        expected = build_metadata(self)
-        for section, key in _INIT_FROM_FIELDS:
-            want = expected[section][key]
-            got = meta.get(section, {}).get(key)
-            if got == want:
-                continue
-            raise ValueError(
-                f"init_from={path.name!r} was written by a run whose {section}.{key} is "
-                f"{got!r}, but this run's is {want!r}. A generator initialised from "
-                f"weights trained under a different architecture, processor, output range "
-                f"or upscaling factor trains and scores without ever erroring — only the "
-                f"numbers are wrong. Point init_from at a matching artifact, or align "
-                f"this run's config with the one that produced it."
-            )
+        # Stricter than the module default on purpose: initialising a generator from
+        # the wrong weights is not merely unlabelled, it silently mistrains.
+        artifacts.require_compatible(
+            meta,
+            build_metadata(self),
+            fields=_INIT_FROM_FIELDS,
+            source=f"init_from={path.name!r}",
+        )
 
-        self.model.load_state_dict(payload["state_dict"], strict=True)
+        self.model.load_state_dict(tensors, strict=True)
 
     def configure_optimizers(self) -> OptimizerLRScheduler:
         """Build the generator and discriminator optimizers, in that order.

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -41,8 +41,10 @@ import sisr
 if TYPE_CHECKING:
     from .lightning_module import SRLightning
 
-#: Bumped whenever the metadata shape changes incompatibly.
-FORMAT_VERSION = "sisr-meta-v1"
+#: Bumped whenever the metadata shape changes incompatibly. v2: the distributable
+#: artifact became safetensors, so the block is carried as a flat string header
+#: rather than a pickled dict, and the `.pt` form stopped existing.
+FORMAT_VERSION = "sisr-meta-v2"
 
 
 def _to_plain(obj: Any) -> Any:

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -59,7 +59,7 @@ model:
         class_path: sisr.models.srgan.SRGANTrainingConfig
         init_args:
           # Bare weights (.pt), never the sibling .ckpt. Mismatches are refused.
-          init_from: "experiments/SRResNet/golden/checkpoints/sr-weights-1000000-psnr_val_RGB=28.8635.pt"
+          init_from: "experiments/SRResNet/golden/checkpoints/sr-weights-1000000-psnr_val_RGB=28.8635.safetensors"
           # Must match the real training input: RGB at hr_crop_size / scale.
           example_input_shape: [3, 24, 24]
           # adversarial_weight 1.0e-3 and d_steps_per_g_step 1 are the defaults.

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,103 @@
+"""The distributable artifact's own contract: header encoding, refusal, drift."""
+
+import json
+
+import pytest
+import safetensors.torch
+import torch
+
+from sisr import artifacts
+
+_META = {
+    "format": "sisr-meta-v2",
+    "kind": "sr_model",
+    "created": "2026-08-28T00:00:00+00:00",
+    "versions": {"sisr": "0.1.0", "torch": "2.13.0", "lightning": "2.6.5"},
+    "io": {"scale": 4, "output_range": [-1.0, 1.0], "output_colorspace": "RGB"},
+    "processor": {"class_path": "sisr.processors.rgb.RGBSignedOutputProcessor"},
+}
+
+
+def test_header_is_one_entry_per_field_not_one_blob():
+    """The whole reason for this encoding: anything that can open the file gets a
+    readable table, not a single opaque string it has to know to parse."""
+    header = artifacts.encode_metadata(_META)
+
+    assert set(header) == set(_META)
+    # A string field stays a string, so it is legible without decoding.
+    assert header["format"] == "sisr-meta-v2"
+    assert json.loads(header["io"])["scale"] == 4
+
+
+def test_metadata_round_trips_through_the_flat_header():
+    assert artifacts.decode_metadata(artifacts.encode_metadata(_META)) == _META
+
+
+def test_save_and_load_round_trip_tensors_and_provenance(tmp_path):
+    tensors = {"a": torch.randn(2, 3), "b": torch.zeros(4)}
+    path = tmp_path / f"m{artifacts.SUFFIX}"
+
+    artifacts.save(path, tensors, _META)
+    loaded, meta = artifacts.load(path)
+
+    assert meta == _META
+    assert torch.equal(loaded["a"], tensors["a"])
+    assert torch.equal(loaded["b"], tensors["b"])
+
+
+def test_save_accepts_a_non_contiguous_tensor(tmp_path):
+    """A state_dict may hand back views, which safetensors refuses outright."""
+    view = torch.randn(4, 4).t()
+    assert not view.is_contiguous()
+    path = tmp_path / f"m{artifacts.SUFFIX}"
+
+    artifacts.save(path, {"w": view}, _META)
+
+    assert torch.equal(artifacts.load(path)[0]["w"], view)
+
+
+def test_load_refuses_a_file_carrying_no_provenance(tmp_path):
+    """Weights whose provenance is unknown are exactly what every downstream
+    check exists to prevent, so an unlabelled file is refused, not guessed at."""
+    path = tmp_path / f"foreign{artifacts.SUFFIX}"
+    safetensors.torch.save_file({"w": torch.zeros(2)}, str(path))
+
+    with pytest.raises(ValueError, match="no sisr provenance header"):
+        artifacts.load(path)
+
+
+@pytest.mark.parametrize(
+    ("section", "key", "value"),
+    [("io", "output_range", [0.0, 1.0]), ("processor", "class_path", "sisr.processors.rgb.RGB")],
+)
+def test_require_compatible_refuses_a_meaning_changing_mismatch(section, key, value):
+    """Both defaults are fields where being wrong yields a plausible image and no
+    error -- apply the wrong output range and every pixel is silently misscaled."""
+    found = {**_META, section: {**_META[section], key: value}}
+
+    with pytest.raises(ValueError, match=f"{section}.{key}"):
+        artifacts.require_compatible(found, _META)
+
+
+def test_require_compatible_accepts_a_match():
+    artifacts.require_compatible(dict(_META), _META)
+
+
+def test_require_compatible_warns_about_version_drift_rather_than_refusing():
+    """Refusing here would expire every artifact on the next dependency bump,
+    and a library version cannot change what the tensors mean."""
+    found = {**_META, "versions": {**_META["versions"], "torch": "2.9.0"}}
+
+    with pytest.warns(UserWarning, match="different library versions"):
+        artifacts.require_compatible(found, _META)
+
+
+def test_require_compatible_takes_a_stricter_field_list_when_the_caller_has_more_to_lose():
+    """Initialising a generator from the wrong weights silently mistrains, so that
+    caller refuses on more than the default set."""
+    found = {**_META, "io": {**_META["io"], "scale": 2}}
+
+    artifacts.require_compatible(found, _META)  # scale is not a default field
+
+    with pytest.raises(ValueError, match="io.scale"):
+        artifacts.require_compatible(found, _META, fields=(("io", "scale"),))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,8 @@ import pytest
 import torch
 import yaml
 
+from sisr import artifacts
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE = REPO_ROOT / "templates" / "config.srcnn.template.yaml"
 SRRESNET_TEMPLATE = REPO_ROOT / "templates" / "config.srresnet.template.yaml"
@@ -366,12 +368,12 @@ def test_srgan_template_ships_a_real_init_from_path():
     """The template's own init_from is exercised nowhere else — the test above
     overrides it to a missing path so it can run without the gitignored
     experiments/ tree. Assert the shipped value at least names a bare-weights
-    .pt, which is one of the artifacts SRGANLightning's setup refuses."""
+    artifact, which is the one kind SRGANLightning's setup accepts."""
     with SRGAN_TEMPLATE.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
     init_from = data["model"]["init_args"]["training_config"]["init_args"]["init_from"]
-    assert init_from.endswith(".pt")
+    assert init_from.endswith(artifacts.SUFFIX)
     assert "sr-weights" in init_from
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -183,7 +183,7 @@ def test_to_onnx_writes_metadata_props(tmp_path):
         "eval_config",
         "training",
     }
-    assert props["format"] == "sisr-meta-v1"  # stored as-is: already a str
+    assert props["format"] == "sisr-meta-v2"  # stored as-is: already a str
     assert props["kind"] == "sr_model"  # stored as-is: already a str
 
     model_field = json.loads(props["model"])

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -15,6 +15,7 @@ from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from PIL import Image
 
+from sisr import artifacts
 from sisr.metrics.scoring import SRScorer
 from sisr.models.srcnn import SRCNN
 from sisr.processors import RGBProcessor, YChannelProcessor
@@ -644,7 +645,7 @@ def test_monitor_error_names_the_actual_callback_class(cls):
 
 def test_sr_weights_checkpoint_file_extension_is_pt():
     ckpt = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", dirpath="/tmp/x")
-    assert ckpt.FILE_EXTENSION == ".pt"
+    assert ckpt.FILE_EXTENSION == ".safetensors"
 
 
 def test_sr_weights_checkpoint_default_filename_prefix_is_sr_weights():
@@ -759,17 +760,17 @@ def test_weights_checkpoint_can_save_a_named_component(tmp_path):
     )
     cb.current_score = None
 
-    cb._save_checkpoint(trainer, str(tmp_path / "d-weights-7.pt"))
+    cb._save_checkpoint(trainer, str(tmp_path / "d-weights-7.safetensors"))
 
-    saved = torch.load(tmp_path / "d-weights-7.pt", weights_only=True)
-    assert set(saved["state_dict"]) == set(module.discriminator.state_dict())
+    saved_tensors, saved_meta = artifacts.load(tmp_path / "d-weights-7.safetensors")
+    assert set(saved_tensors) == set(module.discriminator.state_dict())
     # build_module()'s generator is SRCNN, whose top-level submodules are
     # feat/mapping/recon -- a "feat."-prefixed key here would mean the
     # generator's weights leaked into what must be a discriminator-only file.
-    assert not any(key.startswith("feat.") for key in saved["state_dict"]), (
+    assert not any(key.startswith("feat.") for key in saved_tensors), (
         "generator weights must not appear in a discriminator file"
     )
-    assert saved["meta"]["kind"] == "component"
+    assert saved_meta["kind"] == "component"
 
 
 def test_two_weights_checkpoints_can_watch_different_components():
@@ -828,13 +829,13 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
     """End-to-end proof that Lightning's real save path invokes our
     ``_save_checkpoint`` override, that ``SRCheckpoint``/``SRWeightsCheckpoint``
     coexist in one ``dirpath`` without deleting each other's files, and that the
-    bare ``.pt`` payload is exactly what the spec requires: no optimizer state,
+    bare payload is exactly what the spec requires: no optimizer state,
     no ``model.``-prefixed keys, and the state_dict loads strict into a fresh
     bare model.
 
     This is the loud-failure guard for the private ``_save_checkpoint`` hook: if
-    a future Lightning release stops routing saves through it, the ``.pt`` file
-    would instead contain a full Lightning checkpoint dict (``optimizer_states``,
+    a future Lightning release stops routing saves through it, the artifact
+    would instead be a full Lightning checkpoint dict (``optimizer_states``,
     ``callbacks``, ``model.``-prefixed ``state_dict``, ...) and every assertion
     below would fail.
     """
@@ -873,7 +874,7 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
     trainer.fit(module, datamodule=datamodule)
 
     ckpt_files = list(ckpt_dir.glob("sr-*.ckpt"))
-    pt_files = list(ckpt_dir.glob("sr-weights-*.pt"))
+    pt_files = list(ckpt_dir.glob("sr-weights-*.safetensors"))
     all_files = list(ckpt_dir.iterdir())
     # save_top_k=1 on each: exactly one file per callback survives repeated
     # val-triggered saves, and coexisting in one dirpath produced no cross-deletion.
@@ -886,15 +887,14 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
     assert "sisr_meta" in full_checkpoint  # on_save_checkpoint fired here too
     assert all(k.startswith("model.") for k in full_checkpoint["state_dict"])
 
-    bare = torch.load(pt_files[0], weights_only=True)
-    assert set(bare.keys()) == {"state_dict", "meta"}
-    assert "optimizer_states" not in bare
-    assert not any(k.startswith("model.") for k in bare["state_dict"])
-    assert bare["meta"]["format"] == "sisr-meta-v1"
-    assert bare["meta"]["training"]["monitor"] == "psnr/val/RGB"
+    bare_tensors, bare_meta = artifacts.load(pt_files[0])
+    assert "optimizer_states" not in bare_tensors
+    assert not any(k.startswith("model.") for k in bare_tensors)
+    assert bare_meta["format"] == "sisr-meta-v2"
+    assert bare_meta["training"]["monitor"] == "psnr/val/RGB"
 
     fresh_model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
-    fresh_model.load_state_dict(bare["state_dict"], strict=True)  # the real proof
+    fresh_model.load_state_dict(bare_tensors, strict=True)  # the real proof
 
 
 # ---------------------------------------------------------------------------
@@ -1017,8 +1017,8 @@ def test_sr_weights_checkpoint_rolling_mode_keeps_only_the_last_n(tmp_path):
         monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
     )
     _run_tiny_fit(callbacks=[cb], n_batches=20)
-    files = sorted(p.name for p in tmp_path.glob("*.pt"))
-    assert files == ["sr-weights-17.pt", "sr-weights-19.pt"], files
+    files = sorted(p.name for p in tmp_path.glob("*.safetensors"))
+    assert files == ["sr-weights-17.safetensors", "sr-weights-19.safetensors"], files
 
 
 def test_sr_weights_checkpoint_rolling_filename_has_no_metric_placeholder(tmp_path: Path):
@@ -1043,10 +1043,10 @@ def test_rolling_checkpoints_coexist_without_cross_deletion(tmp_path):
     )
     _run_tiny_fit(callbacks=[sr_ckpt, sr_weights_ckpt], n_batches=20)
     ckpt_files = sorted(p.name for p in tmp_path.glob("sr-*.ckpt"))
-    pt_files = sorted(p.name for p in tmp_path.glob("sr-weights-*.pt"))
+    pt_files = sorted(p.name for p in tmp_path.glob("sr-weights-*.safetensors"))
     all_files = sorted(p.name for p in tmp_path.iterdir())
     assert ckpt_files == ["sr-17.ckpt", "sr-19.ckpt"], ckpt_files
-    assert pt_files == ["sr-weights-17.pt", "sr-weights-19.pt"], pt_files
+    assert pt_files == ["sr-weights-17.safetensors", "sr-weights-19.safetensors"], pt_files
     assert len(all_files) == 4, all_files
 
 
@@ -1118,17 +1118,23 @@ def test_rolling_seed_only_adopts_this_callbacks_own_files(tmp_path: Path):
     """Seeding must not let one rolling callback delete another's files.
 
     The shipped adversarial template puts three rolling callbacks in one
-    ``dirpath`` (``sr-*.ckpt``, ``sr-weights-*.pt``, ``d-weights-*.pt``), and
+    ``dirpath`` (``sr-*.ckpt``, ``sr-weights-*``, ``d-weights-*``), and
     ``sr-weights`` is a strict prefix extension of ``sr`` — a prefix-only or
     extension-only filter adopts a sibling's files and eventually deletes them.
     """
-    for name in ("sr-weights-2.pt", "d-weights-2.pt", "sr-2.ckpt", "last.ckpt", "sr-weights-x.pt"):
+    for name in (
+        "sr-weights-2.safetensors",
+        "d-weights-2.safetensors",
+        "sr-2.ckpt",
+        "last.ckpt",
+        "sr-weights-x.safetensors",
+    ):
         (tmp_path / name).touch()
     cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=3, dirpath=str(tmp_path))
 
     cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
 
-    assert cb._rolling == [str(tmp_path / "sr-weights-2.pt")]
+    assert cb._rolling == [str(tmp_path / "sr-weights-2.safetensors")]
 
 
 def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
@@ -1137,7 +1143,7 @@ def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
     Seeding unconditionally would make a from-scratch run adopt — and, on its
     third save, silently delete — checkpoints a previous run wrote.
     """
-    (tmp_path / "sr-weights-2.pt").touch()
+    (tmp_path / "sr-weights-2.safetensors").touch()
     cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
 
     cb.on_train_start(MagicMock(ckpt_path=None), MagicMock())
@@ -1148,7 +1154,7 @@ def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
 def test_rolling_seed_is_noop_when_monitor_is_set(tmp_path: Path):
     """With a monitor, Lightning's top-k owns retention — seeding would evict
     files top-k still wants, exactly as ``_enforce_rolling_window`` must not."""
-    (tmp_path / "sr-weights-2.pt").touch()
+    (tmp_path / "sr-weights-2.safetensors").touch()
     cb = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(tmp_path))
 
     cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
@@ -1160,14 +1166,16 @@ def test_seeded_window_deletes_the_oldest_pre_resume_file(tmp_path: Path):
     """Seeding is only worth anything if the next save then evicts a pre-resume
     file — the orphaning this fixes is a deletion that never happens."""
     for step in (2, 4):
-        (tmp_path / f"sr-weights-{step}.pt").touch()
+        (tmp_path / f"sr-weights-{step}{SRWeightsCheckpoint.FILE_EXTENSION}").touch()
     cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
     trainer = MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt"))
 
     cb.on_train_start(trainer, MagicMock())
-    cb._enforce_rolling_window(trainer, str(tmp_path / "sr-weights-6.pt"))
+    cb._enforce_rolling_window(trainer, str(tmp_path / "sr-weights-6.safetensors"))
 
-    trainer.strategy.remove_checkpoint.assert_called_once_with(str(tmp_path / "sr-weights-2.pt"))
+    trainer.strategy.remove_checkpoint.assert_called_once_with(
+        str(tmp_path / "sr-weights-2.safetensors")
+    )
 
 
 @_ignore_gpu_warning
@@ -2269,7 +2277,7 @@ def test_every_checkpoint_stamp_is_a_step_the_metrics_were_logged_at(tmp_path: P
 
 
 def test_weights_checkpoint_metadata_records_both_axes_distinguishably(tmp_path: Path):
-    """The ``.pt`` path: the callback builds the metadata itself.
+    """The bare-artifact path: the callback builds the metadata itself.
 
     Both counters are real, so the artifact must say which is which.
     ``global_step`` keeps meaning the optimizer count -- that is what it factually
@@ -2293,7 +2301,7 @@ def test_weights_checkpoint_metadata_records_both_axes_distinguishably(tmp_path:
     path = tmp_path / f"probe{SRWeightsCheckpoint.FILE_EXTENSION}"
     cb._save_checkpoint(trainer, str(path))
 
-    training = torch.load(path, weights_only=True, map_location="cpu")["meta"]["training"]
+    training = artifacts.load(path)[1]["training"]
     assert training["global_step"] == 400_000, "the optimizer count must keep its own name"
     assert training["batch_step"] == 199_999, "the metric axis must be recorded too"
 
@@ -2345,3 +2353,32 @@ def test_checkpoint_metadata_batch_step_is_none_when_the_loop_state_is_absent():
     module.on_save_checkpoint(checkpoint)
 
     assert checkpoint["sisr_meta"]["training"]["batch_step"] is None
+
+
+@pytest.mark.parametrize("is_global_zero", [True, False])
+def test_bare_weights_are_written_by_one_process_only(tmp_path: Path, is_global_zero: bool):
+    """Fails if every process in a distributed run writes the artifact.
+
+    ``ModelCheckpoint``'s own save path gets this for free -- it writes through
+    ``Strategy.save_checkpoint``, which gates on ``is_global_zero``. This callback
+    overrides exactly that method, so the gate has to be restated here or every
+    process races to write the same path. Both directions are asserted: a test
+    that only checked the ``False`` case would also pass if saving were broken
+    outright.
+    """
+    module = SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=YChannelProcessor(),
+        training_config=SRTrainingConfig(scale=2),
+        eval_config=SREvalConfig(),
+    )
+    trainer = _manual_optimization_trainer(batches=10, optimizer_steps=20)
+    trainer.lightning_module = module
+    trainer.is_global_zero = is_global_zero
+    trainer.loggers = []
+
+    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    path = tmp_path / f"sr-weights-10{SRWeightsCheckpoint.FILE_EXTENSION}"
+    cb._save_checkpoint(trainer, str(path))
+
+    assert path.exists() is is_global_zero

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -10,8 +10,10 @@ from types import SimpleNamespace
 
 import lightning
 import pytest
+import safetensors.torch
 import torch
 
+from sisr import artifacts
 from sisr.losses import AdversarialLoss, VGG19FeatureLoss
 from sisr.models.base import SRModel
 from sisr.models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
@@ -98,8 +100,8 @@ def write_weights(tmp_path, **meta_overrides):
     for dotted, value in meta_overrides.items():
         section, key = dotted.split(".")
         meta[section][key] = value
-    path = tmp_path / "sr-weights.pt"
-    torch.save({"state_dict": source.model.state_dict(), "meta": meta}, path)
+    path = tmp_path / "sr-weights.safetensors"
+    artifacts.save(path, source.model.state_dict(), meta)
     return path, source
 
 
@@ -755,28 +757,31 @@ def test_init_from_rejects_a_ckpt_and_names_the_pt(tmp_path):
     strict load into the bare generator fails with an unreadable key dump —
     and it carries no ``meta`` to validate against either."""
     path = tmp_path / "sr-42.ckpt"
-    torch.save({"state_dict": {}}, path)
+    safetensors.torch.save_file({}, str(path))  # no provenance header at all
 
     with pytest.raises(ValueError) as excinfo:
         init_gan_from(path)
 
     message = str(excinfo.value)
     assert "sr-42.ckpt" in message
-    assert ".pt" in message, "the message must point at the sibling weights file"
+    assert "sr-weights" in message, "the message must point at the sibling weights file"
 
 
 def test_init_from_refuses_a_pt_with_no_metadata(tmp_path):
     """Without ``meta`` there is nothing to validate against, so accepting the
     file would silently reinstate every mismatch the checks above refuse."""
-    path = tmp_path / "sr-weights.pt"
-    torch.save({"state_dict": build_source_module().model.state_dict()}, path)
+    path = tmp_path / "sr-weights.safetensors"
+    safetensors.torch.save_file(
+        {k: v.contiguous() for k, v in build_source_module().model.state_dict().items()},
+        str(path),
+    )  # tensors, but no provenance header
 
-    with pytest.raises(ValueError, match="meta"):
+    with pytest.raises(ValueError, match="no sisr provenance header"):
         init_gan_from(path)
 
 
 def test_init_from_names_the_component_artifact_it_was_handed(tmp_path):
-    """A ``d-weights-*.pt`` is the likeliest misuse after a ``.ckpt``: the template
+    """A ``d-weights-*`` file is the likeliest misuse after a ``.ckpt``: the template
     writes both files into one dirpath.
 
     It is refused either way — a component's meta has no generator-scoped ``io``
@@ -784,20 +789,18 @@ def test_init_from_names_the_component_artifact_it_was_handed(tmp_path):
     discriminator's weights, which is the whole mistake.
     """
     module = build_gan_module()
-    path = tmp_path / "d-weights-10000.pt"
-    torch.save(
-        {
-            "state_dict": module.discriminator.state_dict(),
-            "meta": build_component_metadata(module, "discriminator"),
-        },
+    path = tmp_path / "d-weights-10000.safetensors"
+    artifacts.save(
         path,
+        module.discriminator.state_dict(),
+        build_component_metadata(module, "discriminator"),
     )
 
     with pytest.raises(ValueError) as excinfo:
         init_gan_from(path)
 
     message = str(excinfo.value)
-    assert "d-weights-10000.pt" in message
+    assert "d-weights-10000.safetensors" in message
     assert "discriminator" in message, "the message must name the component it was handed"
     assert "sr-weights" in message, "...and the generator file that should have been used"
     assert not [name for name in INIT_FROM_FIELDS if name in message], (
@@ -812,8 +815,8 @@ def test_init_from_accepts_a_pt_written_before_kind_existed(tmp_path):
     source = build_source_module()
     meta = build_metadata(source)
     del meta["kind"]
-    path = tmp_path / "sr-weights.pt"
-    torch.save({"state_dict": source.model.state_dict(), "meta": meta}, path)
+    path = tmp_path / "sr-weights.safetensors"
+    artifacts.save(path, source.model.state_dict(), meta)
 
     init_gan_from(path)  # must not raise
 
@@ -840,7 +843,7 @@ def test_init_from_is_only_read_when_the_run_is_fitting(tmp_path):
     A path that does not exist is the whole proof: the non-fit stages must not
     touch it, and ``fit`` must.
     """
-    missing = tmp_path / "absent-sr-weights.pt"
+    missing = tmp_path / "absent-sr-weights.safetensors"
 
     module = build_gan_module(init_from=str(missing))  # construction must not read it
     for stage in ("validate", "test", "predict"):
@@ -950,8 +953,8 @@ def test_the_bare_weights_sink_stays_component_scoped(tmp_path):
             ),
         ],
     )
-    d_meta = torch.load(next(tmp_path.glob("d-weights-*.pt")), weights_only=True)["meta"]
-    g_meta = torch.load(next(tmp_path.glob("sr-weights-*.pt")), weights_only=True)["meta"]
+    d_meta = artifacts.load(next(tmp_path.glob("d-weights-*.safetensors")))[1]
+    g_meta = artifacts.load(next(tmp_path.glob("sr-weights-*.safetensors")))[1]
 
     assert set(d_meta).isdisjoint({"discriminator", "adversarial"})
     assert d_meta["kind"] == "component"

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1225,7 +1225,7 @@ def test_on_save_checkpoint_injects_sisr_meta(srcnn_rgb_lit: SRLightning):
     checkpoint = {"global_step": 500, "epoch": 2, "state_dict": srcnn_rgb_lit.state_dict()}
     srcnn_rgb_lit.on_save_checkpoint(checkpoint)
     meta = checkpoint["sisr_meta"]
-    assert meta["format"] == "sisr-meta-v1"
+    assert meta["format"] == "sisr-meta-v2"
     assert meta["model"]["class_path"] == "sisr.models.srcnn.model.SRCNN"
     assert meta["training"]["global_step"] == 500
     assert meta["training"]["epoch"] == 2

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -49,7 +49,7 @@ def test_build_metadata_top_level_shape():
         "eval_config",
         "training",
     }
-    assert meta["format"] == "sisr-meta-v1"
+    assert meta["format"] == "sisr-meta-v2"
 
 
 def test_build_metadata_versions_are_plain_strings():


### PR DESCRIPTION
Closes #162. Closes #125. Fourth in the stack.

## What was wrong

The bare-weights file was written in one place as a `torch.save` payload, and its shape re-derived
by hand in **three** readers — one of which, the export path, checked nothing at all. The format was
decided at the write site, so a second format meant editing four files and the readers had no way to
agree with each other.

`sisr/artifacts.py` now owns writing, reading and checking it. **Top-level, not under `training/`**:
reading a published artifact is not a training concern, and two of its three callers do not train.
That placement is what closes #125, whose held trigger — "revisit when a second reader appears" —
fired when a second *format* arrived.

## The safety argument, stated precisely

Not the obvious one. Our own readers were never exposed: every `torch.load` here passes
`weights_only=True` against a pinned torch floor. The exposure is a **consumer** opening a published
file with that turned off, or on an older torch. safetensors removes it by construction.

**This makes the file we hand out pickle-free, not the repository.** The resumable `.ckpt` is still a
pickle and stays one — Lightning owns that format, and it carries optimizer moments, loop state and
hyperparameters that a flat tensor map cannot represent.

`safetensors` is a **core** dependency, not an extra: it is what every run writes, so it cannot be
conditional on an optional install.

## Header encoding

One entry per top-level field, not one blob — the call the ONNX sink already made, for the same
reason. That sink now **shares this encoder** rather than keeping its own copy.

`FORMAT_VERSION` → `v2`. Carrier and encoding both changed and a format stopped existing, which is a
change to the existing shape rather than a new kind (the precedent for *not* bumping was a new kind).

## Validation splits by consequence

| | |
|---|---|
| **Refuse** | processor, output range — being wrong yields a plausible image and no error |
| **Warn** | library versions — cannot change what the tensors mean, and refusing would expire every artifact on the next dependency bump |
| **Refuse, stricter** | generator init keeps its five-field list — the wrong weights there silently *mistrain* |

## The rank gate

`ModelCheckpoint` gets this free by writing through `Strategy.save_checkpoint`, which gates on
`is_global_zero`. This callback overrides **exactly that method**, so every process was racing to
write the same path. Bookkeeping stays unconditional as in the base, and the rolling window's deletes
were already gated inside `Strategy.remove_checkpoint` — verified, not assumed.

Proven both ways: removing the guard fails the `is_global_zero=False` case, keeping it passes both.

## Verification

- 10 new tests for the artifact contract; 2 for the rank gate.
- Full suite: **947 passed, 2 skipped**. `ruff`, `ruff format`, `mypy` clean.

## Also corrected

`docs/configuration.md` still described checkpoint filenames as carrying optimizer steps, with a
worked example claiming a file named 10000 is the state at TensorBoard x=5000. **True before #111,
wrong since.** Found while documenting the format.

## BREAKING CHANGE

Bare-weights artifacts are `.safetensors`; existing `.pt` files cannot be read. No conversion path in
the tree, by decision — regenerate by retraining.

## Risk

Not LOW. Public artifact contract, and a breaking format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)