### PR TITLE
fix: type-check the CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,6 @@ module = [
     "sisr.training.callbacks",
     "sisr.training.gan_module",
     "sisr.training.lightning_module",
-    "sisr.cli",
 ]
 ignore_errors = true
 

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -161,7 +161,9 @@ class SRLightningCLI(LightningCLI):
     ``Trainer`` subclass), as long as it also provides ``export``.
     """
 
-    def __init__(self, *args, trainer_class: type[Trainer] = _ExportTrainer, **kwargs):
+    def __init__(
+        self, *args: Any, trainer_class: type[Trainer] = _ExportTrainer, **kwargs: Any
+    ) -> None:
         # LightningCLI resolves a parser for *every* registered subcommand during
         # __init__, so a trainer_class without `export` fails as a bare AttributeError
         # from inside Lightning. Say what is actually wrong instead.
@@ -182,7 +184,11 @@ class SRLightningCLI(LightningCLI):
         # disabling the selector by name instead would change parsing for every
         # dataclass-typed field in Lightning and jsonargparse too.
         set_parsing_settings(subclasses_enabled=[SREvalConfig, SRTrainingConfig])
-        super().__init__(*args, trainer_class=trainer_class, **kwargs)
+        # mypy cannot rule out a positional *args long enough to reach the parent's own
+        # trainer_class parameter. No caller does that -- every one of ours passes model
+        # and datamodule classes by keyword -- and narrowing *args to forbid it would mean
+        # restating LightningCLI's whole signature here.
+        super().__init__(*args, trainer_class=trainer_class, **kwargs)  # type: ignore[misc]
 
     def parse_arguments(self, parser: LightningArgumentParser, args: ArgsType) -> None:
         """Parse CLI arguments, turning a known jsonargparse crash into an actionable error.
@@ -231,7 +237,7 @@ class SRLightningCLI(LightningCLI):
                 "in your YAML config instead of overriding an existing one from the CLI."
             ) from e
 
-    def add_arguments_to_parser(self, parser):
+    def add_arguments_to_parser(self, parser: LightningArgumentParser) -> None:
         """Wire top-level ``optimizer:`` / ``lr_scheduler:`` / ``matmul_precision:`` keys.
 
         Subclass mode (``subclass_mode_model=True``) means the module's init args
@@ -253,7 +259,7 @@ class SRLightningCLI(LightningCLI):
             ),
         )
 
-    def before_instantiate_classes(self):
+    def before_instantiate_classes(self) -> None:
         """Apply process-global flags (``matmul_precision``) before class instantiation."""
         if self.subcommand is None:
             return

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -15,7 +15,6 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 #: resolution) makes them fight a type checker rather than benefit from one.
 #: Narrowing this list is the point; widening it needs a reason in the diff.
 EXPECTED_IGNORED = {
-    "sisr.cli",
     "sisr.training.callbacks",
     "sisr.training.gan_module",
     "sisr.training.lightning_module",


### PR DESCRIPTION
Second of the modules exempt from the type gate. Three remain, so **#157 stays open**.

## A correction worth making in the issue

The exemption list predicted `cli` would be the hardest. Measured, it is the *easiest* —
four errors. Actual counts with each module's exemption lifted in turn:

| module | errors |
|---|---|
| `sisr.training.callbacks` | 39 |
| `sisr.training.gan_module` | 9 |
| `sisr.training.lightning_module` | 9 |
| `sisr.cli` | 4 |
| `sisr.training.datamodule` | 5 (landed below) |

`callbacks` is the large one, and it is also the module an open review candidate wants
split into three — worth sequencing those together rather than typing it twice.

## The changes

Three were missing annotations on hook overrides (`add_arguments_to_parser`,
`before_instantiate_classes`, `__init__`).

The fourth is real but not actionable: mypy cannot rule out a positional `*args` long
enough to reach `LightningCLI`'s own `trainer_class` parameter, so the forwarding call
looks like it passes that argument twice. No caller does this, and narrowing `*args` to
forbid it would mean restating `LightningCLI`'s whole signature here. Suppressed at the one
call site with the reason stated — one ignore against three real annotations, which is the
ratio #157 asks to stay on the right side of.

## Evidence

`mypy sisr` clean with `sisr.cli` removed from the exemption list. `ruff` + `ruff format`
clean. `tests/test_cli.py` 38 passed.

Stacked on #180.