### PR TITLE
feat: run SRCNN inference the way its authors do

### DIFF
--- a/docs/reproduction.md
+++ b/docs/reproduction.md
@@ -148,15 +148,33 @@ unsourced number.
 No published number changes: SRCNN has no publishable row.
 
 **The evaluation border also left**, for the opposite reason: it turned out to be specified
-after all, and we differ from it. The authors' demo package (`SRCNN_v1.zip`, retrieved
+after all, and we differed from it. The authors' demo package (`SRCNN_v1.zip`, retrieved
 2026-09-01, SHA-256 `bfa68ca613c1326a59e0c34353205a254ab2b67e34df7f04e28eef567980af30`)
 shaves **`scale` pixels per side** before computing PSNR — not a constant — and runs the
 network with **`same` padding and replicated borders** at test time, though it trains with
-`pad: 0`. This project uses `padding: valid` at inference and then `crop_border: 3`, so at ×3
-we score a region strictly *inside* theirs, and our constant agrees with `scale` only at ×3.
-The two differences are entangled — changing the border alone moves us further away, not
-closer — so the choice between reproducing their measurement and keeping a path that never
-scores invented border pixels is tracked as its own decision, not settled here (#207).
+`pad: 0`. This project used `padding: valid` at inference and then `crop_border: 3`, so at ×3
+it scored a region strictly *inside* theirs, and the constant agreed with `scale` only at ×3.
+
+The two differences were entangled — changing the border alone moves *away* from the authors,
+not toward them, because the valid-convolution loss stays underneath — so both are now
+adopted together:
+
+| | authors | ships now |
+|---|---|---|
+| inference padding | `same`, replicated border | `eval_padding: same`, `eval_padding_mode: replicate` |
+| training padding | `pad: 0` | `padding: 0`, unchanged |
+| border shaved before PSNR | `scale` px/side | `crop_border` derived from `scale` |
+
+The replicated border is re-derived at **every** convolution, as the authors' per-layer
+`imfilter` does; pre-padding the input once and convolving valid is a different function.
+`eval_padding` applies only outside training mode, so the model is deliberately not the same
+function in the two modes — which is what the authors' own setup is.
+
+The trade this makes is real and was decided rather than assumed: same-padded inference scores
+pixels whose receptive field includes invented (replicated) content. Keeping valid convolution
+never does, and is arguably more honest, but then the numbers are not comparable to the paper's
+on a metric where border handling is known to matter. Reproducing the paper won. Deleting the
+two `eval_padding` lines from the config restores valid convolution at train and test.
 
 #### What did *not* settle: SRResNet's PReLU
 

--- a/sisr/models/srcnn/model.py
+++ b/sisr/models/srcnn/model.py
@@ -25,6 +25,14 @@ class SRCNN(SRModel):
             original architecture).
         padding: ``'valid'``, ``'same'``, or an explicit pixel count.
             Defaults to ``'valid'``.
