### PR TITLE
refactor: compact prose in sisr/training, losing no rule

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -42,15 +42,9 @@ def _sr(pl_module: lightning.LightningModule) -> "SRLightning":
     with a narrower parameter type is unsound and rejected, so the narrowing
     happens at the boundary instead, once, with a name.
 
-    A cast rather than an ``isinstance`` check on purpose: a module without those
-    attributes already fails at exactly the same call today, and turning that into
-    a different failure is a behaviour change this seam has no business making.
-
-    Args:
-        pl_module: The module Lightning handed the hook.
-
-    Returns:
-        The same object, typed as what it has to be.
+    A cast, not an ``isinstance`` check: a module without those attributes
+    already fails at the same call today, and turning that into a different
+    failure is a behaviour change this seam has no business making.
     """
     return cast("SRLightning", pl_module)
 
@@ -85,14 +79,8 @@ def _logger_step(trainer: lightning.Trainer) -> int:
     ``_batches_that_stepped`` for precisely this reason — "increased once per
     batch disregarding multiple optimizers on purpose for loggers" — and reads
     it back in ``logger_connector``; its own ``LearningRateMonitor`` and
-    ``DeviceStatsMonitor`` reach for the same private attribute, which is what
-    makes matching them here the correct call rather than a shortcut.
-
-    Args:
-        trainer: The active trainer.
-
-    Returns:
-        The batch-counted step shared by every ``self.log`` metric.
+    ``DeviceStatsMonitor`` reach for the same private attribute, which makes
+    matching them here correct rather than a shortcut.
     """
     return trainer.fit_loop.epoch_loop._batches_that_stepped
 
@@ -100,57 +88,44 @@ def _logger_step(trainer: lightning.Trainer) -> int:
 class BenchmarkImageLogger(Callback):
     """Logs bicubic|SR|HR image composites and PSNR/SSIM to TensorBoard for held-out sets.
 
-    Covers one or more held-out test/benchmark dataloaders (Set5, Set14, …).
-    Fires during *both* validation and test stages:
+    Fires during *both* validation and test, and the dataloader indexing
+    differs between them:
 
-    * **During `cli fit` / `cli validate`** — `SRDataModule.val_dataloader()`
-      returns ``[primary_val] + [test_loaders...]``; this callback ignores
-      ``dataloader_idx == 0`` (handled by `SRLightning.validation_step`) and
-      processes indices ``1..N`` against ``dataset_names``.  Images are
-      logged every *n*-th val run (controlled by ``every_n_val_runs``)
-      so TensorBoard storage stays bounded over long training schedules.
-    * **During `cli test`** — `SRDataModule.test_dataloader()` returns the
-      test loaders only (no primary), so indices ``0..N-1`` map straight to
-      ``dataset_names``.  Images are logged every test run (no throttle —
-      ``cli test`` is typically a one-shot final-eval invocation).
+    * **`cli fit` / `cli validate`** — ``val_dataloader()`` returns
+      ``[primary_val] + test_loaders``, so this ignores ``dataloader_idx == 0``
+      (owned by ``SRLightning.validation_step``) and maps ``1..N`` onto
+      ``dataset_names``. Image strips are throttled by ``every_n_val_runs``.
+    * **`cli test`** — ``test_dataloader()`` returns the test loaders only, so
+      ``0..N-1`` map straight across. No throttle; test is one-shot.
 
-    Each image lands as a horizontal **bicubic | SR | HR** strip at HR scale:
-    the LR is bicubic-upsampled to HR size (the standard SR baseline), and the
-    SR output is center-padded when smaller than HR (``padding='valid'``) so
-    all three panels share the same spatial size.
+    Each image is a horizontal **bicubic | SR | HR** strip at HR scale: LR is
+    bicubic-upsampled (the standard SR baseline) and SR is center-padded when
+    ``padding='valid'`` made it smaller, so all three panels align.
 
-    Per-set means go under ``"psnr/{name}/{key}"``, ``"ssim/{name}/{key}"`` and,
-    for each metric in ``eval_config.perceptual_keys``, ``"{metric}/{name}"``
-    (e.g. ``"lpips/Set5"``) every cycle. Per-image scalars under
-    ``"per_image/{name}/psnr/{key}/{filename}"`` and
-    ``"per_image/{name}/ssim/{key}/{filename}"`` are gated by
-    ``log_per_image_metrics`` (default off — see that arg).
+    Tags: per-set means under ``psnr/{name}/{key}``, ``ssim/{name}/{key}`` and
+    ``{metric}/{name}`` for each of ``eval_config.perceptual_keys``, every
+    cycle. Per-image scalars under ``per_image/{name}/{psnr,ssim}/{key}/
+    {filename}``, gated by ``log_per_image_metrics``.
 
-    Border cropping is sourced from ``pl_module.eval_config.crop_border`` at
-    the use site; this avoids dual-knob configuration drift.
+    **Border cropping comes from ``pl_module.eval_config.crop_border`` at the
+    use site**, never a second knob here, so the two cannot drift.
 
-    Metrics are computed directly on the on-device SR/HR slices (mirroring
-    the primary-val-loader path in ``SRLightning.validation_step``) and both
-    the per-image scalars and the image strip are emitted immediately, per
-    image, from :meth:`_collect_batch` — nothing image-shaped is buffered.
-    Buffering full-resolution LR/SR/HR CPU tensors for every image across
-    every test set until epoch end cost ~0.5 GB per validation cycle purely
-    to defer ``add_image``; only a :class:`BenchmarkSample` (filename +
-    PSNR/SSIM/perceptual dicts) is buffered now, for the per-set mean computed in
-    :meth:`_flush_buffer`. The TensorBoard experiment is resolved once, in
-    :meth:`setup`, rather than re-searched on every batch/epoch-end.
+    Metrics are computed on the on-device SR/HR slices, mirroring
+    ``validation_step``, and both the scalars and the strip are emitted per
+    image from :meth:`_collect_batch` — **nothing image-shaped is buffered**.
+    Buffering full-resolution CPU tensors until epoch end cost ~0.5 GB per
+    validation cycle purely to defer ``add_image``; only a
+    :class:`BenchmarkSample` is held now, for the mean in :meth:`_flush_buffer`.
+    The TensorBoard experiment is resolved once in :meth:`setup`.
 
     Args:
-        dataset_names: Ordered list of test set names (e.g.
-            ``["Set5", "Set14"]``) matching the order of
+        dataset_names: Ordered test set names, matching
             ``SRDataModule.test_dataloader()`` / the trailing entries of
-            ``val_dataloader()``.  When ``None`` the callback auto-discovers
-            from ``trainer.datamodule.test_names``.
-        every_n_val_runs: Image-strip throttle for the val stage.  With
-            step-based training (e.g. ``val_check_interval=1000``,
-            ``max_steps=100_000``) val fires ~100 times, so logging every 5
-            runs gives ~20 image snapshots — enough to track visual
-            progress without flooding TensorBoard storage.  Default ``5``.
+            ``val_dataloader()``. ``None`` auto-discovers from
+            ``trainer.datamodule.test_names``.
+        every_n_val_runs: Image-strip throttle for the val stage. Default
+            ``5`` — with ~100 val runs that is ~20 snapshots, enough to track
+            visual progress without flooding storage.
         log_per_image_metrics: Emit the ``per_image/...`` PSNR/SSIM scalars
             (one series per image per key). Default ``False``: with N test
             images and both PSNR/SSIM keyed by colorspace, this is
@@ -365,28 +340,21 @@ class BenchmarkImageLogger(Callback):
     ) -> None:
         """Forward one batch, compute per-image metrics on-device, and stream image strips.
 
-        Shared between :meth:`on_validation_batch_end` and
-        :meth:`on_test_batch_end`. Border cropping is sourced from
-        ``pl_module.eval_config.crop_border`` at the use site.
-        *source_dataloaders* recovers the underlying dataset for filename
-        resolution.
+        Shared by :meth:`on_validation_batch_end` and
+        :meth:`on_test_batch_end`. ``crop_border`` comes from
+        ``pl_module.eval_config`` at the use site; *source_dataloaders*
+        recovers the dataset for filename resolution.
 
