### PR TITLE
feat: record the host's power state, and say so before a long run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ filterwarnings = [
     "ignore::FutureWarning:lightning.*",
     # Post-optimization state is exactly what a checkpoint should hold.
     "ignore:Using ModelCheckpoint with manual optimization:UserWarning",
+    # Advisory by design, and no CI runner is a reference bench. The tests that
+    # care assert it with pytest.warns, which this does not suppress.
+    "ignore:Power state is not the reference condition:UserWarning",
 ]
 
 [tool.ruff]

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -41,6 +41,7 @@ from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCL
 
 from .export import to_onnx
 from .training import SRDataModule, SREvalConfig, SRLightning, SRTrainingConfig
+from .utils.power import warn_unless_reference_power
 
 # Checkpoints saved before SRLightning.__init__ stopped flattening self.hparams for
 # TensorBoard display (see its docstring) stored ONLY these two dataclasses' fields —
@@ -260,12 +261,20 @@ class SRLightningCLI(LightningCLI):
         )
 
     def before_instantiate_classes(self) -> None:
-        """Apply process-global flags (``matmul_precision``) before class instantiation."""
+        """Apply process-global flags, and check the host's power before a long run.
+
+        The power check is ``fit``-only and advisory: it never refuses, because a
+        correctness-only run on a laptop is legitimate. What is not legitimate is
+        not knowing afterwards which conditions a timing came from, so the state
+        is also recorded in every artifact the run writes.
+        """
         if self.subcommand is None:
             return
         precision = self.config[self.subcommand].matmul_precision
         if precision is not None:
             torch.set_float32_matmul_precision(precision)
+        if self.subcommand == "fit":
+            warn_unless_reference_power()
 
     def _parse_ckpt_path(self) -> None:
         """Reload ``--ckpt_path`` hyperparameters via ``_reconstruct_ckpt_hparams`` first.

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -13,7 +13,8 @@ helper (``format``/``kind``/``created``/``versions``/``training``), so the two p
 cannot drift apart either. Each carries a ``kind`` field: ``"sr_model"`` for :func:`build_metadata`,
 ``"component"`` for :func:`build_component_metadata`. This is an additive field, not a format
 change — ``FORMAT_VERSION`` is unchanged, and its absence on a file written before ``kind``
-existed means ``"sr_model"``, the only kind that existed then.
+existed means ``"sr_model"``, the only kind that existed then. ``power`` is additive on the
+same terms -- absent on a file written before it existed, which means unrecorded, not mains.
 
 The first describes the *generator*, the second one other named component; each
 function's ``Returns`` lists its own fields. **Attaching the generator's shape to a
@@ -36,6 +37,7 @@ import lightning
 import torch
 
 import sisr
+from sisr.utils.power import read_power_state
 
 if TYPE_CHECKING:
     from .lightning_module import SRLightning
@@ -101,6 +103,11 @@ def _envelope(
             "monitor": monitor,
             "monitor_value": monitor_value,
         },
+        # Read once per process, so this is the state near the START of the run,
+        # not at this save. A rate quoted from an artifact whose provenance says
+        # BATTERY is then self-refuting rather than merely plausible -- which is
+        # the whole point, since off mains costs roughly half.
+        "power": read_power_state().as_dict(),
     }
 
 

--- a/sisr/utils/__init__.py
+++ b/sisr/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Torch-free support code: the LMDB cache and the vendored MATLAB resize.
+"""Torch-free support code: the LMDB cache, the vendored MATLAB resize, power state.
 
 **Nothing is re-exported here, deliberately.** Both submodules are torch-free,
 and :mod:`~sisr.utils.cache` must stay that way: ``parallel_build`` fans out