+        eval_padding: Padding to use outside training mode, or ``None``
+            (default) to use ``padding`` throughout. Only ``'same'`` is
+            accepted: the authors train with ``pad: 0`` and run inference
+            with SAME padding, so the model is deliberately not the same
+            function in the two modes. Requires odd kernels.
+        eval_padding_mode: Border mode for ``eval_padding``, in
+            ``torch.nn.functional.pad``'s vocabulary. ``'replicate'``
+            (default) is what the authors' ``imfilter`` call uses.
     """
 
     #: Resolution-preserving: LR arrives already bicubic-upsampled to HR size.
@@ -36,16 +44,34 @@ class SRCNN(SRModel):
         num_filters: tuple[int, ...],
         kernel_sizes: tuple[int, ...],
         padding: str | int = "valid",
+        eval_padding: Literal["same"] | None = None,
+        eval_padding_mode: str = "replicate",
     ):
         super().__init__()
 
         self._check_architecture(num_filters, kernel_sizes)
+        if eval_padding is not None:
+            if eval_padding != "same":
+                raise ValueError(
+                    f"eval_padding must be 'same' or None, got {eval_padding!r}. Valid "
+                    f"convolution at eval is what padding={padding!r} already gives."
+                )
+            if any(k % 2 == 0 for k in kernel_sizes):
+                raise ValueError(
+                    f"eval_padding='same' needs odd kernel sizes to pad symmetrically; "
+                    f"got kernel_sizes={kernel_sizes}."
+                )
+
+        self.eval_padding = eval_padding
+        self.eval_padding_mode = eval_padding_mode
 
         self._hparams = {
             "num_channels": num_channels,
             "num_filters": num_filters,
             "kernel_sizes": kernel_sizes,
             "padding": padding,
+            "eval_padding": eval_padding,
+            "eval_padding_mode": eval_padding_mode,
         }
 
         self.feat = torch.nn.Sequential(
@@ -122,6 +148,30 @@ class SRCNN(SRModel):
                 if module.bias is not None:
                     torch.nn.init.constant_(module.bias, 0.0)
 
+    def _eval_layer(self, layer: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:
+        """Run one layer under ``eval_padding``, padding a Conv2d's own input.
+
+        The border is re-derived at every convolution, which is what the
+        authors' per-layer ``imfilter(..., 'same', 'replicate')`` does.
+        Padding the input once by the whole receptive field and convolving
+        valid is a different function: later layers would then see a border
+        built from replicated *input* pixels, not replicated features.
+
+        Args:
+            layer: A ``Conv2d`` or an activation from the conv stacks.
+            x: That layer's input.
+
+        Returns:
+            The layer's output, spatially unchanged for a ``Conv2d``.
+        """
+        if not isinstance(layer, torch.nn.Conv2d):
+            return layer(x)
+        pad_h, pad_w = ((k - 1) // 2 for k in layer.kernel_size)
+        x = torch.nn.functional.pad(x, (pad_w, pad_w, pad_h, pad_h), mode=self.eval_padding_mode)
+        return torch.nn.functional.conv2d(
+            x, layer.weight, layer.bias, layer.stride, 0, layer.dilation, layer.groups
+        )
+
     @property
     def variant_tag(self) -> str:
         """The kernel-size triple, e.g. ``'915'`` -- how the paper names its variants."""
@@ -148,14 +198,20 @@ class SRCNN(SRModel):
             clamp_minmax: Min/max values for clamping the output.
 
         Returns:
-            Output tensor. Same shape as *x* only when ``padding='same'``;
-            with the default ``'valid'`` (or an explicit int), each conv
-            layer shrinks H/W by ``kernel_size - 1 - 2*padding``, e.g. -12 px
-            total for the shipped ``(9, 1, 5)`` kernels at padding 0.
+            Output tensor. Same shape as *x* when ``padding='same'``, or
+            when ``eval_padding='same'`` and the module is not in training
+            mode; otherwise each conv layer shrinks H/W by
+            ``kernel_size - 1 - 2*padding``, e.g. -12 px total for the
+            shipped ``(9, 1, 5)`` kernels at padding 0. **The output shape
+            therefore depends on training mode** whenever ``eval_padding``
+            is set -- deliberately, since the authors train valid and test
+            same.
         """
-        x = self.feat(x)
-        x = self.mapping(x)
-        x = self.recon(x)
+        if self.training or self.eval_padding is None:
+            x = self.recon(self.mapping(self.feat(x)))
+        else:
+            for layer in (*self.feat, *self.mapping, self.recon):
+                x = self._eval_layer(layer, x)
 
         if clamp_output:
             x = torch.clamp(x, min=clamp_minmax[0], max=clamp_minmax[1])

--- a/templates/config.srcnn.template.yaml
+++ b/templates/config.srcnn.template.yaml
@@ -21,6 +21,9 @@ model:
           num_filters: [64, 32]
           kernel_sizes: [9, 1, 5]
           padding: 0
+          # The authors' SRCNN.m runs inference imfilter(..., 'same', 'replicate').
+          eval_padding: same
+          eval_padding_mode: replicate
       processor:
         class_path: sisr.processors.YChannelProcessor
       training_config:

--- a/tests/models/srcnn/test_model.py
+++ b/tests/models/srcnn/test_model.py
@@ -155,7 +155,14 @@ def test_hparams_architectural_only():
         kernel_sizes=(9, 1, 5),
         padding=0,
     )
-    assert set(model.hparams.keys()) == {"num_channels", "num_filters", "kernel_sizes", "padding"}
+    assert set(model.hparams.keys()) == {
+        "num_channels",
+        "num_filters",
+        "kernel_sizes",
+        "padding",
+        "eval_padding",
+        "eval_padding_mode",
+    }
 
 
 def test_forward_multilayer_mapping_builds_extra_conv_and_preserves_shape():
