### PR TITLE
chore: trim .gitignore to the tools this project actually uses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,47 @@
-# Extra files to ignore
+# ---------------------------------------------------------------------------
+# This project's own rules. Everything below the divider is the stock GitHub
+# Python template, trimmed to the tools this repo actually uses -- see the
+# note there before adding anything back.
+# ---------------------------------------------------------------------------
+
+# Datasets and derived caches: large, externally sourced, never committed.
 data
 .lmdb_cache/
+
+# Training runs: weights, event logs, metrics. Numbers that matter are
+# transcribed into the notes before a run is pruned.
 experiments/
+
+# Run configs are per-experiment and untracked; only the *.template.yaml
+# starting points ship. The untracked ones are mirrored outside the repo.
 templates/*
 !templates/*template*
 
-# Claude's local working notes (codebase index, triage, session history)
+# Claude's local working notes (codebase index, triage, session history).
 .claude/
 
 # LLM agentic coding artifacts (brainstorming specs, implementation plans).
 docs/superpowers/
 
-# mattpocock-skills engineering-skill config (dev/personal tooling only, not tracked)
+# mattpocock-skills engineering-skill config (dev/personal tooling only).
 /docs/agents/
 /.scratch/
+
+# Training and benchmark logs. Kept from the stock template on purpose: a run
+# writes these next to the checkout and none of them are ever tracked.
+*.log
+
+# ---------------------------------------------------------------------------
+# Stock GitHub Python template, trimmed 2026-09-01. Removed: Django, Flask,
+# Scrapy, Celery, SageMath, Abstra, Cursor, PyInstaller, PyBuilder, Sphinx,
+# mkdocs, Spyder, Rope, IPython, Cython, Pyre, pytype, PEP 582, and the
+# pipenv/poetry/pdm/uv lockfile commentary -- none of which this project uses.
+# Also dropped `lib/` and `lib64/`: virtualenv-layout leftovers that are dead
+# here (`.venv` is ignored wholesale) and broad enough to swallow a real source
+# directory named `lib`.
+# The removal was proven inert: the set of ignored paths in a full working
+# tree was identical before and after. Add a rule back only with the tool.
+# ---------------------------------------------------------------------------
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -23,7 +51,7 @@ __pycache__/
 # C extensions
 *.so
 
-# Distribution / packaging
+# Distribution / packaging (the packaging test builds a real wheel)
 .Python
 build/
 develop-eggs/
@@ -31,8 +59,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
 parts/
 sdist/
 var/
@@ -42,16 +68,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
@@ -68,81 +84,8 @@ coverage.xml
 .pytest_cache/
 cover/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
 # Jupyter Notebook
 .ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -153,62 +96,18 @@ ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
 # mypy
 .mypy_cache/
 .dmypy.json
 dmypy.json
 
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Abstra
-# Abstra is an AI-powered process automation framework.
-# Ignore directories containing user credentials, local state, and settings.
-# Learn more at https://abstra.io/docs
-.abstra/
-
-# Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
-#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the enitre vscode folder
-# Share a curated subset (settings.json, extensions.json); ignore everything else.
-.vscode/*
-!.vscode/settings.json
-!.vscode/extensions.json
-
-# Ruff stuff:
+# Ruff
 .ruff_cache/
 
 # PyPI configuration file
 .pypirc
 
-# Cursor
-#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
-.cursorignore
-.cursorindexingignore
+# Visual Studio Code -- share a curated subset, ignore everything else.
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,13 @@ docs/superpowers/
 *.log
 
 # ---------------------------------------------------------------------------
-# Stock GitHub Python template, trimmed 2026-09-01. Removed: Django, Flask,
-# Scrapy, Celery, SageMath, Abstra, Cursor, PyInstaller, PyBuilder, Sphinx,
-# mkdocs, Spyder, Rope, IPython, Cython, Pyre, pytype, PEP 582, and the
-# pipenv/poetry/pdm/uv lockfile commentary -- none of which this project uses.
+# Modified from the stock GitHub Python template:
+#   https://github.com/github/gitignore/blob/main/Python.gitignore
+#
+# Trimmed 2026-09-01. Removed: Django, Flask, Scrapy, Celery, SageMath, Abstra,
+# Cursor, PyInstaller, PyBuilder, Sphinx, mkdocs, Spyder, Rope, IPython, Cython,
+# Pyre, pytype, PEP 582, and the pipenv/poetry/pdm/uv lockfile commentary --
+# none of which this project uses.
 # Also dropped `lib/` and `lib64/`: virtualenv-layout leftovers that are dead
 # here (`.venv` is ignored wholesale) and broad enough to swallow a real source
 # directory named `lib`.


### PR DESCRIPTION
Phase 1's packaging audit. `pyproject.toml` and `.gitignore` had never been examined, unlike the
rest of the tree.

## `pyproject.toml` — no change, and that is the finding

Audited and left alone. It is already tight at 143 lines, every dependency carries its
rationale inline as the project requires, and the checks that could have failed all pass:

- all four `docs/configuration.md` references resolve (that file is tracked)
- `requires-python = ">=3.12"`, `target-version = "py312"` and the `3.12`/`3.13` classifiers
  agree with the CI matrix
- the `[export]` and `[perceptual]` extras match their mypy overrides
- `filterwarnings = ["error", ...]` with two justified, scoped exemptions

## `.gitignore` — 213 -> 110 lines

It was the stock GitHub Python template with ~16 project-specific lines on top, carrying rules
for **Django, Flask, Scrapy, Celery, SageMath, Abstra, Cursor, PyInstaller, PyBuilder, Sphinx,
mkdocs, Spyder, Rope, IPython, Cython, Pyre, pytype and PEP 582** — none of which this project
uses — plus lockfile commentary for four package managers it does not use either.

Two rules got attention rather than deletion:

- **`*.log` was filed under `# Django stuff:`** and is genuinely wanted here, since a training
  run writes logs beside the checkout. Kept, and moved into this project's own section with a
  reason attached.
- **`lib/` and `lib64/`** are virtualenv-layout leftovers: dead (`.venv` is ignored wholesale)
  and broad enough to swallow a real source directory named `lib`. Dropped.

The project's own rules also gained the reason each exists, which none of them had.

## Proven inert, not asserted

The risk in trimming an ignore file is silently changing what is ignored. So:

- the full working tree's **ignored-path set is byte-identical** before and after
- **nothing became newly tracked**

Both checked by diffing `git status --porcelain --ignored` across the change.

Anything removed can come back — with the tool that needs it. The header says so.

Public-file scrub for internal identifiers and absolute paths: clean.
