### PR TITLE
fix: type-check the GAN module, and refuse a scheduler it cannot step

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ check_untyped_defs = true
 # Lightning's hook system and jsonargparse's subclass resolution fight a checker.
 module = [
     "sisr.training.callbacks",
-    "sisr.training.gan_module",
 ]
 ignore_errors = true
 

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import torch
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+from lightning.pytorch.core.optimizer import LightningOptimizer
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 from lightning_utilities.core.rank_zero import rank_zero_info
 
@@ -103,6 +104,11 @@ class SRGANLightning(SRLightning):
         TypeError: Via :class:`SRLightning` if ``model`` / ``processor`` are
             not of the required base types.
     """
+
+    # Narrowed from SRLightning's SRTrainingConfig. __init__ already refuses anything
+    # else at construction, so this records a guarantee the class enforces rather than
+    # adding one -- and it is what lets the adversarial-only fields below be read.
+    training_config: SRGANTrainingConfig
 
     def __init__(
         self,
@@ -313,9 +319,48 @@ class SRGANLightning(SRLightning):
             schedulers.append(self.lr_scheduler(opt_g))
         if self.discriminator_lr_scheduler is not None:
             schedulers.append(self.discriminator_lr_scheduler(opt_d))
+        for scheduler in schedulers:
+            if isinstance(scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
+                raise ValueError(
+                    "ReduceLROnPlateau is not supported for adversarial training. "
+                    "Manual optimization means this module steps its own schedulers, "
+                    "in on_train_batch_end, with no metric to hand them -- "
+                    "scheduler.step() would raise mid-run. Lightning's `monitor` "
+                    "plumbing only applies to the automatic-optimization path this "
+                    "module opts out of. Use a schedule that steps on time "
+                    "(StepLR, MultiStepLR, CosineAnnealingLR), which is also what the "
+                    "paper's two-phase 1e-4 -> 1e-5 drop is."
+                )
         return [opt_g, opt_d], schedulers
 
-    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> None:
+    def _paired_optimizers(self) -> tuple[LightningOptimizer, LightningOptimizer]:
+        """The generator and discriminator optimizers, in that order.
+
+        ``optimizers()`` spans the single-optimizer case in its return type, where
+        this module always configures exactly two. The check makes that invariant
+        enforced rather than merely intended, which matters for a subclass that
+        overrides :meth:`configure_optimizers`.
+
+        Returns:
+            ``(generator_optimizer, discriminator_optimizer)``.
+
+        Raises:
+            RuntimeError: If ``configure_optimizers`` did not produce exactly two.
+        """
+        optimizers = self.optimizers()
+        if not isinstance(optimizers, list) or len(optimizers) != 2:
+            raise RuntimeError(
+                f"SRGANLightning expects exactly two optimizers, generator then "
+                f"discriminator, but Lightning holds {optimizers!r}. A subclass "
+                f"overriding configure_optimizers has to keep that shape and order: "
+                f"training_step unpacks them positionally."
+            )
+        g, d = optimizers
+        return g, d
+
+    def training_step(  # type: ignore[override]  # manual optimization returns nothing
+        self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int
+    ) -> None:
         """One Goodfellow outer iteration: a discriminator step, plus every k-th a generator one.
 
         Order is discriminator-first (Algorithm 1), so the generator is updated
@@ -340,7 +385,7 @@ class SRGANLightning(SRLightning):
             returned loss.
         """
         lr_img, hr_img = batch
-        opt_g, opt_d = self.optimizers()
+        opt_g, opt_d = self._paired_optimizers()
 
         sr, _, hr_cropped = self._forward_sr(lr_img, hr_img, need_sr_rgb=False)
         hr_for_loss = self.processor.extract_target(hr_cropped)
@@ -381,6 +426,39 @@ class SRGANLightning(SRLightning):
         self.log("loss/train/adv", adversarial, on_step=True)
         self._log_loss_terms("train")
 
+    def _time_schedulers(self) -> list[torch.optim.lr_scheduler.LRScheduler]:
+        """Every configured scheduler, as a list, each one steppable with no argument.
+
+        ``lr_schedulers()`` returns the scheduler ITSELF when exactly one is
+        configured and a list only when there are several, so the shape has to be
+        normalised before iterating.
+
+        Returns:
+            The configured schedulers, empty when none are.
+
+        Raises:
+            RuntimeError: If a ``ReduceLROnPlateau`` reaches here. It cannot arrive
+                through :meth:`configure_optimizers`, which refuses it; a subclass
+                that builds its own has to refuse it too, because this module steps
+                schedulers by hand and has no metric to pass.
+        """
+        schedulers = self.lr_schedulers()
+        if schedulers is None:
+            return []
+        if not isinstance(schedulers, list):
+            schedulers = [schedulers]
+        stepped = []
+        for scheduler in schedulers:
+            if isinstance(scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
+                raise RuntimeError(
+                    f"{type(scheduler).__name__} needs a monitored metric, and manual "
+                    f"optimization steps schedulers here with none to give it. "
+                    f"configure_optimizers refuses it; a subclass overriding that has "
+                    f"to refuse it too."
+                )
+            stepped.append(scheduler)
+        return stepped
+
     def on_train_batch_end(self, outputs: Any, batch: Any, batch_idx: int) -> None:
         """Step the LR schedulers by hand — manual optimization does not.
 