-        PSNR/SSIM/perceptual are computed from the on-device ``sr``/``hr_cropped``
-        slices — mirroring the primary-val-loader path in
-        ``SRLightning.validation_step`` — so only the scalar ``.item()``
-        results ever leave the GPU. SSIM and perceptual scores go through
-        ``pl_module.scorer`` — the same object ``validation_step`` uses — rather
-        than calling ``torchmetrics``/``perceptual_score`` here directly, so
-        this callback cannot silently diverge from ``validation_step`` on the
-        crop, the reductions, or which SSIM/perceptual backbone a given
-        ``eval_config`` means. When
-        *should_log_images* (or
-        ``self.log_per_image_metrics``), exactly one host transfer per image
-        (``lr_img[i]``/``sr[i]``/``hr_img[i]`` each ``.cpu()`` at most once)
-        composes the bicubic|SR|HR strip and/or the per-image scalars, and
-        both are emitted to TensorBoard immediately — nothing image-shaped is
-        buffered. Only ``BenchmarkSample(filename, psnr_dict, ssim_dict,
-        perceptual_dict)`` is appended to ``self._buffer``, for
+        Metrics are computed from the on-device ``sr``/``hr_cropped`` slices, so
+        only scalar ``.item()`` results leave the GPU, and **they go through
+        ``pl_module.scorer``** — the object ``validation_step`` uses — rather
+        than calling ``torchmetrics``/``perceptual_score`` directly, so this
+        callback cannot diverge from ``validation_step`` on the crop, the
+        reductions, or which backbone an ``eval_config`` means.
+
+        When images or per-image scalars are wanted, exactly one host transfer
+        per image composes them and both are emitted immediately — **nothing
+        image-shaped is buffered**; only a ``BenchmarkSample`` is kept, for
         :meth:`_flush_buffer`'s per-set mean.
         """
         lr_img, hr_img = batch
@@ -667,18 +635,13 @@ class _RollingSaveMixin(_RollingBase):
     ``monitor=None, save_top_k=-1`` (keep everything) with the window
     enforced here. Verified on Lightning 2.6.5.
 
-    Shared by :class:`SRCheckpoint` and :class:`SRWeightsCheckpoint` —
-    siblings under :class:`~lightning.pytorch.callbacks.ModelCheckpoint`, not
-    parent/child, so this logic can't be reused via one ``super()`` chain
-    across both. The window bookkeeping itself lives in
-    :meth:`_enforce_rolling_window`, a seam distinct from ``_save_checkpoint``:
-    :class:`SRWeightsCheckpoint` already overrides ``_save_checkpoint`` to
-    write a bare ``.safetensors`` payload instead of Lightning's full checkpoint, and
-    that override does not call ``super()._save_checkpoint()`` — so a version
-    of this mixin that put the bookkeeping inside its own ``_save_checkpoint``
-    would be shadowed by that override and silently never run. Each
-    subclass's ``_save_checkpoint`` calls :meth:`_enforce_rolling_window`
-    explicitly instead.
+    Shared by :class:`SRCheckpoint` and :class:`SRWeightsCheckpoint`, which are
+    siblings rather than parent/child, so one ``super()`` chain cannot serve
+    both. **The bookkeeping lives in :meth:`_enforce_rolling_window`, not in a
+    ``_save_checkpoint`` of this mixin**: ``SRWeightsCheckpoint`` overrides
+    ``_save_checkpoint`` without calling ``super()``, so a mixin version would
+    be shadowed and silently never run. Each subclass calls
+    :meth:`_enforce_rolling_window` explicitly.
 
     The window itself is never persisted in ``state_dict`` — it is rebuilt from
     the files already on disk when a run resumes (:meth:`on_train_start`), which
@@ -849,15 +812,9 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
 
         Siblings are compared before Lightning has necessarily set them all up, so
         this cannot be read off ``self.filename`` -- that still holds
-        ``DEFAULT_PREFIX`` on anything yet to reach setup.
-
-        Args:
-            pl_module: The model being trained; supplies the provenance a derived
-                prefix is a projection of.
-
-        Returns:
-            The explicit ``filename_prefix`` if one was given, else the stem derived
-            from what this callback saves.
+        ``DEFAULT_PREFIX`` on anything yet to reach setup. Returns the explicit
+        ``filename_prefix`` if given, else the stem derived from what this
+        callback saves.
         """
         if self._explicit_prefix is not None:
             return self._explicit_prefix
@@ -935,9 +892,6 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
         lower-is-better comes from ``PERCEPTUAL_METRICS`` rather than being
         restated here, so a future higher-is-better perceptual metric would still
         be checked in the right direction.
-
-        Args:
-            pl_module: The model being trained; must expose ``eval_config``.
 
         Raises:
             MisconfigurationException: If ``monitor`` does not name a metric
@@ -1024,21 +978,16 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
 class SRCheckpoint(_SRCheckpointBase):
     """Model checkpoint that monitors a super-resolution quality metric.
 
-    A thin convenience wrapper around
-    :class:`~lightning.pytorch.callbacks.ModelCheckpoint` that
-    automatically sets ``mode='max'`` (both PSNR and SSIM are
-    higher-is-better) and builds a descriptive filename pattern.
+    Wraps :class:`~lightning.pytorch.callbacks.ModelCheckpoint` with
+    ``mode='max'`` (PSNR and SSIM are both higher-is-better) and a descriptive
+    filename pattern.
 
-    The filename's metric *label* is sanitised (``/`` -> ``_``) and
-    ``auto_insert_metric_name`` is disabled, so a ``/``-bearing
-    ``monitor_metric`` (e.g. the default ``psnr/val/RGB`` TensorBoard-hierarchy
-    tag) cannot leak a raw ``/`` into the filename template. Lightning's
-    ``_format_checkpoint_name`` does no sanitisation itself, and with
-    ``auto_insert_metric_name=True`` (the default) a raw ``/`` there causes
-    ``TorchCheckpointIO`` to silently create a nested directory tree per
-    save instead of a flat file. The ``metrics`` dict lookup that supplies
-    the interpolated *value* is unaffected — it is a plain dict key and
-    handles ``/`` fine.
+    **The metric label is sanitised (``/`` -> ``_``) and
+    ``auto_insert_metric_name`` is disabled**, so a ``/``-bearing
+    ``monitor_metric`` cannot leak into the filename template. Lightning does
+    no sanitisation itself, and a raw ``/`` there makes ``TorchCheckpointIO``
+    silently create a nested directory tree per save instead of a flat file.
+    The ``metrics`` dict lookup supplying the *value* is unaffected.
 
     Args:
         monitor_metric: The validation metric to monitor. Any ``psnr/val/{key}``
@@ -1079,39 +1028,33 @@ class SRCheckpoint(_SRCheckpointBase):
 class SRWeightsCheckpoint(_SRCheckpointBase):
     """Model checkpoint that saves bare, optimizer-free weights as ``.safetensors``.
 