--- a/sisr/utils/power.py
+++ b/sisr/utils/power.py
@@ -1,0 +1,143 @@
+"""Host power state, recorded so a throughput number carries its own conditions.
+
+A rate measured off mains is worth about half: the same adversarial run on the
+same config managed 172 batches/min on a draining battery against 366 on mains
+under Windows' Best-performance overlay. The crash when the battery ran flat was
+loud and cost 87 minutes; the contaminated rate was silent and went into the
+notes as sound.
+
+**Advisory, never fatal.** A correctness-only run on a laptop is legitimate; not
+knowing afterwards which conditions produced a number is not. So this warns and
+records, and refuses nothing.
+
+WSL/Windows only, because that is where the instrument is: ``nvidia-smi`` cannot
+read the enforced power limit under WSL, and ``powercfg /getactivescheme``
+reports the underlying scheme rather than the overlay sitting on top of it, so
+the registry value is what has to be read. Anywhere else this degrades to
+"unknown", which is a recorded state and not an error.
+
+Torch-free, like everything else in this package -- see the package docstring.
+"""
+
+from __future__ import annotations
+
+import functools
+import shutil
+import subprocess
+import warnings
+from dataclasses import dataclass
+from typing import Any
+
+#: Windows' "Best performance" power overlay -- the reference condition every
+#: throughput figure in this project's notes was measured under.
+BEST_PERFORMANCE_OVERLAY = "ded574b5-45a0-4f42-8737-46345c09c238"
+
+_SCHEME_KEY = r"HKLM:\SYSTEM\CurrentControlSet\Control\Power\User\PowerSchemes"
+
+_PROBE = (
+    "$b=Get-CimInstance -Namespace root\\wmi -ClassName BatteryStatus "
+    "-ErrorAction SilentlyContinue;"
+    "if ($null -eq $b) { Write-Output 'nobattery' } else { Write-Output $b.PowerOnline };"
+    f"$p=Get-ItemProperty '{_SCHEME_KEY}';"
+    "Write-Output $p.ActiveOverlayAcPowerScheme"
+)
+
+
+@dataclass(frozen=True)
+class PowerState:
+    """What the host's power looked like, or why that could not be established.
+
+    Args:
+        on_mains: ``True`` on mains, ``False`` on battery, ``None`` when
+            unreadable — a machine reporting no battery counts as ``True``.
+        overlay: Active AC power overlay GUID, or ``None`` if unreadable.
+        note: Always set, and always readable by a human. This is the field
+            worth putting in front of someone; the other two are for code.
+    """
+
+    on_mains: bool | None
+    overlay: str | None
+    note: str
+
+    @property
+    def is_reference(self) -> bool:
+        """Whether this is the condition the project's throughput figures assume."""
+        return self.on_mains is True and self.overlay == BEST_PERFORMANCE_OVERLAY
+
+    def as_dict(self) -> dict[str, Any]:
+        """Plain-scalar form for artifact metadata (``weights_only``-safe)."""
+        return {"on_mains": self.on_mains, "overlay": self.overlay, "note": self.note}
+
+
+@functools.cache
+def read_power_state(timeout: float = 30.0) -> PowerState:
+    """Read the host power state once per process.
+
+    Cached because the two consumers want the *same* answer: the warning at
+    startup and the provenance recorded in every artifact the run writes. It
+    therefore describes the state at first read, near the start of the run --
+    not at each checkpoint save, which would put a subprocess call, and a
+    chance to hang, in the save path.
+
+    Args:
+        timeout: Seconds to wait on PowerShell before giving up.
+
+    Returns:
+        A :class:`PowerState`; never raises, since no reading is a recorded
+        state rather than a failure.
+    """
+    powershell = shutil.which("powershell.exe")
+    if powershell is None:
+        return PowerState(None, None, "unknown: no powershell.exe on PATH (not WSL/Windows)")
+    try:
+        probe = subprocess.run(
+            [powershell, "-NoProfile", "-Command", _PROBE],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return PowerState(None, None, f"unknown: power probe failed ({type(exc).__name__})")
+
+    lines = [ln.strip() for ln in probe.stdout.replace("\r", "").split("\n") if ln.strip()]
+    if len(lines) < 2:
+        return PowerState(None, None, f"unknown: power probe returned {probe.stdout!r}")
+
+    battery, overlay = lines[0], lines[1]
+    if battery == "nobattery":
+        on_mains: bool | None = True
+    elif battery.lower() in ("true", "false"):
+        on_mains = battery.lower() == "true"
+    else:
+        return PowerState(None, overlay, f"unknown: unreadable battery state {battery!r}")
+
+    supply = "mains" if on_mains else "BATTERY"
+    best = "Best performance" if overlay == BEST_PERFORMANCE_OVERLAY else overlay
+    return PowerState(on_mains, overlay, f"{supply}, overlay {best}")
+
+
+def warn_unless_reference_power(state: PowerState | None = None) -> PowerState:
+    """Warn when the host is readably *not* in the condition throughput figures assume.
+
+    Silent when the state is unknown: there is no instrument outside
+    WSL/Windows, so warning there would fire on every run everywhere and say
+    nothing. Unknown is a recorded state, not a suspicion.
+
+    Args:
+        state: State to judge; read via :func:`read_power_state` when omitted.
+
+    Returns:
+        The state judged, so a caller can record what it warned about.
+    """
+    state = read_power_state() if state is None else state
+    if state.on_mains is not None and not state.is_reference:
+        warnings.warn(
+            f"Power state is not the reference condition for throughput: {state.note}. "
+            f"Timings from this run are not comparable to figures measured on mains "
+            f"under the Best-performance overlay -- off mains costs roughly half. "
+            f"Training is unaffected; this is recorded in the run's artifact metadata.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return state

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -751,6 +751,39 @@ def test_before_instantiate_classes_calls_torch_setter(monkeypatch):
     assert calls == ["medium"]
 
 
+def test_fit_warns_when_the_host_is_not_on_reference_power(monkeypatch):
+    """A long run announces contaminated timing conditions before it starts.
+
+    Advisory only: the run proceeds. The 87 minutes a flat battery cost once
+    were the loud half of that incident; the rate that went into the notes as
+    sound was the half worth catching.
+    """
+    from sisr.utils.power import PowerState
+
+    monkeypatch.setattr(
+        "sisr.utils.power.read_power_state",
+        lambda: PowerState(False, None, "BATTERY, overlay Better battery"),
+    )
+    cli = _make_cli_stub(subcommand="fit", matmul_precision=None)
+
+    with pytest.warns(UserWarning, match="not the reference condition"):
+        cli.before_instantiate_classes()
+
+
+def test_non_fit_subcommands_do_not_check_power(monkeypatch, recwarn):
+    """`validate`/`test`/`export` are short; the check is about long-run timing."""
+    from sisr.utils.power import PowerState
+
+    monkeypatch.setattr(
+        "sisr.utils.power.read_power_state",
+        lambda: PowerState(False, None, "BATTERY, overlay Better battery"),
+    )
+
+    _make_cli_stub(subcommand="validate", matmul_precision=None).before_instantiate_classes()
+
+    assert not [w for w in recwarn if "reference condition" in str(w.message)]
+
+
 def test_before_instantiate_classes_skips_when_unset(monkeypatch):
     """When matmul_precision is None, torch.set_float32_matmul_precision is NOT called."""
     import torch

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -182,6 +182,7 @@ def test_to_onnx_writes_metadata_props(tmp_path):
         "io",
         "eval_config",
         "training",
+        "power",
     }
     assert props["format"] == "sisr-meta-v2"  # stored as-is: already a str
     assert props["kind"] == "sr_model"  # stored as-is: already a str

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -48,6 +48,7 @@ def test_build_metadata_top_level_shape():
         "io",
         "eval_config",
         "training",
+        "power",
     }
     assert meta["format"] == "sisr-meta-v2"
 
