### PR TITLE
feat!: name artifacts after the model they hold

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,6 +276,30 @@ Provenance travels in the file's header, one entry per top-level field rather th
 opaque blob, so anything that can open the artifact gets a readable table. The ONNX
 export writes the same fields the same way.
 
+Filenames say what the model is, so a directory of weights can be read without
+opening anything:
+
+```
+SRCNN_x2_Y_915_s500000.safetensors
+SRResNet_x4_RGB_16B64F_s500000.safetensors
+SRDiscriminator_96_s500000.safetensors
+```
+
+Architecture, scale, colourspace, variant, step. The **variant** is
+architecture-specific — SRCNN's kernel triple, SRResNet's block and filter counts — and
+each architecture supplies its own via `variant_tag`; no generic rule over
+hyperparameters produces a readable tag for all of them. A component drops scale and
+colourspace, since neither describes a critic.
+
+The name is **derived from the artifact's own provenance**, not assembled separately, so
+a file whose name and header disagree is not representable. Set `filename_prefix` to
+override it for a run that wants its own naming.
+
+Two things are deliberately absent. There is **no metric token**: runs monitor different
+metrics and adversarial runs monitor none, so it would make otherwise-identical files
+look unrelated — the value is in the header instead. And `s<step>` is the **batch** axis,
+which is the axis every logged metric uses, so the number can be found on a curve.
+
 Mismatches are checked on read. Fields that change what the output *means* — the
 processor and the output range — are refused, because being wrong about either produces
 a plausible image and no error. Library-version drift is warned about and loaded, since

--- a/sisr/artifacts.py
+++ b/sisr/artifacts.py
@@ -175,3 +175,39 @@ def require_compatible(
             UserWarning,
             stacklevel=2,
         )
+
+
+def stem(meta: dict[str, Any]) -> str:
+    """Filename identity for an artifact, derived from its own provenance.
+
+    Deliberately a projection of the metadata rather than a second description
+    built from the module: a filename and a header that disagree is precisely the
+    class of defect this project keeps finding, and deriving one from the other
+    makes it unrepresentable.
+
+    ``SRResNet_x4_RGB_16B64F`` — architecture, scale, colourspace, variant. A
+    component drops scale and colourspace, neither of which describes a critic:
+    ``SRDiscriminator_96``.
+
+    Args:
+        meta: A block from :func:`~sisr.training.metadata.build_metadata` or
+            :func:`~sisr.training.metadata.build_component_metadata`.
+
+    Returns:
+        The identity, with any absent part simply omitted rather than rendered
+        as ``None``.
+    """
+    if meta.get("kind") == "component":
+        block = meta.get("component", {})
+        parts = [block.get("class_path", "").rsplit(".", 1)[-1], block.get("variant")]
+    else:
+        block = meta.get("model", {})
+        io = meta.get("io", {})
+        scale = io.get("scale")
+        parts = [
+            block.get("class_path", "").rsplit(".", 1)[-1],
+            f"x{scale}" if scale is not None else None,
+            io.get("output_colorspace"),
+            block.get("variant"),
+        ]
+    return "_".join(p for p in parts if p)

--- a/sisr/models/base.py
+++ b/sisr/models/base.py
@@ -32,6 +32,22 @@ class SRModel(nn.Module, abc.ABC):
         """Architecture hyperparameters dict for the Lightning HParams merge."""
         return self._hparams
 
