### PR TITLE
docs: correct every stale .pt reference the artifact arc left behind

### DIFF
--- a/sisr/models/srgan/config.py
+++ b/sisr/models/srgan/config.py
@@ -14,7 +14,7 @@ class SRGANTrainingConfig(SRResNetTrainingConfig):
     """SRGAN training defaults. The generator is SRResNet, so ``scale=4`` is inherited.
 
     Args:
-        init_from: Path to a bare-weights ``.pt`` whose generator weights
+        init_from: Path to a bare-weights ``.safetensors`` whose generator weights
             initialise this run's generator. The paper scopes the MSE-init
             trick to "when training the actual GAN", so a paper-faithful SRGAN
             run starts from an MSE-trained SRResNet. Optional: unset trains

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -624,7 +624,7 @@ class _RollingSaveMixin:
     across both. The window bookkeeping itself lives in
     :meth:`_enforce_rolling_window`, a seam distinct from ``_save_checkpoint``:
     :class:`SRWeightsCheckpoint` already overrides ``_save_checkpoint`` to
-    write a bare ``.pt`` payload instead of Lightning's full checkpoint, and
+    write a bare ``.safetensors`` payload instead of Lightning's full checkpoint, and
     that override does not call ``super()._save_checkpoint()`` — so a version
     of this mixin that put the bookkeeping inside its own ``_save_checkpoint``
     would be shadowed by that override and silently never run. Each
@@ -945,11 +945,11 @@ class SRCheckpoint(_SRCheckpointBase):
 
 
 class SRWeightsCheckpoint(_SRCheckpointBase):
-    """Model checkpoint that saves bare, optimizer-free weights as ``.pt`` files.
+    """Model checkpoint that saves bare, optimizer-free weights as ``.safetensors``.
 
     A distributable sibling to :class:`SRCheckpoint`: that class produces resumable
     ``.ckpt`` files (full training state — optimizer moments, LR scheduler, callback
-    state); this one produces ``.pt`` files containing only
+    state); this one produces ``.safetensors`` files containing only
     ``getattr(pl_module, attribute).state_dict()`` plus a matching provenance dict.
     By default ``attribute='model'`` — the bare :class:`~sisr.models.base.SRModel` (so
     keys carry no ``model.`` wrapper prefix), described by
@@ -969,7 +969,7 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
     ``test_sr_weights_checkpoint_writes_bare_payload_via_real_fit`` guards against a
     future Lightning release routing saves through a different method: that test fails
     loudly rather than silently letting saves fall back to full, optimizer-bearing
-    checkpoints under a misleadingly bare ``.pt`` extension.
+    checkpoints under a misleadingly bare ``.safetensors`` extension.
 
     ``FILE_EXTENSION`` (public) and a distinct default ``filename_prefix`` keep this
     callback's top-k deletion pass — and, in rolling mode, its own oldest-first deletion
@@ -1122,7 +1122,7 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
         ``'model'`` (the default) uses :func:`~sisr.training.metadata.build_metadata`,
         which describes the generator; anything else uses
         :func:`~sisr.training.metadata.build_component_metadata`, so a discriminator's
-        ``.pt`` never carries metadata describing a network it does not contain.
+        artifact never carries metadata describing a network it does not contain.
 
         Rolling-mode deletion (:meth:`_RollingSaveMixin._enforce_rolling_window`) runs
         last, after this method's own writes — it does not go through ``super()``
@@ -1134,7 +1134,7 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
             trainer: The active trainer — supplies ``lightning_module`` (for the
                 component's ``state_dict()`` and metadata) and ``global_step``/``current_epoch``.
             filepath: Destination path, already formatted by ``ModelCheckpoint``
-                (``.pt`` via ``FILE_EXTENSION``).
+                (``.safetensors`` via ``FILE_EXTENSION``).
         """
         pl_module = trainer.lightning_module
         component = getattr(pl_module, self.attribute)

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -454,7 +454,7 @@ class SRGANLightning(SRLightning):
 
         The base builds ``sisr_meta`` around ``module.model`` — still correct,
         since the generator is the distributable artifact. These blocks are
-        added only to the ``.ckpt``: the bare ``.pt`` written by
+        added only to the ``.ckpt``: the bare ``.safetensors`` written by
         :class:`~sisr.training.callbacks.SRWeightsCheckpoint` holds one
         network's weights and gets metadata describing *that* network, not this
         run's whole adversarial setup.

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -2,11 +2,12 @@
 
 One function, three sinks: :meth:`~sisr.training.lightning_module.SRLightning.on_save_checkpoint`
 (the full resumable ``.ckpt``), :class:`~sisr.training.callbacks.SRWeightsCheckpoint` (the bare
-distributable ``.pt``), and :func:`sisr.export.to_onnx` (the ``.onnx``'s ``metadata_props``) all
-call :func:`build_metadata` so the three payloads cannot drift apart — mirrors how
-``SREvalConfig.psnr_keys`` is the single derivation point for its three consumers.
+distributable ``.safetensors``), and :func:`sisr.export.to_onnx` (the ``.onnx``'s
+``metadata_props``) all call :func:`build_metadata` so the three payloads cannot drift
+apart — mirrors how ``SREvalConfig.psnr_keys`` is the single derivation point for its
+three consumers.
 
