### PR TITLE
refactor: compact prose in sisr/metrics and sisr/datasets

### DIFF
--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -291,26 +291,22 @@ class SRLightningCLI(LightningCLI):
         (any nested subclass field with a fallback, e.g. ``eval_config``) — see
         below for which and why.
 
-        The reason: jsonargparse's subclass-merge machinery
-        (``ActionTypeHint._check_type``) looks up the field's *previous* value as
-        ``cfg.get(self.dest)`` — ``self.dest`` is the action's bare name (``"model"``),
-        not a subcommand-qualified one. Reached through the subcommand's own
-        parser, ``cfg`` is already scoped to that subcommand, so ``cfg.get("model")``
-        finds the real, already-resolved value and merges our override's keys onto
-        it, preserving every sibling key we don't mention (``model``, ``processor``,
-        nested ``class_path`` identities) and any subclass-only default our override
-        never names. Reached through the top-level parser, ``cfg`` is the
-        *unscoped* full config, so the same ``cfg.get("model")`` misses the value
-        (it actually lives at ``cfg["validate"]["model"]``) and silently gets
-        "no previous value" instead of a lookup error — jsonargparse then rebuilds
-        the field from schema defaults, which are ``None`` for ``model``/
-        ``processor`` (no default; required) and the bare annotation type for any
-        nested subclass field (``eval_config`` reverts to base ``SREvalConfig``).
-        A resumed run would then either hit that "arguments are required"
-        ``SystemExit`` outright, or — for a field with a valid bare-default
-        fallback — silently drop back to the config file's/annotation's values with
-        nothing in the logs to say so. Re-inlining this as ``self.parser`` "for
-        simplicity" reintroduces exactly that.
+        **The reason**: jsonargparse's subclass-merge
+        (``ActionTypeHint._check_type``) looks up the previous value as
+        ``cfg.get(self.dest)``, and ``self.dest`` is the bare name (``"model"``),
+        never subcommand-qualified. Through the subcommand's parser ``cfg`` is
+        already scoped, so the lookup finds the resolved value and merges onto
+        it, preserving sibling keys and subclass-only defaults. Through the
+        top-level parser ``cfg`` is unscoped, the value actually lives at
+        ``cfg["validate"]["model"]``, and the miss reads as "no previous value"
+        rather than an error — so jsonargparse rebuilds from schema defaults:
+        ``None`` for the required ``model``/``processor``, and the bare
+        annotation for any nested subclass field (``eval_config`` reverts to
+        base ``SREvalConfig``).
+
+        **So a resumed run either dies on "arguments are required" or silently
+        reverts to annotation defaults with nothing in the logs.** Re-inlining
+        this as ``self.parser`` "for simplicity" reintroduces exactly that.
         """
         if not self.config.get("subcommand"):
             return

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -82,22 +82,16 @@ def _degrade(hr_arr: np.ndarray, scale: int) -> np.ndarray:
 class TrainDataset(HRCachedTrainDataset):
     """Dataset serving deterministic LR/HR sub-image pairs, HR held in an LMDB cache.
 
-    On first instantiation with a given set of files, every HR image is
-    decoded once and stored whole (uint8, RGB) in an LMDB database — see
-    :mod:`~sisr.datasets.base`/:mod:`~sisr.datasets.hr_cache` for why. Each
-    ``__getitem__`` maps its flat index to a source image and a deterministic
-    ``(top, left)`` grid position in O(1) (via :func:`_grid_dims`), reads that
-    image's cached bytes through :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`,
-    slices out the ``subimg_size`` square HR sub-image, and degrades it to LR
-    with :func:`_degrade`. The sliding-window grid itself — which sub-images
-    exist and in what order — is derived from exactly one place
-    (:func:`_grid_dims`), so indices can never silently misalign.
+    Every HR image is decoded once into an LMDB cache (uint8 RGB, whole) — see
+    :mod:`~sisr.datasets.base` for why. Each ``__getitem__`` maps its flat index
+    to a source image and a deterministic ``(top, left)`` grid position in O(1),
+    slices the ``subimg_size`` square HR sub-image, and degrades it to LR.
+    **The grid is derived from exactly one place** (:func:`_grid_dims`), so
+    indices can never silently misalign.
 
