### PR TITLE
fix: refuse two checkpoint callbacks that would write the same filename

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -770,6 +770,10 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
         )
         self._keep_last = keep_last
         self._explicit_prefix = filename_prefix
+        # The *raw* dirpath, because setup() resolves self.dirpath against the
+        # trainer -- so when one callback probes another, one side may be resolved
+        # and the other not, and comparing those is comparing different things.
+        self._explicit_dirpath = None if dirpath is None else str(Path(dirpath).resolve())
         # A usable name before setup() can derive the real one -- direct
         # construction in a test never reaches setup.
         self._apply_naming(filename_prefix or self.DEFAULT_PREFIX)
@@ -790,6 +794,83 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
         """
         self.filename = f"{prefix}_s{{step}}"
         self._init_rolling(self._keep_last, prefix)
+
+    def _resolved_prefix(self, pl_module: lightning.LightningModule) -> str:
+        """The identity this callback will write under, whether or not setup() has run.
+
+        Siblings are compared before Lightning has necessarily set them all up, so
+        this cannot be read off ``self.filename`` -- that still holds
+        ``DEFAULT_PREFIX`` on anything yet to reach setup.
+
+        Args:
+            pl_module: The model being trained; supplies the provenance a derived
+                prefix is a projection of.
+
+        Returns:
+            The explicit ``filename_prefix`` if one was given, else the stem derived
+            from what this callback saves.
+        """
+        if self._explicit_prefix is not None:
+            return self._explicit_prefix
+        return artifacts.stem(self._describe(pl_module))
+
+    def _reject_filename_collision(
+        self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
+    ) -> None:
+        """Raise if a sibling callback would write this callback's exact filename.
+
+        Distinct default prefixes keep the two *classes* apart, and their docstrings
+        say so -- but that reasoning never covered two instances of one class, which
+        is what both shipped templates configured: one on ``psnr/val/RGB`` and one on
+        ``ssim/val/RGB``, deriving the same model-provenance stem. Lightning does not
+        refuse it. It keeps one and appends ``-v1`` to the other, **assigned by save
+        order**, so which file wins the bare name is stable across neither runs nor
+        Lightning versions, and neither name says which metric it is best on.
+
+        The comparison is on the whole filename rather than the prefix: ``.ckpt``
+        beside ``.safetensors`` under one prefix is the intended, shipped pair.
+
+        Refusing is deliberately preferred to disambiguating automatically. Any
+        automatic rule has to decide which sibling keeps the bare name, and every
+        answer to that is either order-dependent -- the defect itself -- or silently
+        renames published artifacts when a monitor changes.
+
+        Args:
+            trainer: The active trainer, whose ``checkpoint_callbacks`` are the
+                siblings this could collide with.
+            pl_module: The model being trained.
+
+        Raises:
+            MisconfigurationException: If another :class:`_SRCheckpointBase` in the
+                callback list would write the same name into the same directory.
+        """
+        prefix = self._resolved_prefix(pl_module)
+        mine = (self._explicit_dirpath, prefix, self.FILE_EXTENSION)
+        for other in trainer.checkpoint_callbacks:
+            if other is self or not isinstance(other, _SRCheckpointBase):
+                continue
+            try:
+                theirs = (
+                    other._explicit_dirpath,
+                    other._resolved_prefix(pl_module),
+                    other.FILE_EXTENSION,
+                )
+            except Exception:
+                # A sibling whose own configuration is broken cannot be probed. Its
+                # setup() reports that precisely; masking it with a collision error
+                # raised from over here would be strictly worse than skipping it.
+                continue
+            if theirs != mine:
+                continue
+            raise MisconfigurationException(
+                f"`{type(self).__name__}(monitor_metric={self.monitor!r})` and "
+                f"`{type(other).__name__}(monitor_metric={other.monitor!r})` would both "
+                f"write `{prefix}_s{{step}}{self.FILE_EXTENSION}` into the same directory. "
+                "Lightning keeps one and suffixes the other `-v1`, assigned by save "
+                "order, so which artifact is which is neither stable across runs nor "
+                "readable from its name. HINT: give one of them a distinct "
+                "`filename_prefix`."
+            )
 
     def _describe(self, pl_module: lightning.LightningModule) -> dict[str, Any]:
         """Provenance for whatever this callback saves. Overridden per component."""
@@ -853,7 +934,7 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
         pl_module: lightning.LightningModule,
         stage: str,
     ) -> None:
-        """Validate ``monitor`` against the metrics ``SRLightning`` will log.
+        """Validate ``monitor``, derive the filename, and refuse a colliding sibling.
 
         Lightning itself only raises ``MisconfigurationException`` for a
         missing monitor once the val loop has already run at least once
@@ -871,8 +952,9 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
 
         Raises:
             MisconfigurationException: If ``monitor`` does not name a metric
-                ``SRLightning`` will log during ``fit``, or if ``mode``
-                disagrees with that metric's direction.
+                ``SRLightning`` will log during ``fit``, if ``mode`` disagrees with
+                that metric's direction, or if a sibling callback would write this
+                callback's exact filename.
         """
         super().setup(trainer, pl_module, stage)
         if stage != "fit":
