### PR TITLE
chore: record why pinning is on, where it is set

### DIFF
--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -67,6 +67,12 @@ data:
     batch_size: 64             # not specified by the paper; this project's choice
     # Load-bearing on real data: num_workers=0 hits a hard serial floor.
     num_workers: 16
+    # Page-locked host buffers, worth ~9% of real-run throughput on this box
+    # (46.88 -> 42.71 ms/step, eager fp32). This was once required OFF, because
+    # graph capture could be invalidated mid-flight by the pin thread's
+    # cudaHostAlloc; that path no longer exists, so neither does the constraint.
+    # Bit-identical either way -- pinning changes how host memory reaches the
+    # device, not what reaches it.
     pin_memory: true
     persistent_workers: true
   val_dataloader_kwargs:

--- a/templates/config.srgan.template.yaml
+++ b/templates/config.srgan.template.yaml
@@ -105,6 +105,12 @@ data:
     batch_size: 16
     # !! These counts have OOM'd host RAM on a 16-worker box. Lower them if you do.
     num_workers: 16
+    # Page-locked host buffers, worth ~9% of real-run throughput on this box
+    # (46.88 -> 42.71 ms/step, eager fp32). This was once required OFF, because
+    # graph capture could be invalidated mid-flight by the pin thread's
+    # cudaHostAlloc; that path no longer exists, so neither does the constraint.
+    # Bit-identical either way -- pinning changes how host memory reaches the
+    # device, not what reaches it.
     pin_memory: true
     persistent_workers: true
   val_dataloader_kwargs:

--- a/templates/config.srresnet.template.yaml
+++ b/templates/config.srresnet.template.yaml
@@ -71,6 +71,12 @@ data:
     batch_size: 16
     # Load-bearing on real data: num_workers=0 hits a hard serial floor.
     num_workers: 16
+    # Page-locked host buffers, worth ~9% of real-run throughput on this box
+    # (46.88 -> 42.71 ms/step, eager fp32). This was once required OFF, because
+    # graph capture could be invalidated mid-flight by the pin thread's
+    # cudaHostAlloc; that path no longer exists, so neither does the constraint.
+    # Bit-identical either way -- pinning changes how host memory reaches the
+    # device, not what reaches it.
     pin_memory: true
     persistent_workers: true
   val_dataloader_kwargs:


### PR DESCRIPTION
Closes #176.

## The flip already happened

`pin_memory: true` is what **every** config ships — the reference SRResNet config included. The
divergence this issue was filed about is gone; only the recording of *why* was outstanding.

| acceptance | |
|---|---|
| The reference config and the templates agree on pinning | ✅ every config: `true` |
| The reason for the chosen value is recorded where the value is set | ✅ **this PR** — it was in the reference config, missing from the three tracked templates |
| Host memory at the shipped worker count is checked, not assumed | ✅ measured live, below |

## Host memory, measured rather than assumed

Taken from the long SRGAN run occupying the box right now — `num_workers: 16`, `pin_memory: true`:

```
20 processes, run-owned PSS = 7.19 GiB     on an 11 GiB VM (8 GiB available)
```

That is the real configuration under real load, not a probe. Pinned pages cannot be swapped,
which was the specific concern; there is comfortable headroom at the shipped worker count, and
several long runs have since completed on this cap.

## Why the comment earns its lines

The obvious guess about this value is **wrong**. `pin_memory` used to be required *off*, because
graph capture could be invalidated mid-flight by the pin thread's `cudaHostAlloc`. Anyone who
knows that history and not its end reads `true` as a mistake and turns it back. The comment says
the capture path is gone, so the constraint is too — and that pinning is bit-identical either
way, since it changes how host memory reaches the device, not what reaches it.

Worth ~9% of real-run throughput (46.88 → 42.71 ms/step, eager fp32).

Public-file scrub for internal identifiers and absolute paths: clean.