@@ -372,3 +373,16 @@ def test_build_metadata_refuses_an_artifact_that_cannot_state_its_scale():
 
     with pytest.raises(ValueError, match="without a scale"):
         build_metadata(module)
+
+
+def test_build_metadata_records_the_hosts_power_state():
+    """Provenance a rate can be checked against: off mains costs roughly half.
+
+    The value is whatever this host reports — asserting the *shape* is the
+    point, since a run on battery must produce a record that says so rather
+    than one that is merely silent.
+    """
+    meta = build_metadata(_make_srcnn_lit())
+    assert set(meta["power"]) == {"on_mains", "overlay", "note"}
+    assert isinstance(meta["power"]["note"], str) and meta["power"]["note"]
+    assert isinstance(meta["power"]["on_mains"], bool | type(None))

--- a/tests/utils/test_power.py
+++ b/tests/utils/test_power.py
@@ -1,0 +1,131 @@
+"""Power-state provenance — a rate measured off mains is worth about half."""
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from sisr.utils import power
+from sisr.utils.power import (
+    BEST_PERFORMANCE_OVERLAY,
+    PowerState,
+    read_power_state,
+    warn_unless_reference_power,
+)
+
+OTHER_OVERLAY = "961cc777-2547-4f9d-8174-7d86181b8a7a"  # "Better battery"
+
+
+@pytest.fixture(autouse=True)
+def _uncached():
+    """`read_power_state` is process-cached; each test needs its own answer."""
+    read_power_state.cache_clear()
+    yield
+    read_power_state.cache_clear()
+
+
+def _stub_powershell(monkeypatch, stdout: str) -> None:
+    monkeypatch.setattr(power.shutil, "which", lambda _: "/usr/bin/powershell.exe")
+    monkeypatch.setattr(
+        power.subprocess, "run", lambda *a, **k: MagicMock(stdout=stdout, returncode=0)
+    )
+
+
+def test_mains_under_best_performance_is_the_reference_condition(monkeypatch):
+    _stub_powershell(monkeypatch, f"True\r\n{BEST_PERFORMANCE_OVERLAY}\r\n")
+    state = read_power_state()
+    assert state.on_mains is True
+    assert state.is_reference
+    assert state.note == "mains, overlay Best performance"
+
+
+def test_battery_is_detected_and_named_in_the_note(monkeypatch):
+    _stub_powershell(monkeypatch, f"False\r\n{BEST_PERFORMANCE_OVERLAY}\r\n")
+    state = read_power_state()
+    assert state.on_mains is False
+    assert not state.is_reference
+    assert "BATTERY" in state.note
+
+
+def test_mains_under_a_different_overlay_is_not_the_reference(monkeypatch):
+    """The overlay is half the condition: 172 vs 366 batches/min was the same host."""
+    _stub_powershell(monkeypatch, f"True\r\n{OTHER_OVERLAY}\r\n")
+    state = read_power_state()
+    assert state.on_mains is True
+    assert not state.is_reference
+    assert OTHER_OVERLAY in state.note
+
+
+def test_a_host_with_no_battery_counts_as_mains(monkeypatch):
+    _stub_powershell(monkeypatch, f"nobattery\r\n{BEST_PERFORMANCE_OVERLAY}\r\n")
+    assert read_power_state().is_reference
+
+
+def test_no_powershell_degrades_to_unknown_not_an_error(monkeypatch):
+    """Outside WSL/Windows there is no instrument. Unknown is a recorded state."""
+    monkeypatch.setattr(power.shutil, "which", lambda _: None)
+    state = read_power_state()
+    assert state == PowerState(None, None, state.note)
+    assert "no powershell.exe" in state.note
+
+
+@pytest.mark.parametrize(
+    "boom", [OSError("nope"), subprocess.TimeoutExpired(cmd="powershell.exe", timeout=30)]
+)
+def test_a_failing_probe_degrades_to_unknown(monkeypatch, boom):
+    monkeypatch.setattr(power.shutil, "which", lambda _: "/usr/bin/powershell.exe")
+
+    def _raise(*_a, **_k):
+        raise boom
+
+    monkeypatch.setattr(power.subprocess, "run", _raise)
+    assert read_power_state().on_mains is None
+
+
+def test_unreadable_output_degrades_to_unknown(monkeypatch):
+    _stub_powershell(monkeypatch, "\r\n")
+    assert read_power_state().on_mains is None
+
+
+def test_warning_fires_on_battery_and_names_what_is_in_force():
+    state = PowerState(False, BEST_PERFORMANCE_OVERLAY, "BATTERY, overlay Best performance")
+    with pytest.warns(UserWarning, match="not the reference condition"):
+        warn_unless_reference_power(state)
+
+
+def test_warning_is_silent_on_the_reference_condition(recwarn):
+    state = PowerState(True, BEST_PERFORMANCE_OVERLAY, "mains, overlay Best performance")
+    warn_unless_reference_power(state)
+    assert not [w for w in recwarn if "reference condition" in str(w.message)]
+
+
+def test_warning_is_silent_when_the_state_is_unknown(recwarn):
+    """No instrument is not evidence of a problem — it must not cry wolf."""
+    warn_unless_reference_power(PowerState(None, None, "unknown: no powershell.exe on PATH"))
+    assert not [w for w in recwarn if "reference condition" in str(w.message)]
+
+
+def test_state_is_read_once_per_process(monkeypatch):
+    """Two consumers, one answer — and no subprocess call in the checkpoint path."""
+    calls = []
+    monkeypatch.setattr(power.shutil, "which", lambda _: "/usr/bin/powershell.exe")
+    monkeypatch.setattr(
+        power.subprocess,
+        "run",
+        lambda *a, **k: (
+            calls.append(1) or MagicMock(stdout=f"True\r\n{BEST_PERFORMANCE_OVERLAY}\r\n")
+        ),
+    )
+    read_power_state()
+    read_power_state()
+    assert len(calls) == 1
+
+
+def test_as_dict_is_plain_scalars_for_weights_only_safety():
+    state = PowerState(True, BEST_PERFORMANCE_OVERLAY, "mains, overlay Best performance")
+    assert state.as_dict() == {
+        "on_mains": True,
+        "overlay": BEST_PERFORMANCE_OVERLAY,
+        "note": "mains, overlay Best performance",
+    }
+    assert all(isinstance(v, bool | str | type(None)) for v in state.as_dict().values())


