### PR TITLE
fix: give SRCNN biases the authors learning rate

### DIFF
--- a/docs/reproduction.md
+++ b/docs/reproduction.md
@@ -113,8 +113,17 @@ both rows at once:
 | `hdf5_data_param.batch_size` (train) | `128` | `batch_size: 128` (was `64`) |
 | `max_iter` | `15000000` | see below |
 | `base_lr` / `momentum` / `weight_decay` | `0.0001` / `0.9` / `0` | already matched |
-| per-layer `lr_mult` (weights) | `1`, `1`, `0.1` | already matched — `layer_lrs: [1e-4, 1e-4, 1e-5]` |
+| per-layer `lr_mult` (weights) | `1`, `1`, `0.1` | already matched |
+| per-layer `lr_mult` (biases) | `0.1`, `0.1`, `0.1` | **now matched** — see below |
 | `weight_filler` std | `0.001` | already matched |
+
+The **bias** row was not matched, and the same file is what exposed it. Caffe applies a
+layer's two `param` blocks to its blobs in order — weights, then bias — so conv1 and conv2 pair
+`lr_mult` 1 with 0.1 and every bias trains at a tenth of `base_lr`, independently of the
+per-layer weight schedule. This project assigned one rate to a layer's weight *and* bias, so
+conv1 and conv2 biases trained at 10x the authors' rate; conv3 happened to agree, because its
+weight rate is already 1e-5. A `layer_lrs` entry may now be a `[weight_lr, bias_lr]` pair, and
+the shipped SRCNN recipe uses one per layer.
 
 `max_iter` settles one thing and opens another.
 

--- a/sisr/models/srcnn/config.py
+++ b/sisr/models/srcnn/config.py
@@ -17,6 +17,16 @@ from sisr.processors.base import SRProcessor
 from sisr.training.config import SREvalConfig, SRTrainingConfig
 
 
+def _authors_layer_lrs() -> list[float | list[float]]:
+    """``[weight_lr, bias_lr]`` per conv, from ``base_lr`` x the prototxt's ``lr_mult``.
+
+    A function rather than a lambda so the element type is ``float |
+    list[float]`` -- ``list`` is invariant, so an inferred
+    ``list[list[float]]`` will not satisfy the field.
+    """
+    return [[1.0e-4, 1.0e-5], [1.0e-4, 1.0e-5], [1.0e-5, 1.0e-5]]
+
+
 @dataclass
 class SRCNNTrainingConfig(SRTrainingConfig):
     """SRCNN-paper-faithful training defaults.
@@ -25,7 +35,9 @@ class SRCNNTrainingConfig(SRTrainingConfig):
     layer by pairing with ``YChannelProcessor``) and
     uses a per-layer learning rate of ``1e-4`` for the feature-extraction
     and non-linear-mapping layers and ``1e-5`` for the reconstruction layer
-    — i.e. the last layer learns 10× slower. Weight initialization follows
+    — i.e. the last layer learns 10× slower — and, per the authors'
+    released prototxt, trains **every bias at a tenth of the base rate**
+    independently of that per-layer weight schedule. Weight initialization follows
     the paper's Gaussian schedule (``N(0, 0.001)`` with zero biases); set
     ``init_strategy='default'`` to fall back to PyTorch's built-in init.
     Override any field in YAML to deviate.
@@ -37,8 +49,11 @@ class SRCNNTrainingConfig(SRTrainingConfig):
     single fixed factor, so there is no one paper-correct value to pin.
 
     Args:
-        layer_lrs: Per-``Conv2d`` LRs ``[1e-4, 1e-4, 1e-5]`` matching the
-            paper's recipe. Set to ``None`` to disable per-layer LRs.
+        layer_lrs: Per-``Conv2d`` ``[weight_lr, bias_lr]`` pairs matching
+            the authors' released ``SRCNN_net.prototxt``, whose two ``param``
+            blocks per layer carry ``lr_mult`` 1/0.1, 1/0.1 and 0.1/0.1
+            against ``base_lr: 0.0001``. conv3 reads the same either way;
+            conv1 and conv2 do not. Set to ``None`` to disable per-layer LRs.
         init_strategy: ``'paper'`` (default) triggers the Gaussian
             init via ``SRCNN.reset_parameters`` in
             ``SRLightning``'s constructor;
@@ -50,7 +65,7 @@ class SRCNNTrainingConfig(SRTrainingConfig):
             paper actually specifies. Override in YAML to deviate.
     """
 
