### PR TITLE
feat: let a config select torch.compile's mode, not just its backend

### DIFF
--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -121,12 +121,31 @@ class SRTrainingConfig:
             ``SRLightning.on_fit_start`` turns into an immediate failure via
             a warm-up forward instead of an arbitrary mid-run crash.
             Measured on one RTX 5060 Laptop (SRResNet, batch 16, 24x24 LR):
-            ``'cudagraphs'`` gave +4% steps/s over eager — it only captures
-            the model forward, so backward and the optimizer step stay
-            eager and most kernel launches in a training step are never
-            captured. ``'inductor'`` fails outright there (no upstream
-            Windows Triton wheel). Defaults to ``None`` so this mostly-
-            unproven-on-this-project path never ships on by default.
+            ``'inductor'`` is the only backend that pays, and by a mid-teens
+            percent rather than the multiples a microbenchmark suggests;
+            ``'cudagraphs'`` is within noise of eager — it captures the model
+            forward only, so backward and the optimizer step stay eager and
+            most kernel launches in a training step are never captured — and
+            ``'aot_eager'`` is slower. On SRCNN eager wins every comparison.
+            No backend is bit-identical to eager on SRResNet, so a compiled
+            run does not reproduce an eager one exactly. Defaults to ``None``,
+            and staying there is the standing recommendation.
+
+        compile_mode: ``torch.compile``'s ``mode`` — ``'reduce-overhead'``,
+            ``'max-autotune'``, ... — applied alongside ``compile_backend``.
+            ``None`` (default) leaves inductor on its own default mode, which
+            is what every configured run got before this field existed: the
+            call site passed ``backend`` and nothing else, so a published
+            ``reduce-overhead`` or ``max-autotune`` figure described something
+            no YAML could select. Requires ``compile_backend='inductor'``,
+            because ``mode`` is an inductor setting and torch forwards it to
+            any other backend as a keyword its compiler function does not
+            accept — a failure on the first compiled call, which this refuses
+            at construction instead. An unrecognized mode also raises there,
+            from torch. Which mode wins does not hold across precisions on
+            this hardware: ``'max-autotune'`` beat ``'reduce-overhead'`` under
+            bf16 and lost to it under fp32, so treat a mode as measured per
+            configuration, never as a default.
     """
 
     layer_lrs: list[float] | None = None
@@ -136,6 +155,23 @@ class SRTrainingConfig:
     init_std: float = 0.01
     scale: int | None = None
     compile_backend: str | None = None
+    compile_mode: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a compile mode that nothing will apply.
+
+        Raises:
+            ValueError: If ``compile_mode`` is set without
+                ``compile_backend='inductor'``.
+        """
+        if self.compile_mode is not None and self.compile_backend != "inductor":
+            raise ValueError(
+                f"compile_mode={self.compile_mode!r} needs compile_backend='inductor'; got "
+                f"compile_backend={self.compile_backend!r}. `mode` is an inductor setting: "
+                "with no backend nothing is compiled and the mode is dead config, and with "
+                "another backend torch passes `mode` to a compiler function that does not "
+                "take it, which fails on the first compiled call rather than at startup."
+            )
 
     def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
         """Validate this config against the model/processor it will pair with.

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -116,7 +116,11 @@ class SRLightning(lightning.LightningModule):
             )
 
         backend = self.training_config.compile_backend
-        compiled = torch.compile(self.model, backend=backend) if backend is not None else None
+        compiled = (
+            torch.compile(self.model, backend=backend, mode=self.training_config.compile_mode)
+            if backend is not None
+            else None
+        )
         # torch.compile() returns an OptimizedModule, itself an nn.Module — a
         # plain `self._compiled = compiled` would register it as a submodule
         # (nn.Module.__setattr__ registers any nn.Module value regardless of

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -58,6 +58,7 @@ def test_sr_training_config_field_names():
         "init_std",
         "scale",
         "compile_backend",
+        "compile_mode",
     }
 
 

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -1192,6 +1192,86 @@ def test_compile_backend_off_uses_eager_model_regardless_of_training_flag():
     torch.testing.assert_close(out_train, out_eval)
 
 
+# ---------------------------------------------------------------------------
+# compile_mode -- the inductor mode a YAML run could not previously select
+# ---------------------------------------------------------------------------
+
+
+def test_compile_mode_reaches_torch_compile(monkeypatch):
+    """The whole point of the field: a mode set in YAML must arrive at
+    `torch.compile`.
+
+    Every published `reduce-overhead` / `max-autotune` figure described something
+    no config could select, because the call site passed `backend` and nothing
+    else -- so a configured run silently got inductor's default mode.
+    """
+    seen = {}
+
+    def spy(model, **kwargs):
+        # Records rather than compiles: a real inductor compile here would only
+        # add a slow, toolchain-dependent step to a question about argument
+        # passing. That inductor accepts the mode is pinned separately, by
+        # test_compile_mode_unrecognised_by_torch_raises_at_construction.
+        seen.update(kwargs)
+        return model
+
+    model = SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same")
+    monkeypatch.setattr(torch, "compile", spy)
+    SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(
+            compile_backend="inductor", compile_mode="reduce-overhead"
+        ),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    assert seen["mode"] == "reduce-overhead"
+
+
+def test_compile_mode_defaults_to_none_so_compiled_runs_are_unchanged(monkeypatch):
+    """Adding the field must not renumber any existing compiled run: unset means
+    `mode=None`, which is what `torch.compile` already defaulted to."""
+    seen = {}
+    real_compile = torch.compile
+
+    def spy(model, **kwargs):
+        seen.update(kwargs)
+        return real_compile(model, **kwargs)
+
+    monkeypatch.setattr(torch, "compile", spy)
+    _make_compilable_lit(compile_backend="eager")
+    assert seen["mode"] is None
+
+
+@pytest.mark.parametrize("backend", [None, "cudagraphs", "aot_eager"])
+def test_compile_mode_without_the_inductor_backend_is_refused(backend):
+    """`mode` is an inductor concept. With no backend nothing is compiled and the
+    mode is dead config; with another backend torch forwards `mode` as a keyword
+    to a compiler function that does not take one, which fails on the first
+    compiled call -- a mid-run crash, which is exactly what this project's
+    compile plumbing exists to convert into a startup one.
+    """
+    with pytest.raises(ValueError, match="compile_mode"):
+        SRTrainingConfig(compile_backend=backend, compile_mode="reduce-overhead")
+
+
+def test_compile_mode_unrecognised_by_torch_raises_at_construction():
+    """A typo'd mode must fail at `SRLightning` construction, like a typo'd
+    backend already does -- not 12 hours into a run."""
+    model = SRCNN(num_channels=3, num_filters=(4, 4), kernel_sizes=(3, 1, 3), padding="same")
+    with pytest.raises(RuntimeError, match="mode"):
+        SRLightning(
+            model=model,
+            processor=RGBProcessor(),
+            training_config=SRTrainingConfig(
+                compile_backend="inductor", compile_mode="not_a_real_mode"
+            ),
+            eval_config=SREvalConfig(),
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+        )
+
+
 def test_on_fit_start_warms_up_compiled_path():
     """on_fit_start must actually invoke the compiled callable once, so a
     missing-toolchain backend fails at fit-start rather than mid-run."""


### PR DESCRIPTION
Makes `torch.compile`'s `mode` selectable from a config. It was not, and that quietly
invalidated a class of benchmark figure.

## What changed

- `SRTrainingConfig.compile_mode`, passed to `torch.compile` alongside `compile_backend`.
- Defaults to `None`, which is what `torch.compile` already used — **no existing compiled run
  changes**.
- Requires `compile_backend='inductor'`, refused at config construction otherwise.
- The `compile_backend` docstring's measurements were stale and are corrected.

## Why

The call site passed `backend` and nothing else, so every configured run got inductor's *default*
mode. Every `reduce-overhead` / `max-autotune` figure in the benchmark record was produced by
patching the mode into a benchmark process — describing something no YAML could select. On this
hardware the gap between default mode and `reduce-overhead` is around 15% at fp32, so it is not a
rounding difference.

## Why it requires inductor

`mode` is an inductor setting. With no backend nothing is compiled and the mode is dead config.
With any *other* backend, torch forwards `mode` as a keyword to a compiler function that does not
accept one — which fails on the **first compiled call**, not at startup. This project's compile
plumbing (the `on_fit_start` warm-up, the eager `InvalidBackend` check) exists precisely to turn
that class of late failure into an early one, so the config refuses the combination instead.

Verified against torch 2.13.0: inductor validates the mode name eagerly at `torch.compile()`,
while non-inductor backends accept any string and defer.

## Evidence

Six tests, all proven RED before the implementation (`TypeError: unexpected keyword argument
'compile_mode'`). Full suite: **854 passed, 5 skipped**.

## Note

This does not recommend compiling. #121's finding stands — no backend is bit-identical to eager on
SRResNet. The value here is that the benchmark record becomes reproducible from a config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)