+    @property
+    @abc.abstractmethod
+    def variant_tag(self) -> str:
+        """Short token distinguishing this configuration from siblings of the same class.
+
+        Appears in artifact filenames, so a directory of weights can be read
+        without opening anything: ``SRCNN_x2_Y_915`` and ``SRResNet_x4_RGB_16B64F``
+        differ in exactly this token when the architecture and scale match.
+
+        Abstract, never defaulted, for the same reason ``input_contract`` is
+        declared rather than inferred: no rule over ``hparams`` produces a
+        readable tag for every architecture, and an inherited default would
+        silently label two different configurations identically. Keep it short,
+        stable, and filename-safe.
+        """
+
     @abc.abstractmethod
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the model on input ``x`` and return the SR output tensor."""

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -122,6 +122,11 @@ class SRCNN(SRModel):
                 if module.bias is not None:
                     torch.nn.init.constant_(module.bias, 0.0)
 
+    @property
+    def variant_tag(self) -> str:
+        """The kernel-size triple, e.g. ``'915'`` -- how the paper names its variants."""
+        return "".join(str(k) for k in self._hparams["kernel_sizes"])
+
     def forward(
         self,
         x: torch.Tensor,

--- a/sisr/models/srgan/discriminator.py
+++ b/sisr/models/srgan/discriminator.py
@@ -98,6 +98,15 @@ class SRDiscriminator(torch.nn.Module):
         """Architecture hyperparameters, for provenance metadata."""
         return self._hparams
 
+    @property
+    def variant_tag(self) -> str:
+        """The HR input size it was built for -- the one knob that must match the data.
+
+        Not an ``SRModel``, so this is duck-typed rather than inherited. The
+        artifact naming reads it the same way either way.
+        """
+        return str(self._hparams["hr_input_size"])
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Score a batch of HR-sized images.
 

--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -182,6 +182,11 @@ class SRResNet(SRModel):
                 f"num_residual_blocks must be a positive integer. Got {num_residual_blocks}."
             )
 
+    @property
+    def variant_tag(self) -> str:
+        """Blocks and width, e.g. ``'16B64F'`` -- the two knobs that move capacity."""
+        return f"{self._hparams['num_residual_blocks']}B{self._hparams['hidden_channel']}F"
+
     def forward(
         self,
         x: torch.Tensor,

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -631,7 +631,7 @@ class _RollingSaveMixin:
         # sibling callback in the same dirpath differs in prefix or extension, and
         # `last.ckpt`/a monitored callback's metric-bearing name never match.
         self._rolling_pattern = re.compile(
-            rf"{re.escape(filename_prefix)}-(\d+){re.escape(self.FILE_EXTENSION)}"
+            rf"{re.escape(filename_prefix)}_s(\d+){re.escape(self.FILE_EXTENSION)}"
         )
 
     def on_train_start(
@@ -736,30 +736,49 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
         monitor_metric: str | None = "psnr/val/RGB",
         save_top_k: int = 3,
         dirpath: str | None = None,
-        filename_prefix: str = "sr",
+        filename_prefix: str | None = None,
         mode: str = "max",
         keep_last: int = 3,
         **kwargs: Any,
     ):
         if monitor_metric is None:
-            # Rolling: no metric in the filename (there is none), and step
-            # must be in it or every save overwrites the last.
-            filename = f"{filename_prefix}-{{step}}"
+            # Lightning refuses save_top_k > 1 with nothing to rank by; the
+            # window is enforced by _RollingSaveMixin instead.
             save_top_k = -1
-        else:
-            # '/' is a path separator; a monitor tag carries several.
-            label = monitor_metric.replace("/", "_")
-            filename = f"{filename_prefix}-{{step}}-{label}={{{monitor_metric}:.4f}}"
         super().__init__(
             monitor=monitor_metric,
             mode=mode,
             save_top_k=save_top_k,
             dirpath=dirpath,
-            filename=filename,
             auto_insert_metric_name=False,
             **kwargs,
         )
-        self._init_rolling(keep_last, filename_prefix)
+        self._keep_last = keep_last
+        self._explicit_prefix = filename_prefix
+        # A usable name before setup() can derive the real one -- direct
+        # construction in a test never reaches setup.
+        self._apply_naming(filename_prefix or self.DEFAULT_PREFIX)
+
+    #: Placeholder identity used until setup() can derive the real one. Distinct
+    #: per subclass so two sinks sharing a dirpath cannot collide before then.
+    DEFAULT_PREFIX: str = "sr"
+
+    def _apply_naming(self, prefix: str) -> None:
+        """Set the filename template and the rolling window's matching pattern together.
+
+        They must agree: the window finds this callback's own files by matching
+        exactly what it writes, so a prefix change that touched only one of them
+        would either orphan every save or adopt a sibling callback's.
+
+        Args:
+            prefix: Identity portion of the filename, without the step.
+        """
+        self.filename = f"{prefix}_s{{step}}"
+        self._init_rolling(self._keep_last, prefix)
+
+    def _describe(self, pl_module: lightning.LightningModule) -> dict[str, Any]:
+        """Provenance for whatever this callback saves. Overridden per component."""
+        return build_metadata(pl_module)
 
     def _validate_monitor(self, pl_module: lightning.LightningModule) -> None:
         """Raise if this callback's ``monitor``/``mode`` pair is unloggable or inverted.
@@ -843,6 +862,15 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
             return
+        self._validate(pl_module)
+        # Derived here rather than in __init__ because it comes from the module,
+        # which does not exist when a callback is built from YAML -- and after
+        # _validate, because it reads whatever that just checked.
+        if self._explicit_prefix is None:
+            self._apply_naming(artifacts.stem(self._describe(pl_module)))
+
+    def _validate(self, pl_module: lightning.LightningModule) -> None:
+        """Everything that must hold before this callback can name or write anything."""
         self._validate_monitor(pl_module)
 
 
@@ -955,13 +983,14 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
     """
 
     FILE_EXTENSION = artifacts.SUFFIX
+    DEFAULT_PREFIX = "sr-weights"
 
     def __init__(
         self,
         monitor_metric: str | None = "psnr/val/RGB",
         save_top_k: int = 3,
         dirpath: str | None = None,
-        filename_prefix: str = "sr-weights",
+        filename_prefix: str | None = None,
         mode: str = "max",
         keep_last: int = 3,
         attribute: str = "model",
@@ -977,6 +1006,12 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
             **kwargs,
         )
         self.attribute = attribute
+
+    def _describe(self, pl_module: lightning.LightningModule) -> dict[str, Any]:
+        """Component-scoped when this callback saves anything but the generator."""
+        if self.attribute == "model":
+            return build_metadata(pl_module)
+        return build_component_metadata(pl_module, self.attribute)
 
     @property
     def state_key(self) -> str:
@@ -1039,8 +1074,15 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
                 ``pl_module`` has no attribute named ``attribute``.
         """
         super().setup(trainer, pl_module, stage)