-    A distributable sibling to :class:`SRCheckpoint`: that class produces resumable
-    ``.ckpt`` files (full training state — optimizer moments, LR scheduler, callback
-    state); this one produces ``.safetensors`` files containing only
-    ``getattr(pl_module, attribute).state_dict()`` plus a matching provenance dict.
-    By default ``attribute='model'`` — the bare :class:`~sisr.models.base.SRModel` (so
-    keys carry no ``model.`` wrapper prefix), described by
-    :func:`~sisr.training.metadata.build_metadata`. Any other ``attribute`` (e.g.
-    ``'discriminator'``) saves that component instead, described by
-    :func:`~sisr.training.metadata.build_component_metadata` — ``build_metadata``'s
-    generator-scoped fields (``io.scale``, ``criterion``, ``eval_config``) would
-    describe something a non-generator file does not contain. Both run side by side
-    off the same validation metrics — top-k selection, monitor validation (inherited
-    from ``SRCheckpoint``'s ``setup``), and filename formatting are inherited from
-    :class:`~lightning.pytorch.callbacks.ModelCheckpoint` unchanged; only
-    :meth:`_save_checkpoint` — the single method that actually writes bytes to disk —
-    is overridden to swap the payload.
+    The distributable sibling to :class:`SRCheckpoint`: that writes resumable
+    ``.ckpt`` files (optimizer moments, scheduler, callback state); this writes
+    only ``getattr(pl_module, attribute).state_dict()`` plus provenance.
+    ``attribute='model'`` (default) saves the bare ``SRModel`` — so keys carry
+    no ``model.`` prefix — described by
+    :func:`~sisr.training.metadata.build_metadata`. Any other attribute uses
+    :func:`~sisr.training.metadata.build_component_metadata` instead, because
+    ``build_metadata``'s generator-scoped fields (``io.scale``, ``criterion``,
+    ``eval_config``) would describe something the file does not contain.
 
-    ``_save_checkpoint`` is a private Lightning method, unlike the rest of this class's
-    public-API surface. ``tests/training/test_callbacks.py``'s
-    ``test_sr_weights_checkpoint_writes_bare_payload_via_real_fit`` guards against a
-    future Lightning release routing saves through a different method: that test fails
-    loudly rather than silently letting saves fall back to full, optimizer-bearing
+    Everything else — top-k selection, monitor validation, filename formatting
+    — is inherited unchanged; **only :meth:`_save_checkpoint` is overridden**,
+    to swap the payload.
+
+    That method is private Lightning API, unlike the rest of this class's
+    surface. ``test_sr_weights_checkpoint_writes_bare_payload_via_real_fit``
+    guards it: if a future Lightning routes saves elsewhere, that test fails
+    loudly rather than letting saves fall back to full, optimizer-bearing
     checkpoints under a misleadingly bare ``.safetensors`` extension.
 
-    ``FILE_EXTENSION`` (public) and a distinct default ``filename_prefix`` keep this
-    callback's top-k deletion pass — and, in rolling mode, its own oldest-first deletion
-    (see :class:`_RollingSaveMixin`) — from ever touching :class:`SRCheckpoint`'s files
-    when both share one ``dirpath``: each callback only ever names/deletes files matching
-    its own ``filename``/``FILE_EXTENSION`` combination.
-
-    That keeps the two *classes* apart. It does not keep two instances of one class
-    apart — a pair differing only in ``monitor_metric`` derives one stem and collides,
-    which :meth:`_SRCheckpointBase._reject_filename_collision` now refuses at startup.
+    ``FILE_EXTENSION`` plus a distinct default ``filename_prefix`` keep this
+    callback's deletion passes off :class:`SRCheckpoint`'s files when both
+    share a ``dirpath`` — each only names and deletes files matching its own
+    ``filename``/``FILE_EXTENSION`` pair. That separates the two *classes*, not
+    two instances of one: a pair differing only in ``monitor_metric`` derives
+    the same stem and collides, which
+    :meth:`_SRCheckpointBase._reject_filename_collision` refuses at startup.
 
     Args:
         monitor_metric: The validation metric to monitor — same contract as
@@ -1176,17 +1119,14 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
         configuration ``attribute`` exists for, and the one the SRGAN template
         ships — cannot be constructed at all.
 
-        Appended to ``super()``'s key rather than rebuilding it, so a Lightning
-        release that adds or renames a key field is carried through here
-        unchanged instead of silently dropping it.
+        Appended to ``super()``'s key rather than rebuilt, so a Lightning
+        release that adds or renames a key field carries through unchanged.
 
-        Resuming a ``.ckpt`` written before this key gained its ``attribute``
-        suffix finds no state under the new key, so this callback's monitored
-        bookkeeping (``best_model_score``/``best_k_models``, i.e. what a
-        ``save_top_k`` run has already kept) restarts from empty for the rest of
-        that run. Rolling mode loses nothing — its window was never persisted
-        under any key, and :meth:`_RollingSaveMixin.on_train_start` rebuilds it
-        from this callback's own files on disk before the first save.
+        **Resuming a ``.ckpt`` written before this key gained its ``attribute``
+        suffix finds no state under the new key**, so monitored bookkeeping
+        (``best_model_score``/``best_k_models``) restarts empty for the rest of
+        that run. Rolling mode loses nothing: its window was never persisted,
+        and :meth:`_RollingSaveMixin.on_train_start` rebuilds it from disk.
 
         Returns:
             A key unique per ``(monitor, mode, cadence, attribute)``.
@@ -1250,27 +1190,18 @@ class SRWeightsCheckpoint(_SRCheckpointBase):
         public save path (``_save_topk_checkpoint``, ``_save_none_monitor_checkpoint``,
         ``_save_last_checkpoint``) funnels through — so ``save_top_k``/filename/removal
         bookkeeping all keep working unmodified; only the on-disk payload changes.
-        Mirrors the base implementation's post-save bookkeeping (``_last_global_step_saved``,
-        ``_last_checkpoint_saved``, logger notification) so this callback stays a drop-in
-        peer of :class:`SRCheckpoint` from the trainer's point of view.
+        Mirrors the base's post-save bookkeeping (``_last_global_step_saved``,
+        ``_last_checkpoint_saved``, logger notification) so this stays a drop-in
+        peer of :class:`SRCheckpoint` to the trainer.
 
-        ``self.attribute`` selects both the saved component and its metadata builder:
-        ``'model'`` (the default) uses :func:`~sisr.training.metadata.build_metadata`,
-        which describes the generator; anything else uses
-        :func:`~sisr.training.metadata.build_component_metadata`, so a discriminator's
-        artifact never carries metadata describing a network it does not contain.
+        ``self.attribute`` selects the saved component *and* its metadata
+        builder: ``'model'`` uses ``build_metadata`` (generator-scoped),
+        anything else ``build_component_metadata`` — so a discriminator's
+        artifact never carries metadata for a network it does not contain.
 
