### PR TITLE
refactor!: give config keys their unit, and stop restating a derived value

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,7 @@ to the torch hub cache, and TV's `2e-8` presumes the `[-1, 1]` output range that
 
 | Field | Notes |
 | --- | --- |
-| `example_input_shape` | Must match the real training input. |
+| `example_input_shape` | **Optional.** Derived from the real training patch when unset; checked against it when set. |
 | `compile_backend` | A `torch._dynamo` backend name, or unset for eager. |
 | `layer_lrs` | Per-`Conv2d` learning rates; requires every trainable parameter to live in a `Conv2d`. |
 | `init_strategy`, `init_mean`, `init_std` | Weight initialisation. |
@@ -121,6 +121,12 @@ resize the input by before feeding it. It is deliberately *not* inferred from th
 `example_input_shape` is **not** only a TensorBoard-graph dummy. It also shapes the
 `torch.compile` warm-up — a wrong size compiles once and then recompiles on step 1 —
 and it drives `ModelSummary`'s FLOPs count.
+
+You may leave it unset: it is derived from the first real training patch. Setting it is
+still useful, because a stated value is *checked* against that patch rather than
+replaced by it — an intent that can be contradicted. **The shipped templates state it**
+for one reason: they are also the input to `sisr export`, which never sees training data
+and so has nothing to derive from.
 
 ### `eval_config` and the two SSIM conventions
 
@@ -317,8 +323,18 @@ does not (5 → still every 5).
 | `BenchmarkImageLogger` | Writes benchmark-set image strips each val run. |
 | `SRCheckpoint` | Resumable `.ckpt`. |
 | `SRWeightsCheckpoint` | Distributable, optimizer-free `.safetensors` weights — roughly a third the size, and safe to hand out without leaking optimizer state. `attribute` picks which component is saved. |
-| `GradNormLogger` | Logs `diag/grad_norm`. |
+| `GradNormLogger` | Logs `diag/grad_norm` every `every_n_batches`. |
 | `LearningRateMonitor` | Lightning's, logging per step. |
+
+Our own cadence arguments are named `every_n_batches` and `every_n_val_runs`, following
+Lightning's own `every_n_train_steps` / `every_n_epochs`: the unit is in the name. The
+old `log_every_n_steps` on a callback was a homonym of `Trainer.log_every_n_steps`, which
+means the metric *flush* cadence — the same word for two different things in one file.
+
+Lightning's own names cannot change, so the residual asymmetry stays: `max_steps` and
+`every_n_train_steps` count optimizer steps while everything else counts batches. An
+adversarial run now **prints the conversion at start** against its own numbers, rather
+than relying on you to have read this page.
 
 Set `monitor_metric` for a metric-monitored top-k, or `monitor_metric: null` with
 `keep_last` for rolling last-N saves by step. **A monitor's direction is validated at

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -81,7 +81,7 @@ class BenchmarkImageLogger(Callback):
       returns ``[primary_val] + [test_loaders...]``; this callback ignores
       ``dataloader_idx == 0`` (handled by `SRLightning.validation_step`) and
       processes indices ``1..N`` against ``dataset_names``.  Images are
-      logged every *n*-th val run (controlled by ``log_every_n_val_runs``)
+      logged every *n*-th val run (controlled by ``every_n_val_runs``)
       so TensorBoard storage stays bounded over long training schedules.
     * **During `cli test`** — `SRDataModule.test_dataloader()` returns the
       test loaders only (no primary), so indices ``0..N-1`` map straight to
@@ -120,7 +120,7 @@ class BenchmarkImageLogger(Callback):
             ``SRDataModule.test_dataloader()`` / the trailing entries of
             ``val_dataloader()``.  When ``None`` the callback auto-discovers
             from ``trainer.datamodule.test_names``.
-        log_every_n_val_runs: Image-strip throttle for the val stage.  With
+        every_n_val_runs: Image-strip throttle for the val stage.  With
             step-based training (e.g. ``val_check_interval=1000``,
             ``max_steps=100_000``) val fires ~100 times, so logging every 5
             runs gives ~20 image snapshots — enough to track visual