@@ -883,6 +965,7 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
         # _validate, because it reads whatever that just checked.
         if self._explicit_prefix is None:
             self._apply_naming(artifacts.stem(self._describe(pl_module)))
+        self._reject_filename_collision(trainer, pl_module)
 
     def _validate(self, pl_module: lightning.LightningModule) -> None:
         """Everything that must hold before this callback can name or write anything."""
@@ -976,6 +1059,10 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
     (see :class:`_RollingSaveMixin`) — from ever touching :class:`SRCheckpoint`'s files
     when both share one ``dirpath``: each callback only ever names/deletes files matching
     its own ``filename``/``FILE_EXTENSION`` combination.
+
+    That keeps the two *classes* apart. It does not keep two instances of one class
+    apart — a pair differing only in ``monitor_metric`` derives one stem and collides,
+    which :meth:`_SRCheckpointBase._reject_filename_collision` now refuses at startup.
 
     Args:
         monitor_metric: The validation metric to monitor — same contract as

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -99,10 +99,16 @@ trainer:
       init_args:
         monitor_metric: psnr/val/RGB
         save_top_k: 3
+    # A distinct prefix, because the derived name is a projection of the *model*'s
+    # provenance and says nothing about which metric selected the file. Without it
+    # this callback and the PSNR one above write the same name and Lightning
+    # suffixes one `-v1` by save order. Startup now refuses that rather than
+    # publishing two artifacts whose names cannot tell you which is which.
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
+        filename_prefix: sr-ssim
     # Distributable, optimizer-free weights alongside the resumable .ckpt files.
     - class_path: sisr.training.SRWeightsCheckpoint
       init_args:
@@ -112,6 +118,7 @@ trainer:
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
+        filename_prefix: sr-weights-ssim
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -102,10 +102,16 @@ trainer:
       init_args:
         monitor_metric: psnr/val/RGB
         save_top_k: 3
+    # A distinct prefix, because the derived name is a projection of the *model*'s
+    # provenance and says nothing about which metric selected the file. Without it
+    # this callback and the PSNR one above write the same name and Lightning
+    # suffixes one `-v1` by save order. Startup now refuses that rather than
+    # publishing two artifacts whose names cannot tell you which is which.
     - class_path: sisr.training.SRCheckpoint
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
+        filename_prefix: sr-ssim
     # Distributable, optimizer-free weights alongside the resumable .ckpt files.
     - class_path: sisr.training.SRWeightsCheckpoint
       init_args:
@@ -115,6 +121,7 @@ trainer:
       init_args:
         monitor_metric: ssim/val/RGB
         save_top_k: 3
+        filename_prefix: sr-weights-ssim
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -31,6 +31,7 @@ from sisr.training import (
     WeightHistogramLogger,
 )
 from sisr.training.callbacks import BenchmarkSample
+from sisr.training.metadata import build_metadata
 
 # ---------------------------------------------------------------------------
 # BenchmarkImageLogger.setup auto-discovery
@@ -587,6 +588,158 @@ def test_srcheckpoint_setup_error_lists_valid_metrics(tmp_path: Path):
     assert "psnr/val/RGB" in str(exc_info.value)
     assert "ssim/val/RGB" in str(exc_info.value)
     assert "ssim/val/Y" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Sibling checkpoint callbacks that would write the same filename
