### PR TITLE
fix: the SRGAN template names a generator artifact no run can produce

### DIFF
--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -60,7 +60,11 @@ model:
         init_args:
           # Bare weights (.pt), never the sibling .ckpt. Mismatches are refused.
           example_input_shape: [3, 24, 24]
-          init_from: "experiments/SRResNet/golden/checkpoints/SRResNet_x4_RGB_16B64F_s1000000.safetensors"
+          # NOTE: s999999, not s1000000, for a 1e6-step run. The step in an artifact
+          # filename is the metric axis -- the index of the step just completed --
+          # while max_steps counts completed steps, so the two differ by exactly one.
+          # Naming the round number points at a file no run can produce.
+          init_from: "experiments/SRResNet/golden/checkpoints/SRResNet_x4_RGB_16B64F_s999999.safetensors"
           # adversarial_weight 1.0e-3 and d_steps_per_g_step 1 are the defaults.
       # Defaults add lpips + dists; 'lpips' needs the [perceptual] extra.
       eval_config:


### PR DESCRIPTION
`init_from` pointed at `SRResNet_x4_RGB_16B64F_s1000000.safetensors`. **A 1,000,000-step
SRResNet run produces `s999999`.**

Verified against a real run that just finished: the checkpoints directory holds `s899999`,
`s949999`, `s999999`, and the metrics CSV's maximum step is `999999`.

## Why

The step in an artifact filename is the **metric axis** — the index of the step just
completed — while `max_steps` counts **completed** steps. They differ by exactly one. That is
the second, unconditional half of this project's step-axis trap: it holds even under
automatic optimization, where the two counters otherwise look identical.

The template was written against the pre-#111 naming, which stamped the *optimizer* axis and
so did name the round number. #111 corrected the stamp; the template was never updated with
it.

## Impact

Anyone following the documented SRGAN recipe hits a missing-file failure at setup. It fails
loudly and early rather than training something wrong, which is the one mercy here.

## How it was found

By running the reference retrain to completion and then looking for the file the template
asks for. A shorter run would not have surfaced it — the name only becomes checkable once
something has actually produced one.

## Note on the comment style

The added note is deliberately plain ASCII. Config YAML in this repo must stay ASCII:
jsonargparse opens config files with the platform encoding, so a non-ASCII character is a
hard `UnicodeDecodeError` at launch. I verified all three shipped templates are ASCII-clean
after this change.

## Evidence

`tests/test_cli.py` passes — it resolves the shipped SRGAN template, so it exercises this
field's parsing.