-        Rolling-mode deletion (:meth:`_RollingSaveMixin._enforce_rolling_window`) runs
-        last, after this method's own writes — it does not go through ``super()``
-        the way :class:`SRCheckpoint`'s does, since this override never calls
-        ``ModelCheckpoint._save_checkpoint`` at all (that would write the full,
-        optimizer-bearing payload this class exists to avoid).
-
-        Args:
-            trainer: The active trainer — supplies ``lightning_module`` (for the
-                component's ``state_dict()`` and metadata) and ``global_step``/``current_epoch``.
-            filepath: Destination path, already formatted by ``ModelCheckpoint``
-                (``.safetensors`` via ``FILE_EXTENSION``).
+        **Rolling deletion runs last and is called explicitly**, because this
+        override never calls ``ModelCheckpoint._save_checkpoint`` (that would
+        write the optimizer-bearing payload this class exists to avoid).
         """
         pl_module = trainer.lightning_module
         component = getattr(pl_module, self.attribute)

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -1,31 +1,22 @@
 """Per-architecture training and evaluation configuration dataclasses.
 
-Split into two classes by lifecycle:
-
-* ``SRTrainingConfig`` controls behaviour during ``cli fit`` — per-Conv2d
-  learning rates, paper-init knobs, and the example input shape used to log
-  the model graph to TensorBoard.
-* ``SREvalConfig`` controls validation/test metric computation —
-  boundary-pixel exclusion (``crop_border``) and which colorspaces PSNR/SSIM
-  are reported in.
+Split by lifecycle: ``SRTrainingConfig`` controls ``cli fit`` (per-Conv2d LRs,
+paper-init knobs, the TensorBoard graph's example input); ``SREvalConfig``
+controls validation/test scoring only (border exclusion, metric colorspaces).
 
 Per-architecture defaults live in subclasses next to the model code (e.g.
-``sisr.models.srcnn.SRCNNTrainingConfig``); a YAML user picks them via
-``class_path`` on ``model.training_config`` / ``model.eval_config`` and
-overrides individual fields with ``init_args``.
+``sisr.models.srcnn.SRCNNTrainingConfig``); YAML picks one via ``class_path``
+on ``model.training_config`` / ``model.eval_config``.
 
-The colorspace the model trains in is no longer a string field here; it is
-expressed by the choice of processor (see ``sisr.processors``).
+The model's training colorspace is not a field here — it is the choice of
+processor (see ``sisr.processors``).
 
-``SRTrainingConfig.validate_against`` / ``SREvalConfig.psnr_keys`` /
-``SREvalConfig.ssim_keys`` are the config-side half of the correlated-field
-validation seam: fields like
-``num_channels`` (model) and ``class_path`` (processor) live in sibling
-objects a single dataclass ``__post_init__`` cannot see across, so the
-cross-object check happens once both are constructed, orchestrated by
+``validate_against`` / ``psnr_keys`` / ``ssim_keys`` are the config half of the
+correlated-field validation seam: ``num_channels`` (model) and ``class_path``
+(processor) live in sibling objects no single ``__post_init__`` can see across,
+so the cross-object check runs once both exist, orchestrated by
 ``SRLightning.__init__``.
 """
-
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -35,16 +26,10 @@ from ..metrics.perceptual import PERCEPTUAL_METRICS
 from ..models.base import SRModel
 from ..processors.base import SRProcessor
 
-# Colorspace entries map to their sub-channel names, expanded only when
-# separate_psnr=True; single-channel entries (e.g. 'Y') map to () since
-# there's nothing further to decompose — this lets a bare channel name be
-# requested as a first-class psnr_channels/ssim_channels entry (e.g.
-# ['RGB', 'Y'] for the paper's Y-only metric without YCbCr's
-# smoother-chroma-diluted aggregate).
-# Doubles as the set of supported ``psnr_channels``/``ssim_channels`` entries
-# (validated in `SREvalConfig.__post_init__`) — shared by both metric
-# families so PSNR and SSIM cannot silently diverge on which colorspace
-# names are legal.
+# Maps a colorspace to its sub-channel names, expanded only when separate_psnr=True;
+# single-channel entries map to () so a bare channel name is itself a legal
+# psnr_channels/ssim_channels entry. Doubles as the allowlist for both metric
+# families, so PSNR and SSIM cannot diverge on which names are legal.
 _CHANNEL_SUBNAMES: dict[str, tuple[str, ...]] = {
     "RGB": ("R", "G", "B"),
     "YCbCr": ("Y", "Cb", "Cr"),
@@ -62,90 +47,64 @@ class SRTrainingConfig:
     """How to train the SR model — affects optimizer setup and weight init.
 
     Args:
-        layer_lrs: Absolute per-``Conv2d`` learning rates (one entry per
-            ``Conv2d`` in the model, in module-traversal order).  When
-            ``None`` (default), training uses the optimizer's base ``lr``
-            uniformly across all parameters.  Only valid for architectures
-            where every trainable parameter lives in a ``Conv2d`` (no
-            BatchNorm / PReLU); ``SRLightning.configure_optimizers``
-            raises ``ValueError`` otherwise.
+        layer_lrs: Absolute per-``Conv2d`` LRs, one per ``Conv2d`` in
+            module-traversal order. ``None`` (default) uses the optimizer's
+            base ``lr`` uniformly. Only valid where every trainable parameter
+            lives in a ``Conv2d`` — no BatchNorm / PReLU;
+            ``SRLightning.configure_optimizers`` raises ``ValueError``
+            otherwise. Applies to a layer's weight *and* bias together.
 
-        example_input_shape: Shape of a single input sample *excluding* the
-            batch dimension (e.g. ``(1, 33, 33)`` for a 33×33 Y-channel patch).
-            When provided, ``self.example_input_array`` is set so the
-            TensorBoard logger can capture the model graph, and
-            :meth:`validate_against` probes the model with it.
+        example_input_shape: One sample's shape *excluding* batch (e.g.
+            ``(1, 33, 33)``). Sets ``example_input_array`` so TensorBoard can
+            capture the graph, and gives :meth:`validate_against` a probe.
 
-        init_strategy: ``'paper'`` triggers a paper-faithful weight init via
-            ``SRModel.reset_parameters`` in ``SRLightning``'s constructor;
-            ``'default'`` (the default) skips it and uses PyTorch's defaults.
-            Subclasses pin a paper-faithful default (e.g. ``SRCNNTrainingConfig``
-            uses ``'paper'``).
+        init_strategy: ``'paper'`` runs ``SRModel.reset_parameters`` from
+            ``SRLightning``'s constructor; ``'default'`` uses PyTorch's.
+            Subclasses pin a paper-faithful default.
 
-        init_mean: Mean of the Gaussian for ``init_strategy='paper'``
-            implementations. Not itself paper-derived — this shared base
-            has no single paper to match; architectures with a paper init
-            (e.g. ``SRCNNTrainingConfig``) override with their actual value.
-            Defaults to ``0.0``.
+        init_mean: Gaussian mean for ``init_strategy='paper'``. **Not
+            paper-derived** — this base has no single paper; architectures with
+            one override it.
 
-        init_std: Std of the Gaussian for ``init_strategy='paper'``
-            implementations. Not itself paper-derived — see ``init_mean``;
-            e.g. ``SRCNNTrainingConfig`` overrides this to ``0.001``, the
-            value its paper specifies. Defaults to ``0.01``.
+        init_std: Gaussian std for ``init_strategy='paper'``. Not paper-derived
+            either — see ``init_mean``.
 
-        scale: The model's upscaling factor, for provenance metadata and
-            cross-checking against the model's own ``scale`` hparam (see
-            :meth:`validate_against`). **Required for any run that writes an
-            artifact** on an architecture carrying no ``scale`` hparam of its
-            own — :func:`~sisr.training.metadata.build_metadata` refuses rather
-            than recording a null. It used to be documented as optional there,
-            which held while the metadata was read only by us; a file handed to
-            a stranger has to state the factor, because for a pre-upsampled
-            architecture it is what they must resize the input by. Still
-            deliberately not inferred from
-            ``trainer.datamodule.train_dataset.scale``: that attribute lives
-            outside the ``SRDataset`` contract (``PredictDataset`` has none at
-            all), whereas per-paper knobs already live here.
+        scale: The model's upscaling factor, for provenance metadata and for
+            cross-checking the model's own ``scale`` hparam. **Required for any
+            run that writes an artifact** on an architecture carrying no
+            ``scale`` hparam: :func:`~sisr.training.metadata.build_metadata`
+            refuses rather than record a null, because a file handed to a
+            stranger must state the factor — for a pre-upsampled architecture
+            it is what they resize the input by. Deliberately not inferred from
+            the datamodule: that attribute is outside the ``SRDataset``
+            contract (``PredictDataset`` has none), whereas per-paper knobs
+            already live here.
 
