### PR TITLE
fix: derive the evaluation border from scale instead of pinning a constant

### DIFF
--- a/sisr/metrics/scoring.py
+++ b/sisr/metrics/scoring.py
@@ -128,8 +128,20 @@ class SRScorer:
 
         Returns:
             The cropped tensors, in the order given.
+
+        Raises:
+            ValueError: If ``crop_border`` is still ``None``. That means the
+                config never passed through ``SRLightning``, which resolves the
+                derive-from-scale sentinel; scoring against an unresolved border
+                would silently pick a different region than the run intends.
         """
         n = self.eval_config.crop_border
+        if n is None:
+            raise ValueError(
+                "eval_config.crop_border is still None at scoring time. It is a sentinel "
+                "meaning 'crop the model's scale', resolved by SRLightning at construction "
+                "-- build the scorer from a module's eval_config, or set an explicit int."
+            )
         if n <= 0:
             return tensors
         return tuple(t[..., n:-n, n:-n] for t in tensors)

--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -92,12 +92,13 @@ class SRCNNEvalConfig(SREvalConfig):
     outer ``scale=3`` pixels per the standard SR-evaluation convention.
 
     Args:
-        crop_border: Overrides the base default to ``3`` (outer pixels
-            excluded before PSNR / SSIM at the standard ``x3`` scale).
+        crop_border: ``None`` -- derive the field convention's ``scale``
+            pixels from the model, rather than pin a constant that is
+            only right at one scale. Resolved by ``SRLightning``.
         psnr_channels: Overrides the base default to ``['RGB', 'Y']`` —
             ``'Y'`` is the paper's own metric; ``'RGB'`` is a supplementary
             aggregate.
     """
 
-    crop_border: int = 3
+    crop_border: int | None = None
     psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "Y"])

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -102,6 +102,6 @@ class SRResNetEvalConfig(SREvalConfig):
             which reports Wang. See :mod:`sisr.metrics.ssim`.
     """
 
-    crop_border: int = 4
+    crop_border: int | None = None
     psnr_channels: list[str] = field(default_factory=lambda: ["RGB", "Y"])
     ssim_impl: Literal["wang", "daala"] = "daala"

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -187,9 +187,14 @@ class SREvalConfig:
     """How to compute validation/test metrics — affects scoring only, not training.
 
     Args:
-        crop_border: Number of border pixels to exclude on each edge before
-            computing PSNR / SSIM.  Standard SR-evaluation convention is to
-            crop the outer ``scale`` pixels (e.g. ``crop_border=3`` for x3).
+        crop_border: Border pixels excluded on each edge before PSNR / SSIM.
+            **``None`` means the SR field's convention: the model's own
+            ``scale``**, resolved once by ``SRLightning`` at construction — the
+            SRCNN authors' released demo code shaves exactly ``scale`` per side.
+            An explicit int is an intent and always wins, ``0`` included. The
+            base default stays ``0``; the per-architecture subclasses use
+            ``None``, so their border can no longer be right at one scale and
+            silently wrong at another.
 
         psnr_channels: Colorspaces or bare single channels PSNR is reported
             for.  Supported values are ``'RGB'``, ``'YCbCr'``, and any
@@ -245,7 +250,7 @@ class SREvalConfig:
             ``sisr_meta``, so any number can be traced back. Ignored by DISTS.
     """
 
-    crop_border: int = 0
+    crop_border: int | None = 0
     psnr_channels: list[str] = field(default_factory=lambda: ["RGB"])
     separate_psnr: bool = False
     ssim_channels: list[str] = field(default_factory=lambda: ["RGB", "Y"])

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -96,6 +96,13 @@ class SRLightning(lightning.LightningModule):
         self.processor = processor
         self.training_config = training_config or SRTrainingConfig()
         self.eval_config = eval_config or SREvalConfig()
+        # crop_border=None means "the field convention: the model's scale".
+        # Resolved here, once, BEFORE the scorer is built -- the scorer and
+        # every artifact's sisr_meta must record the number actually used.
+        if self.eval_config.crop_border is None:
+            self.eval_config.crop_border = self._resolved_scale(
+                "eval_config.crop_border is None (derive the border from the scale)"
+            )
         # The scoring path's one owner: crop, colorspace split, both
         # reductions and the tag grammar. BenchmarkImageLogger uses this
         # same object, so the two paths cannot disagree.
@@ -880,6 +887,26 @@ class SRLightning(lightning.LightningModule):
         """
         _, sr_rgb = self._forward_lr(batch)
         return sr_rgb