-        if stage != "fit":
-            return
+
+    def _validate(self, pl_module: lightning.LightningModule) -> None:
+        """The base's monitor check, plus that ``attribute`` names something real.
+
+        Runs before the filename is derived, which reads the very component this
+        confirms exists -- otherwise a typo surfaces as a bare ``AttributeError``
+        from inside the naming code rather than as this message.
+        """
+        super()._validate(pl_module)
         if not hasattr(pl_module, self.attribute):
             raise MisconfigurationException(
                 f"`SRWeightsCheckpoint(attribute={self.attribute!r})` has nothing to save: "

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -160,6 +160,7 @@ def build_metadata(
     meta["model"] = {
         "class_path": _class_path(model),
         "init_args": _to_plain(model.hparams),
+        "variant": model.variant_tag,
     }
     meta["processor"] = {
         "class_path": _class_path(processor),
@@ -221,6 +222,9 @@ def build_component_metadata(
         "name": attribute,
         "class_path": _class_path(component),
         "init_args": _to_plain(getattr(component, "hparams", {})),
+        # Duck-typed: a co-trained component need not be an SRModel, and one
+        # without a tag simply contributes nothing to the filename.
+        "variant": getattr(component, "variant_tag", None),
     }
     meta["io"] = {
         "input_range": list(processor.output_range),

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -59,7 +59,7 @@ model:
         class_path: sisr.models.srgan.SRGANTrainingConfig
         init_args:
           # Bare weights (.pt), never the sibling .ckpt. Mismatches are refused.
-          init_from: "experiments/SRResNet/golden/checkpoints/sr-weights-1000000-psnr_val_RGB=28.8635.safetensors"
+          init_from: "experiments/SRResNet/golden/checkpoints/SRResNet_x4_RGB_16B64F_s1000000.safetensors"
           # Must match the real training input: RGB at hr_crop_size / scale.
           example_input_shape: [3, 24, 24]
           # adversarial_weight 1.0e-3 and d_steps_per_g_step 1 are the defaults.
@@ -141,14 +141,12 @@ trainer:
         keep_last: 3
         every_n_train_steps: 10000
         attribute: model
-        filename_prefix: sr-weights
     - class_path: sisr.training.SRWeightsCheckpoint
       init_args:
         monitor_metric: null
         keep_last: 3
         every_n_train_steps: 10000
         attribute: discriminator
-        filename_prefix: d-weights
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step

--- a/tests/models/srcnn/test_model.py
+++ b/tests/models/srcnn/test_model.py
@@ -178,3 +178,9 @@ def test_forward_multilayer_mapping_builds_extra_conv_and_preserves_shape():
     x = torch.zeros(2, 3, 16, 16)
     out = model(x)
     assert out.shape == (2, 3, 16, 16)
+
+
+def test_variant_tag_is_the_kernel_triple():
+    """The paper names its variants by kernel sizes, so the artifact does too."""
+    assert SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5)).variant_tag == "915"
+    assert SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 5, 5)).variant_tag == "955"

--- a/tests/models/srresnet/test_model.py
+++ b/tests/models/srresnet/test_model.py
@@ -148,3 +148,9 @@ def test_clamp_output_default_bounds_are_the_paper_signed_range():
     assert torch.isclose(out.min(), torch.tensor(-1.0), atol=1e-6), (
         f"floor was {out.min().item()}; a (0.0, 1.0) default floors at 0.0"
     )
+
+
+def test_variant_tag_is_blocks_and_width():
+    """The two knobs that move capacity, and the two a reader wants off `ls`."""
+    assert SRResNet(scale=4).variant_tag == "16B64F"
+    assert SRResNet(scale=4, num_residual_blocks=8, hidden_channel=32).variant_tag == "8B32F"

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -22,6 +22,10 @@ def test_srmodel_subclass_inherits_nn_module():
             self._hparams = {"trivial": True}
             self.conv = nn.Conv2d(3, 3, 1)
 
+        @property
+        def variant_tag(self):
+            return "t"
+
         def forward(self, x):
             return self.conv(x)
 
@@ -37,6 +41,10 @@ def test_srmodel_hparams_returns_underlying_dict():
         def __init__(self):
             super().__init__()
             self._hparams = {"foo": 1, "bar": "two"}
+
+        @property
+        def variant_tag(self):
+            return "t"
 
         def forward(self, x):
             return x
@@ -60,6 +68,10 @@ def test_srmodel_reset_parameters_default_is_noop():
             self._hparams = {}
             self.conv = nn.Conv2d(3, 3, 1)
 
+        @property
+        def variant_tag(self):
+            return "t"
+
         def forward(self, x):
             return self.conv(x)
 
@@ -68,3 +80,22 @@ def test_srmodel_reset_parameters_default_is_noop():
     assert m.reset_parameters() is None  # no kwargs
     assert m.reset_parameters(mean=0.5, std=0.1) is None  # kwargs absorbed
     assert torch.equal(m.conv.weight, before)
+
+
+def test_srmodel_refuses_a_subclass_with_no_variant_tag():
+    """The tag is abstract on purpose: an inherited default would silently label
+    two different configurations identically, which is what filenames exist to
+    prevent."""
+
+    class _NoTag(SRModel):
+        input_contract = "native_lr"
+
+        def __init__(self):
+            super().__init__()
+            self._hparams = {}
+
+        def forward(self, x):
+            return x
+
+    with pytest.raises(TypeError, match="variant_tag"):
+        _NoTag()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -101,3 +101,36 @@ def test_require_compatible_takes_a_stricter_field_list_when_the_caller_has_more
 
     with pytest.raises(ValueError, match="io.scale"):
         artifacts.require_compatible(found, _META, fields=(("io", "scale"),))
