### PR TITLE
feat: make the metric path correct under distributed training

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,43 @@ Note the asymmetry in the table: `every_n_train_steps` is Lightning's own and co
 optimizer steps, while the filename it produces counts batches. Under SRGAN that means
 a cadence of 10000 writes a file named for batch 5000.
 
+### Multi-GPU
+
+`SRLightning` runs distributed. Two settings are required together:
+
+```yaml
+trainer:
+  devices: 2
+  strategy: ddp
+  use_distributed_sampler: false     # required -- see below
+```
+
+**`use_distributed_sampler: false` is not optional, and a distributed run refuses to
+start without it.** This project shards the *training* loader itself and leaves the
+validation and benchmark loaders whole on every process. Lightning's injection is a
+single trainer-wide switch, so leaving it on would split those too — and
+`DistributedSampler` pads a set to a multiple of the world size by **repeating** samples.
+A five-image benchmark across four processes becomes eight, three counted twice, and the
+reported figure is no longer that set's score. Every process therefore evaluates every
+benchmark image; the cross-process reduction on those metrics is then exact, and doubles
+as a check that the processes have not diverged.
+
+Every validation metric is reduced across processes. Without that each process reports
+its own value as though it were global, and the checkpoint monitors read those and pick
+different checkpoints on different processes. The bare-weights artifact is written by one
+process only.
+
+**`SRGANLightning` still refuses multi-GPU.** Manual optimization opts out of Lightning's
+gradient synchronisation, so the two networks' gradients would not be reduced and each
+process would train its own divergent pair with nothing failing. Supporting it means
+writing that synchronisation explicitly; that is separate work.
+
+**What has been proven, and what has not.** The rank-correctness above is verified on two
+real processes over the gloo backend on CPU, which is what the test suite runs. NCCL
+behaviour, device placement on real GPUs and multi-GPU throughput are **not** covered —
+those need genuine multi-GPU hardware, and containers do not substitute since they share
+the host's devices.
+
 ### The distributable artifact
 
 `SRWeightsCheckpoint` writes **safetensors**, and it is the only format it writes — the

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -445,13 +445,25 @@ class BenchmarkImageLogger(Callback):
 
             for key in psnr_keys:
                 mean_psnr = sum(s.psnr[key] for s in samples) / len(samples)
-                pl_module.log(f"psnr/{dataset_name}/{key}", mean_psnr, add_dataloader_idx=False)
+                pl_module.log(
+                    f"psnr/{dataset_name}/{key}",
+                    mean_psnr,
+                    add_dataloader_idx=False,
+                    sync_dist=True,
+                )
             for key in ssim_keys:
                 mean_ssim = sum(s.ssim[key] for s in samples) / len(samples)
-                pl_module.log(f"ssim/{dataset_name}/{key}", mean_ssim, add_dataloader_idx=False)
+                pl_module.log(
+                    f"ssim/{dataset_name}/{key}",
+                    mean_ssim,
+                    add_dataloader_idx=False,
+                    sync_dist=True,
+                )
             for name in samples[0].perceptual:
                 mean = sum(s.perceptual[name] for s in samples) / len(samples)
-                pl_module.log(f"{name}/{dataset_name}", mean, add_dataloader_idx=False)
+                pl_module.log(
+                    f"{name}/{dataset_name}", mean, add_dataloader_idx=False, sync_dist=True
+                )
 
         self._buffer.clear()
 
@@ -530,7 +542,7 @@ class GradNormLogger(Callback):
             torch.linalg.vector_norm(torch.stack(grad_norms), ord=2).item() if grad_norms else 0.0
         )
 
-        pl_module.log("diag/grad_norm", total_norm, on_step=True, on_epoch=False)
+        pl_module.log("diag/grad_norm", total_norm, on_step=True, on_epoch=False, sync_dist=True)
 
 
 class WeightHistogramLogger(Callback):

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -12,8 +12,9 @@ import inspect
 from typing import Any
 
 import lightning
+import torch.distributed as dist
 from lightning.pytorch.cli import instantiate_class
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader, Dataset, DistributedSampler
 
 _SPEC_KEYS = frozenset({"class_path", "init_args"})
 
@@ -258,15 +259,29 @@ class SRDataModule(lightning.LightningDataModule):
             self._predict_ds = _instantiate_spec("data.predict_dataset", self._predict_spec)
 
     def train_dataloader(self) -> DataLoader:
-        """Build the training DataLoader.
+        """Build the training DataLoader, sharded across processes when distributed.
 
         ``shuffle=True`` is forced — any ``shuffle`` entry the user supplies
         in ``train_dataloader_kwargs`` would be a TypeError (duplicate
         kwarg) and the YAML schema does not expose ``shuffle``.
 