@@ -138,12 +138,12 @@ class BenchmarkImageLogger(Callback):
     def __init__(
         self,
         dataset_names: list[str] | None = None,
-        log_every_n_val_runs: int = 5,
+        every_n_val_runs: int = 5,
         log_per_image_metrics: bool = False,
     ):
         super().__init__()
         self.dataset_names = list(dataset_names) if dataset_names else None
-        self.log_every_n_val_runs = log_every_n_val_runs
+        self.every_n_val_runs = every_n_val_runs
         self.log_per_image_metrics = log_per_image_metrics
 
         # Val: primary val is at idx 0, test sets at 1..N → {1: 'Set5', ...}
@@ -317,7 +317,7 @@ class BenchmarkImageLogger(Callback):
 
     def _on_image_log_interval(self) -> bool:
         """Return True when this val run should also log image strips."""
-        return self._val_run_count % self.log_every_n_val_runs == 0
+        return self._val_run_count % self.every_n_val_runs == 0
 
     def _collect_batch(
         self,
@@ -496,16 +496,19 @@ class GradNormLogger(Callback):
     after the backward pass and logs it as the ``"diag/grad_norm"`` scalar.
 
     Args:
-        log_every_n_steps (int): Compute and log every *n* **batches**.
-            Defaults to ``100``. The unit is batches, not optimizer steps, so
-            the configured cadence means the same thing under automatic and
-            manual optimization — and matches the axis the emitted scalar is
-            plotted on. See :func:`_logger_step`.
+        every_n_batches (int): Compute and log every *n* batches. Defaults to
+            ``100``. The unit is in the name deliberately: Lightning's own
+            callbacks do the same (``every_n_train_steps``, ``every_n_epochs``),
+            and the old name was a homonym of ``Trainer.log_every_n_steps``,
+            which means something else — the metric *flush* cadence. Batches
+            also make the setting mean one thing under both automatic and manual
+            optimization, and match the axis the emitted scalar is plotted on.
+            See :func:`_logger_step`.
     """
 
-    def __init__(self, log_every_n_steps: int = 100):
+    def __init__(self, every_n_batches: int = 100):
         super().__init__()
-        self.log_every_n_steps = log_every_n_steps
+        self.every_n_batches = every_n_batches
 
     def on_after_backward(self, trainer: lightning.Trainer, pl_module: lightning.LightningModule):
         """Compute and log gradient norm if on the right step cadence.
@@ -519,7 +522,7 @@ class GradNormLogger(Callback):
             trainer: The trainer instance.
             pl_module: The model being trained.
         """
-        if _logger_step(trainer) % self.log_every_n_steps != 0:
+        if _logger_step(trainer) % self.every_n_batches != 0:
             return
 
         grad_norms = [p.grad.detach().norm(2) for p in pl_module.parameters() if p.grad is not None]
@@ -536,9 +539,9 @@ class WeightHistogramLogger(Callback):
     Groups by prefix, e.g. ``model.feat``, ``model.mapping``, ``model.recon``.
 
     Args:
-        log_every_n_steps (int): Log histograms every *n* **batches**.
-            The unit is batches, not optimizer steps, matching the axis the
-            histograms are written on — see :func:`_logger_step`.
+        every_n_batches (int): Log histograms every *n* batches, matching the
+            axis they are written on — see :func:`_logger_step`. Named for its
+            unit, following Lightning's own ``every_n_*`` callback arguments.
             Defaults to ``10000``. Histograms dominate event-file size, and
             one is written per tracked parameter on every cadence hit — at
             the templates' 1M-step schedule the old default of ``100`` was
@@ -549,9 +552,9 @@ class WeightHistogramLogger(Callback):
             trend across a full run.
     """
 
-    def __init__(self, log_every_n_steps: int = 10000):
+    def __init__(self, every_n_batches: int = 10000):
         super().__init__()
-        self.log_every_n_steps = log_every_n_steps
+        self.every_n_batches = every_n_batches
 
     def on_train_batch_end(
         self,
@@ -571,7 +574,7 @@ class WeightHistogramLogger(Callback):
             batch_idx: Unused.
         """
         step = _logger_step(trainer)
-        if step % self.log_every_n_steps != 0:
+        if step % self.every_n_batches != 0:
             return
 
         tb_logger = next(

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -19,6 +19,7 @@ from typing import Any
 import torch
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
+from lightning_utilities.core.rank_zero import rank_zero_info
 
 from .. import artifacts
 from ..losses import AdversarialLoss
@@ -407,7 +408,7 @@ class SRGANLightning(SRLightning):
             scheduler.step()
 
     def on_fit_start(self) -> None:
-        """Refuse distributed training, then run the base's compile warm-up.
+        """State the step-axis conversion, refuse distributed training, then warm up.
 
         Manual optimization opts out of Lightning's gradient synchronisation:
         with ``automatic_optimization = False`` the strategy's backward no
@@ -423,6 +424,20 @@ class SRGANLightning(SRLightning):
         Raises:
             RuntimeError: If ``trainer.world_size > 1``.
         """
+        # Lightning's own knobs cannot be renamed, and under this paradigm they
+        # count different things: max_steps and every_n_train_steps are optimizer
+        # steps, everything else is batches. Documentation has not been enough --
+        # a max_steps copied from the SRResNet template trains half as long -- so
+        # the conversion is stated once, against this run's actual numbers.
+        max_steps = self.trainer.max_steps
+        if max_steps and max_steps > 0:
+            rank_zero_info(
+                f"SRGAN takes 2 optimizer steps per batch, so max_steps={max_steps} is "
+                f"{max_steps // 2} batches. val_check_interval, every_n_batches and the "
+                f"hand-stepped scheduler milestones all count batches; max_steps and "
+                f"every_n_train_steps count optimizer steps."
+            )
+
         if self.trainer.world_size > 1:
             raise RuntimeError(
                 f"SRGANLightning does not support distributed training "

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -224,10 +224,12 @@ class SRLightning(lightning.LightningModule):
                 self._check_input_contract(s.lr, s.hr, s.source, s.dataset)
                 self._extra_probe(s.lr, s.hr, s.source)
 
-            if self.training_config.example_input_shape is not None:
-                train = probe.train_lr()
-                if train is not None:
-                    train_dataset, train_lr = train
+            train = probe.train_lr()
+            if train is not None:
+                train_dataset, train_lr = train
+                if self.training_config.example_input_shape is None:
+                    self._adopt_example_input_shape(train_lr)
+                else:
                     self._check_example_input_shape(train_lr, train_dataset)
 
     def _check_input_contract(
@@ -308,6 +310,25 @@ class SRLightning(lightning.LightningModule):
             hr: HR sample, ``(C, H, W)``.
             source: Config path the sample came from, for error messages.
         """
+
+    def _adopt_example_input_shape(self, lr: torch.Tensor) -> None:
+        """Take the shape from the real train sample when the config states none.
+
+        The value was previously written out by hand and then checked against this
+        exact tensor — two different rules to compute (crop size over scale for a
+        native-LR dataset, sub-image size for a pre-upsampled one), both derivable
+        from data the probe already holds. A value the code can check is a value
+        the code can supply. An explicit setting still wins, and is still checked,
+        so a config can state an intent and have it verified.
+
+        Args:
+            lr: Real LR sample from the train dataset, shape ``(C, H, W)``.
+        """
+        shape = tuple(int(d) for d in lr.shape)
+        self.training_config.example_input_shape = shape
+        # Drives ModelSummary's FLOPs count and the logged graph; the compile
+        # warm-up reads training_config directly.
+        self.example_input_array = torch.zeros(1, *shape)
 
     def _check_example_input_shape(self, lr: torch.Tensor, train_dataset: Any) -> None:
         """Raise if ``example_input_shape``'s H/W disagrees with the real train LR patch.

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -27,7 +27,6 @@ model:
         class_path: sisr.models.srcnn.SRCNNTrainingConfig
         init_args:
           scale: &scale 3
-          # Must match the real training input: 1-channel Y at subimg_size.
           example_input_shape: [1, 33, 33]
       # Defaults to ssim_impl: wang, the field standard.
       eval_config:
@@ -95,7 +94,7 @@ trainer:
   callbacks:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
-        log_every_n_val_runs: 1
+        every_n_val_runs: 1
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: psnr/val/RGB
@@ -118,7 +117,7 @@ trainer:
         logging_interval: step
     - class_path: sisr.training.GradNormLogger
       init_args:
-        log_every_n_steps: 5000
+        every_n_batches: 5000
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -16,7 +16,7 @@ optimizer:
 lr_scheduler:
   class_path: torch.optim.lr_scheduler.MultiStepLR
   init_args:
-    milestones: [100000]   # BATCHES, not global steps
+    milestones: [100000]
     gamma: 0.1
 
 model:
@@ -52,16 +52,15 @@ model:
       discriminator_lr_scheduler:
         class_path: torch.optim.lr_scheduler.MultiStepLR
         init_args:
-          milestones: [100000]   # BATCHES, not global steps
+          milestones: [100000]
           gamma: 0.1
       # adversarial_loss unset means sisr.losses.AdversarialLoss, over LOGITS.
       training_config:
         class_path: sisr.models.srgan.SRGANTrainingConfig
         init_args:
           # Bare weights (.pt), never the sibling .ckpt. Mismatches are refused.
-          init_from: "experiments/SRResNet/golden/checkpoints/SRResNet_x4_RGB_16B64F_s1000000.safetensors"
-          # Must match the real training input: RGB at hr_crop_size / scale.
           example_input_shape: [3, 24, 24]
+          init_from: "experiments/SRResNet/golden/checkpoints/SRResNet_x4_RGB_16B64F_s1000000.safetensors"
           # adversarial_weight 1.0e-3 and d_steps_per_g_step 1 are the defaults.
       # Defaults add lpips + dists; 'lpips' needs the [perceptual] extra.
       eval_config:
@@ -111,12 +110,12 @@ data:
 
 trainer:
   max_epochs: -1
-  # !! GLOBAL STEPS; val_check_interval and log_every_n_steps are BATCHES. See the docs.
-  max_steps: 400000            # the paper's 2e5 generator iterations
-  val_check_interval: 5000     # batches = every 10000 global steps
+  # Optimizer steps; the run prints the batch equivalent at start.
+  max_steps: 400000
+  val_check_interval: 5000
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
-  log_every_n_steps: 1000      # batches
+  log_every_n_steps: 1000
   deterministic: false
   # Free here: every training step feeds the same fixed crop shape.
   benchmark: true
@@ -127,7 +126,7 @@ trainer:
   callbacks:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
-        log_every_n_val_runs: 1
+        every_n_val_runs: 1
     # Rolling and monitor-free: a PSNR/SSIM top-k would keep the least adversarial state.
     - class_path: sisr.training.SRCheckpoint
       init_args:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -29,7 +29,8 @@ model:
       training_config:
         class_path: sisr.models.srresnet.SRResNetTrainingConfig
         init_args:
-          # Must match the real training input: RGB at hr_crop_size / scale.
+          # Optional when training -- derived from the data. Stated here because
+          # `sisr export` reads this file and has no data to derive it from.
           example_input_shape: [3, 24, 24]
       # Defaults to ssim_impl: daala, the convention this paper used.
       eval_config:
@@ -96,7 +97,7 @@ trainer:
   callbacks:
     - class_path: sisr.training.BenchmarkImageLogger
       init_args:
-        log_every_n_val_runs: 1
+        every_n_val_runs: 1
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: psnr/val/RGB
@@ -119,7 +120,7 @@ trainer:
         logging_interval: step
     - class_path: sisr.training.GradNormLogger
       init_args:
-        log_every_n_steps: 5000
+        every_n_batches: 5000
   logger:
     - class_path: lightning.pytorch.loggers.TensorBoardLogger
       init_args:

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -288,7 +288,7 @@ def _make_gradnorm_pl_module():
 
 
 def test_grad_norm_logger_logs_on_cadence():
-    cb = GradNormLogger(log_every_n_steps=10)
+    cb = GradNormLogger(every_n_batches=10)
     # batch axis ON cadence, optimizer axis OFF -- the gate must read the former.
     trainer = _make_step_axis_trainer(global_step=17, batches_that_stepped=10)
     pl_module = _make_gradnorm_pl_module()
@@ -300,7 +300,7 @@ def test_grad_norm_logger_logs_on_cadence():
 
 
 def test_grad_norm_logger_skips_off_cadence():
-    cb = GradNormLogger(log_every_n_steps=10)
+    cb = GradNormLogger(every_n_batches=10)
     # batch axis OFF cadence, optimizer axis ON.
     trainer = _make_step_axis_trainer(global_step=20, batches_that_stepped=7)
     pl_module = _make_gradnorm_pl_module()
@@ -309,7 +309,7 @@ def test_grad_norm_logger_skips_off_cadence():
 
 
 def test_grad_norm_logger_handles_none_grads():
-    cb = GradNormLogger(log_every_n_steps=1)
+    cb = GradNormLogger(every_n_batches=1)
     pl_module = MagicMock()
     p = torch.zeros(4, requires_grad=True)
     p.grad = None
@@ -333,7 +333,7 @@ def test_grad_norm_logger_uses_grad_detach_not_grad_data():
     assert ".grad.data" not in src
     assert "p.grad.detach()" in src
 
-    cb = GradNormLogger(log_every_n_steps=1)
+    cb = GradNormLogger(every_n_batches=1)
     trainer = _make_step_axis_trainer(global_step=2, batches_that_stepped=1)
     pl_module = _make_gradnorm_pl_module()
     cb.on_after_backward(trainer, pl_module)
@@ -343,7 +343,7 @@ def test_grad_norm_logger_uses_grad_detach_not_grad_data():
 
 
 def test_grad_norm_logger_cadence_counts_batches_not_optimizer_steps():
-    """``log_every_n_steps`` must gate on the axis ``self.log`` writes to.
+    """``every_n_batches`` must gate on the axis ``self.log`` writes to.
 
     ``trainer.global_step`` counts *optimizer* steps, so under manual
     optimization gating on it makes the configured cadence mean a different
@@ -354,13 +354,13 @@ def test_grad_norm_logger_cadence_counts_batches_not_optimizer_steps():
     single direction, passes under a gate reading either axis.
     """
     # global_step ON cadence, batch count OFF -> must not fire.
-    cb = GradNormLogger(log_every_n_steps=10)
+    cb = GradNormLogger(every_n_batches=10)
     pl_module = _make_gradnorm_pl_module()
     cb.on_after_backward(_make_step_axis_trainer(global_step=10, batches_that_stepped=7), pl_module)
     pl_module.log.assert_not_called()
 
     # global_step OFF cadence, batch count ON -> must fire.
-    cb = GradNormLogger(log_every_n_steps=10)
+    cb = GradNormLogger(every_n_batches=10)
     pl_module = _make_gradnorm_pl_module()
     cb.on_after_backward(
         _make_step_axis_trainer(global_step=14, batches_that_stepped=10), pl_module
@@ -397,7 +397,7 @@ def test_weight_histogram_logger_cadence_counts_batches_not_optimizer_steps(
 ):
     """Same gate, same reason as the ``GradNormLogger`` case above."""
     pl_module, tb_logger, add_histogram = _make_histogram_probe(tmp_path, monkeypatch)
-    cb = WeightHistogramLogger(log_every_n_steps=10)
+    cb = WeightHistogramLogger(every_n_batches=10)
 
     # global_step ON cadence, batch count OFF -> must not fire.
     trainer = _make_step_axis_trainer(global_step=10, batches_that_stepped=7)
@@ -424,7 +424,7 @@ def test_weight_histogram_logger_writes_on_the_batch_counted_axis_not_global_ste
     optimizers.
     """
     pl_module, tb_logger, add_histogram = _make_histogram_probe(tmp_path, monkeypatch)
-    cb = WeightHistogramLogger(log_every_n_steps=1)
+    cb = WeightHistogramLogger(every_n_batches=1)
 
     trainer = _make_step_axis_trainer(global_step=400, batches_that_stepped=200)
     trainer.loggers = [tb_logger]
@@ -436,7 +436,7 @@ def test_weight_histogram_logger_writes_on_the_batch_counted_axis_not_global_ste
 
 
 def test_weight_histogram_logger_skips_off_cadence():
-    cb = WeightHistogramLogger(log_every_n_steps=10)
+    cb = WeightHistogramLogger(every_n_batches=10)
     trainer = _make_step_axis_trainer(global_step=20, batches_that_stepped=7)
     pl_module = MagicMock()
     cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
@@ -444,7 +444,7 @@ def test_weight_histogram_logger_skips_off_cadence():
 
 
 def test_weight_histogram_logger_skips_when_no_tb_logger():
-    cb = WeightHistogramLogger(log_every_n_steps=1)
+    cb = WeightHistogramLogger(every_n_batches=1)
     trainer = _make_step_axis_trainer(global_step=2, batches_that_stepped=1)
     pl_module = MagicMock()
     cb.on_train_batch_end(trainer, pl_module, outputs=None, batch=None, batch_idx=0)
@@ -1301,7 +1301,7 @@ def test_benchmark_validation_batch_end_skips_primary_loader():
 
 def test_benchmark_validation_batch_end_collects_for_test_loader():
     """dataloader_idx >= 1 populates the buffer with a BenchmarkSample per image."""
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = _make_real_pl_module()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
@@ -1335,7 +1335,7 @@ def test_benchmark_collect_batch_buffers_no_image_tensors():
     LR/SR/HR tensors -- even when should_log_images is True, since image
     strips are now streamed directly from _collect_batch instead of being
     deferred to epoch end."""
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = _make_real_pl_module()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
@@ -1437,7 +1437,7 @@ def test_benchmark_logger_uses_module_ssim_impl():
     torchmetrics. Guards against the two metric paths drifting apart."""
     import sisr.metrics.ssim
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     pl_module = SRLightning(
@@ -1474,7 +1474,7 @@ def test_benchmark_logger_uses_module_ssim_impl():
 def test_benchmark_validation_epoch_end_logs_means():
     """on_validation_epoch_end consumes the buffer and emits per-dataset mean
     PSNR + SSIM via pl_module.log (verified by mocking the log method)."""
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=99)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=99)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
@@ -1510,7 +1510,7 @@ def test_benchmark_collect_batch_emits_add_image_and_add_scalar(tmp_path: Path, 
     monkeypatch.setattr(experiment, "add_scalar", add_scalar)
 
     cb = BenchmarkImageLogger(
-        dataset_names=["Set5"], log_every_n_val_runs=1, log_per_image_metrics=True
+        dataset_names=["Set5"], every_n_val_runs=1, log_per_image_metrics=True
     )
     trainer = SimpleNamespace(
         datamodule=None,
@@ -1565,7 +1565,7 @@ def test_benchmark_collect_batch_default_omits_per_image_scalars_but_keeps_image
     monkeypatch.setattr(experiment, "add_image", add_image)
     monkeypatch.setattr(experiment, "add_scalar", add_scalar)
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     assert cb.log_per_image_metrics is False
     trainer = SimpleNamespace(
         datamodule=None,
@@ -1600,7 +1600,7 @@ def test_benchmark_collect_batch_log_per_image_metrics_decoupled_from_image_stri
     tmp_path: Path, monkeypatch
 ):
     """log_per_image_metrics=True must emit per-image scalars even on a val run
-    where should_log_images is False (log_every_n_val_runs throttles images,
+    where should_log_images is False (every_n_val_runs throttles images,
     not per-image metrics) — proving the two concerns are independently gated."""
     import lightning.pytorch.loggers as pl_loggers
 
@@ -1612,7 +1612,7 @@ def test_benchmark_collect_batch_log_per_image_metrics_decoupled_from_image_stri
     monkeypatch.setattr(experiment, "add_scalar", add_scalar)
 
     cb = BenchmarkImageLogger(
-        dataset_names=["Set5"], log_every_n_val_runs=99, log_per_image_metrics=True
+        dataset_names=["Set5"], every_n_val_runs=99, log_per_image_metrics=True
     )
     trainer = SimpleNamespace(
         datamodule=None,
@@ -1667,7 +1667,7 @@ def test_benchmark_collect_batch_image_strip_first_panel_is_bicubic_at_hr_size(
     monkeypatch.setattr(torchvision.utils, "make_grid", spy_make_grid)
 
     tb_logger = pl_loggers.TensorBoardLogger(save_dir=str(tmp_path), name="run", version="v")
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     trainer = SimpleNamespace(
         datamodule=None,
         loggers=[tb_logger],
@@ -1724,7 +1724,7 @@ def test_benchmark_collect_batch_image_strip_upsamples_lr_to_hr_size(tmp_path: P
     add_image = MagicMock(wraps=experiment.add_image)
     monkeypatch.setattr(experiment, "add_image", add_image)
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     trainer = SimpleNamespace(
         datamodule=None,
         loggers=[tb_logger],
@@ -1818,7 +1818,7 @@ def test_benchmark_collect_batch_populates_perceptual_dict(monkeypatch):
         "sisr.metrics.scoring.perceptual_score",
         lambda name, sr, hr, lpips_net: sr.sum() - hr.sum(),
     )
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     pl_module = SRLightning(
@@ -1864,7 +1864,7 @@ def test_benchmark_logs_perceptual_per_set():
     MagicMock pl_module is enough here, mirroring
     test_benchmark_validation_epoch_end_logs_means.
     """
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=99)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=99)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = MagicMock()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
@@ -1892,7 +1892,7 @@ def test_weight_histogram_logger_calls_add_histogram_for_model_params_only(
     broken `model.` filter or a missing emit would have passed."""
     import lightning.pytorch.loggers as pl_loggers
 
-    cb = WeightHistogramLogger(log_every_n_steps=1)
+    cb = WeightHistogramLogger(every_n_batches=1)
     pl_module = MagicMock()
     pl_module.named_parameters = MagicMock(
         return_value=[
@@ -1928,7 +1928,7 @@ def test_crop_border_init_arg_rejected():
 def test_benchmark_collect_batch_crops_per_eval_config():
     """When eval_config.crop_border=3, _collect_batch crops 3 pixels per edge
     before computing per-image PSNR/SSIM."""
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     # Real SRLightning with crop_border=3 in eval_config.
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
@@ -1966,7 +1966,7 @@ def test_benchmark_collect_batch_routes_through_processor():
     model forward, then reconstruct SR back to RGB. Bypassing the processor would
     feed 3-channel RGB to a 1-channel Conv2d and crash with a shape mismatch (proven
     here by the forward completing and yielding the expected metric key sets)."""
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     # 1-channel SRCNN paired with YChannelProcessor — production SRCNN template shape.
     model = SRCNN(num_channels=1, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
@@ -2007,7 +2007,7 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_fals
     `_build_psnr_tensors` populates for the colorspace *family*, not the
     configured key set. The emitted key set must equal `eval_config.psnr_keys`
     exactly."""
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     pl_module = SRLightning(
@@ -2039,7 +2039,7 @@ def test_benchmark_collect_batch_psnr_dict_matches_configured_keys_separate_true
     """separate_psnr=True must surface per-channel keys alongside the
     aggregate key for the requested colorspace only — no keys from an
     unrequested colorspace family leak in."""
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
     pl_module = SRLightning(
@@ -2079,7 +2079,7 @@ def test_benchmark_collect_batch_routes_through_predict_rgb():
     spy = MagicMock(wraps=pl_module.predict_rgb)
     pl_module.predict_rgb = spy
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)
     ds = _stub_dataset_with_img_paths(n=2, name="Set5")
@@ -2192,7 +2192,7 @@ def test_benchmark_collect_batch_consumes_srdataset_img_paths(tiny_rgb_image_dir
     ds = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2)
     assert isinstance(ds, SRDataset)
 
-    cb = BenchmarkImageLogger(dataset_names=["Set5"], log_every_n_val_runs=1)
+    cb = BenchmarkImageLogger(dataset_names=["Set5"], every_n_val_runs=1)
     cb.setup(SimpleNamespace(datamodule=None), pl_module=None, stage="fit")
     pl_module = _make_real_pl_module()
     cb.on_validation_epoch_start(trainer=SimpleNamespace(), pl_module=pl_module)

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -572,7 +572,7 @@ def test_matching_discriminator_channels_are_accepted():
 
 def test_ddp_refused():
     module = build_gan_module()
-    module.trainer = SimpleNamespace(world_size=2, precision="32-true")
+    module.trainer = SimpleNamespace(world_size=2, precision="32-true", max_steps=-1)
 
     with pytest.raises(RuntimeError, match="world_size"):
         module.on_fit_start()

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -95,7 +95,7 @@ def test_fast_dev_run_fit_and_test_logs_module_and_callback_metrics(
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
-        callbacks=[BenchmarkImageLogger(log_every_n_val_runs=1)],
+        callbacks=[BenchmarkImageLogger(every_n_val_runs=1)],
     )
 
     trainer.fit(module, datamodule=datamodule)

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1889,3 +1889,50 @@ def test_no_perceptual_tags_when_unrequested(monkeypatch):
     logged = capture_logged_metrics(module)
     module.validation_step((torch.rand(1, 3, 8, 8), torch.rand(1, 3, 32, 32)), 0)
     assert not [tag for tag in logged if tag.startswith(("lpips", "dists"))]
+
+
+def test_example_input_shape_is_derived_from_the_real_train_sample(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """A value the code already checks is a value the code can supply.
+
+    It used to be written out by hand under two different rules -- crop size over
+    scale for a native-LR dataset, sub-image size for a pre-upsampled one -- and
+    then validated against the very tensor those rules describe.
+    """
+    lit = SRLightning(
+        model=SRResNet(scale=2, num_residual_blocks=1),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=2),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    assert lit.training_config.example_input_shape is None
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    lit.setup(stage="fit")
+
+    # hr_crop_size 24 over scale 2, in 3 channels -- never stated anywhere.
+    assert lit.training_config.example_input_shape == (3, 12, 12)
+    assert tuple(lit.example_input_array.shape) == (1, 3, 12, 12)
+
+
+def test_an_explicit_example_input_shape_is_still_checked_not_overwritten(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+):
+    """Stating an intent and having it verified is the reason the field survives."""
+    lit = SRLightning(
+        model=SRResNet(scale=2, num_residual_blocks=1),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=2, example_input_shape=(3, 99, 99)),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    dm = _srresnet_datamodule(tiny_rgb_image_dir, tmp_path, scale=2, hr_crop_size=24)
+    dm.setup(stage="fit")
+    lit.trainer = SimpleNamespace(datamodule=dm)
+
+    with pytest.raises(ValueError, match="example_input_shape"):
+        lit.setup(stage="fit")


### PR DESCRIPTION
Closes #165. Sixth in the stack.

## One name, two meanings

`log_every_n_steps` appeared **twice in every template**, meaning different things: the trainer's
metric *flush* cadence, and a diagnostic callback's *sampling* cadence.

Ours are now `every_n_batches` and `every_n_val_runs`. That **follows** Lightning's convention rather
than breaking it — its own callbacks already name the unit (`every_n_train_steps`, `every_n_epochs`),
and copying a *Trainer* argument name onto a *callback* was the deviation.

## The residual asymmetry, handled honestly

Lightning's own names cannot change, so `max_steps` and `every_n_train_steps` still count optimizer
steps while everything else counts batches. Documentation was not enough — a `max_steps` copied from
the SRResNet template trains an adversarial run **half as long**. So the run now *prints the
conversion at start*, against its own numbers:

```
SRGAN takes 2 optimizer steps per batch, so max_steps=400000 is 200000 batches.
val_check_interval, every_n_batches and the hand-stepped scheduler milestones all
count batches; max_steps and every_n_train_steps count optimizer steps.
```

Five capitalised warning comments come out of the SRGAN template as a result.

## Arithmetic the config did by hand

`example_input_shape` was written out under **two different rules** — crop size over scale for a
native-LR dataset, sub-image size for a pre-upsampled one — and then validated against the very
tensor those rules describe. A value the code can check is a value the code can supply.

It is now optional and derived. An explicit value still wins **and is still checked**, so a config can
state an intent and have it contradicted.

**The templates keep an explicit value**, and the reason is now stated where it is set: they are also
the input to `sisr export`, which never sees training data and has nothing to derive from. I removed
it first and the export subcommand broke — worth saying, because it is the one thing that made this
not a pure simplification.

## Not in scope, deliberately

Splitting configs into a base plus overrides. Considered and rejected before — one self-contained
file per experiment.

## Verification

Full suite: **957 passed, 2 skipped**. `ruff`, `ruff format`, `mypy` clean. New tests cover the
derivation and that an explicit value is still contradicted.

## Note on untracked configs

The gitignored golden run configs still use the old key names. Left alone on purpose — they record
what those runs actually used, and editing them would falsify that.

## BREAKING CHANGE

`GradNormLogger`/`WeightHistogramLogger` take `every_n_batches`; `BenchmarkImageLogger` takes
`every_n_val_runs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)