-    A SHA-256 checksum over the file manifest (plus a format tag) is stored
-    inside the LMDB so subsequent runs over the same files skip the build
-    entirely — the checksum does not depend on
-    ``subimg_size``/``stride``/``scale``, since none of them affect the raw
-    bytes written.
+    **The checksum keys only on the file manifest** (plus a format tag), not on
+    ``subimg_size``/``stride``/``scale`` — none of those affect the bytes
+    written — so subsequent runs over the same files skip the build.
 
     Reference:
         Image Super-Resolution Using Deep Convolutional Networks

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -31,26 +31,21 @@ from .hr_cache import process_hr_image as _process_hr_image
 class TrainDataset(HRCachedTrainDataset):
     """Random-crop HR/LR pairs for SRResNet-style training, HR held in an LMDB cache.
 
-    On first instantiation with a given set of parameters, every HR image is
-    decoded once and stored whole (uint8, RGB, with its own ``(H, W)`` header)
-    in an LMDB database — see :mod:`~sisr.datasets.base`/
-    :mod:`~sisr.datasets.hr_cache` for why. Each ``__getitem__`` then reads
-    that image's cached bytes via
-    :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`, takes a fresh
-    random ``hr_crop_size`` square crop (plain numpy slicing — crop
-    randomness must survive the cache, so only the *decode* is memoized,
-    never the crop), and bicubic-downsamples it by ``scale`` (via
-    :func:`sisr.utils.imresize.resize`) to form the LR input. Unlike
-    :class:`sisr.datasets.srcnn.TrainDataset` there is **no
-    downsample+upsample round-trip** and the LR is *not* upsampled back —
-    the model is responsible for the ×``scale`` upsampling, so the LR tensor is
-    ``hr_crop_size // scale`` on a side.
+    Every HR image is decoded once into an LMDB cache (uint8 RGB, whole, with
+    its ``(H, W)`` header) — see :mod:`~sisr.datasets.base` for why. Each
+    ``__getitem__`` reads those bytes, takes a fresh random ``hr_crop_size``
+    square crop, and bicubic-downsamples by ``scale`` for the LR input.
+    **Only the decode is memoized, never the crop** — crop randomness has to
+    survive the cache.
 
-    Because the cache holds whole decoded images rather than crops, it is independent of
-    ``hr_crop_size``/``crops_per_image``/``scale`` — the checksum keys only on
-    the file manifest, so changing the crop recipe never invalidates the
-    cache. HR is always served as RGB; Y/YCbCr selection happens downstream in
-    :class:`SRLightning`.
+    Unlike :class:`sisr.datasets.srcnn.TrainDataset` there is **no
+    downsample+upsample round-trip**: the LR is not upsampled back, the model
+    owns the x``scale`` upsampling, and the LR tensor is
+    ``hr_crop_size // scale`` a side.
+
+    **The checksum keys only on the file manifest**, so changing
+    ``hr_crop_size``/``crops_per_image``/``scale`` never invalidates the cache.
+    HR is always RGB; Y/YCbCr selection happens downstream.
 
     Reference:
         Photo-Realistic Single Image Super-Resolution Using a Generative

--- a/sisr/losses/pixel.py
+++ b/sisr/losses/pixel.py
@@ -58,29 +58,24 @@ class CharbonnierLoss(torch.nn.Module):
 class TotalVariationLoss(torch.nn.Module):
     """Total-variation loss: isotropic ``sqrt(dx^2 + dy^2 + eps^2)``, reduced per ``reduction``.
 
-    Ledig et al. §3.4 add this to the VGG22 content loss at weight
-    ``2e-8`` when training SRResNet-VGG22 — the one VGG variant reproducible
-    without a discriminator, so this is required for that recipe rather than
-    optional. Their ``l_TV = 1/(r^2 WH) * sum ||grad G(I_LR)||`` is a norm of
-    the gradient *vector*, i.e. the isotropic form; ``isotropic=False`` gives
-    the more common ``|dx| + |dy|`` reimplementation, which is a different
-    function (up to ``sqrt(2)`` larger on diagonal structure) and not a
-    rescaling of it.
+    Ledig et al. Sec. 3.4 add this to the VGG22 content loss at weight ``2e-8``
+    for SRResNet-VGG22 — the one VGG variant reproducible without a
+    discriminator, so it is required for that recipe, not optional. Their
+    ``l_TV`` is a norm of the gradient *vector*, i.e. isotropic;
+    ``isotropic=False`` gives the common ``|dx| + |dy|`` reimplementation, which
+    is a **different function** (up to ``sqrt(2)`` larger on diagonal
+    structure), not a rescaling. Both difference grids are cropped to a common
+    ``(H-1, W-1)`` so the norm can combine them per pixel.
 
-    Both difference grids are cropped to a common ``(H-1, W-1)`` so the
-    isotropic norm can combine them per pixel.
+    Two traps before setting a weight:
 
-    Two things worth knowing before setting a weight:
-
-    - ``target`` is **ignored**. This is a regulariser, not a distance; the
-      uniform ``(pred, target)`` signature is what lets
-      :class:`~sisr.losses.composite.WeightedSumLoss` dispatch every term
-      identically.
-    - The value **scales with the intensity range**, so the paper's ``2e-8``
-      presumes the model's ``[-1, 1]`` output range
-      (:class:`~sisr.processors.rgb.RGBSignedOutputProcessor`). Under a
-      ``[0, 1]`` processor the same image gives exactly half the TV, so the
-      effective weight differs by 2x.
+    - ``target`` is **ignored** — this is a regulariser, not a distance. The
+      uniform ``(pred, target)`` signature exists so ``WeightedSumLoss`` can
+      dispatch every term identically.
+    - **The value scales with the intensity range.** The paper's ``2e-8``
+      presumes a ``[-1, 1]`` output range; under a ``[0, 1]`` processor the
+      same image gives exactly half the TV, so the effective weight differs
+      by 2x.
 
     Args:
         isotropic: Use the paper's ``sqrt(dx^2 + dy^2)`` norm. ``False``