+
+
+def test_stem_names_a_model_by_what_distinguishes_it():
+    """`ls` should answer "which model is this" without opening anything."""
+    meta = {
+        "kind": "sr_model",
+        "model": {"class_path": "sisr.models.srresnet.model.SRResNet", "variant": "16B64F"},
+        "io": {"scale": 4, "output_colorspace": "RGB"},
+    }
+    assert artifacts.stem(meta) == "SRResNet_x4_RGB_16B64F"
+
+
+def test_stem_drops_the_parts_that_do_not_describe_a_critic():
+    """Scale and colourspace describe a generator's output; a discriminator has
+    neither, so naming it with them would assert something untrue."""
+    meta = {
+        "kind": "component",
+        "component": {
+            "class_path": "sisr.models.srgan.discriminator.SRDiscriminator",
+            "variant": "96",
+        },
+    }
+    assert artifacts.stem(meta) == "SRDiscriminator_96"
+
+
+def test_stem_omits_an_absent_part_rather_than_rendering_it():
+    """A missing variant must not produce a literal 'None' in a filename."""
+    meta = {
+        "kind": "sr_model",
+        "model": {"class_path": "a.b.Thing", "variant": None},
+        "io": {"scale": 2, "output_colorspace": "Y"},
+    }
+    assert artifacts.stem(meta) == "Thing_x2_Y"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,7 +374,9 @@ def test_srgan_template_ships_a_real_init_from_path():
 
     init_from = data["model"]["init_args"]["training_config"]["init_args"]["init_from"]
     assert init_from.endswith(artifacts.SUFFIX)
-    assert "sr-weights" in init_from
+    # Names a generator, not the sibling discriminator file and not a .ckpt --
+    # both of which SRGANLightning's setup refuses, with different messages.
+    assert Path(init_from).name.startswith("SRResNet_")
 
 
 @_ignore_random_vgg

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -456,11 +456,16 @@ def test_weight_histogram_logger_skips_when_no_tb_logger():
 # ---------------------------------------------------------------------------
 
 
-def test_srcheckpoint_filename_pattern():
-    """monitor_metric='val_psnr(RGB)' -> filename pattern uses that metric."""
+def test_srcheckpoint_filename_carries_the_step_and_not_the_metric():
+    """The monitored metric is deliberately absent from the name.
+
+    Runs monitor different metrics and adversarial runs monitor none, so a metric
+    token would make otherwise-identical files look unrelated. The value lives in
+    the artifact's own provenance instead. ``{step}`` must stay, or every save
+    overwrites the last.
+    """
     ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", save_top_k=3, dirpath="/tmp/x")
-    # ModelCheckpoint stores `filename` — verify the metric appears in the format.
-    assert "val_psnr(RGB)" in ckpt.filename
+    assert "val_psnr(RGB)" not in ckpt.filename
     assert "step" in ckpt.filename
 
 
@@ -476,14 +481,14 @@ def test_srcheckpoint_custom_filename_prefix():
         dirpath="/tmp/x",
         filename_prefix="myrun",
     )
-    assert ckpt.filename.startswith("myrun-")
+    assert ckpt.filename.startswith("myrun_s")
 
 
 def test_srcheckpoint_default_filename_prefix_is_neutral_sr():
     """The generic checkpoint's default prefix must be arch-neutral 'sr',
     not the SRCNN-specific 'srcnn'."""
     ckpt = SRCheckpoint(monitor_metric="val_psnr(RGB)", dirpath="/tmp/x")
-    assert ckpt.filename.startswith("sr-")
+    assert ckpt.filename.startswith("sr_s")
 
 
 def test_srcheckpoint_disables_auto_insert_metric_name():
@@ -504,13 +509,15 @@ def test_srcheckpoint_slash_monitor_renders_flat_filename(tmp_path: Path):
     silently create a nested directory tree (one per save) instead of a flat
     checkpoint file. The `metrics` dict lookup that supplies the *value* is
     unaffected by the `/` — it's just a dict key."""
-    ckpt = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    ckpt = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path), filename_prefix="sr")
     rendered = ckpt.format_checkpoint_name(
         {"step": torch.tensor(1000), "psnr/val/RGB": torch.tensor(30.1234)}
     )
     basename = Path(rendered).name
     assert "/" not in basename
-    assert basename == "sr-1000-psnr_val_RGB=30.1234.ckpt"
+    # The metric no longer appears in the name at all -- identity plus step only --
+    # so the monitor tag cannot reach the path however many separators it carries.
+    assert basename == "sr_s1000.ckpt"
 
 
 # ---------------------------------------------------------------------------
@@ -652,14 +659,14 @@ def test_sr_weights_checkpoint_default_filename_prefix_is_sr_weights():
     """Distinct from SRCheckpoint's 'sr' default so a shared dirpath's top-k
     deletion passes can never mistake one callback's files for the other's."""
     ckpt = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", dirpath="/tmp/x")
-    assert ckpt.filename.startswith("sr-weights-")
+    assert ckpt.filename.startswith("sr-weights_s")
 
 
 def test_sr_weights_checkpoint_custom_filename_prefix():
     ckpt = SRWeightsCheckpoint(
         monitor_metric="psnr/val/RGB", dirpath="/tmp/x", filename_prefix="myrun"
     )
-    assert ckpt.filename.startswith("myrun-")
+    assert ckpt.filename.startswith("myrun_s")
 
 
 def test_sr_weights_checkpoint_default_max_mode():
@@ -756,13 +763,17 @@ def test_weights_checkpoint_can_save_a_named_component(tmp_path):
     # auto-attribute would reach torch.save and fail there, not here.
     trainer.fit_loop.epoch_loop._batches_that_stepped = 6
     cb = SRWeightsCheckpoint(
-        monitor_metric=None, keep_last=1, attribute="discriminator", dirpath=str(tmp_path)
+        monitor_metric=None,
+        keep_last=1,
+        attribute="discriminator",
+        dirpath=str(tmp_path),
+        filename_prefix="d-weights",
     )
     cb.current_score = None
 
