### PR TITLE
fix: use the SRCNN authors' own batch size and training budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,15 +340,25 @@ both rows at once:
 | per-layer `lr_mult` (weights) | `1`, `1`, `0.1` | already matched — `layer_lrs: [1e-4, 1e-4, 1e-5]` |
 | `weight_filler` std | `0.001` | already matched |
 
-`max_iter` also settles how to read the paper's *"the same number of backpropagations
-(i.e. 8×10⁸)"*. It **cannot** mean iterations: 8×10⁸ exceeds the authors' own cap of 1.5×10⁷
-by two orders of magnitude. Per-sample is the only consistent reading — which is what this
-project had already inferred, and it is no longer an inference. Nor is `max_iter` the paper's
-budget: paired with `snapshot: 500` it is a run-long ceiling to snapshot from, which is what
-an earlier reading of *"up to 8×10⁸"* was picking up on. Both readings reconcile.
+`max_iter` settles one thing and opens another.
 
-`max_steps` is therefore **6,250,000** — 6,250,000 × 128 = 8×10⁸ backpropagations exactly,
-where before it was an approximation at ≈0.8× the paper's figure.
+**Settled:** the paper's *"the same number of backpropagations (i.e. 8×10⁸)"* **cannot** mean
+iterations — 8×10⁸ exceeds the authors' own cap of 1.5×10⁷ by two orders of magnitude. Per-sample
+is the only consistent reading, which this project had already inferred and no longer has to.
+
+**Open, and deliberately left open:** at batch 128 the authors' `max_iter` is
+15,000,000 × 128 = **1.92×10⁹** backpropagations, against the paper's stated **8×10⁸** — which
+would be 6,250,000 iterations. **The released code and the paper disagree, by 2.4×.**
+
+This project ships the authors' value, `max_steps: 15000000`, because that is the number a
+primary source states. Choosing 6,250,000 instead would make the paper's sentence come out exact
+at the cost of shipping a value no source states, resolved by our inference that `max_iter` is a
+ceiling rather than a target. Their `snapshot: 500` makes that inference plausible — but **which
+snapshot produced the published numbers is recorded nowhere**, so it stays an inference, and the
+honest position is to follow the file and say the two disagree.
+
+Practically this is a long run; stop at a checkpoint rather than lower the config to an
+unsourced number.
 
 No published number changes: SRCNN has no publishable row.
 

--- a/README.md
+++ b/README.md
@@ -314,14 +314,43 @@ picking a value and asserting it in code — that would dress a guess as a check
 
 | choice | what ships | what it rests on |
 |---|---|---|
-| SRCNN batch size | `64` | **Nothing.** Not in the paper, not on the authors' project page, re-verified twice. The authors' released Caffe solver prototxt would settle it and **has not been inspected**; a community reimplementation is not a substitute. |
-| SRCNN training budget | `max_steps: 10000000`, ≈0.8× the paper's figure | The paper gives *"the same number of backpropagations (i.e. 8×10⁸)"*. Read here as **per-sample** updates, because the mini-batch reading implies an implausible iterations-per-second rate on 2014 hardware. That is an inference. An earlier reading of ours recorded *"up to 8×10⁸"* — a ceiling rather than a target — and the two readings are **unreconciled**. |
 | SRCNN evaluation border | `crop_border: 3`, on top of the 6 px per side that `padding: valid` already trims | The paper states no test-time boundary convention. Neither value is correct or incorrect, only stated. |
 | SRResNet PReLU parameterisation | `torch.nn.PReLU()` — one shared slope | The paper specifies neither shared nor per-channel, and no official reference implementation exists to check against. |
 
 The practical consequence: a reproduction that differs from this project on any of these
 rows is not necessarily wrong, and neither is this one. Compare the rows before comparing
 the numbers.
+
+#### Two rows left this table on 2026-09-01
+
+SRCNN's **batch size** and **training budget** were listed here as resting on nothing
+checkable. They are now specified by a primary source, so they no longer belong in a list of
+choices with nothing to be faithful to.
+
+The SRCNN authors released a Caffe training package (`SRCNN_train.zip`, from the project page
+both papers link; retrieved 2026-09-01, SHA-256
+`001146419f7acfb12a3e7929c8acd5de88a08d687d6881085f81321ad6982b1a`). Its two files settle
+both rows at once:
+
+| field | authors' value | what this project now ships |
+|---|---|---|
+| `hdf5_data_param.batch_size` (train) | `128` | `batch_size: 128` (was `64`) |
+| `max_iter` | `15000000` | see below |
+| `base_lr` / `momentum` / `weight_decay` | `0.0001` / `0.9` / `0` | already matched |
+| per-layer `lr_mult` (weights) | `1`, `1`, `0.1` | already matched — `layer_lrs: [1e-4, 1e-4, 1e-5]` |
+| `weight_filler` std | `0.001` | already matched |
+
+`max_iter` also settles how to read the paper's *"the same number of backpropagations
+(i.e. 8×10⁸)"*. It **cannot** mean iterations: 8×10⁸ exceeds the authors' own cap of 1.5×10⁷
+by two orders of magnitude. Per-sample is the only consistent reading — which is what this
+project had already inferred, and it is no longer an inference. Nor is `max_iter` the paper's
+budget: paired with `snapshot: 500` it is a run-long ceiling to snapshot from, which is what
+an earlier reading of *"up to 8×10⁸"* was picking up on. Both readings reconcile.
+
+`max_steps` is therefore **6,250,000** — 6,250,000 × 128 = 8×10⁸ backpropagations exactly,
+where before it was an approximation at ≈0.8× the paper's figure.
+
+No published number changes: SRCNN has no publishable row.
 
 ### What these were computed against
 

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -77,11 +77,18 @@ data:
 
 trainer:
   max_epochs: -1