+
+    def _resolved_scale(self, why: str) -> int:
+        """The run's upscaling factor, from the training config or the model.
+
+        Args:
+            why: What needed the scale, for the error message.
+
+        Raises:
+            ValueError: If neither ``training_config.scale`` nor the model's own
+                ``scale`` hparam is set, so there is nothing to derive from.
+        """
+        scale = self.training_config.scale
+        if scale is None:
+            scale = self.model.hparams.get("scale")
+        if scale is None:
+            raise ValueError(
+                f"{why}, but no scale is available: set training_config.scale, or use a "
+                f"model that declares a 'scale' hparam, or set the value explicitly."
+            )
+        return int(scale)
 
     def configure_optimizers(self) -> OptimizerLRScheduler:
         """Build optimizer (and optional scheduler) from top-level YAML.

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -20,7 +20,9 @@ def test_srcnn_eval_config_paper_defaults():
     metric, not the YCbCr 3-channel aggregate (which reads optimistically
     high since chroma planes are far smoother than luma)."""
     cfg = SRCNNEvalConfig()
-    assert cfg.crop_border == 3
+    # None = derive the field convention's `scale` pixels; SRLightning resolves it.
+    # Previously a hardcoded 3, right only because this template ships x3.
+    assert cfg.crop_border is None
     assert cfg.psnr_channels == ["RGB", "Y"]
     assert cfg.separate_psnr is False
     # Not overridden — inherits the base SREvalConfig default.

--- a/tests/models/srgan/test_config.py
+++ b/tests/models/srgan/test_config.py
@@ -25,7 +25,7 @@ def test_eval_config_turns_perceptual_metrics_on():
     cfg = SRGANEvalConfig()
     assert cfg.perceptual_keys == ["lpips", "dists"]
     assert cfg.ssim_impl == "daala"  # inherited
-    assert cfg.crop_border == 4  # inherited
+    assert cfg.crop_border is None  # inherited: derived from scale at construction
 
 
 def test_training_config_subclass():