-:func:`build_component_metadata` is a second builder for a bare ``.pt`` that is **not** the SR
+:func:`build_component_metadata` is a second builder for a bare artifact that is **not** the SR
 model — e.g. a discriminator's weights. Both builders are built on one private :func:`_envelope`
 helper (``format``/``kind``/``created``/``versions``/``training``), so the two payload shapes
 cannot drift apart either. Each carries a ``kind`` field: ``"sr_model"`` for :func:`build_metadata`,

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -58,7 +58,7 @@ model:
       training_config:
         class_path: sisr.models.srgan.SRGANTrainingConfig
         init_args:
-          # Bare weights (.pt), never the sibling .ckpt. Mismatches are refused.
+          # Bare weights (.safetensors), never the sibling .ckpt. Mismatches are refused.
           example_input_shape: [3, 24, 24]
           init_from: "experiments/SRResNet/golden/checkpoints/SRResNet_x4_RGB_16B64F_s1000000.safetensors"
           # adversarial_weight 1.0e-3 and d_steps_per_g_step 1 are the defaults.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,7 +34,7 @@ def _offline_args(template_path: Path, tmp_path: Path) -> list[str]:
     a ``null`` CLI value for a ``str | None`` field to the *string* ``'None'``,
     which is exactly the silent-wrong-value class these two settings guard.
 
-    ``init_from`` points at a golden ``.pt`` under the gitignored ``experiments/``
+    ``init_from`` points at a golden ``.safetensors`` under the gitignored ``experiments/``
     tree — present on a training box, absent in CI and in every worktree.
     ``criterion.weights`` would otherwise download ~548 MB of VGG19 weights just
     to resolve a config; ``null`` builds a random VGG (and warns).
@@ -334,7 +334,7 @@ def test_srgan_template_ships_the_papers_full_two_phase_schedule():
 def test_srgan_template_resolves_without_the_init_from_artifact(tmp_path: Path):
     """Instantiating the model is what every subcommand does — ``validate``/``test``/
     ``export --ckpt_path`` included — so reading ``init_from`` at construction made
-    all of them depend on the gitignored golden ``.pt``. This resolves the shipped
+    all of them depend on the gitignored golden ``.safetensors``. This resolves the shipped
     template with ``init_from`` pointed at a file that does not exist: it must build,
     because nothing here is fitting.
     """