-  # The paper's 8e8 backpropagations exactly, at batch 128. "Backpropagations" is
-  # per-sample: the authors' solver caps at max_iter 15000000 ITERATIONS, so the
-  # mini-batch reading (8e8 iterations) is impossible against their own file.
-  max_steps: 6250000
-  val_check_interval: 312500   # 20 validation cycles over the run
+  # The authors' released solver: max_iter 15000000 ITERATIONS.
+  # !! This DISAGREES with the paper, and the disagreement is deliberate to
+  # preserve rather than resolve. 15000000 x 128 = 1.92e9 backpropagations,
+  # against the paper's stated 8e8 (which would be 6250000 iterations here).
+  # We follow the authors' file, because it is the value they state; the paper's
+  # figure is presumably where they snapshotted from (snapshot: 500), but which
+  # snapshot produced the published numbers is not recorded anywhere.
+  # PRACTICAL: this is a very long run. snapshot cadence is what it is for --
+  # stop early at a checkpoint rather than lowering this to a number no source
+  # states.
+  max_steps: 15000000
+  val_check_interval: 750000   # 20 validation cycles over the run
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
   log_every_n_steps: 1000

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -64,7 +64,8 @@ data:
         img_dir: data/BSD100_HR
         scale: *scale
   train_dataloader_kwargs:
-    batch_size: 64             # not specified by the paper; this project's choice
+    # The authors' released Caffe train prototxt: hdf5_data_param.batch_size 128.
+    batch_size: 128
     # Load-bearing on real data: num_workers=0 hits a hard serial floor.
     num_workers: 16
     pin_memory: true
@@ -76,9 +77,11 @@ data:
 
 trainer:
   max_epochs: -1
-  # ~0.8x the paper's 8e8 backprops, read as per-sample updates. An approximation.
-  max_steps: 10000000
-  val_check_interval: 500000   # 20 validation cycles over the run
+  # The paper's 8e8 backpropagations exactly, at batch 128. "Backpropagations" is
+  # per-sample: the authors' solver caps at max_iter 15000000 ITERATIONS, so the
+  # mini-batch reading (8e8 iterations) is impossible against their own file.
+  max_steps: 6250000
+  val_check_interval: 312500   # 20 validation cycles over the run
   check_val_every_n_epoch: null
   num_sanity_val_steps: -1
   log_every_n_steps: 1000


### PR DESCRIPTION
Closes #202. Bottom of the #199 stack.

## What settles it

The SRCNN authors released a Caffe training package. It was named in #199 as the artifact
that would settle rows 1 and 2 of the README's "Where the papers stop specifying" table, and
it does — both, from one file each.

- **`SRCNN_train.zip`**, from the CUHK project page linked by both the ECCV 2014 and TPAMI
  2015 papers
- retrieved **2026-09-01**, SHA-256
  `001146419f7acfb12a3e7929c8acd5de88a08d687d6881085f81321ad6982b1a`

## The two rows

| field | authors | shipped before | shipped now |
|---|---|---|---|
| `hdf5_data_param.batch_size` (TRAIN phase) | `128` | `64` | **`128`** |
| `max_iter` | `15000000` | `max_steps: 10000000` | **`max_steps: 15000000`** |

## The paper and the authors' code disagree, and this preserves that

The paper says *"the same number of backpropagations (i.e. 8x10^8)"*. The solver says
`max_iter: 15000000`. At batch 128 that is **1.92x10^9** — a factor of **2.4** apart.

**Settled by the file:** 8x10^8 cannot mean *iterations*, since it exceeds the authors' own cap
by two orders of magnitude. Per-sample is the only consistent reading, which this project had
already inferred and no longer has to.

**Deliberately left open:** which number is the training budget. This ships the authors'
`15000000`, because that is what a primary source states.

An earlier revision of this branch shipped `6250000` — the value that makes the paper's 8x10^8
come out exact at batch 128. That was **cherry-picking one artifact**: it took `batch_size` from
the solver as authoritative and then overrode `max_iter` from the same file, on the strength of
our own inference that `max_iter` paired with `snapshot: 500` is a ceiling rather than a target.
That inference is plausible, and **which snapshot produced the published numbers is recorded
nowhere**, so it stays an inference. Following the file and stating the disagreement is the
honest position; resolving it silently is not.

Practically this is a long run. Stop on a checkpoint rather than lower the config to a number
no source states.

## Five fields that already matched

Worth stating, because it is evidence the port was faithful where it could be checked:
`base_lr: 0.0001`, `momentum: 0.9`, `weight_decay: 0`, the per-layer `lr_mult` structure
(`1`, `1`, `0.1` -> our `layer_lrs: [1e-4, 1e-4, 1e-5]`), and `weight_filler` std `0.001`.

## Blast radius

**No published number changes** — SRCNN has no publishable row, as the README already states.
`val_check_interval` scales with `max_steps` to keep 20 validation cycles.

One divergence *was* found while comparing, and is filed separately rather than fixed here
because it needs a schema change rather than a value change.

Public-file scrub for internal identifiers and absolute paths: clean.