-        compile_backend: Name of a ``torch._dynamo`` backend (e.g.
-            ``'cudagraphs'``, ``'inductor'``) to compile the training-mode
-            forward with via ``torch.compile``; ``None`` (default) trains
-            eager. Only ``training_step`` is compiled — ``SRLightning``
-            dispatches on ``self.training``, so validation/test/predict
-            always run eager, which the widely varying benchmark image
-            sizes require (CUDA-graph-style backends need static shapes).
-            An unrecognized name raises immediately at ``SRLightning``
-            construction (``torch._dynamo.exc.InvalidBackend``); a
-            recognized name whose toolchain is missing (e.g. ``'inductor'``
-            without a Triton install) only fails on first call, which
-            ``SRLightning.on_fit_start`` turns into an immediate failure via
-            a warm-up forward instead of an arbitrary mid-run crash.
-            Measured on one RTX 5060 Laptop (SRResNet, batch 16, 24x24 LR):
-            ``'inductor'`` is the only backend that pays, and by a mid-teens
-            percent rather than the multiples a microbenchmark suggests;
-            ``'cudagraphs'`` is within noise of eager — it captures the model
-            forward only, so backward and the optimizer step stay eager and
-            most kernel launches in a training step are never captured — and
-            ``'aot_eager'`` is slower. On SRCNN eager wins every comparison.
-            No backend is bit-identical to eager on SRResNet, so a compiled
-            run does not reproduce an eager one exactly. Defaults to ``None``,
-            and staying there is the standing recommendation.
+        compile_backend: A ``torch._dynamo`` backend to compile the
+            training-mode forward with; ``None`` (default) trains eager. **Only
+            ``training_step`` is compiled** — validation/test/predict stay eager,
+            which the widely varying benchmark image sizes require. An
+            unrecognized name raises at ``SRLightning`` construction; a
+            recognized name with a missing toolchain (e.g. ``'inductor'``
+            without Triton) would fail on first call, so
+            ``SRLightning.on_fit_start`` forces it early with a warm-up forward
+            rather than crash mid-run. Measured: ``'inductor'`` is the only
+            backend that pays, by a mid-teens percent; ``'cudagraphs'`` is
+            within noise (it captures the forward only) and ``'aot_eager'`` is
+            slower; on SRCNN eager wins outright. **No backend is bit-identical
+            to eager on SRResNet**, so a compiled run does not reproduce an
+            eager one. Staying at ``None`` is the standing recommendation.
 
-        compile_mode: ``torch.compile``'s ``mode`` — ``'reduce-overhead'``,
-            ``'max-autotune'``, ... — applied alongside ``compile_backend``.
-            ``None`` (default) leaves inductor on its own default mode, which
-            is what every configured run got before this field existed: the
-            call site passed ``backend`` and nothing else, so a published
-            ``reduce-overhead`` or ``max-autotune`` figure described something
-            no YAML could select. Requires ``compile_backend='inductor'``,
-            because ``mode`` is an inductor setting and torch forwards it to
-            any other backend as a keyword its compiler function does not
-            accept — a failure on the first compiled call, which this refuses
-            at construction instead. An unrecognized mode also raises there,
-            from torch. Which mode wins does not hold across precisions on
-            this hardware: ``'max-autotune'`` beat ``'reduce-overhead'`` under
-            bf16 and lost to it under fp32, so treat a mode as measured per
-            configuration, never as a default.
+        compile_mode: ``torch.compile``'s ``mode``, applied alongside
+            ``compile_backend``. ``None`` (default) leaves inductor on its own
+            default. **Requires ``compile_backend='inductor'``** — ``mode`` is
+            an inductor setting, and torch forwards it to any other backend as
+            a keyword its compiler does not accept, failing on the first
+            compiled call; this refuses at construction instead. An
+            unrecognized mode raises there too, from torch. **Which mode wins
+            does not hold across precisions**: ``'max-autotune'`` beat
+            ``'reduce-overhead'`` under bf16 and lost under fp32 — measure per
+            configuration, never assume.
     """
 
     layer_lrs: list[float] | None = None
@@ -176,40 +135,26 @@ class SRTrainingConfig:
     def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
         """Validate this config against the model/processor it will pair with.
 
-        Universal, architecture-agnostic checks:
+        Universal checks: ``self.scale`` must agree with the model's ``'scale'``
+        hparam when both exist (either absent skips, rather than guessing); and
+        when ``example_input_shape`` is set its channel dimension must equal
+        ``processor.model_channels`` and a ``no_grad`` forward of the real
+        model must succeed. The probe exercises the actual ``nn.Module``, so it
+        cannot go stale as the architecture evolves.
 
-        - When ``self.scale`` is set and ``model.hparams`` declares a
-          ``'scale'`` entry, the two must agree. Either side being absent
-          (``self.scale is None``, or the model has no ``'scale'`` hparam —
-          e.g. SRCNN) skips the check silently rather than guessing.
-        - When ``example_input_shape`` is set, its channel dimension must
-          equal ``processor.model_channels``, and a ``torch.no_grad()``
-          forward pass of the real ``model`` on a zero tensor of that shape
-          must succeed. The probe exercises the actual ``nn.Module`` rather
-          than a separate description of it, so it cannot go stale as the
-          architecture evolves. This half is a no-op when
-          ``example_input_shape`` is unset — it is optional (TensorBoard
-          graph / FLOPs reporting only).
-
-        Subclasses (e.g. ``SRCNNTrainingConfig``) override this to add
-        architecture-specific correlation checks — e.g. ``num_channels`` vs
-        ``processor.model_channels`` — that exist purely to raise an
-        actionable message *before* a mismatched pairing would otherwise
-        surface as a raw shape-mismatch error from this probe. They call
-        ``super().validate_against(model, processor)`` to keep the universal
-        checks.
+        Subclasses add architecture-specific correlation checks so a mismatched
+        pairing raises an actionable message *before* it would surface as a raw
+        shape mismatch from this probe; they call ``super()`` to keep these.
 
         Args:
-            model: The constructed :class:`~sisr.models.base.SRModel` this
-                config will train/evaluate.
+            model: The constructed :class:`~sisr.models.base.SRModel`.
             processor: The :class:`~sisr.processors.base.SRProcessor` paired
-                with ``model`` for this run.
+                with ``model``.
 
         Raises:
-            ValueError: If ``self.scale`` is set and disagrees with the
-                model's own ``scale`` hparam, or if ``example_input_shape``
-                is set and its channel dimension doesn't match
-                ``processor.model_channels``.
+            ValueError: If ``self.scale`` disagrees with the model's ``scale``
+                hparam, or ``example_input_shape``'s channel dimension does not
+                match ``processor.model_channels``.
         """
         if self.scale is not None and "scale" in model.hparams:
             model_scale = model.hparams["scale"]

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -17,6 +17,7 @@ correlated-field validation seam: ``num_channels`` (model) and ``class_path``
 so the cross-object check runs once both exist, orchestrated by
 ``SRLightning.__init__``.
 """
+
 from dataclasses import dataclass, field
 from typing import Literal
 