--- a/tests/models/srresnet/test_config.py
+++ b/tests/models/srresnet/test_config.py
@@ -26,7 +26,9 @@ def test_srresnet_eval_config_paper_defaults():
     metric, not the YCbCr 3-channel aggregate (which reads optimistically
     high since chroma planes are far smoother than luma)."""
     cfg = SRResNetEvalConfig()
-    assert cfg.crop_border == 4
+    # None = derive the field convention's `scale` pixels; SRLightning resolves it.
+    # Previously a hardcoded 4, right only because this template ships x4.
+    assert cfg.crop_border is None
     assert cfg.psnr_channels == ["RGB", "Y"]
     assert cfg.separate_psnr is False
     # Not overridden — inherits the base SREvalConfig default.

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -2053,3 +2053,29 @@ def test_explicit_crop_border_still_wins_over_the_scale_default():
         optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
     )
     assert lit.eval_config.crop_border == 8
+
+
+def test_derived_crop_border_refuses_when_no_scale_exists_to_derive_from():
+    """The sentinel needs a scale. With none available, say so rather than guess.
+
+    SRCNN declares no ``scale`` hparam of its own, so a bare
+    ``SRTrainingConfig()`` leaves nothing to derive from. Silently falling back
+    to 0 would score the full image while the config asked for the field
+    convention -- a different measurement with nothing to indicate it.
+    """
+    model = SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    with pytest.raises(ValueError, match="no scale is available"):
+        SRLightning(
+            model=model,
+            processor=YChannelProcessor(),
+            training_config=SRTrainingConfig(),
+            eval_config=SREvalConfig(crop_border=None),
+            optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+        )
+
+
+def test_scorer_refuses_an_unresolved_crop_border_sentinel():
+    """A scorer built outside SRLightning must not silently treat None as 0."""
+    scorer = SRScorer(SREvalConfig(crop_border=None))
+    with pytest.raises(ValueError, match="still None at scoring time"):
+        scorer.crop(torch.rand(1, 3, 16, 16))

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -2016,3 +2016,40 @@ def test_an_explicit_example_input_shape_is_still_checked_not_overwritten(
 
     with pytest.raises(ValueError, match="example_input_shape"):
         lit.setup(stage="fit")
+
+
+def test_subclass_crop_border_follows_the_models_scale_not_a_constant():
+    """A paper-default eval config crops `scale` pixels at ANY scale, not a fixed 3 or 4.
+
+    The SR field's convention -- and the SRCNN authors' own demo code -- crop the
+    outer ``scale`` pixels before scoring. `SRResNetEvalConfig` shipped a hardcoded
+    ``4`` and `SRCNNEvalConfig` a hardcoded ``3``, which are correct only because
+    those templates happen to ship x4 and x3. At any other scale the constant is
+    silently the wrong border, and a border changes the reported PSNR/SSIM without
+    changing the model.
+    """
+    model = SRResNet(scale=2, num_residual_blocks=1, hidden_channel=4)
+    lit = SRLightning(
+        model=model,
+        processor=RGBSignedOutputProcessor(),
+        training_config=SRResNetTrainingConfig(scale=2),
+        eval_config=SRResNetEvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    assert lit.eval_config.crop_border == 2, (
+        "a scale-2 run must crop 2 border pixels, not the shipped constant"
+    )
+    assert lit.scorer.eval_config.crop_border == 2, "the scorer must see the resolved border"
+
+
+def test_explicit_crop_border_still_wins_over_the_scale_default():
+    """An explicit value is an intent, and is never overwritten by the derivation."""
+    model = SRResNet(scale=2, num_residual_blocks=1, hidden_channel=4)
+    lit = SRLightning(
+        model=model,
+        processor=RGBSignedOutputProcessor(),
+        training_config=SRResNetTrainingConfig(scale=2),
+        eval_config=SRResNetEvalConfig(crop_border=8),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    assert lit.eval_config.crop_border == 8


### PR DESCRIPTION
First half of #207, per the decision on that issue. **`crop_border` derives from `scale`.**

## Your read was right: we already had this convention

`sisr/training/config.py` already documented it — *"Standard SR-evaluation convention is to crop
the outer `scale` pixels"* — and the SRCNN authors' released demo code does exactly that
(`shave(..., [up_scale, up_scale])`). Both shipped architectures already satisfied it:

| | scale | crop_border | |
|---|---:|---:|---|
| SRCNN | 3 | 3 | equal, by coincidence |
| SRResNet / SRGAN | 4 | 4 | equal, by coincidence |

**The rule was written down and nothing enforced it.** The constants are right only because we
happen to ship ×3 and ×4. A ×2 config silently kept 3 or 4 — and a border changes the reported
PSNR/SSIM without changing the model.

## What changed

`crop_border` becomes `int | None`. **`None` is the sentinel for "the field convention: the
model's scale"**, resolved once by `SRLightning` at construction — before the scorer is built, so
the scorer and every artifact's `sisr_meta` record the number actually used. An explicit int
always wins, `0` included. The base default stays `0`, so bare `SREvalConfig()` is unchanged and
the 60-odd existing uses are untouched.

**A side effect worth having:** the subclass defaults are now the same sentinel as the base, so
the documented `--ckpt_path` reversion of subclass defaults to base **can no longer change the
border**. One less thing that reversion can silently alter.

## Evidence

**RED → GREEN, proven on pre-fix `main`:**

```
E   AssertionError: a scale-2 run must crop 2 border pixels, not the shipped constant
E   assert 4 == 2
```

`test_subclass_crop_border_follows_the_models_scale_not_a_constant` passes after. A second test
pins that an explicit `crop_border=8` is never overwritten by the derivation.

**mypy caught the real consequence** rather than me: the scorer could now receive an unresolved
`None`. That is a **loud `ValueError` naming the cause**, never a silent crop of 0 — an
unresolved sentinel means the config never passed through `SRLightning`, which is a bug, not a
default.

**No shipped number changes**: 3 and 4 are exactly what ×3 and ×4 now derive.

376 tests pass locally across `metrics`, `models` and `training`; `ruff check`,
`ruff format --check` and `mypy` clean.

## Not in this PR

The other half of #207 — adopting the authors' `same`+`replicate` inference path with an opt-out
to keep valid convolutions at both train and test — changes what SRCNN *outputs* at eval time and
needs its own tests. It follows separately.

Public-file scrub for internal identifiers and absolute paths: clean.