--- a/sisr/metrics/ssim.py
+++ b/sisr/metrics/ssim.py
@@ -18,24 +18,21 @@ Four further differences from ``torchmetrics``, all load-bearing:
 * Pooling is a **weight-weighted** mean over those positions.
 * Input is **8-bit**; ``samplemax`` is 255.
 
-Vectorisation is exact, not an approximation: daala clips the kernel at edges
-and accumulates only the weights it used, so a zero-padded separable
-convolution produces identical moment sums (missing taps contribute zero), and
-a zero-padded ones-mask convolution produces exactly its ``m.w`` -- horizontal
-truncation depends only on x and vertical only on y, so the 2-D weight
-factorises into what the separable mask convolution computes.
+**Vectorisation is exact, not an approximation.** daala clips the kernel at
+edges and accumulates only the weights it used, so a zero-padded separable
+convolution gives identical moment sums (missing taps contribute zero) and a
+zero-padded ones-mask convolution gives exactly its ``m.w`` -- horizontal
+truncation depends only on x, vertical only on y, so the 2-D weight factorises.
 
-All arithmetic runs in float64. daala accumulates moments in ``int64`` with
-integer weights; the largest quantity involved is ~2.8e14, well under 2**53, so
-float64 reproduces its integer accumulation **exactly** and the per-position
-divide runs in the same double arithmetic as the C. Only the final pooling
-*summation order* differs (C: sequential row-major; torch: tree reduction), so
-parity against ``tests/reference/daala_ssim.c`` is asserted at ``rel=1e-9``
-rather than bit-equality. That bound is measured, not conservative padding: the
-pooling divergence grows as ~``eps*n/4``, so a *correct* implementation already
-exceeds ``1e-12`` on flat content at 256x256, while the faintest real defect
-observed (a float32 leak) reads ``5e-8``. See the parity test's docstring for
-the full bracket before tightening it.
+**float64 throughout, and it is exact.** daala accumulates in ``int64``; the
+largest quantity is ~2.8e14, well under 2**53, so float64 reproduces its integer
+accumulation exactly. Only the pooling *summation order* differs (C row-major vs
+torch tree reduction), so parity against ``tests/reference/daala_ssim.c`` is
+asserted at ``rel=1e-9``, not bit-equality. **That bound is measured, not
+padding**: divergence grows as ~``eps*n/4``, so a correct implementation already
+exceeds ``1e-12`` on flat 256x256 content, while the faintest real defect seen
+(a float32 leak) reads ``5e-8``. Read the parity test's bracket before
+tightening it.
 
 ------------------------------------------------------------------------------
 Algorithm ported from daala's ``tools/dump_ssim.c``.


### PR DESCRIPTION
Third PR of the prose stack. Stacked on #213.

`sisr/metrics` 3.39 -> 3.37, `sisr/datasets` 1.92 -> 1.88, plus the two densest docstrings
outside any package pass (`cli.py::_parse_ckpt_path`, `losses/pixel.py::TotalVariationLoss`).

## `sisr/metrics` barely moved, and that is the finding

122 lines of code against 414 of prose — the worst ratio in the package — **because the prose is
the deliverable there.** It carries Ledig's own quoted sentence, the four load-bearing deviations
from `torchmetrics`, and a parity bound that is measured rather than padded. Cutting it would
delete the evidence that makes this project's SSIM claim checkable, which is the opposite of the
point. `ssim.py`'s vectorisation and float64 arguments become two headed claims instead of two
paragraphs; nothing else was safe to touch.

## Constraint ledger

**compressed (6).**

- `ssim.py` — the exact-vectorisation argument and the float64/parity-bound argument, both
  keeping the measured bracket (`1e-12` for a correct implementation, `5e-8` for the faintest
  real defect seen) that stops someone tightening `rel=1e-9`.
- `datasets/srresnet.py`, `datasets/srcnn.py` — step-by-step narration out, three rules kept and
  now stated as rules: **only the decode is memoized, never the crop**; **the grid comes from
  exactly one place**; **the checksum keys only on the file manifest**.
- `cli.py::_parse_ckpt_path` — keeps both substitutions, the subcommand-parser requirement and
  both failure modes, but the jsonargparse internals collapse to one paragraph and the
  consequence gets stated on its own, so *"re-inlining this as `self.parser` reintroduces
  exactly that"* is no longer buried at the end of twenty lines.
- `losses/pixel.py::TotalVariationLoss` — both traps kept and given headings: `target` is
  ignored, and the paper's `2e-8` presumes a `[-1, 1]` range so a `[0, 1]` processor halves the
  effective weight.

**deleted (0). moved (0). kept — unsure (0).**

The daala BSD licence in `ssim.py` is verbatim and unmodified — checked.

`ruff check`, `ruff format --check` and `mypy` clean across all 48 modules.

Public-file scrub for internal identifiers and absolute paths: clean.
