### PR TITLE
fix: let a run resume into a run directory that does not exist yet

### DIFF
--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -681,6 +681,11 @@ class _RollingSaveMixin(_RollingBase):
         assigned until the checkpoint connector restores state, which is after
         every ``setup`` hook.
 
+        A ``dirpath`` that does not exist yet is a no-op, not an error: resuming
+        into a **fresh** run directory (branching a run, or restarting a crashed
+        one so the old directory survives as evidence) reaches this hook before
+        Lightning has created it.
+
         Args:
             trainer: The active trainer — supplies ``ckpt_path``.
             pl_module: Unused; part of the hook signature.
@@ -688,9 +693,15 @@ class _RollingSaveMixin(_RollingBase):
         super().on_train_start(trainer, pl_module)
         if self.monitor is not None or not trainer.ckpt_path or not self.dirpath:
             return
+        # Lightning creates dirpath lazily, in its IO plugin, at the first save --
+        # so resuming into a run directory that has not saved yet finds nothing to
+        # list. Missing and empty mean the same thing here: no window to adopt.
+        directory = Path(self.dirpath)
+        if not directory.is_dir():
+            return
         found = sorted(
             (int(match.group(1)), str(path))
-            for path in Path(self.dirpath).iterdir()
+            for path in directory.iterdir()
             if (match := self._rolling_pattern.fullmatch(path.name))
         )
         self._rolling = [path for _, path in found]

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -1340,6 +1340,28 @@ def test_rolling_window_is_not_seeded_on_a_fresh_run(tmp_path: Path):
     assert cb._rolling == []
 
 
+def test_rolling_seed_survives_a_dirpath_that_does_not_exist_yet(tmp_path: Path):
+    """Resuming into a *fresh* run directory must reach training, not crash.
+
+    Lightning creates the checkpoint directory lazily, inside its IO plugin, at
+    the first save — so on a resume into a run directory that has not saved yet
+    there is no directory to list. The guard checked only that ``dirpath`` was
+    set, so ``iterdir()`` raised ``FileNotFoundError`` at ``on_train_start``:
+    after model construction, dataloader setup and the sanity pass, which on an
+    adversarial config is tens of minutes thrown away.
+    """
+    dirpath = tmp_path / "version_1" / "checkpoints"
+    assert not dirpath.exists()
+    cb = SRWeightsCheckpoint(
+        monitor_metric=None, keep_last=2, dirpath=str(dirpath), filename_prefix="sr-weights"
+    )
+
+    cb.on_train_start(MagicMock(ckpt_path=str(tmp_path / "resumed-from.ckpt")), MagicMock())
+
+    assert cb._rolling == []
+    assert not dirpath.exists(), "seeding must not create the directory Lightning owns"
+
+
 def test_rolling_seed_is_noop_when_monitor_is_set(tmp_path: Path):
     """With a monitor, Lightning's top-k owns retention — seeding would evict
     files top-k still wants, exactly as ``_enforce_rolling_window`` must not."""


### PR DESCRIPTION
## What changed

Resuming into a run directory that does not exist yet reaches training instead of crashing.

## Why

`_RollingSaveMixin.on_train_start` seeds the rolling window from disk on resume, and its guard
checked that `dirpath` was *set* — never that it existed:

```python
if self.monitor is not None or not trainer.ckpt_path or not self.dirpath:
    return
found = sorted(... for path in Path(self.dirpath).iterdir() ...)
```

Lightning creates that directory **lazily, inside its IO plugin, at the first save**. So
`fit --ckpt_path <ckpt>` into a *new* run directory raised:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../checkpoints'
```

That is a legitimate thing to do — branching a run, or restarting a crashed one into a clean
directory so the old one survives as evidence. Resuming *in place* was unaffected, because the
directory already holds the checkpoint being resumed from, which is why it went unnoticed.

It failed fast and corrupted nothing, but it failed *after* model construction, dataloader setup
and the sanity pass — on an adversarial config with perceptual metrics, tens of minutes thrown
away.

## Evidence

`test_rolling_seed_survives_a_dirpath_that_does_not_exist_yet`, confirmed RED on `main`
(`FileNotFoundError` from `iterdir()`), GREEN after. It also asserts the callback does **not**
create the directory — Lightning owns that, and the same family of bug is what `artifacts.py`'s
directory-creation fix was about.

The existing seeding coverage is unchanged and still passes: resuming in place still adopts the
files already there, a fresh run into a populated directory still leaves them alone, and a
monitored callback still no-ops.

Missing and empty mean the same thing here — no window to adopt, which is exactly what the
seeding code would infer from an empty directory anyway.

Closes #200