+        **Training is the only loader this module shards, and it shards it here
+        rather than letting Lightning do it.** Lightning's injection is a single
+        trainer-wide switch, and it would also split the validation and benchmark
+        loaders — which must not be split. ``DistributedSampler`` pads a set to a
+        multiple of the world size by *repeating* samples, so a five-image
+        benchmark across four processes becomes eight, three of them counted
+        twice, and the reported figure is no longer that set's score. Every
+        process therefore evaluates every benchmark image, and the reduction
+        across them is a no-op that also catches divergence.
+
         Returns:
-            DataLoader over the train spec, shuffled.
+            DataLoader over the train spec: shuffled, and split per process when
+            a process group is running.
         """
+        if dist.is_available() and dist.is_initialized():
+            sampler = DistributedSampler(self._train_ds, shuffle=True)
+            return DataLoader(self._train_ds, sampler=sampler, **self._train_dl_kwargs)
         return DataLoader(self._train_ds, shuffle=True, **self._train_dl_kwargs)
 
     def val_dataloader(self) -> list[DataLoader]:

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -620,6 +620,9 @@ class SRLightning(lightning.LightningModule):
                 on_step=on_step,
                 on_epoch=not on_step,
                 add_dataloader_idx=False,
+                # Epoch-level only: a per-step training scalar is already the
+                # process's own and reducing it would stall every step.
+                sync_dist=not on_step,
             )
 
     def validation_step(
@@ -646,7 +649,14 @@ class SRLightning(lightning.LightningModule):
 
         # add_dataloader_idx=False keeps metric names clean — needed because the
         # primary val loader is at idx 0 of a list that also contains test loaders.
-        self.log("loss/val", loss, prog_bar=True, on_step=False, add_dataloader_idx=False)
+        # sync_dist on every validation metric: without it each process reports
+        # its own value as though it were global, and the checkpoint monitors
+        # then read those and diverge. Exact here rather than approximate,
+        # because the validation loaders are deliberately not split -- see
+        # SRDataModule.train_dataloader.
+        self.log(
+            "loss/val", loss, prog_bar=True, on_step=False, add_dataloader_idx=False, sync_dist=True
+        )
         self._log_loss_terms("val")
         # prog_bar is a display choice, so it stays with the caller rather than
         # moving into the scorer — the scorer decides values, not presentation.
@@ -661,6 +671,7 @@ class SRLightning(lightning.LightningModule):
                 prog_bar=(tag in prog_bar_tags),
                 on_step=False,
                 add_dataloader_idx=False,
+                sync_dist=True,
             )
 
     def on_fit_start(self) -> None:
@@ -679,11 +690,43 @@ class SRLightning(lightning.LightningModule):
         ``training_config.example_input_shape`` is unset — there is then no
         input shape to probe with (both shipped templates set it).
         """
+        self._check_sampler_ownership()
         if self._compiled is None or self.training_config.example_input_shape is None:
             return
         dummy = torch.zeros(1, *self.training_config.example_input_shape, device=self.device)
         with torch.no_grad():
             self._compiled(dummy)
+
+    def _check_sampler_ownership(self) -> None:
+        """Refuse a distributed run that would let Lightning split the eval loaders.
+
+        :meth:`~sisr.training.datamodule.SRDataModule.train_dataloader` shards the
+        training set itself, precisely so the validation and benchmark loaders are
+        left whole. Lightning's injection is one trainer-wide switch, so leaving it
+        on both double-shards training and splits the benchmark sets --
+        ``DistributedSampler`` pads by repeating samples, so a five-image set across
+        four processes reports a figure that is not that set's score. Silent, and on
+        the metric path, so it is refused rather than warned about.
+
+        Raises:
+            RuntimeError: If running distributed with Lightning's sampler
+                injection still enabled.
+        """
+        # Same degradation as setup(): direct construction in a test attaches no
+        # trainer, and there is then no distributed run to refuse.
+        if self._trainer is None or self.trainer.world_size <= 1:
+            return
+        connector = getattr(self.trainer, "_accelerator_connector", None)
+        if getattr(connector, "use_distributed_sampler", False):
+            raise RuntimeError(
+                "Distributed training needs `trainer.use_distributed_sampler: false`. "
+                "This project shards the training loader itself so the validation and "
+                "benchmark loaders stay whole on every process; leaving Lightning's "
+                "injection on splits those too, and DistributedSampler pads a set by "
+                "repeating samples -- a five-image benchmark across four processes "
+                "would report a score for eight images, three of them counted twice. "
+                "Set trainer.use_distributed_sampler to false in your config."
+            )
 
     def on_train_start(self) -> None:
         """Register val metric tags with TensorBoard's HParams tab.

--- a/tests/training/test_distributed.py
+++ b/tests/training/test_distributed.py
@@ -7,12 +7,21 @@ harness and pin the mechanism the rank-sensitive tests elsewhere depend on;
 they assert nothing about ``sisr`` itself.
 """
 
