### PR TITLE
fix: an artifact save creates the directory it is given

### DIFF
--- a/sisr/artifacts.py
+++ b/sisr/artifacts.py
@@ -83,10 +83,16 @@ def save(path: str | PathLike, tensors: dict[str, torch.Tensor], meta: dict[str,
     """Write one component's weights plus its provenance.
 
     Args:
-        path: Destination. The caller owns the filename.
+        path: Destination. The caller owns the filename; this owns the directory.
         tensors: A component's ``state_dict()``.
         meta: Provenance to carry in the header.
     """
+    # Lightning creates a checkpoint's directory inside its own IO plugin, and
+    # SRWeightsCheckpoint._save_checkpoint deliberately bypasses that path to write a
+    # different payload -- so nothing was creating this one. It worked only while a sibling
+    # SRCheckpoint happened to run first and make the directory; a weights-only
+    # configuration failed on its first save.
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
     # safetensors stores raw buffers and so refuses a view; a state_dict is free
     # to hand back non-contiguous tensors.
     save_file(

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -45,6 +45,25 @@ def test_save_and_load_round_trip_tensors_and_provenance(tmp_path):
     assert torch.equal(loaded["b"], tensors["b"])
 
 
+def test_save_creates_the_directory_it_is_given(tmp_path):
+    """The caller owns the filename; this module owns the directory.
+
+    Lightning creates a checkpoint's directory inside its own IO plugin, and
+    SRWeightsCheckpoint._save_checkpoint deliberately bypasses that path to write a
+    different payload — so nothing created this one. It worked only while a sibling
+    SRCheckpoint happened to run first and make the directory, which made a weights-only
+    configuration fail on its very first save.
+    """
+    path = tmp_path / "run" / "checkpoints" / f"m{artifacts.SUFFIX}"
+    assert not path.parent.exists()
+
+    artifacts.save(path, {"a": torch.ones(2)}, _META)
+
+    loaded, meta = artifacts.load(path)
+    assert meta == _META
+    assert torch.equal(loaded["a"], torch.ones(2))
+
+
 def test_save_accepts_a_non_contiguous_tensor(tmp_path):
     """A state_dict may hand back views, which safetensors refuses outright."""
     view = torch.randn(4, 4).t()


### PR DESCRIPTION
`SRWeightsCheckpoint` could not write into a directory nothing else had made.

## Why it never surfaced

Lightning creates a checkpoint's directory inside its own IO plugin
(`fabric/plugins/io/torch_io.py`, `fs.makedirs`). `SRWeightsCheckpoint._save_checkpoint`
**deliberately bypasses that path** to write a different payload — bare safetensors rather
than a full checkpoint — so nothing was creating the directory.

It worked only because every shipped template pairs it with an `SRCheckpoint`, which uses
Lightning's own save path and makes the directory first. **The dependency was invisible and
unstated.**

A weights-only configuration — or one whose weights callback fires first — dies on its very
first save with a bare `SafetensorError` about a temp file, naming neither the callback nor
the missing directory.

## How it was found

A smoke test that added a third checkpoint callback firing on a step boundary
(`every_n_train_steps`) rather than on validation, so it ran before any `SRCheckpoint` had
created the directory.

## Where the fix goes

`artifacts.save`, not the callback. That function owns writing the artifact, so it owns
making the destination writable; the caller still owns the filename. Putting it in the
callback would leave the same trap for the next caller — `sisr export` writes through the
same function.

## Evidence

- Test proven RED on pre-fix `main` (`SafetensorError`) → GREEN.
- `ruff` + `ruff format` + `mypy sisr` clean.
- `tests/test_artifacts.py` + `tests/training/test_callbacks.py` + `tests/test_typing.py`:
  128 passed. (`test_typing.py` included deliberately — it is the guard I missed on an
  earlier batch.)