@@ -345,7 +345,7 @@ def test_srgan_template_resolves_without_the_init_from_artifact(tmp_path: Path):
                 "model": {
                     "init_args": {
                         "training_config": {
-                            "init_args": {"init_from": str(tmp_path / "absent.pt")}
+                            "init_args": {"init_from": str(tmp_path / "absent.safetensors")}
                         },
                         "criterion": {
                             "class_path": "sisr.losses.VGG19FeatureLoss",
@@ -361,7 +361,7 @@ def test_srgan_template_resolves_without_the_init_from_artifact(tmp_path: Path):
 
     cli = _resolve("--config", str(SRGAN_TEMPLATE), "--config", str(overlay))
 
-    assert cli.model.training_config.init_from == str(tmp_path / "absent.pt")
+    assert cli.model.training_config.init_from == str(tmp_path / "absent.safetensors")
 
 
 def test_srgan_template_ships_a_real_init_from_path():
@@ -414,7 +414,7 @@ def test_dotted_override_keeps_the_config_subclass(tmp_path: Path):
                 "model": {
                     "init_args": {
                         "training_config": {
-                            "init_args": {"init_from": str(tmp_path / "absent.pt")}
+                            "init_args": {"init_from": str(tmp_path / "absent.safetensors")}
                         },
                         "criterion": {
                             "class_path": "sisr.losses.VGG19FeatureLoss",
@@ -434,7 +434,7 @@ def test_dotted_override_keeps_the_config_subclass(tmp_path: Path):
     assert kept.training_config.adversarial_weight == pytest.approx(0.5)
     # Both are absent from the base class or default differently there, so their
     # survival is what says no rebuild happened.
-    assert kept.training_config.init_from == str(tmp_path / "absent.pt")
+    assert kept.training_config.init_from == str(tmp_path / "absent.safetensors")
     assert kept.training_config.example_input_shape == (3, 24, 24)
 
     kept_eval = _resolve(*args, "--model.init_args.eval_config.crop_border=0").model

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -713,7 +713,7 @@ def test_sr_weights_checkpoint_setup_accepts_a_present_component(tmp_path: Path)
 def test_sr_weights_checkpoint_save_checkpoint_is_actually_overridden():
     """Cheap static guard: the override must exist as a distinct method, not
     silently inherit ModelCheckpoint's (which would write full, optimizer-bearing
-    checkpoints under the .pt extension). The real, functional guard against a
+    checkpoints under the .safetensors extension). The real, functional guard against a
     Lightning release routing saves through a different private method entirely
     is test_sr_weights_checkpoint_writes_bare_payload_via_real_fit below, which
     exercises the actual save path end-to-end."""
@@ -1029,7 +1029,7 @@ def test_srcheckpoint_rolling_filename_has_no_metric_placeholder(tmp_path: Path)
 
 @_ignore_gpu_warning
 def test_sr_weights_checkpoint_rolling_mode_keeps_only_the_last_n(tmp_path):
-    """SRWeightsCheckpoint's own _save_checkpoint override (bare .pt weights)
+    """SRWeightsCheckpoint's own _save_checkpoint override (bare .safetensors weights)
     must still compose with rolling deletion — it doesn't inherit
     ModelCheckpoint's save path the way SRCheckpoint does, so this is the
     place a mixin-only implementation would silently do nothing."""

--- a/tests/training/test_gan_module.py
+++ b/tests/training/test_gan_module.py
@@ -80,7 +80,7 @@ def build_source_module():
     """The realistic ``init_from`` source: a plain, MSE-trained SRResNet run.
 
     Its generator and processor match :func:`build_gan_module`'s exactly, so a
-    ``.pt`` written from it is the one artifact ``init_from`` must accept.
+    ``.safetensors`` written from it is the one artifact ``init_from`` must accept.
     """
     return SRLightning(
         model=SRResNet(scale=4, num_residual_blocks=1),
@@ -90,7 +90,7 @@ def build_source_module():
 
 
 def write_weights(tmp_path, **meta_overrides):
-    """A generator-weights ``.pt`` whose meta can be corrupted one field at a time.
+    """A generator-weights ``.safetensors`` whose meta can be corrupted one field at a time.
 
     Written with the same :func:`~sisr.training.metadata.build_metadata` that
     ``SRWeightsCheckpoint`` uses, so what is exercised is the real payload shape.
@@ -926,7 +926,7 @@ def test_the_bare_weights_sink_stays_component_scoped(tmp_path):
 
     ``SRWeightsCheckpoint`` writes one network's weights and describes exactly
     that network; adding this run's whole adversarial setup to a discriminator's
-    (or a generator's) ``.pt`` would describe things the file does not contain.
+    (or a generator's) artifact would describe things the file does not contain.
     Both sinks are checked — the template runs one of each side by side, and the
     generator's is the distributable artifact ``init_from`` consumes.
 

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -185,7 +185,7 @@ def test_build_metadata_is_weights_only_safe(tmp_path):
         monitor="ssim/val/RGB",
         monitor_value=0.87,
     )
-    path = tmp_path / "meta.pt"
+    path = tmp_path / "meta.ckpt"
     torch.save({"meta": meta}, path)
     loaded = torch.load(path, weights_only=True)
     assert loaded["meta"] == meta
@@ -245,7 +245,7 @@ def test_metadata_stays_weights_only_loadable_with_a_criterion_block(tmp_path):
         processor=RGBProcessor(),
         training_config=SRTrainingConfig(scale=3),
     )
-    path = tmp_path / "meta.pt"
+    path = tmp_path / "meta.ckpt"
     torch.save({"meta": build_metadata(module)}, path)
 
     loaded = torch.load(path, weights_only=True)
@@ -346,7 +346,7 @@ def test_component_metadata_training_fields_forwarded():
 def test_component_metadata_is_weights_only_safe(tmp_path):
     module = _make_srresnet_lit_with_component(_StubComponent(hr_input_size=96))
     meta = build_component_metadata(module, "discriminator", global_step=7, epoch=0)
-    path = tmp_path / "component_meta.pt"
+    path = tmp_path / "component_meta.ckpt"
     torch.save({"meta": meta}, path)
 
     loaded = torch.load(path, weights_only=True)


### PR DESCRIPTION
The arc removed `.pt` entirely. **Fifteen references in tracked files still named it.**

## One of them reaches users

`SRGANTrainingConfig.init_from`'s docstring is what jsonargparse renders into `--help`. It
said *"Path to a bare-weights `.pt`"* — so the CLI was telling a reader to pass a file format
the code now refuses to load.

## One contradicted itself three lines apart

```yaml
# Bare weights (.pt), never the sibling .ckpt. Mismatches are refused.
example_input_shape: [3, 24, 24]
init_from: "…/SRResNet_x4_RGB_16B64F_s1000000.safetensors"
```

## The rest

Docstrings in `callbacks.py` (4), `gan_module.py`, `metadata.py` (2), and test docstrings
that described the artifact by an extension it no longer has.

Also renamed the metadata tests' temp files from `meta.pt` to `meta.ckpt`. Those round-trip
through `torch.save`/`torch.load`, whose sink is the **resumable checkpoint**, not the bare
artifact — so `.pt` was doubly wrong there and `.ckpt` is what it actually is.

## Deliberately kept

`docs/configuration.md` and `metadata.py`'s `FORMAT_VERSION` comment both state that the
`.pt` form no longer exists, and the CHANGELOG records its removal. Those are *about* the
format rather than *in* it.

## Evidence

`ruff` + `ruff format` + `mypy sisr` clean. `tests/test_cli.py` + `tests/training/test_metadata.py`
63 passed. Re-scanned tracked files afterwards: the only `.pt` left is in the three places
named above.