### PR TITLE
fix: type-check the datamodule, and refuse a loader built before setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ check_untyped_defs = true
 # Lightning's hook system and jsonargparse's subclass resolution fight a checker.
 module = [
     "sisr.training.callbacks",
-    "sisr.training.datamodule",
     "sisr.training.gan_module",
     "sisr.training.lightning_module",
     "sisr.cli",

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -85,6 +85,29 @@ def _accepted_init_args(class_path: str) -> list[str] | None:
     )
 
 
+def _require(ds: Dataset | None, which: str, stage: str) -> Dataset:
+    """Narrow a lazily-instantiated dataset, naming what should have created it.
+
+    Args:
+        ds: The dataset attribute, ``None`` until ``setup`` has run.
+        which: Loader name, used to build the error message.
+        stage: The ``setup`` stage that instantiates this dataset.
+
+    Returns:
+        ``ds``, narrowed to non-optional.
+
+    Raises:
+        RuntimeError: If ``setup`` has not instantiated it yet.
+    """
+    if ds is None:
+        raise RuntimeError(
+            f"SRDataModule.{which}_dataloader() called before setup({stage!r}) "
+            f"instantiated the {which} dataset. Lightning calls setup() itself; a "
+            "direct caller has to."
+        )
+    return ds
+
+
 def _instantiate_spec(field_name: str, spec: dict[str, Any]) -> Any:
     """Materialises a dataset spec, naming the field when an init_arg is wrong.
 
@@ -278,11 +301,15 @@ class SRDataModule(lightning.LightningDataModule):
         Returns:
             DataLoader over the train spec: shuffled, and split per process when
             a process group is running.
+
+        Raises:
+            RuntimeError: If ``setup('fit')`` has not run.
         """
+        train_ds = _require(self._train_ds, "train", "fit")
         if dist.is_available() and dist.is_initialized():
-            sampler = DistributedSampler(self._train_ds, shuffle=True)
-            return DataLoader(self._train_ds, sampler=sampler, **self._train_dl_kwargs)
-        return DataLoader(self._train_ds, shuffle=True, **self._train_dl_kwargs)
+            sampler: DistributedSampler[Any] = DistributedSampler(train_ds, shuffle=True)
+            return DataLoader(train_ds, sampler=sampler, **self._train_dl_kwargs)
+        return DataLoader(train_ds, shuffle=True, **self._train_dl_kwargs)
 
     def val_dataloader(self) -> list[DataLoader]:
         """Primary validation loader followed by every test loader.
@@ -294,8 +321,12 @@ class SRDataModule(lightning.LightningDataModule):
         Returns:
             List ``[primary_val_loader, test_loader_1, test_loader_2,
             ...]``. Length is ``1 + len(test_names)``.
+
+        Raises:
+            RuntimeError: If ``setup('fit')`` has not run.
         """
-        loaders = [DataLoader(self._val_ds, shuffle=False, **self._val_dl_kwargs)]
+        val_ds = _require(self._val_ds, "val", "fit")
+        loaders = [DataLoader(val_ds, shuffle=False, **self._val_dl_kwargs)]
         for ds in self._test_ds.values():
             loaders.append(DataLoader(ds, shuffle=False, **self._test_dl_kwargs))
         return loaders

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -17,7 +17,6 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 EXPECTED_IGNORED = {
     "sisr.cli",
     "sisr.training.callbacks",
-    "sisr.training.datamodule",
     "sisr.training.gan_module",
     "sisr.training.lightning_module",
 }

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -279,6 +279,23 @@ def test_predict_dataloader_default_kwargs(tiny_rgb_image_dir: Path):
     assert dm._predict_dl_kwargs == {"batch_size": 1, "num_workers": 0}
 
 
+@pytest.mark.parametrize("loader", ["train", "val"])
+def test_dataloader_before_setup_names_the_stage_that_was_missed(
+    tiny_rgb_image_dir: Path, loader: str
+):
+    """Loader called before setup() -> a RuntimeError naming setup, not a NoneType crash.
+
+    Lightning calls setup() itself, so this only fires for a direct caller — a test,
+    a notebook, or a script driving the module by hand. Before the guard the call
+    **did not raise at all**: DataLoader wraps ``None`` without complaint because its
+    sampler only takes ``len()`` on iteration, so the failure surfaced later and
+    somewhere else, naming neither the module nor the call that was skipped.
+    """
+    dm = _make_dm(tiny_rgb_image_dir)
+    with pytest.raises(RuntimeError, match=r"setup\('fit'\)"):
+        getattr(dm, f"{loader}_dataloader")()
+
+
 def test_predict_dataloader_without_predict_dataset_raises(tiny_rgb_image_dir: Path):
     """No predict_dataset configured -> a clear RuntimeError, not a silent None loader."""
     dm = _make_dm(tiny_rgb_image_dir)


### PR DESCRIPTION
First of the five modules exempt from the type gate, and the cheapest. Four remain, so
**#157 stays open** — this PR does not close it.

## The finding

Typing the module surfaced exactly the class of defect the narrowing was expected to
surface. The dataset attributes are `Optional` until `setup()` instantiates them, and
`train_dataloader` / `val_dataloader` read them without narrowing.

That is not merely a checker complaint. **`DataLoader` wraps `None` without complaint** —
its sampler only takes `len()` on iteration — so a loader built before `setup()` came back
looking fine and failed later, somewhere else, naming neither the module nor the call that
had been skipped. The test is `DID NOT RAISE` on pre-fix `main`, not a wrong exception type.

## The fix

`_require()` narrows and raises, naming the `setup` stage that fills the dataset. It follows
the shape `predict_dataloader()` already used for its own missing-dataset case, so the
module now answers both questions the same way.

## Evidence

- Test proven RED on pre-fix `main` (`DID NOT RAISE RuntimeError`, both loaders) → GREEN.
- `sisr.training.datamodule` removed from the mypy exemption list; `mypy sisr` clean.
- `ruff` + `ruff format` clean; `tests/training/test_datamodule.py` + `test_distributed.py`
  36 passed.