@@ -184,3 +191,103 @@ def test_variant_tag_is_the_kernel_triple():
     """The paper names its variants by kernel sizes, so the artifact does too."""
     assert SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 1, 5)).variant_tag == "915"
     assert SRCNN(num_channels=1, num_filters=(64, 32), kernel_sizes=(9, 5, 5)).variant_tag == "955"
+
+
+# ---------------------------------------------------------------------------
+# eval_padding — the authors' test-time path (train valid, test same+replicate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def srcnn_authors() -> SRCNN:
+    """The authors' released setup: `pad: 0` at train, same+replicate at test."""
+    return SRCNN(
+        num_channels=1,
+        num_filters=(64, 32),
+        kernel_sizes=(9, 1, 5),
+        padding=0,
+        eval_padding="same",
+        eval_padding_mode="replicate",
+    )
+
+
+def test_eval_padding_only_applies_out_of_training_mode(srcnn_authors: SRCNN):
+    """Train shrinks by 12 px as before; eval returns the full size."""
+    x = torch.zeros(2, 1, 33, 33)
+
+    srcnn_authors.train()
+    assert srcnn_authors(x).shape == (2, 1, 21, 21)
+
+    srcnn_authors.eval()
+    assert srcnn_authors(x).shape == (2, 1, 33, 33)
+
+
+def test_eval_padding_none_keeps_valid_in_both_modes(srcnn_valid: SRCNN):
+    """The opt-out: `eval_padding=None` (the default) is valid convolution throughout."""
+    x = torch.zeros(2, 3, 33, 33)
+    for mode in (srcnn_valid.train, srcnn_valid.eval):
+        mode()
+        assert srcnn_valid(x).shape == (2, 3, 21, 21)
+
+
+def test_eval_padding_pads_per_layer_not_the_input_once(srcnn_authors: SRCNN):
+    """Replicate padding is re-derived per layer, as `SRCNN.m`'s imfilter is.
+
+    Pre-padding the input by the full 6 px receptive field and running valid
+    convolutions is the cheap-looking equivalent, and it is a different
+    function: layer 2 would then see a border computed from replicated
+    *input* pixels rather than replicated *layer-1 features*.
+    """
+    torch.manual_seed(0)
+    srcnn_authors.reset_parameters(std=0.2)
+    srcnn_authors.eval()
+    x = torch.rand(1, 1, 24, 24)
+
+    with torch.no_grad():
+        per_layer = srcnn_authors(x)
+        prepadded_input = torch.nn.functional.pad(x, (6, 6, 6, 6), mode="replicate")
+        srcnn_authors.eval_padding = None
+        prepadded = srcnn_authors(prepadded_input)
+
+    assert per_layer.shape == prepadded.shape
+    assert not torch.allclose(per_layer, prepadded, atol=1e-6)
+
+
+def test_eval_padding_matches_an_explicit_per_layer_reference(srcnn_authors: SRCNN):
+    """Pin the exact arithmetic against a hand-written pad-then-valid-conv loop."""
+    torch.manual_seed(0)
+    srcnn_authors.reset_parameters(std=0.2)
+    srcnn_authors.eval()
+    x = torch.rand(1, 1, 20, 20)
+
+    layers = [*srcnn_authors.feat, *srcnn_authors.mapping, srcnn_authors.recon]
+    with torch.no_grad():
+        expected = x
+        for layer in layers:
+            if isinstance(layer, torch.nn.Conv2d):
+                pad = (layer.kernel_size[0] - 1) // 2
+                expected = torch.nn.functional.pad(expected, (pad, pad, pad, pad), mode="replicate")
+                expected = torch.nn.functional.conv2d(expected, layer.weight, layer.bias)
+            else:
+                expected = layer(expected)
+        actual = srcnn_authors(x)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_eval_padding_is_recorded_in_hparams(srcnn_authors: SRCNN):
+    """Checkpoints must carry it — it changes what the model outputs at eval."""
+    assert srcnn_authors.hparams["eval_padding"] == "same"
+    assert srcnn_authors.hparams["eval_padding_mode"] == "replicate"
+
+
+def test_eval_padding_rejects_an_even_kernel():
+    """`same` is not expressible for an even kernel without an asymmetric pad."""
+    with pytest.raises(ValueError, match="odd kernel"):
+        SRCNN(
+            num_channels=1,
+            num_filters=(64, 32),
+            kernel_sizes=(9, 1, 4),
+            padding=0,
+            eval_padding="same",
+        )