+import functools
+import json
 from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
 
 import lightning
 import pytest
 import torch
 from torch.utils.data import DataLoader, TensorDataset
+
+from sisr.models.srcnn import SRCNN
+from sisr.processors import RGBProcessor
+from sisr.training import SRDataModule, SREvalConfig, SRLightning
+from sisr.training.config import SRTrainingConfig
 
 # Defined at module scope because ddp_spawn pickles the module across to each
 # worker process; a locally-defined class cannot make that trip.
@@ -42,6 +51,44 @@ class _RankProbe(lightning.LightningModule):
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         return torch.optim.SGD(self.parameters(), lr=0.1)
+
+
+def _make_module() -> SRLightning:
+    """A tiny real module -- the distributed behaviour under test is the project's."""
+    return SRLightning(
+        model=SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same"),
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scale=2),
+        eval_config=SREvalConfig(crop_border=0),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+
+
+def _make_datamodule(image_dir: Path, tmp_path: Path) -> SRDataModule:
+    """Train plus a primary val set and one benchmark set, over the fixture images."""
+    train = {
+        "class_path": "sisr.datasets.srcnn.TrainDataset",
+        "init_args": {
+            "img_dir": str(image_dir),
+            "subimg_size": 33,
+            "stride": 33,
+            "scale": 2,
+            "use_tqdm": False,
+            "cache_dir": str(tmp_path / ".lmdb_ddp"),
+        },
+    }
+    val = {
+        "class_path": "sisr.datasets.srcnn.ValidationDataset",
+        "init_args": {"img_dir": str(image_dir), "scale": 2},
+    }
+    return SRDataModule(
+        train_dataset=train,
+        val_dataset=val,
+        test_datasets={"Set5": val},
+        train_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+        val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+        test_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+    )
 
 
 def _loaders() -> tuple[DataLoader, DataLoader]:
@@ -85,3 +132,83 @@ def test_sync_dist_reduces_across_processes_and_its_absence_does_not(
     assert metrics["probe/reduced"] == pytest.approx(0.5)
     # The reporting process's own rank index, never the mean.
     assert metrics["probe/unreduced"] == pytest.approx(0.0)
+
+
+class _CountsWhatEachProcessSaw(lightning.Callback):
+    """Records per-process batch counts to disk, since ddp_spawn discards workers.
+
+    Written to a rank-named file rather than returned: the spawned processes are
+    gone by the time the test resumes, so anything they learned has to survive
+    them.
+    """
+
+    def __init__(self, out_dir: Path) -> None:
+        self.out_dir = Path(out_dir)
+        self.train = 0
+        self.val = 0
+
+    def on_train_batch_end(self, trainer, pl_module, *args) -> None:
+        self.train += 1
+
+    def on_validation_batch_end(self, trainer, pl_module, *args, **kwargs) -> None:
+        self.val += 1
+
+    def on_fit_end(self, trainer, pl_module) -> None:
+        path = self.out_dir / f"rank{trainer.global_rank}.json"
+        path.write_text(json.dumps({"train": self.train, "val": self.val}))
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_training_is_split_across_processes_and_evaluation_is_not(
+    tiny_rgb_image_dir: Path, tmp_path: Path, two_process_trainer
+) -> None:
+    """The invariant the whole distributed design rests on.
+
+    Training splits, because that is what distributing it means. Evaluation does
+    **not**, because ``DistributedSampler`` pads a set to a multiple of the world
+    size by repeating samples -- a five-image benchmark across four processes
+    would report a figure for eight images with three counted twice, which is not
+    that set's score. Every process therefore scores every image.
+    """
+    counts_dir = tmp_path / "counts"
+    counts_dir.mkdir()
+    module = _make_module()
+    datamodule = _make_datamodule(tiny_rgb_image_dir, tmp_path)
+
+    trainer = two_process_trainer(
+        max_epochs=1,
+        limit_train_batches=1.0,
+        use_distributed_sampler=False,
+        callbacks=[_CountsWhatEachProcessSaw(counts_dir)],
+    )
+    trainer.fit(module, datamodule=datamodule)
+
+    counts = [json.loads((counts_dir / f"rank{r}.json").read_text()) for r in (0, 1)]
+    # Three training samples split evenly over two processes -- and note the
+    # total is FOUR, not three: DistributedSampler pads by repeating one sample
+    # so the shards are equal. Harmless while training, and precisely why the
+    # evaluation loaders below must never go through it.
+    assert [c["train"] for c in counts] == [2, 2], counts
+    # Both loaders in the val list, whole, on both processes: 3 images each.
+    assert all(c["val"] == 6 for c in counts), counts
+
+
+def test_a_distributed_run_refuses_lightning_s_own_sampler_injection() -> None:
+    """Leaving the injection on splits the benchmark sets, silently and on the
+    metric path -- so it is refused rather than warned about."""
+    module = _make_module()
+    module.trainer = SimpleNamespace(
+        world_size=2, _accelerator_connector=SimpleNamespace(use_distributed_sampler=True)
+    )
+
+    with pytest.raises(RuntimeError, match="use_distributed_sampler"):
+        module.on_fit_start()
+
+
+def test_a_single_process_run_is_unaffected_by_the_check() -> None:
+    module = _make_module()
+    module.trainer = SimpleNamespace(
+        world_size=1, _accelerator_connector=SimpleNamespace(use_distributed_sampler=True)
+    )
+
+    module.on_fit_start()  # must not raise

--- a/tests/training/test_distributed.py
+++ b/tests/training/test_distributed.py
@@ -212,3 +212,48 @@ def test_a_single_process_run_is_unaffected_by_the_check() -> None:
     )
 
     module.on_fit_start()  # must not raise