### PR DESCRIPTION
## What changed

`fit` now warns when the host is not in the power condition throughput figures assume, and every
artifact the run writes records that state.

## Why

A rate measured off mains is worth about half. The same adversarial run, same config:

| condition | rate |
|---|---:|
| draining battery | 172 batches/min |
| mains, Best-performance overlay | 366 batches/min |

It died when the battery ran flat 87 minutes in — and **every timing taken from it went into the
notes as if it were sound**. The crash was loud and cost 87 minutes; the bad number was silent
and would have outlived it. The rate harness already refuses to measure without this check.
`fit` had no guard at all.

## Advisory, never fatal

A correctness-only run on a laptop is legitimate. What is not legitimate is not knowing
afterwards which conditions a number came from. So this warns, records, and refuses nothing.

The metadata is the half that pays off later: a rate quoted from a run whose provenance says
`BATTERY` is self-refuting rather than merely plausible.

## Three decisions, not accidents

- **Read once per process, not per save.** The warning and the metadata want the *same* answer,
  and a per-save read would put a subprocess call — and a chance to hang — in the checkpoint
  path. The recorded field is therefore the state near the *start* of the run, and says so.
- **Silent when the state is unknown.** There is no instrument outside WSL/Windows, so warning
  there would fire on every run everywhere and say nothing. Unknown is a recorded state, not a
  suspicion. `fit`-only for the same reason: `validate`/`test`/`export` are short.