-    cb._save_checkpoint(trainer, str(tmp_path / "d-weights-7.safetensors"))
+    cb._save_checkpoint(trainer, str(tmp_path / "d-weights_s7.safetensors"))
 
-    saved_tensors, saved_meta = artifacts.load(tmp_path / "d-weights-7.safetensors")
+    saved_tensors, saved_meta = artifacts.load(tmp_path / "d-weights_s7.safetensors")
     assert set(saved_tensors) == set(module.discriminator.state_dict())
     # build_module()'s generator is SRCNN, whose top-level submodules are
     # feat/mapping/recon -- a "feat."-prefixed key here would mean the
@@ -853,9 +864,14 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
     # (-> error, under this suite's strict filter) if dirpath is non-empty at startup.
     ckpt_dir = tmp_path / "checkpoints"
 
-    sr_ckpt = SRCheckpoint(monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(ckpt_dir))
+    sr_ckpt = SRCheckpoint(
+        monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(ckpt_dir), filename_prefix="sr"
+    )
     sr_weights_ckpt = SRWeightsCheckpoint(
-        monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(ckpt_dir)
+        monitor_metric="psnr/val/RGB",
+        save_top_k=1,
+        dirpath=str(ckpt_dir),
+        filename_prefix="sr-weights",
     )
     trainer = lightning.Trainer(
         max_epochs=-1,
@@ -873,8 +889,8 @@ def test_sr_weights_checkpoint_writes_bare_payload_via_real_fit(
 
     trainer.fit(module, datamodule=datamodule)
 
-    ckpt_files = list(ckpt_dir.glob("sr-*.ckpt"))
-    pt_files = list(ckpt_dir.glob("sr-weights-*.safetensors"))
+    ckpt_files = list(ckpt_dir.glob("sr_s*.ckpt"))
+    pt_files = list(ckpt_dir.glob("sr-weights_s*.safetensors"))
     all_files = list(ckpt_dir.iterdir())
     # save_top_k=1 on each: exactly one file per callback survives repeated
     # val-triggered saves, and coexisting in one dirpath produced no cross-deletion.
@@ -965,7 +981,11 @@ def test_rolling_mode_keeps_only_the_last_n(tmp_path):
     likely one from the first few thousand steps.
     """
     cb = SRCheckpoint(
-        monitor_metric=None, keep_last=3, every_n_train_steps=2, dirpath=str(tmp_path)
+        monitor_metric=None,
+        keep_last=3,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path),
+        filename_prefix="sr",
     )
     _run_tiny_fit(callbacks=[cb], n_batches=20)
     files = sorted(p.name for p in tmp_path.glob("*.ckpt"))
@@ -976,7 +996,7 @@ def test_rolling_mode_keeps_only_the_last_n(tmp_path):
     # Stamps are the batch axis, which is what every logged metric uses -- so
     # 15/17/19, not the 16/18/20 `trainer.global_step` would give. Those older
     # numbers named steps that appear on no curve; see the step-axis tests below.
-    assert files == ["sr-15.ckpt", "sr-17.ckpt", "sr-19.ckpt"], files
+    assert files == ["sr_s15.ckpt", "sr_s17.ckpt", "sr_s19.ckpt"], files
 
 
 @_ignore_gpu_warning
@@ -1001,7 +1021,7 @@ def test_srcheckpoint_rolling_filename_has_no_metric_placeholder(tmp_path: Path)
     step-only — MEASURED FACT 3: omitting {step} would make every save
     overwrite the last."""
     ckpt = SRCheckpoint(monitor_metric=None, dirpath=str(tmp_path))
-    assert ckpt.filename == "sr-{step}"
+    assert ckpt.filename == "sr_s{step}"
     assert ckpt.save_top_k == -1
     assert ckpt.monitor is None
     assert ckpt.keep_last == 3
@@ -1014,16 +1034,20 @@ def test_sr_weights_checkpoint_rolling_mode_keeps_only_the_last_n(tmp_path):
     ModelCheckpoint's save path the way SRCheckpoint does, so this is the
     place a mixin-only implementation would silently do nothing."""
     cb = SRWeightsCheckpoint(
-        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+        monitor_metric=None,
+        keep_last=2,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path),
+        filename_prefix="sr-weights",
     )
     _run_tiny_fit(callbacks=[cb], n_batches=20)
     files = sorted(p.name for p in tmp_path.glob("*.safetensors"))
-    assert files == ["sr-weights-17.safetensors", "sr-weights-19.safetensors"], files
+    assert files == ["sr-weights_s17.safetensors", "sr-weights_s19.safetensors"], files
 
 
 def test_sr_weights_checkpoint_rolling_filename_has_no_metric_placeholder(tmp_path: Path):
     ckpt = SRWeightsCheckpoint(monitor_metric=None, dirpath=str(tmp_path))
-    assert ckpt.filename == "sr-weights-{step}"
+    assert ckpt.filename == "sr-weights_s{step}"
     assert ckpt.save_top_k == -1
     assert ckpt.monitor is None
     assert ckpt.keep_last == 3
@@ -1036,17 +1060,25 @@ def test_rolling_checkpoints_coexist_without_cross_deletion(tmp_path):
     of its own filepaths, and FILE_EXTENSION/filename_prefix already keep the
     two from colliding by name."""
     sr_ckpt = SRCheckpoint(
-        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+        monitor_metric=None,
+        keep_last=2,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path),
+        filename_prefix="sr",
     )
     sr_weights_ckpt = SRWeightsCheckpoint(
-        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+        monitor_metric=None,
+        keep_last=2,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path),
+        filename_prefix="sr-weights",
     )
     _run_tiny_fit(callbacks=[sr_ckpt, sr_weights_ckpt], n_batches=20)