-    layer_lrs: list[float] | None = field(default_factory=lambda: [1.0e-4, 1.0e-4, 1.0e-5])
+    layer_lrs: list[float | list[float]] | None = field(default_factory=_authors_layer_lrs)
     init_strategy: Literal["default", "paper"] = "paper"
     init_std: float = 0.001
 

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -48,12 +48,18 @@ class SRTrainingConfig:
     """How to train the SR model — affects optimizer setup and weight init.
 
     Args:
-        layer_lrs: Absolute per-``Conv2d`` LRs, one per ``Conv2d`` in
+        layer_lrs: Absolute per-``Conv2d`` LRs, one entry per ``Conv2d`` in
             module-traversal order. ``None`` (default) uses the optimizer's
             base ``lr`` uniformly. Only valid where every trainable parameter
             lives in a ``Conv2d`` — no BatchNorm / PReLU;
             ``SRLightning.configure_optimizers`` raises ``ValueError``
-            otherwise. Applies to a layer's weight *and* bias together.
+            otherwise. An entry is either a **float**, applying to that
+            layer's weight *and* bias together, or a
+            ``[weight_lr, bias_lr]`` **pair** splitting them — which is what
+            a Caffe prototxt's two per-layer ``param`` blocks express, and
+            the only way to state a bias schedule that differs from its
+            layer's weight schedule. LRs are absolute either way, so there
+            is no base rate to be relative to.
 
         example_input_shape: One sample's shape *excluding* batch (e.g.
             ``(1, 33, 33)``). Sets ``example_input_array`` so TensorBoard can
@@ -108,7 +114,7 @@ class SRTrainingConfig:
             configuration, never assume.
     """
 
-    layer_lrs: list[float] | None = None
+    layer_lrs: list[float | list[float]] | None = None
     example_input_shape: tuple[int, ...] | None = None
     init_strategy: Literal["default", "paper"] = "default"
     init_mean: float = 0.0

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -908,6 +908,51 @@ class SRLightning(lightning.LightningModule):
             )
         return int(scale)
 
