### PR TITLE
docs: write the weight-licence policy before there are weights to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,12 +525,42 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Model weights
 
-No pretrained checkpoint is released yet. When one is, it will be MIT-licensed by
-default, matching the code. One caveat worth stating up front: training data such as
-DIV2K carries an "academic research purpose only" restriction, and whether that kind of
-training-data restriction legally propagates to a derivative model's weights is a
-genuinely unsettled question in ML/copyright practice today — a prospective commercial
-user of a future checkpoint should treat that as an open question, not a resolved one.
+**No pretrained checkpoint is released yet.** This section is the policy that will apply
+when one is, written now because it is free to decide today and awkward to decide under
+pressure later.
+
+**Licence: MIT, matching the code**, with the caveat below stated alongside the download
+rather than buried.
+
+**The caveat.** Training data such as DIV2K carries an *"academic research purpose only"*
+restriction. Whether that kind of training-data restriction legally propagates to a
+derivative model's weights is a **genuinely unsettled question** in ML/copyright practice
+today. A prospective commercial user of a future checkpoint should treat it as an open
+question, not a resolved one — this project states the input and declines to assert the
+conclusion in either direction.
+
+**What this repository redistributes, now and at release.**
+
+| artifact | redistributed? |
+|---|---|
+| Source code | Yes — MIT. |
+| Training data (DIV2K) | **No.** Fetched by the user; `data/` is not tracked. |
+| Benchmark data (Set5, Set14, BSD100) | **No.** Fetched by the user from the EDSR authors' archive, whose SHA-256 is pinned under [Comparability](#comparability) so the copy can be checked without being shipped. |
+| Generated LR / `Bicubic_up` reference pairs | **No** — they are derivatives of the above and inherit whatever those carry. |
+| Trained weights | Not yet. MIT when released, under the caveat above. |
+| Benchmark output images (SR reconstructions) | Not yet, and **not without a per-set check first**. |
+
+**Benchmark sets carry real and differing licensing friction**, which is why the last row is
+not a blanket yes. Set5, Set14 and BSD100 originate from separate publications with separate
+terms, and "we redistribute nothing" is what currently makes that moot. Any release that
+ships reconstructed images — a qualitative figure, a demo gallery — stops it being moot and
+needs the terms of that specific set checked first. Pinning the archive hash rather than
+mirroring the archive is a deliberate choice in the same direction.
+
+**The tests are hermetic for this reason too.** Every test that needs benchmark data skips
+cleanly when it is absent, so CI never requires a copy and a contributor without the archive
+still gets a green suite. **A skip means the case was not exercised, never that it passed**
+— check the skip count, not just the exit code.
 
 ## License
 


### PR DESCRIPTION
Closes #131. Top of the docs stack (#185 → #186 → this).

## What was missing

The README already said a future checkpoint would be MIT and named the DIV2K restriction.
What it did **not** say is what this project redistributes — which is the half that actually
constrains anything.

Now a table covering every artifact: no dataset is shipped, no derived LR/`Bicubic_up` pair
is shipped, and **benchmark output images are explicitly not a blanket yes**.

## The substantive point

**Benchmark sets carry real and differing licensing friction.** Set5, Set14 and BSD100 come
from separate publications with separate terms. "We redistribute nothing" is what currently
makes that moot — and any release that ships reconstructed images (a qualitative figure, a
demo gallery) stops it being moot and needs that specific set's terms checked first.

Pinning the archive's SHA-256 rather than mirroring the archive is the same choice in
miniature, now stated as a choice rather than left as an implementation detail. So is the
reason every data-dependent test skips rather than requires the data.

## Needs your sign-off, not just review

Two judgement calls here are yours rather than mine, and both are one-line edits if you
disagree:

1. **MIT for the weights**, matching the code — carried over from what the README already
   said, not newly decided.
2. **Stating the DIV2K propagation question as unsettled and declining to assert a
   conclusion either way.** The alternative is to assert one, which I do not think this
   project should do.

I have deliberately **not** asserted any specific external licence text for the benchmark
sets, because I have not verified it against the primary sources. The policy says those
terms must be checked per set before anything is redistributed, which is true regardless of
what they turn out to say.