-    ckpt_files = sorted(p.name for p in tmp_path.glob("sr-*.ckpt"))
-    pt_files = sorted(p.name for p in tmp_path.glob("sr-weights-*.safetensors"))
+    ckpt_files = sorted(p.name for p in tmp_path.glob("sr_s*.ckpt"))
+    pt_files = sorted(p.name for p in tmp_path.glob("sr-weights_s*.safetensors"))
     all_files = sorted(p.name for p in tmp_path.iterdir())
-    assert ckpt_files == ["sr-17.ckpt", "sr-19.ckpt"], ckpt_files
-    assert pt_files == ["sr-weights-17.safetensors", "sr-weights-19.safetensors"], pt_files
+    assert ckpt_files == ["sr_s17.ckpt", "sr_s19.ckpt"], ckpt_files
+    assert pt_files == ["sr-weights_s17.safetensors", "sr-weights_s19.safetensors"], pt_files
     assert len(all_files) == 4, all_files
 
 
@@ -1102,15 +1134,15 @@ def test_rolling_window_is_seeded_from_disk_on_resume(cls, prefix, tmp_path: Pat
     an error under this suite's strict filter).
     """
     for step in (4, 20, 12):
-        (tmp_path / f"{prefix}-{step}{cls.FILE_EXTENSION}").touch()
-    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+        (tmp_path / f"{prefix}_s{step}{cls.FILE_EXTENSION}").touch()
+    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix=prefix)
 
     cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
 
     # Ordered by step, not lexicographically -- "12" sorts before "4" as text,
     # and deletion is oldest-first, so a string sort would evict the newest file.
     assert cb._rolling == [
-        str(tmp_path / f"{prefix}-{step}{cls.FILE_EXTENSION}") for step in (4, 12, 20)
+        str(tmp_path / f"{prefix}_s{step}{cls.FILE_EXTENSION}") for step in (4, 12, 20)
     ]
 
 
@@ -1123,18 +1155,20 @@ def test_rolling_seed_only_adopts_this_callbacks_own_files(tmp_path: Path):
     extension-only filter adopts a sibling's files and eventually deletes them.
     """
     for name in (
-        "sr-weights-2.safetensors",
-        "d-weights-2.safetensors",
-        "sr-2.ckpt",
+        "sr-weights_s2.safetensors",
+        "d-weights_s2.safetensors",
+        "sr_s2.ckpt",
         "last.ckpt",
-        "sr-weights-x.safetensors",
+        "sr-weights_sx.safetensors",
     ):
         (tmp_path / name).touch()
-    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=3, dirpath=str(tmp_path))
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=3, dirpath=str(tmp_path), filename_prefix="sr-weights"
+    )
 
     cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
 
-    assert cb._rolling == [str(tmp_path / "sr-weights-2.safetensors")]
+    assert cb._rolling == [str(tmp_path / "sr-weights_s2.safetensors")]
 
 
 def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
@@ -1143,8 +1177,10 @@ def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
     Seeding unconditionally would make a from-scratch run adopt — and, on its
     third save, silently delete — checkpoints a previous run wrote.
     """
-    (tmp_path / "sr-weights-2.safetensors").touch()
-    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    (tmp_path / "sr-weights_s2.safetensors").touch()
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix="sr-weights"
+    )
 
     cb.on_train_start(MagicMock(ckpt_path=None), MagicMock())
 
@@ -1154,7 +1190,7 @@ def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
 def test_rolling_seed_is_noop_when_monitor_is_set(tmp_path: Path):
     """With a monitor, Lightning's top-k owns retention — seeding would evict
     files top-k still wants, exactly as ``_enforce_rolling_window`` must not."""
-    (tmp_path / "sr-weights-2.safetensors").touch()
+    (tmp_path / "sr-weights_s2.safetensors").touch()
     cb = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", save_top_k=1, dirpath=str(tmp_path))
 
     cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
@@ -1166,15 +1202,17 @@ def test_seeded_window_deletes_the_oldest_pre_resume_file(tmp_path: Path):
     """Seeding is only worth anything if the next save then evicts a pre-resume
     file — the orphaning this fixes is a deletion that never happens."""
     for step in (2, 4):
-        (tmp_path / f"sr-weights-{step}{SRWeightsCheckpoint.FILE_EXTENSION}").touch()
-    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+        (tmp_path / f"sr-weights_s{step}{SRWeightsCheckpoint.FILE_EXTENSION}").touch()
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix="sr-weights"
+    )
     trainer = MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt"))
 
     cb.on_train_start(trainer, MagicMock())
-    cb._enforce_rolling_window(trainer, str(tmp_path / "sr-weights-6.safetensors"))
+    cb._enforce_rolling_window(trainer, str(tmp_path / "sr-weights_s6.safetensors"))
 
     trainer.strategy.remove_checkpoint.assert_called_once_with(
-        str(tmp_path / "sr-weights-2.safetensors")
+        str(tmp_path / "sr-weights_s2.safetensors")
     )
 
 
@@ -1194,17 +1232,25 @@ def test_real_resume_keeps_the_window_at_keep_last(tmp_path: Path):
     exactly ``keep_last`` files; unseeded, 3 and 5 are orphaned and six survive.
     """
     ckpt_cb = SRCheckpoint(
-        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+        monitor_metric=None,
+        keep_last=2,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path),
+        filename_prefix="sr",
     )
     _run_tiny_fit(callbacks=[ckpt_cb], n_batches=6)