+    @staticmethod
+    def _param_groups_from_layer_lrs(
+        conv_layers: list[torch.nn.Conv2d], lrs: list[float | list[float]]
+    ) -> list[dict[str, Any]]:
+        """Turn one ``layer_lrs`` entry per ``Conv2d`` into optimizer param groups.
+
+        A scalar entry gives the layer's weight and bias one shared LR; a
+        ``[weight_lr, bias_lr]`` pair splits them, which is what a Caffe
+        prototxt's two per-layer ``param`` blocks express.
+
+        Args:
+            conv_layers: The model's ``Conv2d`` modules, in traversal order.
+            lrs: One entry per layer, already length-checked by the caller.
+
+        Returns:
+            Param groups in layer order, a pair entry contributing two.
+
+        Raises:
+            ValueError: If a pair entry is not exactly two values, or aims a
+                bias LR at a layer built with ``bias=False`` -- silently
+                dropping it would leave the config claiming a rate nothing
+                applies.
+        """
+        groups: list[dict[str, Any]] = []
+        for i, (layer, lr) in enumerate(zip(conv_layers, lrs, strict=True)):
+            if isinstance(lr, int | float):
+                groups.append({"params": list(layer.parameters()), "lr": float(lr)})
+                continue
+            if len(lr) != 2:
+                raise ValueError(
+                    f"training_config.layer_lrs[{i}] has {len(lr)} values; a non-scalar "
+                    f"entry must be exactly 2 -- [weight_lr, bias_lr]. Use a bare float "
+                    f"to give weight and bias one shared LR."
+                )
+            weight_lr, bias_lr = lr
+            groups.append({"params": [layer.weight], "lr": float(weight_lr)})
+            if layer.bias is None:
+                raise ValueError(
+                    f"training_config.layer_lrs[{i}] sets bias_lr={bias_lr}, but that "
+                    f"Conv2d has no bias (built with bias=False). Use a bare float for "
+                    f"bias-free layers."
+                )
+            groups.append({"params": [layer.bias], "lr": float(bias_lr)})
+        return groups
+
     def configure_optimizers(self) -> OptimizerLRScheduler:
         """Build optimizer (and optional scheduler) from top-level YAML.
 
@@ -952,10 +997,7 @@ class SRLightning(lightning.LightningModule):
                     f"a Conv2d; these do not: {other}. Set layer_lrs=None for models with "
                     f"non-Conv layers (BatchNorm, PReLU, etc.)."
                 )
-            param_groups = [
-                {"params": list(layer.parameters()), "lr": lr}
-                for layer, lr in zip(conv_layers, lrs, strict=False)
-            ]
+            param_groups = self._param_groups_from_layer_lrs(conv_layers, lrs)
             optimizer = self.optimizer(param_groups)
 
         if self.lr_scheduler is None:

--- a/tests/models/srcnn/test_config.py
+++ b/tests/models/srcnn/test_config.py
@@ -9,7 +9,7 @@ def test_srcnn_training_config_paper_defaults():
     cfg = SRCNNTrainingConfig()
     # model_colorspace was removed in the SR base-classes refactor;
     # colorspace intent is now expressed by pairing with sisr.processors.YChannelProcessor.
-    assert cfg.layer_lrs == [1.0e-4, 1.0e-4, 1.0e-5]
+    assert cfg.layer_lrs == [[1.0e-4, 1.0e-5], [1.0e-4, 1.0e-5], [1.0e-5, 1.0e-5]]
     # Unlike SRResNet, not paper-fixed to one scale — SRCNN's own model
     # carries no 'scale' hparam at all, and the paper reports x2/x3/x4.
     assert cfg.scale is None
@@ -43,7 +43,7 @@ def test_srcnn_training_config_layer_lrs_independent_per_instance():
     a = SRCNNTrainingConfig()
     b = SRCNNTrainingConfig()
     a.layer_lrs.append(1.0)
-    assert b.layer_lrs == [1.0e-4, 1.0e-4, 1.0e-5]
+    assert b.layer_lrs == [[1.0e-4, 1.0e-5], [1.0e-4, 1.0e-5], [1.0e-5, 1.0e-5]]
 
 
 def test_srcnn_eval_config_psnr_channels_independent_per_instance():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,8 +201,10 @@ def test_srcnn_config_resolves_in_process():
     assert isinstance(m.eval_config, SRCNNEvalConfig)
     assert m.eval_config.crop_border == 3  # inherited-default check
     assert m.eval_config.ssim_impl == "wang"  # inherited-default check
-    # Paper recipe: reconstruction layer learns 10x slower than the other two.
-    assert m.training_config.layer_lrs == [1.0e-4, 1.0e-4, 1.0e-5]
+    # The authors' prototxt: reconstruction weights learn 10x slower than the other
+    # two layers', and every bias learns 10x slower than the base rate. The nested
+    # form also proves jsonargparse resolves layer_lrs' float-or-pair union.
+    assert m.training_config.layer_lrs == [[1.0e-4, 1.0e-5], [1.0e-4, 1.0e-5], [1.0e-5, 1.0e-5]]
     # Top-level optimizer block linked from YAML.
     assert cli.config.optimizer.class_path == "torch.optim.SGD"
     # The removed model_colorspace field must not reappear.

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -220,6 +220,85 @@ def test_configure_optimizers_per_layer_lrs():
     assert lrs == [1e-4, 1e-4, 1e-5]
 
 
+def test_configure_optimizers_per_blob_lrs():
+    """A 2-element entry splits a Conv2d into separate weight and bias LRs.
+
+    The SRCNN authors' prototxt carries two ``param`` blocks per layer
+    (weights, then bias), so conv1/conv2 biases train at a tenth of their
+    weights' rate. One LR per Conv2d cannot express that.
+    """
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(
+            layer_lrs=[[1.0e-4, 1.0e-5], [1.0e-4, 1.0e-5], [1.0e-5, 1.0e-5]]
+        ),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4, momentum=0.9),
+    )
+    out = lit.configure_optimizers()
+    opt = out[0][0] if isinstance(out, tuple) else out
+
+    convs = [m for m in model.modules() if isinstance(m, torch.nn.Conv2d)]
+    lr_of = {}
+    for group in opt.param_groups:
+        for param in group["params"]:
+            lr_of[id(param)] = group["lr"]
+
+    assert [lr_of[id(c.weight)] for c in convs] == [1e-4, 1e-4, 1e-5]
+    assert [lr_of[id(c.bias)] for c in convs] == [1e-5, 1e-5, 1e-5]
+
+
+def test_configure_optimizers_scalar_and_pair_entries_mix():
+    """A bare float still means 'weight and bias together', alongside pairs."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(layer_lrs=[1.0e-4, [1.0e-4, 1.0e-5], 1.0e-5]),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    out = lit.configure_optimizers()
+    opt = out[0][0] if isinstance(out, tuple) else out
+
+    convs = [m for m in model.modules() if isinstance(m, torch.nn.Conv2d)]
+    lr_of = {id(p): g["lr"] for g in opt.param_groups for p in g["params"]}
+
+    assert [lr_of[id(c.weight)] for c in convs] == [1e-4, 1e-4, 1e-5]
+    assert [lr_of[id(c.bias)] for c in convs] == [1e-4, 1e-5, 1e-5]
+
+
+def test_configure_optimizers_per_blob_wrong_pair_length_raises():
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(layer_lrs=[[1e-4, 1e-5, 1e-6], 1e-4, 1e-5]),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    with pytest.raises(ValueError, match="exactly 2"):
+        lit.configure_optimizers()
+
+
+def test_configure_optimizers_per_blob_bias_lr_without_bias_raises():
+    """A bias LR aimed at a bias-free Conv2d is a config error, not a silent drop."""
+    model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
+    convs = [m for m in model.modules() if isinstance(m, torch.nn.Conv2d)]
+    convs[1].bias = None
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(layer_lrs=[1e-4, [1e-4, 1e-5], 1e-5]),
+        eval_config=SREvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    with pytest.raises(ValueError, match="has no bias"):
+        lit.configure_optimizers()
+
+
 def test_configure_optimizers_per_layer_count_mismatch_raises():
     model = SRCNN(num_channels=3, num_filters=(64, 32), kernel_sizes=(9, 1, 5), padding=0)
     lit = SRLightning(


### PR DESCRIPTION
## What changed

SRCNN's conv1 and conv2 biases now train at `1e-5`, the rate the authors specify, instead of
`1e-4`. A `layer_lrs` entry may be a `[weight_lr, bias_lr]` pair as well as a float.

## Why

The authors' released `SRCNN_net.prototxt` gives every convolution two `param` blocks, which
Caffe applies to the layer's blobs in order — weights, then bias:

| layer | weight `lr_mult` | bias `lr_mult` | weight LR | bias LR |
|---|---:|---:|---:|---:|
| conv1 | `1` | `0.1` | 1e-4 | **1e-5** |
| conv2 | `1` | `0.1` | 1e-4 | **1e-5** |
| conv3 | `0.1` | `0.1` | 1e-5 | 1e-5 |

Every bias trains at a tenth of `base_lr`, independently of the per-layer weight schedule.
`layer_lrs` assigned one LR to `list(layer.parameters())` — weight *and* bias — so conv1 and
conv2 biases ran at 10x. conv3 happened to agree, because its weight rate is already 1e-5.

The per-layer weight schedule and `init_std: 0.001` already matched; this was the one part of
the port that did not.

## Why a pair, and not a `bias_lr_mult`

A single multiplier would have had to say what it multiplies. These LRs are **absolute** and
the optimizer's own `lr` is ignored when they are set, so there is no base rate in scope:
relative-to-layer-LR gives conv3 a bias rate of 1e-6, not the authors' 1e-5. Absolute pairs
read straight off the table above with no inference step, and a bare float still means "weight
and bias together", so nothing existing changes meaning.

## Evidence

Four tests, all confirmed RED on `main` before the fix:

- `test_configure_optimizers_per_blob_lrs` — weights `[1e-4, 1e-4, 1e-5]`, biases
  `[1e-5, 1e-5, 1e-5]`, read back off the built optimizer's param groups.
- `test_configure_optimizers_scalar_and_pair_entries_mix` — a bare float still means both.
- `test_configure_optimizers_per_blob_wrong_pair_length_raises`
- `test_configure_optimizers_per_blob_bias_lr_without_bias_raises` — a bias LR aimed at a
  `bias=False` layer is a config error, not a silent drop.

The CLI test resolves the shipped template and asserts the nested value, which is also what
proves jsonargparse handles the `float | list[float]` union.

## Blast radius

None published — SRCNN has no publishable row. 96 bias scalars out of ~57k, all initialised to
zero; how much it matters in practice is unmeasured. It is a fidelity claim, and the point of
this project is that the fidelity claims are checkable.

## Merge

**Rebase, not squash** — this PR carries a code commit and a docs commit, and per
CONTRIBUTING.md those stay separate.

Closes #210