@@ -397,14 +475,7 @@ class SRGANLightning(SRLightning):
                 every batch steps the schedulers, including the ones that skip
                 the generator, since the discriminator stepped regardless.
         """
-        schedulers = self.lr_schedulers()
-        if schedulers is None:
-            return
-        # lr_schedulers() returns the scheduler ITSELF when exactly one is
-        # configured, and a list only when there are several.
-        if not isinstance(schedulers, list):
-            schedulers = [schedulers]
-        for scheduler in schedulers:
+        for scheduler in self._time_schedulers():
             scheduler.step()
 
     def on_fit_start(self) -> None:

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -16,7 +16,6 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 #: Narrowing this list is the point; widening it needs a reason in the diff.
 EXPECTED_IGNORED = {
     "sisr.training.callbacks",
-    "sisr.training.gan_module",
 }
 
 

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -493,6 +493,50 @@ def test_training_keeps_updating_across_a_validation_boundary():
 # ---------------------------------------------------------------------------
 
 
+def plateau():
+    return lambda opt: torch.optim.lr_scheduler.ReduceLROnPlateau(opt)
+
+
+@pytest.mark.parametrize("which", ["lr_scheduler", "discriminator_lr_scheduler"])
+def test_a_plateau_scheduler_is_refused_where_it_cannot_be_stepped(which):
+    """ReduceLROnPlateau.step() takes a metric; this module steps by hand with none.
+
+    Manual optimization opts out of Lightning's `monitor` plumbing, so a plateau
+    scheduler configured here does not fail at setup -- it fails on the first
+    on_train_batch_end, part-way into a run, with a bare TypeError about a missing
+    positional argument. Refusing it at configure_optimizers turns a mid-run crash
+    into a startup error that says what to use instead.
+    """
+    module = build_gan_module(**{which: plateau()})
+
+    with pytest.raises(ValueError, match="ReduceLROnPlateau is not supported"):
+        module.configure_optimizers()
+
+
+def test_a_plateau_scheduler_reaching_the_step_hook_is_refused_too():
+    """The refusal above lives in configure_optimizers, which a subclass may replace.
+
+    _time_schedulers is what actually steps them, so it re-checks rather than
+    trusting a guarantee it does not own.
+    """
+    module = build_gan_module()
+    opt = torch.optim.SGD(module.model.parameters(), lr=0.1)
+    module.lr_schedulers = lambda: torch.optim.lr_scheduler.ReduceLROnPlateau(opt)
+
+    with pytest.raises(RuntimeError, match="needs a monitored metric"):
+        module._time_schedulers()
+
+
+def test_optimizers_are_unpacked_by_a_checked_pair_not_positionally():
+    """training_step unpacks two optimizers positionally, which is silent if a
+    subclass's configure_optimizers returns a different shape."""
+    module = build_gan_module()
+    module.optimizers = lambda: torch.optim.SGD(module.model.parameters(), lr=0.1)
+
+    with pytest.raises(RuntimeError, match="exactly two optimizers"):
+        module._paired_optimizers()
+
+
 @_ignore_cpu_fit_warnings
 def test_a_single_lr_scheduler_steps_once_per_batch():
     """With exactly one scheduler configured, LightningModule.lr_schedulers()


### PR DESCRIPTION
Fourth of the five modules exempt from the type gate. **Only `callbacks` remains**, so #157
stays open.

## A real defect, found by typing

`ReduceLROnPlateau.step()` takes a metric. This module steps its schedulers **by hand** in
`on_train_batch_end`, with none to give them, because manual optimization opts out of
Lightning's `monitor` plumbing.

Configuring one did not fail at setup. It failed **part-way into a run**, with a bare
`TypeError` about a missing positional argument — after however many hours of training had
already happened.

`configure_optimizers` now refuses it at startup and names what to use instead (the paper's
own `1e-4 -> 1e-5` drop is time-based anyway). `_time_schedulers` re-checks rather than
trusting a guarantee it does not own, since a subclass can replace `configure_optimizers`.

## The bulk: one missing declaration

Six of the nine errors were the same thing. `SRGANLightning.__init__` already refuses a
`training_config` that is not an `SRGANTrainingConfig` — but the attribute kept the base
class's type, so every adversarial-only field it reads (`init_from`, `adversarial_weight`,
`d_steps_per_g_step`) looked undefined. Declaring the narrowed type records a guarantee the
class already enforces.

## Also

`_paired_optimizers` turns "there are exactly two optimizers, generator first" from an
invariant `training_step` assumed into one it checks — `optimizers()` spans the
single-optimizer case in its return type, and a subclass returning a different shape would
otherwise fail as a confusing unpack.

**One ignore remains, deliberately**: `training_step` returns `None`. Lightning's own
contract permits that under manual optimization; only this project's base class narrows the
return to `Tensor`.

## Evidence

- Four tests proven RED on pre-fix code, GREEN after.
- `mypy sisr` clean with `sisr.training.gan_module` removed from the exemption list.
- `ruff` + `ruff format` clean; `tests/training/test_gan_module.py` 43 passed.

Stacked on #183.