-    assert sorted(p.name for p in tmp_path.glob("*.ckpt")) == ["sr-3.ckpt", "sr-5.ckpt"]
+    assert sorted(p.name for p in tmp_path.glob("*.ckpt")) == ["sr_s3.ckpt", "sr_s5.ckpt"]
 
     resumed_cb = SRCheckpoint(
-        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+        monitor_metric=None,
+        keep_last=2,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path),
+        filename_prefix="sr",
     )
-    _run_tiny_fit(callbacks=[resumed_cb], n_batches=12, ckpt_path=str(tmp_path / "sr-5.ckpt"))
+    _run_tiny_fit(callbacks=[resumed_cb], n_batches=12, ckpt_path=str(tmp_path / "sr_s5.ckpt"))
 
-    assert sorted(p.name for p in tmp_path.glob("*.ckpt")) == ["sr-11.ckpt", "sr-9.ckpt"]
+    assert sorted(p.name for p in tmp_path.glob("*.ckpt")) == ["sr_s11.ckpt", "sr_s9.ckpt"]
 
 
 # ---------------------------------------------------------------------------
@@ -2201,7 +2247,7 @@ def test_checkpoint_step_placeholder_uses_the_batch_axis(cls, prefix, tmp_path: 
     curve. Measured on the real runs before this fix: ``experiments/SRGAN/golden``
     held ``sr-400000`` against its own metrics maxing at 199,999.
     """
-    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix=prefix)
     trainer = _manual_optimization_trainer(batches=200_000, optimizer_steps=400_000)
 
     assert int(cb._monitor_candidates(trainer)["step"]) == 200_000
@@ -2216,12 +2262,12 @@ def test_checkpoint_filename_renders_the_batch_axis(cls, prefix, tmp_path: Path)
     what a human actually reads off ``ls``, and what the rolling window parses
     back out.
     """
-    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix=prefix)
     trainer = _manual_optimization_trainer(batches=200_000, optimizer_steps=400_000)
 
     name = Path(cb.format_checkpoint_name(cb._monitor_candidates(trainer))).name
 
-    assert name == f"{prefix}-200000{cls.FILE_EXTENSION}"
+    assert name == f"{prefix}_s200000{cls.FILE_EXTENSION}"
 
 
 @pytest.mark.parametrize("cls, prefix", _CKPT_CLASSES)
