### PR TITLE
ci: stop a cancelled run publishing a red required check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,13 @@ jobs:
   # Stable required-check context: matrix legs are not fixed contexts themselves.
   build:
     needs: [build-matrix, editable-install]
-    if: always()
+    # Not always(): that also fires when the RUN is cancelled, and a cancelled upstream is
+    # neither success nor skipped, so the gate published a red required check for a run
+    # nobody cares about. !cancelled() still runs on success, failure and skip -- the skip
+    # case is a doc-only PR, and is the whole reason this job cannot simply depend on
+    # success. An upstream cancelled while the run itself lives (fail-fast killing a
+    # sibling) still reports red, which is correct.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all matrix legs to pass or be skipped (doc-only PR)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,13 @@ jobs:
   # Stable required-check context: matrix legs are not fixed contexts themselves.
   test:
     needs: [test-matrix, onnx-export]
-    if: always()
+    # Not always(): that also fires when the RUN is cancelled, and a cancelled upstream is
+    # neither success nor skipped, so the gate published a red required check for a run
+    # nobody cares about. !cancelled() still runs on success, failure and skip -- the skip
+    # case is a doc-only PR, and is the whole reason this job cannot simply depend on
+    # success. An upstream cancelled while the run itself lives (fail-fast killing a
+    # sibling) still reports red, which is correct.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all matrix legs to pass or be skipped (doc-only PR)


### PR DESCRIPTION
Closes #161.

## The change

Both workflows' gate jobs move from `if: always()` to `if: ${{ !cancelled() }}`.

`always()` also fires when the **run** was cancelled. The upstream results are then
`cancelled` — neither `success` nor `skipped` — so the gate exits 1 and leaves a red
required check sitting on the same commit as the successful run. Pushing a stack fires two
`pull_request` events per branch and `cancel-in-progress` kills the first, so this recurred
on every stack push.

`always()` was not gratuitous: it is what lets the gate pass when the legs are **skipped**,
which is what the path filter does on a doc-only PR. `!cancelled()` keeps that and drops
only the cancelled case.

An upstream cancelled while the run itself lives (fail-fast killing a sibling) still reports
red — correct, so the shell test is unchanged.

## Acceptance

- [x] A genuine matrix run still reports the gate green — this PR touches `.github/**`,
      which the filter treats as code, so its own matrix is the evidence.
- [ ] A doc-only PR still reports the gate green — **verified by the PR stacked on top of
      this one**, which is `CHANGELOG.md` only and so runs with the legs skipped. That is
      why it is stacked rather than independent: the issue asks for this to be verified
      against a real doc-only PR, not by reading the expression.
- [ ] A cancelled run publishes no red check — observable the next time a stack push
      double-triggers.