+# ---------------------------------------------------------------------------
+
+
+def _trainer_holding(*callbacks: lightning.Callback, root: Path) -> lightning.Trainer:
+    """Bare Trainer that actually *holds* the callbacks.
+
+    `_make_bare_trainer` passes none and disables checkpointing, so a callback
+    set up against it can never see a sibling — which is the whole subject here.
+    """
+    return lightning.Trainer(
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        default_root_dir=str(root),
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        callbacks=list(callbacks),
+    )
+
+
+@_ignore_gpu_warning
+def test_two_checkpoints_with_different_monitors_are_refused_at_setup(tmp_path: Path):
+    """The shape both shipped templates configured: one class, one dirpath, two
+    monitors, no explicit prefix.
+
+    Each derives its name from the *model*'s provenance, which says nothing about
+    the selection criterion, so both land on the same stem and Lightning keeps one
+    and suffixes the other `-v1` — assigned by save order, so which file is the
+    PSNR-best is neither stable across runs nor recoverable from the name.
+    """
+    pl_module = _make_real_pl_module()
+    psnr = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    ssim = SRCheckpoint(monitor_metric="ssim/val/RGB", dirpath=str(tmp_path))
+
+    with pytest.raises(MisconfigurationException) as exc_info:
+        psnr.setup(_trainer_holding(psnr, ssim, root=tmp_path), pl_module, stage="fit")
+    message = str(exc_info.value)
+    assert "psnr/val/RGB" in message
+    assert "ssim/val/RGB" in message
+
+
+@_ignore_gpu_warning
+def test_the_refusal_does_not_depend_on_which_sibling_lightning_sets_up_first(tmp_path: Path):
+    """Setup order is Lightning's to choose, and `-v1`-by-save-order is the defect
+    being fixed — a check that only fires from one side would reintroduce it."""
+    pl_module = _make_real_pl_module()
+    psnr = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    ssim = SRCheckpoint(monitor_metric="ssim/val/RGB", dirpath=str(tmp_path))
+
+    with pytest.raises(MisconfigurationException):
+        ssim.setup(_trainer_holding(psnr, ssim, root=tmp_path), pl_module, stage="fit")
+
+
+@_ignore_gpu_warning
+def test_the_refusal_names_the_filename_the_pair_would_share(tmp_path: Path):
+    """Actionable without reading source: the message says what the collision *is*
+    and how to resolve it, not merely that one exists."""
+    pl_module = _make_real_pl_module()
+    shared = artifacts.stem(build_metadata(pl_module))
+    psnr = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    ssim = SRCheckpoint(monitor_metric="ssim/val/RGB", dirpath=str(tmp_path))
+
+    with pytest.raises(MisconfigurationException) as exc_info:
+        psnr.setup(_trainer_holding(psnr, ssim, root=tmp_path), pl_module, stage="fit")
+    message = str(exc_info.value)
+    assert shared in message
+    assert "filename_prefix" in message
+
+
+@_ignore_gpu_warning
+def test_a_distinct_prefix_on_one_of_the_pair_is_enough(tmp_path: Path):
+    """The refusal must not outlaw the configuration that resolves it — this is
+    what the shipped templates now do."""
+    pl_module = _make_real_pl_module()
+    psnr = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    ssim = SRCheckpoint(
+        monitor_metric="ssim/val/RGB", dirpath=str(tmp_path), filename_prefix="sr-ssim"
+    )
+    trainer = _trainer_holding(psnr, ssim, root=tmp_path)
+
+    psnr.setup(trainer, pl_module, stage="fit")  # must not raise
+    ssim.setup(trainer, pl_module, stage="fit")  # must not raise
+
+
+@_ignore_gpu_warning
+def test_the_two_classes_may_share_a_prefix_because_their_extensions_differ(tmp_path: Path):
+    """`.ckpt` beside `.safetensors` under one prefix is the documented design, and
+    the pair every template ships. Only the whole filename collides, so only the
+    whole filename may be checked — a prefix-only check would break the templates
+    it is meant to protect.
+    """
+    pl_module = _make_real_pl_module()
+    resumable = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    weights = SRWeightsCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path))
+    trainer = _trainer_holding(resumable, weights, root=tmp_path)
+
+    resumable.setup(trainer, pl_module, stage="fit")  # must not raise
+    weights.setup(trainer, pl_module, stage="fit")  # must not raise
+
+
+@_ignore_gpu_warning
+def test_weights_checkpoints_on_different_components_do_not_collide(tmp_path: Path):
+    """The SRGAN template's generator/discriminator pair: same class, same dirpath,
+    same (null) monitor — and legal, because their stems come from different
+    components. `attribute` exists precisely to make this configuration work."""
+    module = build_module_with_component()
+    generator = SRWeightsCheckpoint(monitor_metric=None, attribute="model", dirpath=str(tmp_path))
+    discriminator = SRWeightsCheckpoint(
+        monitor_metric=None, attribute="discriminator", dirpath=str(tmp_path)
+    )
+    trainer = _trainer_holding(generator, discriminator, root=tmp_path)
+
+    generator.setup(trainer, module, stage="fit")  # must not raise
+    discriminator.setup(trainer, module, stage="fit")  # must not raise
+
+
+@_ignore_gpu_warning
+def test_a_sibling_that_cannot_be_named_is_skipped_not_reported(tmp_path: Path):
+    """Probing a sibling means deriving its name, which a misconfigured sibling
+    cannot do.
+
+    Whichever callback Lightning sets up first would then raise from inside the
+    collision check, replacing the sibling's own precise complaint -- here, an
+    `attribute` the module does not have -- with a confusing one from somewhere
+    else. The broken sibling's own setup() still reports it.
+    """
+    module = build_module_with_component()
+    good = SRWeightsCheckpoint(monitor_metric=None, attribute="model", dirpath=str(tmp_path))
+    broken = SRWeightsCheckpoint(monitor_metric=None, attribute="nope", dirpath=str(tmp_path))
+    trainer = _trainer_holding(good, broken, root=tmp_path)
+
+    good.setup(trainer, module, stage="fit")  # must not raise
+
+    with pytest.raises(MisconfigurationException, match=r"nope"):
+        broken.setup(trainer, module, stage="fit")
+
+
+@_ignore_gpu_warning
+def test_separate_dirpaths_are_not_a_collision(tmp_path: Path):
+    """Same class, same monitorless config, different directories — nothing is
+    ambiguous, so nothing may be refused."""
+    pl_module = _make_real_pl_module()
+    first = SRCheckpoint(monitor_metric="psnr/val/RGB", dirpath=str(tmp_path / "a"))
+    second = SRCheckpoint(monitor_metric="ssim/val/RGB", dirpath=str(tmp_path / "b"))
+    trainer = _trainer_holding(first, second, root=tmp_path)
+
+    first.setup(trainer, pl_module, stage="fit")  # must not raise
+    second.setup(trainer, pl_module, stage="fit")  # must not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #191.