@@ -2234,12 +2280,12 @@ def test_checkpoint_name_introduces_no_scaling_of_its_own(cls, prefix, tmp_path:
     test above and fail here the moment a paradigm used one optimizer per batch
     under manual optimization.
     """
-    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    cb = cls(monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix=prefix)
     trainer = _manual_optimization_trainer(batches=1_000_000, optimizer_steps=1_000_000)
 
     name = Path(cb.format_checkpoint_name(cb._monitor_candidates(trainer))).name
 
-    assert name == f"{prefix}-1000000{cls.FILE_EXTENSION}"
+    assert name == f"{prefix}_s1000000{cls.FILE_EXTENSION}"
 
 
 @_ignore_gpu_warning
@@ -2261,11 +2307,15 @@ def test_every_checkpoint_stamp_is_a_step_the_metrics_were_logged_at(tmp_path: P
 
     logger = CSVLogger(str(tmp_path / "logs"), name="r", version="v")
     cb = SRCheckpoint(
-        monitor_metric=None, keep_last=10, every_n_train_steps=2, dirpath=str(tmp_path / "ck")
+        monitor_metric=None,
+        keep_last=10,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path / "ck"),
+        filename_prefix="sr",
     )
     _run_tiny_fit(callbacks=[cb], n_batches=12, logger=logger, log_every_n_steps=2)
 
-    stamps = sorted(int(p.stem.split("-")[1]) for p in (tmp_path / "ck").glob("*.ckpt"))
+    stamps = sorted(int(p.stem.split("_s")[1]) for p in (tmp_path / "ck").glob("*.ckpt"))
     with open(tmp_path / "logs" / "r" / "v" / "metrics.csv") as fh:
         logged = {int(row["step"]) for row in csv.DictReader(fh) if row.get("step")}
 
@@ -2297,7 +2347,9 @@ def test_weights_checkpoint_metadata_records_both_axes_distinguishably(tmp_path:
     trainer.is_global_zero = True
     trainer.loggers = []
 
-    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix="sr-weights"
+    )
     path = tmp_path / f"probe{SRWeightsCheckpoint.FILE_EXTENSION}"
     cb._save_checkpoint(trainer, str(path))
 
@@ -2377,8 +2429,48 @@ def test_bare_weights_are_written_by_one_process_only(tmp_path: Path, is_global_
     trainer.is_global_zero = is_global_zero
     trainer.loggers = []
 
-    cb = SRWeightsCheckpoint(monitor_metric=None, keep_last=2, dirpath=str(tmp_path))
-    path = tmp_path / f"sr-weights-10{SRWeightsCheckpoint.FILE_EXTENSION}"
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, dirpath=str(tmp_path), filename_prefix="sr-weights"
+    )
+    path = tmp_path / f"sr-weights_s10{SRWeightsCheckpoint.FILE_EXTENSION}"
     cb._save_checkpoint(trainer, str(path))
 
     assert path.exists() is is_global_zero
+
+
+@_ignore_gpu_warning
+def test_a_real_fit_names_its_artifacts_after_the_model(tmp_path: Path):
+    """The identity is derived from the run, not configured, and it survives to disk.
+
+    The name is a projection of the artifact's own provenance rather than a second
+    description assembled beside it, so a file whose name and header disagree is
+    not representable.
+    """
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, every_n_train_steps=2, dirpath=str(tmp_path)
+    )
+    _run_tiny_fit(callbacks=[cb], n_batches=6)
+
+    names = sorted(p.name for p in tmp_path.glob(f"*{SRWeightsCheckpoint.FILE_EXTENSION}"))
+    assert names, "no artifact was written -- the test proves nothing"
+    for name in names:
+        assert name.startswith("SRCNN_x2_RGB_313_s"), name
+    # And the header agrees with the name it was given.
+    assert artifacts.stem(artifacts.load(tmp_path / names[0])[1]) == "SRCNN_x2_RGB_313"
+
+
+@_ignore_gpu_warning
+def test_an_explicit_prefix_still_wins_over_the_derived_identity(tmp_path: Path):
+    """The derivation is a default, not a policy -- a run that wants its own
+    naming keeps it."""
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None,
+        keep_last=2,
+        every_n_train_steps=2,
+        dirpath=str(tmp_path),
+        filename_prefix="myrun",
+    )
+    _run_tiny_fit(callbacks=[cb], n_batches=6)
+
+    names = sorted(p.name for p in tmp_path.glob(f"*{SRWeightsCheckpoint.FILE_EXTENSION}"))
+    assert names and all(n.startswith("myrun_s") for n in names), names

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -227,6 +227,10 @@ class ShrinkingGenerator(SRModel):
 
     input_contract = "pre_upsampled"
 
+    @property
+    def variant_tag(self) -> str:
+        return "shrink"
+
     def __init__(self, channels=3, shrink=16):
         super().__init__()
         self.conv = torch.nn.Conv2d(channels, channels, kernel_size=shrink + 1, padding="valid")
@@ -953,8 +957,8 @@ def test_the_bare_weights_sink_stays_component_scoped(tmp_path):
             ),
         ],
     )
-    d_meta = artifacts.load(next(tmp_path.glob("d-weights-*.safetensors")))[1]
-    g_meta = artifacts.load(next(tmp_path.glob("sr-weights-*.safetensors")))[1]
+    d_meta = artifacts.load(next(tmp_path.glob("d-weights_s*.safetensors")))[1]
+    g_meta = artifacts.load(next(tmp_path.glob("sr-weights_s*.safetensors")))[1]
 
     assert set(d_meta).isdisjoint({"discriminator", "adversarial"})
     assert d_meta["kind"] == "component"


### PR DESCRIPTION
Closes #163. Fifth in the stack.

## Before / after

```
sr-weights-500000-psnr_val_RGB=28.8635.pt     ->  SRResNet_x4_RGB_16B64F_s500000.safetensors
sr-weights-500000.pt                          ->  SRCNN_x2_Y_915_s500000.safetensors
d-weights-500000.pt                           ->  SRDiscriminator_96_s500000.safetensors
```

Architecture, scale, colourspace, variant, step. A directory of weights is now readable with `ls`.

## The design point

The name is **derived from the artifact's own provenance**, not assembled beside it. A filename and a
header that disagree is the defect class this project keeps rediscovering — deriving one from the
other makes it unrepresentable. `build_metadata` gained the variant, `artifacts.stem` projects a name
from it, and the callback applies that in `setup()` — the earliest point at which the module exists,
since a callback built from YAML has no model.

## `SRModel.variant_tag`

Abstract, **never defaulted**, for the reason `input_contract` is declared rather than inferred: no
rule over `hparams` yields a readable tag for every architecture, and an inherited default would
label two different configurations identically. SRCNN gives its kernel triple (`915`), SRResNet its
blocks and width (`16B64F`). The discriminator supplies one too, duck-typed, since it is deliberately
not an `SRModel`.

## Two deliberate absences

**No metric token.** Runs monitor different metrics and adversarial runs monitor none, so the token
made otherwise-identical files look unrelated. The value is in the header. As a *side effect* the
`/`-sanitisation hazard disappears rather than being handled — a monitor tag can no longer reach a
path at all.

**`s<step>` is the batch axis**, unchanged from #111, so the number can be found on a curve.

## One structural fix found on the way

Validation became a hook, so a subclass's checks run **before** the name is derived from the very
component they confirm exists. Without it, a bad `attribute` surfaced as a bare `AttributeError` from
inside the naming code instead of the actionable message that already existed.

## Test approach

Tests whose subject is the rolling window, the step axis or the payload now **pin an explicit
prefix** — they should not move every time naming does. New tests cover the identity end-to-end, the
override, and that a subclass omitting `variant_tag` cannot be instantiated.

Full suite: **955 passed, 2 skipped**. `ruff`, `ruff format`, `mypy` clean.

## BREAKING CHANGE

Filenames change shape, and every `SRModel` subclass must supply `variant_tag`.

## Risk

Not LOW — base-class contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)