+
+
+def test_the_train_loader_gets_a_distributed_sampler_and_the_eval_loaders_do_not(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+) -> None:
+    """The sampler decision, asserted in-process against a real process group.
+
+    The two-process test above proves the *effect*; this pins the mechanism where
+    it can be read and measured, since that one does its work in processes this
+    one never sees.
+    """
+    datamodule = _make_datamodule(tiny_rgb_image_dir, tmp_path)
+    datamodule.setup(stage="fit")
+
+    # A file-backed rendezvous rather than an in-memory one: HashStore does not
+    # exist in the Windows build, and CI runs there.
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"file:///{(tmp_path / 'pg_store').as_posix().lstrip('/')}",
+        world_size=1,
+        rank=0,
+    )
+    try:
+        train = datamodule.train_dataloader()
+        val_loaders = datamodule.val_dataloader()
+        assert isinstance(train.sampler, torch.utils.data.DistributedSampler)
+        # Every evaluation loader, the primary and the benchmark sets alike.
+        assert not any(
+            isinstance(loader.sampler, torch.utils.data.DistributedSampler)
+            for loader in val_loaders
+        )
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def test_the_train_loader_is_plain_when_no_process_group_is_running(
+    tiny_rgb_image_dir: Path, tmp_path: Path
+) -> None:
+    """A single-process run must not pay for machinery it is not using."""
+    datamodule = _make_datamodule(tiny_rgb_image_dir, tmp_path)
+    datamodule.setup(stage="fit")
+
+    assert not isinstance(
+        datamodule.train_dataloader().sampler, torch.utils.data.DistributedSampler
+    )


### PR DESCRIPTION
Closes #118. Top of the stack.

## The state before

Only the adversarial module said anything about multi-GPU. The base module and every callback **failed
open**: nothing was wrong until someone set `devices: 2`, and then nothing failed either — the numbers
were just wrong.

## Three silent defects

**1. `sync_dist` appeared nowhere.** Every validation metric was one process's shard mean presented as
global, and the checkpoint monitors read those — so different processes would have kept different
checkpoints. All validation and benchmark metrics now reduce. Per-step *training* scalars deliberately
do not: they are already the process's own, and reducing one would stall every step.

**2. The evaluation loaders would have been split.** This is the subtle one, and it is why this PR
looks the way it does. `DistributedSampler` pads a set to a multiple of the world size by
**repeating** samples. A five-image benchmark across four processes reports a figure for *eight*
images with three counted twice — not that set's score, on the metric path this project's central
claim rests on.

So the datamodule shards the **training** loader itself and leaves evaluation whole on every process.
Lightning's injection is one trainer-wide switch, so a distributed run **refuses to start** with it
still enabled rather than silently re-splitting them.

**3. The bare-weights write happened on every process** — already fixed earlier in this stack.

## The padding is demonstrated, not asserted

The test found it rather than assuming it: three training samples across two processes produce **four**
batches, not three. That is the padding, visible. Harmless while training, and exactly why evaluation
must not go through it.

## Verification, and its limits

Proven on **two real processes over gloo, on CPU**, using the harness at the bottom of this stack — so
rank-correctness is demonstrated rather than reasoned about, on a single-GPU machine. Stable across
three consecutive runs.

**Not covered, and the docs say so:** NCCL behaviour, device placement on real GPUs, throughput. Those
need genuine multi-GPU hardware; containers do not substitute, since they share the host's devices.

## Scope note

`SRGANLightning` **still refuses**. Manual optimization opts out of Lightning's gradient
synchronisation, so the two networks' gradients would not be reduced and each process would train its
own divergent pair with nothing failing. Supporting that means writing the synchronisation explicitly
— its own piece of work, not a line in this one. The models are covered; the adversarial paradigm is
not.

Full suite: **960 passed, 2 skipped**. `ruff`, `ruff format`, `mypy` clean.

## Risk

Not LOW. Metric path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)