--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -23,15 +23,13 @@ def _validate_spec(field_name: str, spec: dict[str, Any]) -> None:
     """Raise if ``spec`` isn't a well-formed ``{class_path, init_args}`` mapping.
 
     Every dataset field on this module is typed ``dict[str, Any]`` (not the
-    real dataset class) so :meth:`SRDataModule.setup` can instantiate it
-    lazily, only for the stages that need it (see the module docstring). That
-    laziness has a cost: jsonargparse treats the field as an opaque dict, so a
-    dotted CLI override like ``--data.train_dataset.init_args.crops_per_image=8``
-    cannot reach the nested ``init_args`` key — it lands as a stray sibling
-    key next to ``class_path``/``init_args`` instead, invisible to
-    :func:`~lightning.pytorch.cli.instantiate_class`, which silently keeps
-    building the dataset with its old, unoverridden value. This check turns
-    that silent no-op into an immediate, actionable error.
+    real dataset class) so :meth:`SRDataModule.setup` can instantiate it lazily.
+    The cost: jsonargparse treats the field as an opaque dict, so a dotted CLI
+    override like ``--data.train_dataset.init_args.crops_per_image=8`` **cannot
+    reach the nested key** — it lands as a stray sibling next to
+    ``class_path``/``init_args``, invisible to ``instantiate_class``, which goes
+    on building the dataset with the old value. This turns that silent no-op
+    into an immediate error.
 
     Args:
         field_name: Dotted config path for the error message, e.g.
@@ -289,14 +287,13 @@ class SRDataModule(lightning.LightningDataModule):
         kwarg) and the YAML schema does not expose ``shuffle``.
 
         **Training is the only loader this module shards, and it shards it here
-        rather than letting Lightning do it.** Lightning's injection is a single
-        trainer-wide switch, and it would also split the validation and benchmark
-        loaders — which must not be split. ``DistributedSampler`` pads a set to a
-        multiple of the world size by *repeating* samples, so a five-image
-        benchmark across four processes becomes eight, three of them counted
-        twice, and the reported figure is no longer that set's score. Every
-        process therefore evaluates every benchmark image, and the reduction
-        across them is a no-op that also catches divergence.
+        rather than letting Lightning do it.** Lightning's injection is one
+        trainer-wide switch that would also split the eval loaders, and
+        ``DistributedSampler`` pads by *repeating* samples — a five-image
+        benchmark across four processes becomes eight, three counted twice, and
+        the figure is no longer that set's score. Every process therefore scores
+        every benchmark image, and the reduction is a no-op that catches
+        divergence.
 
         Returns:
             DataLoader over the train spec: shuffled, and split per process when

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -180,16 +180,12 @@ class SRGANLightning(SRLightning):
         pretrained weights and silently restart it, while the discriminator and
         the optimizer state carried on from where they were.
 
-        On a ``fit --ckpt_path`` resume, this runs (``Trainer._run`` calls the
-        setup hook at line 1039) *before* the resume restores the module's own
-        state (line 1046), so the resumed generator wins and the final model
-        state is correct either way. The costs are one wasted weights read and
-        a hard dependency on ``init_from``'s artifact existing on the resuming
-        box, even though its result is about to be discarded. The upside: the
-        five metadata refusals below still run on every resume, so a config
-        that has drifted from the run being resumed (a changed architecture,
-        processor, or scale) is still caught rather than only checked on a
-        fresh ``fit``.
+        On a ``fit --ckpt_path`` resume this runs *before* the resume restores
+        the module's state, so the resumed generator wins and the final state is
+        correct either way. It costs one wasted read and a hard dependency on
+        ``init_from``'s artifact existing on the resuming box. The upside is that
+        the metadata refusals below run on **every** resume, so a config that has
+        drifted from the run being resumed is still caught.
 
         Args:
             stage: Lightning trainer stage — ``'fit'``, ``'validate'``,
@@ -561,16 +557,14 @@ class SRGANLightning(SRLightning):
         which would both fail this check for no reason and pay a
         full-resolution generator forward on CPU at setup.
 
-        The probe forward puts the **whole module** in ``eval`` mode under
+        The probe forward puts the **whole module** in ``eval`` under
         ``no_grad``, not just ``self.model``: the forward selector reads
-        ``self.training`` (the LightningModule's flag), so ``self.model.eval()``
-        alone would still route a compiled run through ``self._compiled`` and
-        trigger a dynamo compile here — before, and at a different shape from,
-        the deliberate :meth:`on_fit_start` warm-up. ``self.eval()`` recurses
-        into ``self.model``, so the reason the eval-mode forward existed in the
-        first place still holds: a train-mode forward would fold this sample
-        into the generator's BatchNorm running statistics before training has
-        taken a single step.
+        ``self.training``, so ``self.model.eval()`` alone would still route a
+        compiled run through ``self._compiled`` and trigger a dynamo compile
+        here, at a different shape from the deliberate :meth:`on_fit_start`
+        warm-up. ``self.eval()`` recurses, so the original reason still holds
+        too — a train-mode forward would fold this sample into the generator's
+        BatchNorm statistics before training has taken a step.
 
         Args:
             lr: LR sample, ``(C, H, W)``.

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -312,12 +312,11 @@ class SRLightning(lightning.LightningModule):
     def _extra_probe(self, lr: torch.Tensor, hr: torch.Tensor, source: str) -> None:
         """Subclass hook: additional checks against a real ``(lr, hr)`` sample.
 
-        No-op by default. Called from inside
+        No-op by default. Called inside
         :func:`~sisr.training.probe.probe_pair`'s guarded block, so a subclass
-        gets RNG transparency and pickle-clone sampling without asking for them
-        — and cannot opt out of them either. A subclass that needs its *own*
-        sample should use ``probe_pair`` directly rather than reading a dataset,
-        for the reasons that module documents.
+        gets RNG transparency and pickle-clone sampling — and cannot opt out.
+        A subclass needing its *own* sample must use ``probe_pair`` directly
+        rather than read a dataset; see that module.
 
         Args:
             lr: LR sample, ``(C, H, W)``.
@@ -328,12 +327,10 @@ class SRLightning(lightning.LightningModule):
     def _adopt_example_input_shape(self, lr: torch.Tensor) -> None:
         """Take the shape from the real train sample when the config states none.
 
-        The value was previously written out by hand and then checked against this
-        exact tensor — two different rules to compute (crop size over scale for a
-        native-LR dataset, sub-image size for a pre-upsampled one), both derivable
-        from data the probe already holds. A value the code can check is a value
-        the code can supply. An explicit setting still wins, and is still checked,
-        so a config can state an intent and have it verified.
+        Derived from the probe's own sample rather than hand-written, since the
+        two rules (crop size over scale for native-LR, sub-image size for
+        pre-upsampled) are both computable from data it already holds. An
+        explicit setting still wins, and is still checked.
 
         Args:
             lr: Real LR sample from the train dataset, shape ``(C, H, W)``.
@@ -350,9 +347,8 @@ class SRLightning(lightning.LightningModule):
         """Raise if ``example_input_shape``'s H/W disagrees with the real train LR patch.
 
         Args:
-            expected: The configured ``example_input_shape``. Passed in by the
-                caller that already branched on it being set, rather than re-read
-                here, so it is a shape and not a maybe-shape.
+            expected: The configured ``example_input_shape``, passed in by the
+                caller that already branched on it, so it is not a maybe-shape.
             lr: Real LR sample from the train dataset, shape ``(C, H, W)``.
             train_dataset: The train dataset instance, for its class name in
                 the error.