- **PowerShell is the instrument** because nothing else can see it: `nvidia-smi` cannot read the
  enforced power limit under WSL, and `powercfg /getactivescheme` reports the *underlying
  scheme* rather than the overlay sitting on top of it, so the registry value is what gets read.

`sisr/utils/power.py` is stdlib-only, keeping `sisr.utils` torch-free as its package docstring
requires — the guard test for that covers the package, not just `cache`.

## Evidence

13 tests in `tests/utils/test_power.py` covering both wirings and every degradation path:
mains + Best performance is the reference; battery is not; **mains under a different overlay is
not either** (the overlay is half the condition); a host reporting no battery counts as mains;
no `powershell.exe`, a raising probe, a timeout and unreadable output each degrade to unknown
rather than raising; the warning fires on battery, is silent on the reference condition, and is
silent on unknown; the state is read exactly once per process; `as_dict` is plain scalars, for
`weights_only` safety.

Plus `test_fit_warns_when_the_host_is_not_on_reference_power` and
`test_non_fit_subcommands_do_not_check_power` in the CLI tests, and
`test_build_metadata_records_the_hosts_power_state` for the artifact shape.

The suite gains one `filterwarnings` ignore, because no CI runner is a reference bench and the
warning is advisory by design. It is matched by message, and `pytest.warns` is unaffected by it,
so the tests that assert the warning still assert it.

`power` is additive metadata on the same terms as `kind` — `FORMAT_VERSION` is unchanged, and
its absence on an older file means *unrecorded*, not mains.

Stacked on #222. Closes #201