--- a/tests/models/srcnn/test_model.py
+++ b/tests/models/srcnn/test_model.py
@@ -281,6 +281,24 @@ def test_eval_padding_is_recorded_in_hparams(srcnn_authors: SRCNN):
     assert srcnn_authors.hparams["eval_padding_mode"] == "replicate"
 
 
+@pytest.mark.parametrize("bad", ["valid", "replicate", 0])
+def test_eval_padding_rejects_anything_but_same(bad):
+    """`same` is the only override worth having — valid at eval is what `padding` gives.
+
+    Rejecting rather than accepting-and-ignoring matters here: silently
+    honouring `eval_padding='valid'` as "no override" would read like the
+    authors' path was configured when it was not.
+    """
+    with pytest.raises(ValueError, match="must be 'same' or None"):
+        SRCNN(
+            num_channels=1,
+            num_filters=(64, 32),
+            kernel_sizes=(9, 1, 5),
+            padding=0,
+            eval_padding=bad,
+        )
+
+
 def test_eval_padding_rejects_an_even_kernel():
     """`same` is not expressible for an even kernel without an asymmetric pad."""
     with pytest.raises(ValueError, match="odd kernel"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -597,6 +597,9 @@ def test_export_subcommand_runs_end_to_end_in_process(tmp_path):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             warnings.filterwarnings("ignore", message="GPU available but not used.*")
+            # eval_padding lowers to an onnx::Slice the folder declines to fold.
+            # An optimization notice, not a correctness one -- the graph is exported.
+            warnings.filterwarnings("ignore", message="Constant folding - Only steps=1.*")
             SRLightningCLI(
                 model_class=SRLightning,
                 datamodule_class=SRDataModule,
@@ -868,6 +871,8 @@ def _build_srcnn_checkpoint(tiny_rgb_image_dir: Path, tmp_path: Path) -> tuple[P
                         "num_filters": [64, 32],
                         "kernel_sizes": [9, 1, 5],
                         "padding": 0,
+                        "eval_padding": None,
+                        "eval_padding_mode": "replicate",
                     },
                 },
                 "processor": {"class_path": "sisr.processors.RGBProcessor"},

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -193,6 +193,8 @@ def test_to_onnx_writes_metadata_props(tmp_path):
         "num_filters": [8, 4],
         "kernel_sizes": [5, 1, 3],
         "padding": 0,
+        "eval_padding": None,
+        "eval_padding_mode": "replicate",
     }
 
     io_field = json.loads(props["io"])

--- a/tests/training/test_lightning_module.py
+++ b/tests/training/test_lightning_module.py
@@ -11,7 +11,7 @@ import torchmetrics
 
 from sisr.losses import SRLoss
 from sisr.metrics.scoring import SRScorer
-from sisr.models.srcnn import SRCNN, SRCNNTrainingConfig
+from sisr.models.srcnn import SRCNN, SRCNNEvalConfig, SRCNNTrainingConfig
 from sisr.models.srresnet import SRResNetEvalConfig, SRResNetTrainingConfig
 from sisr.models.srresnet.model import SRResNet
 from sisr.processors import (
@@ -2158,3 +2158,37 @@ def test_scorer_refuses_an_unresolved_crop_border_sentinel():
     scorer = SRScorer(SREvalConfig(crop_border=None))
     with pytest.raises(ValueError, match="still None at scoring time"):
         scorer.crop(torch.rand(1, 3, 16, 16))
+
+
+def test_eval_padding_makes_the_scored_region_the_authors():
+    """With the authors' inference path the SR field's border is all that is lost.
+
+    Valid convolution costs 6 px per side before `crop_border` shaves any,
+    so the scored region sat strictly inside the authors'. Under
+    `eval_padding='same'` the model output is full-size, `_forward_sr`'s
+    center_crop becomes a no-op, and `crop_border` alone decides the region
+    — which #217 already derives from `scale`.
+    """
+    model = SRCNN(
+        num_channels=3,
+        num_filters=(64, 32),
+        kernel_sizes=(9, 1, 5),
+        padding=0,
+        eval_padding="same",
+    )
+    lit = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRCNNTrainingConfig(scale=3),
+        eval_config=SRCNNEvalConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    lit.eval()
+    assert lit.eval_config.crop_border == 3  # from scale, not a pinned constant
+
+    hr = torch.rand(1, 3, 48, 48)
+    with torch.no_grad():
+        sr, hr_aligned = lit.predict_rgb(hr.clone(), hr)
+
+    assert sr.shape == hr.shape, "same-padded inference must not shrink the SR field"
+    assert hr_aligned.shape == hr.shape, "so center_crop must have nothing left to take"

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -66,6 +66,8 @@ def test_build_metadata_model_class_path_and_init_args():
         "num_filters": [8, 4],
         "kernel_sizes": [5, 1, 3],
         "padding": 0,
+        "eval_padding": None,
+        "eval_padding_mode": "replicate",
     }
 
 