## What changed

Two checkpoint callbacks that would write the same filename into the same directory are now
refused at `setup()`, with a message naming both callbacks, the filename they share, and how to
resolve it. Both shipped templates now give their SSIM-monitored callbacks a distinct
`filename_prefix`.

## Why

The templates configured exactly the colliding shape: `SRCheckpoint` on `psnr/val/RGB` beside one
on `ssim/val/RGB`, plus the same pair of `SRWeightsCheckpoint`. Both derive their name from the
model's provenance, which says nothing about the selection criterion, so both land on one stem and
Lightning keeps one and appends `-v1` to the other — **assigned by save order**. The published
artifacts then cannot say which is best on which metric, and which file wins the bare name is
stable across neither runs nor Lightning versions.

Distinct default prefixes already kept the two *classes* apart, and their docstrings said so. That
reasoning never covered two instances of one class.

### Why refuse rather than disambiguate automatically

Any automatic rule has to decide which sibling keeps the bare name, and every answer is either
order-dependent — which is the defect itself — or silently renames published artifacts when a
monitor changes.

Putting the metric back into the derived name (issue #191's option 1) would be better still, and
this change does not foreclose it. It is deliberately not done here: it changes a filename that a
just-merged template's `init_from` names and that a completed reference run has already written on
disk, so it wants to be one deliberate rename, coordinated with those, rather than a side effect.
**Issue #191 stays open for that**; its third acceptance box — "the reference config no longer
needs a `filename_prefix` workaround" — is not ticked by this PR, and the prefix is now required
rather than merely advisable.

## Evidence

**Bug fix** — proven RED against the unfixed code, GREEN after, at implementation time:

```
$ pytest tests/training/test_callbacks.py -k "<the seven new tests>"
3 failed, 4 passed          # against unmodified main
115 passed                  # after the fix (108 pre-existing + 7 new)
```

The three that failed did so with `DID NOT RAISE MisconfigurationException`:

- `test_two_checkpoints_with_different_monitors_are_refused_at_setup`
- `test_the_refusal_does_not_depend_on_which_sibling_lightning_sets_up_first`
- `test_the_refusal_names_the_filename_the_pair_would_share`

The other four were written to pass *both* ways on purpose — they pin what must stay legal, so an
over-broad check is caught:

- `test_a_distinct_prefix_on_one_of_the_pair_is_enough`
- `test_the_two_classes_may_share_a_prefix_because_their_extensions_differ` — `.ckpt` beside
  `.safetensors` under one prefix is the intended, shipped pair, so the comparison is on the whole
  filename and not the prefix
- `test_weights_checkpoints_on_different_components_do_not_collide` — the SRGAN template's
  generator/discriminator pair, same class and same null monitor, must stay constructable
- `test_separate_dirpaths_are_not_a_collision`

Full suite: **404 passed** (`tests/training/`, `test_typing.py`, `test_artifacts.py`) plus the
remainder green. `ruff check` and `ruff format --check` clean.

## Notes

- The check is symmetric, so it does not matter which sibling Lightning sets up first.
- It compares the *raw* `dirpath` rather than the resolved one, because `setup()` resolves
  `self.dirpath` against the trainer — when one callback probes another, one side may be resolved
  and the other not.
- A sibling whose own configuration is broken is skipped rather than probed, so its own `setup()`
  reports that precisely instead of being masked by a collision error raised from elsewhere.