@@ -451,37 +447,29 @@ class SRLightning(lightning.LightningModule):
     def _forward_lr(
         self, lr_img: torch.Tensor, need_sr_rgb: bool = True
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """LR-only core of the forward pipeline: extract → model → (reconstruct).
+        """LR-only core of the forward pipeline: extract -> model -> (reconstruct).
 
-        Factored out of :meth:`_forward_sr` so :meth:`predict_step` can share
-        the exact colorspace pipeline instead of forking it — HR is only ever
-        needed for the center-crop :meth:`_forward_sr` adds on top, which has
-        no meaning without an HR reference at inference time.
+        Shared with :meth:`predict_step` rather than forked, so the colorspace
+        pipeline cannot diverge; HR is only needed for the center-crop
+        :meth:`_forward_sr` adds, which is meaningless at inference time.
 
         Dispatches to the ``torch.compile``d model iff ``self.training`` and
-        ``training_config.compile_backend`` is set; ``self.training`` is
-        exactly right here since Lightning maintains it and training uses
-        fixed patch shapes while validation/predict see widely varying
-        image sizes (see ``training_config.compile_backend``'s docstring).
+        ``training_config.compile_backend`` is set. ``self.training`` is the
+        right gate: training uses fixed patch shapes while validation/predict
+        see widely varying image sizes.
 
         Args:
-            lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
-                ``(B, 3, H, W)``.
-            need_sr_rgb: Whether to run ``processor.reconstruct`` at all.
-                ``training_step`` (via :meth:`_step`) is the only caller that
-                passes ``False``: it discards ``sr_rgb`` entirely
-                (``loss, *_ = self._step(...)``), yet reconstruct still costs
-                real per-step time (measured: ~11.5% of a data-free SRCNN
-                step for ``YChannelProcessor``'s bicubic Cb/Cr interpolate;
-                ~0 for SRResNet's identity/elementwise processors). Every
-                other caller — validation, test, predict, and direct calls
-                like these from tests — keeps the default ``True`` and gets
-                exactly the reconstruction this project has always produced.
+            lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, ``(B, 3, H, W)``.
+            need_sr_rgb: Whether to run ``processor.reconstruct``.
+                ``training_step`` (via :meth:`_step`) is the only caller
+                passing ``False`` — it discards ``sr_rgb``, and reconstruct
+                costs real time (~11.5% of a data-free SRCNN step for
+                ``YChannelProcessor``; ~0 for SRResNet's elementwise ones).
 
         Returns:
-            ``(sr_model_out, sr_rgb)`` — the raw model output in the model IO
-            colorspace, and the reconstructed SR RGB clamped to ``[0, 1]``;
-            ``sr_rgb`` is ``None`` iff ``need_sr_rgb`` is ``False``.
+            ``(sr_model_out, sr_rgb)`` — raw model output in the model IO
+            colorspace, and the SR RGB clamped to ``[0, 1]``; ``sr_rgb`` is
+            ``None`` iff ``need_sr_rgb`` is ``False``.
         """
         model_input = self.processor.extract(lr_img)
         model_fn = self._compiled if self.training and self._compiled is not None else self.model
@@ -489,14 +477,12 @@ class SRLightning(lightning.LightningModule):
         if not need_sr_rgb:
             return sr_model_out, None
         sr_rgb = self.processor.reconstruct(sr_model_out, lr_img)
-        # Clamp display-space output only, here, once — every reconstruct()
-        # consumer (_forward_sr's callers, predict_step) reads through this
-        # one line, so PSNR/SSIM never diverge from what an 8-bit image would
-        # score. sr_model_out (the loss target) is untouched: clamping
+        # Clamp display space once, here: every reconstruct() consumer reads
+        # through this line, so PSNR/SSIM never diverge from what an 8-bit image
+        # would score. sr_model_out (the loss target) stays unclamped -- clamping
         # it would kill gradients on saturated pixels. Idempotent where
-        # reconstruct() already clamps (YCbCrProcessor/YChannelProcessor's
-        # ycbcr_to_rgb) — don't move this into forward() or a processor, or
-        # the bound would depend on training colorspace again.
+        # reconstruct() already clamps. Moving this into forward() or a processor
+        # would make the bound depend on training colorspace again.
         sr_rgb = sr_rgb.clamp(0.0, 1.0)
         return sr_model_out, sr_rgb
 
@@ -518,39 +504,33 @@ class SRLightning(lightning.LightningModule):
     def _forward_sr(
         self, lr_img: torch.Tensor, hr_img: torch.Tensor, need_sr_rgb: bool = True
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
-        """Canonical SR forward: extract → model → (reconstruct) → crop HR.
+        """Canonical SR forward: extract -> model -> (reconstruct) -> crop HR.
 
-        The single source of truth for the forward pipeline. Shared by
-        :meth:`_step` (which also needs the model-space output for the loss),
-        :meth:`predict_rgb` (the public scoring seam), and — via
-        :meth:`_forward_lr` — :meth:`predict_step` (the HR-free inference
-        seam), so the training, benchmark-logging, and prediction paths
-        cannot silently diverge.
+        The single source of truth for the forward pipeline, shared by
+        :meth:`_step`, :meth:`predict_rgb` and — via :meth:`_forward_lr` —
+        :meth:`predict_step`, so the training, benchmark-logging and
+        prediction paths cannot silently diverge. Do not re-implement it.
 
         Args:
-            lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, shape
-                ``(B, 3, H, W)``.
+            lr_img: LR batch, RGB ``float32`` in ``[0, 1]``, ``(B, 3, H, W)``.
             hr_img: HR batch, RGB ``float32`` in ``[0, 1]``.
-            need_sr_rgb: Forwarded to :meth:`_forward_lr` — see there. The
-                HR crop uses ``sr_model_out.shape[-2:]`` regardless, since
-                every shipped ``SRProcessor.reconstruct`` preserves H/W, so
-                it always agrees with what ``sr_rgb.shape[-2:]`` would be.
+            need_sr_rgb: Forwarded to :meth:`_forward_lr`. The HR crop uses
+                ``sr_model_out.shape[-2:]`` regardless, since every shipped
+                ``SRProcessor.reconstruct`` preserves H/W.
 
         Returns:
-            ``(sr_model_out, sr_rgb, hr_cropped)`` — the raw (unclamped)
-            model output in the model IO colorspace, the reconstructed SR RGB
-            clamped to ``[0, 1]`` (``None`` iff ``need_sr_rgb`` is ``False``),
-            and HR center-cropped to the SR spatial size.
+            ``(sr_model_out, sr_rgb, hr_cropped)`` — raw (unclamped) model
+            output in the model IO colorspace, SR RGB clamped to ``[0, 1]``
+            (``None`` iff ``need_sr_rgb`` is ``False``), and HR center-cropped
+            to the SR spatial size.
 
         Raises:
             ValueError: If ``hr_img`` is spatially smaller than the model
-                output in either dimension — ``center_crop`` would zero-pad
-                instead of cropping, silently corrupting the loss/metrics
-                that follow. :meth:`setup` catches the common cause (a
-                model/dataset ``input_contract`` mismatch) earlier and
-                louder; this is the last-resort guard for callers that
-                bypass it (e.g. direct ``_forward_sr``/``_step`` calls in
-                tests, or a datamodule with no ``trainer`` attached).
+                output — ``center_crop`` would zero-pad instead of crop,
+                silently corrupting the loss and metrics that follow.
+                :meth:`setup` catches the common cause (an ``input_contract``
+                mismatch) earlier and louder; this guards callers that bypass
+                it, such as direct ``_forward_sr``/``_step`` calls in tests.
         """
         sr_model_out, sr_rgb = self._forward_lr(lr_img, need_sr_rgb=need_sr_rgb)
         hr_hw, sr_hw = hr_img.shape[-2:], sr_model_out.shape[-2:]
@@ -606,14 +586,13 @@ class SRLightning(lightning.LightningModule):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
         """Shared forward + loss for training and validation steps.
 
-        The processor handles all colorspace conversion; loss is computed in
-        the model's *output* space (against HR mapped into it via
-        ``processor.extract_target``, which defaults to ``processor.extract``
-        and differs only where a model's input and output ranges differ).
-        Metrics downstream consume ``sr_rgb`` / ``hr_cropped`` (both full
-        RGB, spatially aligned) — unavailable (``None``) when the caller
-        passed ``need_sr_rgb=False``, which is only correct for callers (like
-        ``training_step``) that never look at ``sr_rgb``.
+        The processor does all colorspace conversion; loss is computed in the
+        model's *output* space, against HR mapped into it by
+        ``processor.extract_target`` (defaults to ``extract``, differing only
+        where a model's input and output ranges differ). Downstream metrics
+        consume ``sr_rgb`` / ``hr_cropped``, both RGB and spatially aligned —
+        ``None`` when ``need_sr_rgb=False``, which is only correct for callers
+        that never look at ``sr_rgb``.
 
         Args:
             batch: ``(lr_img, hr_img)`` tuple from a loader. Both RGB,
@@ -763,13 +742,12 @@ class SRLightning(lightning.LightningModule):
     def _check_sampler_ownership(self) -> None:
         """Refuse a distributed run that would let Lightning split the eval loaders.
 
-        :meth:`~sisr.training.datamodule.SRDataModule.train_dataloader` shards the
-        training set itself, precisely so the validation and benchmark loaders are
-        left whole. Lightning's injection is one trainer-wide switch, so leaving it
-        on both double-shards training and splits the benchmark sets --
-        ``DistributedSampler`` pads by repeating samples, so a five-image set across
-        four processes reports a figure that is not that set's score. Silent, and on
-        the metric path, so it is refused rather than warned about.
+        ``SRDataModule.train_dataloader`` shards the training set itself, so the
+        eval loaders stay whole. Lightning's injection is one trainer-wide
+        switch: leaving it on both double-shards training and splits the
+        benchmark sets, and ``DistributedSampler`` pads by *repeating* samples,
+        so a five-image set across four processes reports a figure that is not
+        that set's score. Silent, and on the metric path — refused, not warned.
 
         Raises:
             RuntimeError: If running distributed with Lightning's sampler

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -15,13 +15,11 @@ cannot drift apart either. Each carries a ``kind`` field: ``"sr_model"`` for :fu
 change — ``FORMAT_VERSION`` is unchanged, and its absence on a file written before ``kind``
 existed means ``"sr_model"``, the only kind that existed then.
 
-:func:`build_metadata` carries ``format``, ``kind``, ``created``, ``versions``, ``model``,
-``processor``, ``criterion``, ``io``, ``eval_config``, and ``training`` — it describes the
-*generator*. :func:`build_component_metadata` carries ``format``, ``kind``, ``created``,
-``versions``, ``component``, ``io``, and ``training`` — it describes one other named component
-only. Attaching the former to the latter's weights would describe things the file does not
-contain (``io.scale``, ``criterion``, ``eval_config``); this is the silent-wrong-artifact class
-this metadata exists to prevent, so the two never share a shape beyond the envelope.
+The first describes the *generator*, the second one other named component; each
+function's ``Returns`` lists its own fields. **Attaching the generator's shape to a
+component's weights would describe things the file does not contain**
+(``io.scale``, ``criterion``, ``eval_config``) — the silent-wrong-artifact class
+this metadata exists to prevent — so the two never share a shape beyond the envelope.
 
 Deliberately omits dataset paths: Ultralytics' ``train_args`` leaks local filesystem layout into
 distributed files; this stays leak-free by construction. If dataset provenance is ever added,

--- a/sisr/training/probe.py
+++ b/sisr/training/probe.py
@@ -15,19 +15,11 @@ guarantees have to hold, and neither is visible at the call site:
   ``spawn`` must pickle the dataset to reach worker processes — and the crash
   lands inside torch or Lightning, far from here.
 
-Before this module both guarantees lived in ``SRLightning.setup``: the RNG
-snapshot inline in the method body, the pickle clone in a sibling staticmethod,
-and neither reachable without going through a ``LightningModule`` with a
-``Trainer`` and a datamodule attached. ``SRLightning._extra_probe`` is the proof
-that this was the wrong shape — its docstring says it exists so a subclass can
-validate against real data *without repeating* the discipline, which is another
-way of saying the discipline could be avoided but never reused.
-
-Here the guarantees are the module's, and :func:`probe_pair` is a context
-manager for exactly that reason: there is no way to obtain a sample without
-being inside the guarded region, and everything the caller then does with that
-sample is guarded too. What used to be a convention a reviewer had to remember
-is now the shape of the API.
+The guarantees are the module's, and :func:`probe_pair` is a context manager
+for exactly that reason: **there is no way to obtain a sample without being
+inside the guarded region**, and whatever the caller then does with it is
+guarded too. What was once a convention a reviewer had to remember is now the
+shape of the API.
 
 This module depends on ``random``, ``pickle`` and duck-typed dataset/datamodule
 reads — no Lightning, no ``SRLightning``, no torch beyond the type annotation.
@@ -125,23 +117,20 @@ def _sample_zero(dataset: Any) -> Any:
     the throwaway clone, which is discarded immediately — the original is never
     touched and stays exactly as picklable as it was.
 
-    Falls back to reading ``dataset`` directly when it can't currently be
-    pickled. That happens when something *else* already opened its environment
-    for real — e.g. a ``num_workers=0`` training read, harmless on its own since
-    such a loader never pickles, but enough to fail this call's own pickle
-    attempt on a re-probe (``fit`` then ``test`` in one process). Reading the
-    live object at that point adds no new harm: this function only guarantees it
-    will never be the *first* thing to open a pristine dataset's environment. It
-    does not promise a dataset stays picklable regardless of what real training
-    does to it afterwards.
+    Falls back to reading ``dataset`` directly when it cannot be pickled —
+    something else already opened its environment for real (e.g. a
+    ``num_workers=0`` read, then a re-probe in the same process). That adds no
+    new harm: **the guarantee is only that this is never the *first* thing to
+    open a pristine dataset's environment**, not that a dataset stays picklable
+    through whatever real training does to it.
 
     Args:
-        dataset: The live dataset instance. Mutated only in the fallback case,
-            and only exactly as a real ``num_workers=0`` read already would.
+        dataset: The live dataset. Mutated only in the fallback case, exactly as
+            a real ``num_workers=0`` read already would.
 
     Returns:
-        ``dataset[0]`` — an ``(lr, hr)`` tuple for every paired dataset, or a
-        bare LR tensor for :class:`~sisr.datasets.predict.PredictDataset`.
+        ``dataset[0]`` — an ``(lr, hr)`` tuple, or a bare LR tensor for
+        :class:`~sisr.datasets.predict.PredictDataset`.
     """
     try:
         clone = pickle.loads(pickle.dumps(dataset))


### PR DESCRIPTION
First PR of the prose-compaction stack. **Do not merge without reading the ledger** — that is
what it is for.

`sisr/training` carries **46% of the package's prose** (2,348 of 5,120 lines), so it goes first.

| | before | after |
|---|---:|---:|
| `sisr/training` | 1.80 : 1 | **1.66 : 1** |
| whole package | 1.73 : 1 | **1.67 : 1** |

## Constraint ledger

25 blocks across 7 files. Every removed block is one of:

**compressed (23).** Measurement essays to their conclusion; run-on explanations to the
constraint they carry.

- `config.py` — `compile_backend`'s four-backend benchmark narrative becomes the three facts a
  caller acts on: only inductor pays and by a mid-teens percent, nothing is bit-identical to
  eager, stay at `None`. `compile_mode` keeps its whole refusal rule and the
  "measure per configuration" warning.
- `callbacks.py` — `BenchmarkImageLogger` 62 -> 49 lines with **every** tag name, both
  dataloader-index conventions, the `crop_border` anti-drift rule and the 0.5 GB buffering
  lesson intact. `SRWeightsCheckpoint` 55 -> 49. Nine private docstrings lose trivial
  `Args:`/`Returns:` blocks only.
- `lightning_module.py` — `_forward_lr` / `_forward_sr` keep every constraint including the
  unclamped-loss-target rule and the `center_crop` zero-pad failure.
- `gan_module.py`, `datamodule.py` — the setup-hook ordering rule and the DistributedSampler
  repeat-padding hazard both kept in full.

**deleted as restatement/history (2).**

- `probe.py`'s account of what its two guarantees looked like *before* this module existed.
  The guarantees themselves are untouched.
- `metadata.py`'s restatement of two field lists that both builders' own `Returns:` already
  carry.

**moved (0).** Nothing needed a new owner.

**kept — unsure (0).**

## How "no rule was lost" was checked

Not by eye. **30 named constraints and failure modes** were listed from the pre-change text and
re-checked against the rewritten package: the two step axes, `DistributedSampler`'s
repeat-padding, `auto_insert_metric_name`'s silent directory-tree failure, the unclamped loss
target, `_RollingSaveMixin`'s shadowed-`super()` hazard, the pickle-clone "never first to open"
guarantee, `PERCEPTUAL_METRICS` as the direction source, and the rest. **30/30 present.**

Separately, every `__init__` parameter of the three touched public classes is still documented —
checked by walking the AST, not by reading.

Trivial `Args:`/`Returns:` were dropped from **private** methods only. `conventions` mandates
Google-style structure on public API and explicitly mandates nothing for private docstrings.

## Not yet at the gate, and here is the arithmetic

The target is aggregate **<= 1.00**. This lands at 1.67. Measured floor analysis over all 48
modules, so the remaining work is a known quantity rather than a guess:

| scenario | prose lines | ratio |
|---|---:|---:|
| today | 4,952 | 1.67 |
| every private docstring to one line | 3,371 | 1.14 |
| that, plus 15% off public docstrings | 2,953 | **0.996** |
| that, plus 30% off public docstrings | 2,534 | 0.85 |

**<= 1.00 is reachable without stripping a rule.** The calibration in `samples/` already
demonstrated 58% off a single docstring; the gate needs ~15% across public ones on top of a real
private-docstring pass. The remaining packages follow in later PRs.

`ruff` and `mypy` clean across all 48 modules.

Public-file scrub for internal identifiers and absolute paths: clean.