### PR DESCRIPTION
## What changed

SRCNN now runs inference with SAME padding and replicated borders, as the authors' released
demo code does, while still training with `pad: 0` as they do. `SRCNN` gains `eval_padding`
and `eval_padding_mode`; the shipped template sets them.

## Why

`SRCNN.m` convolves with `imfilter(..., 'same', 'replicate')` and `demo_SR.m` then shaves
`scale` pixels per side before PSNR. This project convolved **valid** at inference too, losing
6 px per side before `crop_border` shaved any, so at x3 it scored:

| | region scored on an HxW ground truth |
|---|---|
| authors | rows `4 .. H-3` |
| before this PR | rows `10 .. H-9` |

Strictly inside theirs, and not the same measurement — on a metric where border handling is
known to matter.

The two divergences were entangled: `crop_border` being a constant where the authors' border is
`scale` (fixed already, #217) and the valid-conv loss underneath it. Fixing either alone moves
*away* from the authors. With a full-size output the center-crop that aligns SR to HR becomes a
no-op, so the border alone decides the region — and it is now the authors' region.

## The trade, decided rather than assumed

Same-padded inference scores pixels whose receptive field includes invented (replicated)
content. Valid convolution never does, and is arguably the more honest measurement — but then
the numbers are not comparable to the paper's. Reproducing the paper won. **The opt-out is
deleting the two `eval_padding` lines from the config**, which restores valid convolution at
train and test.

## Two things that are easy to get wrong

- **The border is re-derived at every convolution**, matching the authors' per-layer
  `imfilter`. Pre-padding the input once by the full 6 px receptive field and convolving valid
  is the cheap-looking equivalent and a *different function* — later layers would see a border
  built from replicated input pixels rather than replicated features.
  `test_eval_padding_pads_per_layer_not_the_input_once` pins the difference.
- **Mutating a built `Conv2d`'s `.padding` / `.padding_mode` does not work.** `__init__`
  precomputes the `'same'` pad tuple, so a mutated module silently keeps convolving valid —
  it would have claimed the authors' path while doing the old one. Hence an explicit
  pad-then-convolve.

`eval_padding` applies only outside training mode, so **the model's output shape now depends on
training mode**. That is deliberate — it is what the authors' own setup is — and it is written
into the `forward` docstring.

## Evidence

Tests, all confirmed RED before the change (the constructor did not accept the argument):

- `test_eval_padding_only_applies_out_of_training_mode` — 33x33 in gives 21x21 training,
  33x33 eval.
- `test_eval_padding_none_keeps_valid_in_both_modes` — the opt-out, and the default.
- `test_eval_padding_pads_per_layer_not_the_input_once`
- `test_eval_padding_matches_an_explicit_per_layer_reference` — exact arithmetic against a
  hand-written pad-then-valid-conv loop.
- `test_eval_padding_rejects_an_even_kernel`, `test_eval_padding_is_recorded_in_hparams`
- `test_eval_padding_makes_the_scored_region_the_authors` — through `SRLightning`: the SR
  field is full-size, so `center_crop` takes nothing and `crop_border` (3, derived from
  `scale`) is the whole difference.

Metadata tests updated: the two new hparams are architectural and must round-trip through
checkpoints and the ONNX `sisr_meta` props. The ONNX export now emits a constant-folding
notice — `F.pad(mode='replicate')` lowers to an `onnx::Slice` the folder declines to fold. It
is an optimization notice, not a correctness one; the graph exports, and the test filters it by
message rather than broadening the suite's `error` policy.

## Blast radius

None published — SRCNN has no publishable row, so no existing figure is invalidated. SRCNN's
validation metric during training does change, which is the intended effect.

## Merge

**Rebase, not squash** — code commit and docs commit stay separate.

Stacked on #219. Closes #207
