### PR TITLE
refactor: compact the prose in the four packages that had none

### DIFF
--- a/sisr/artifacts.py
+++ b/sisr/artifacts.py
@@ -1,26 +1,21 @@
 """The distributable weights artifact: one owner for writing, reading and checking it.
 
-A run produces two kinds of file. The resumable ``.ckpt`` belongs to Lightning —
-it carries optimizer moments, loop state and hyperparameters, and stays exactly
-as it is. This module owns the other one: the bare, optimizer-free weights file
-that gets handed to somebody else.
+A run produces two kinds of file. The resumable ``.ckpt`` is Lightning's, and
+stays as it is. This module owns the other: the bare, optimizer-free weights
+file handed to somebody else. Writing, reading and validation live here so the
+payload's shape has one owner rather than being re-derived per reader.
 
-**Why it exists.** The payload used to be written in one place and its shape
-re-derived by hand in three readers, one of which checked nothing at all. The
-format was `torch.save`, decided at the write site. Adding a second format meant
-editing four files, and the readers had no way to agree with each other.
+**Why safetensors.** Not because our readers are unsafe -- every ``torch.load``
+here passes ``weights_only=True`` against a pinned torch floor. The exposure is
+a *consumer* loading a published file without it, or on an older torch.
+safetensors removes that by construction rather than by mitigation, and it is
+what the surrounding ecosystem reads.
 
-**Why safetensors.** Not because our own readers were unsafe — every
-``torch.load`` here already passes ``weights_only=True`` and the torch floor is
-pinned for it. The exposure is a *consumer* loading a published file with that
-turned off, or on an older torch. safetensors removes it by construction rather
-than by mitigation, and it is what the surrounding ecosystem reads.
-
-**The header is flat.** safetensors metadata is ``str -> str``, so the nested
-provenance block is written one entry per top-level field, with non-strings
-JSON-encoded. Deliberately not a single blob: per-field survives inspection by
-anything that can open the file, which is most of the value. The ONNX sink made
-the same call for the same reason and now shares this encoder.
+**The header is flat.** safetensors metadata is ``str -> str``, so the block is
+written one entry per top-level field, non-strings JSON-encoded. Not a single
+blob, deliberately: per-field survives inspection by anything that can open the
+file, which is most of the value. The ONNX sink shares this encoder for the
+same reason.
 """
 
 from __future__ import annotations

--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -10,24 +10,20 @@ Usage:
 The ``sisr`` console script is registered by ``pyproject.toml``; ``python -m
 sisr.cli ...`` also works.
 
-Top-level YAML keys ``optimizer:`` / ``lr_scheduler:`` are linked into
-``model.init_args.optimizer`` / ``model.init_args.lr_scheduler`` by
-``SRLightningCLI`` so :class:`~sisr.training.SRLightning` can build its
-``configure_optimizers`` from them while keeping the YAML symmetric across
-architectures.
+Top-level ``optimizer:`` / ``lr_scheduler:`` are linked into
+``model.init_args.*`` so ``SRLightning.configure_optimizers`` can build from
+them and the YAML stays symmetric across architectures.
 
-Top-level ``matmul_precision:`` (``'highest' | 'high' | 'medium'``) calls
-:func:`torch.set_float32_matmul_precision` once at startup. Set to ``'high'``
-on Ampere+ GPUs to enable TF32 matmul kernels.
+Top-level ``matmul_precision:`` calls
+:func:`torch.set_float32_matmul_precision` once at startup (``'high'`` enables
+TF32 matmul kernels on Ampere+).
 
-``sisr export`` is a thin CLI wrapper around
-:func:`sisr.export.to_onnx` — see that module for what gets exported and its
-SRCNN limitation. It requires the optional ``export`` extra
-(``pip install '.[export]'``).
+``sisr export`` wraps :func:`sisr.export.to_onnx` -- see that module for its
+SRCNN limitation. Needs the ``export`` extra.
 
-cuDNN autotuning is *not* exposed here — Lightning's own ``trainer.benchmark:``
-already assigns ``torch.backends.cudnn.benchmark``, and it coordinates with
-``trainer.deterministic``. A separate top-level key would silently bypass that.
+**cuDNN autotuning is deliberately not exposed.** ``trainer.benchmark:``
+already assigns it and coordinates with ``trainer.deterministic``; a separate
+top-level key would silently bypass that.
 """
 
 import sys
@@ -42,11 +38,9 @@ from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCL
 from .export import to_onnx
 from .training import SRDataModule, SREvalConfig, SRLightning, SRTrainingConfig
 
-# Checkpoints saved before SRLightning.__init__ stopped flattening self.hparams for
-# TensorBoard display (see its docstring) stored ONLY these two dataclasses' fields —
-# under '/'-joined keys, e.g. 'training_config/example_input_shape/0' — plus incidental
-# 'model/*'/'processor'/'criterion' entries that were never part of the loadable
-# contract. _reconstruct_ckpt_hparams rebuilds exactly what current SRLightning saves.
+# The only keys a checkpoint's hyper_parameters can restore. Legacy checkpoints also
+# carry 'model/*'/'processor'/'criterion', which were TensorBoard-only and never part
+# of the loadable contract.
 _CKPT_HPARAM_KEYS = ("training_config", "eval_config")
 
 # jsonargparse's own crash (see SRLightningCLI.parse_arguments) when a whole-dict
@@ -57,17 +51,13 @@ _JSONARGPARSE_INIT_ARGS_CRASH = "'dict' object has no attribute 'init_args'"
 def _reconstruct_ckpt_hparams(hparams: dict[str, Any], sep: str = "/") -> dict[str, Any]:
     """Rebuild a checkpoint's training_config/eval_config overrides for ``--ckpt_path``.
 
-    Tolerates both the current nested ``hyper_parameters`` format (each key already
-    a plain dict, e.g. ``{"training_config": {...}}``) and the legacy '/'-flattened
-    one older checkpoints carry (e.g. ``training_config/example_input_shape/0``).
-    ``LightningCLI._parse_ckpt_path`` re-parses ``hyper_parameters`` verbatim as CLI
-    options (``model.<key>``); a literal ``/`` in a key isn't a valid option-name
-    character, so every legacy checkpoint failed to reload via ``--ckpt_path``
-    (``fit`` resume, ``validate``, ``test``, ``export``) with a jsonargparse
-    ``SystemExit``. Non-config entries (``model/*``, ``processor``, ``criterion``,
-    ``_instantiator``) are dropped — they were TensorBoard-only in old checkpoints,
-    and the ``--config`` file required alongside ``--ckpt_path`` already supplies
-    those classes.
+    Accepts both the current nested format and the legacy ``'/'``-flattened one
+    (``training_config/example_input_shape/0``). ``LightningCLI._parse_ckpt_path``
+    re-parses ``hyper_parameters`` verbatim as ``model.<key>`` CLI options, and
+    ``/`` is not a valid option-name character -- so every legacy checkpoint died
+    with a jsonargparse ``SystemExit`` on any ``--ckpt_path`` subcommand.
+    Non-config entries are dropped; the ``--config`` required alongside
+    ``--ckpt_path`` already supplies those classes.
 
     Args:
         hparams: The checkpoint's raw ``hyper_parameters`` dict, in either format.
@@ -142,23 +132,15 @@ class SRLightningCLI(LightningCLI):
     With ``auto_configure_optimizers=False``, LightningCLI does *not* inject
     a default ``configure_optimizers`` into the model.  Instead we explicitly
     add the top-level args via ``add_optimizer_args(link_to=...)`` so they
-    populate ``model.init_args.optimizer`` / ``model.init_args.lr_scheduler``
-    as ``OptimizerCallable`` / ``LRSchedulerCallable``.  ``SRLightning``'s
-    own ``configure_optimizers`` then constructs the optimizer (uniform or
-    per-Conv2d ``param_groups`` depending on ``training_config.layer_lrs``).
+    populate ``model.init_args.optimizer`` / ``.lr_scheduler``, which
+    ``SRLightning.configure_optimizers`` then builds from. Also exposes
+    top-level ``matmul_precision``, which ``Trainer`` has no equivalent for.
 
-    Also exposes a top-level ``matmul_precision`` YAML key that calls
-    :func:`torch.set_float32_matmul_precision` in
-    :meth:`before_instantiate_classes`. ``Trainer`` has no equivalent, unlike
-    cuDNN autotuning which ``trainer.benchmark:`` already covers.
-
-    Defaults ``trainer_class`` to :class:`_ExportTrainer`: :meth:`subcommands`
-    unconditionally registers ``export``, and ``LightningCLI`` resolves every
-    subcommand's parser via ``getattr(trainer_class, subcommand)`` regardless
-    of which subcommand is actually invoked — so any caller constructing this
-    class needs a ``trainer_class`` that has an ``export`` method, not just
-    ``main()``. Callers may still override it explicitly (e.g. a project-specific
-    ``Trainer`` subclass), as long as it also provides ``export``.
+    **``trainer_class`` must have an ``export`` method.** :meth:`subcommands`
+    registers ``export`` unconditionally and ``LightningCLI`` resolves *every*
+    subcommand's parser at construction, whichever one is invoked. Hence the
+    :class:`_ExportTrainer` default; override it with anything that also
+    provides ``export``.
     """
 
     def __init__(
@@ -175,45 +157,32 @@ class SRLightningCLI(LightningCLI):
                 f"an `export` method with the same signature."
             )
         # Must precede super().__init__(), which builds every subcommand's parser.
-        # jsonargparse treats a pure dataclass as a *closed* type by default (its
-        # `is_pure_dataclass` selector), so a dotted override such as
-        # --model.init_args.eval_config.crop_border=0 arrives as a NestedArg and
-        # rebuilds the whole field from the bare annotation, discarding the
-        # architecture's subclass and every subclass-only default with it. Naming
-        # the two base classes re-enables subclasses for all their descendants;
-        # disabling the selector by name instead would change parsing for every
-        # dataclass-typed field in Lightning and jsonargparse too.
+        # jsonargparse treats a pure dataclass as a *closed* type, so a dotted
+        # override like --model.init_args.eval_config.crop_border=0 rebuilds the
+        # field from the bare annotation and discards the architecture's subclass
+        # with every subclass-only default. Naming the two bases re-enables
+        # subclasses for all descendants; disabling the selector instead would
+        # change parsing for every dataclass field in Lightning too.
         set_parsing_settings(subclasses_enabled=[SREvalConfig, SRTrainingConfig])
-        # mypy cannot rule out a positional *args long enough to reach the parent's own
-        # trainer_class parameter. No caller does that -- every one of ours passes model
-        # and datamodule classes by keyword -- and narrowing *args to forbid it would mean
-        # restating LightningCLI's whole signature here.
+        # mypy cannot rule out an *args long enough to reach the parent's own
+        # trainer_class. No caller does that, and forbidding it would mean restating
+        # LightningCLI's whole signature here.
         super().__init__(*args, trainer_class=trainer_class, **kwargs)  # type: ignore[misc]
 
     def parse_arguments(self, parser: LightningArgumentParser, args: ArgsType) -> None:
         """Parse CLI arguments, turning a known jsonargparse crash into an actionable error.
 
-        A whole-dict/JSON CLI override of a ``data.*_dataset`` field (e.g.
-        ``--data.train_dataset='{...}'`` or
-        ``--data.train_dataset.init_args='{...}'``) only crashes when it
-        collides with an *existing* ``class_path``/``init_args`` value for
-        that field — typically one set by ``--config`` (both shipped
-        templates set ``train_dataset``/``val_dataset``/``test_datasets``,
-        so overriding those this way always collides). jsonargparse's merge
-        logic then reaches for ``prev_val.init_args`` assuming ``prev_val``
-        is a ``Namespace``, but every ``data.*_dataset`` field on
-        :class:`~sisr.training.SRDataModule` is typed ``dict[str, Any]``
-        (not the real dataset class, so datasets can be instantiated lazily —
-        see that module's docstring), so ``prev_val`` is a plain ``dict`` and
-        the attribute access raises. When there is no prior value (e.g.
-        ``predict_dataset``, which neither template sets — the documented
-        ``sisr predict`` workflow overrides it this exact way), the same
-        whole-dict override parses fine.
+        A whole-dict override of a ``data.*_dataset`` field crashes **only**
+        when it collides with an existing ``class_path``/``init_args`` value,
+        which ``--config`` always supplies for ``train``/``val``/``test``.
+        jsonargparse's merge then reads ``prev_val.init_args`` assuming a
+        ``Namespace``, but those fields are typed ``dict[str, Any]`` (so
+        datasets stay lazily instantiable), and the attribute access raises.
+        With no prior value it parses fine -- which is exactly the documented
+        ``sisr predict`` workflow overriding ``predict_dataset``.
 
-        A prior version of this guard pre-scanned the raw CLI tokens and
-        rejected *any* whole-dict override of these fields, which broke that
-        working ``predict_dataset`` case. Catching the actual jsonargparse
-        failure here instead only intercepts the forms that really crash.
+        **Catch the failure, do not pre-scan.** An earlier guard rejected every
+        whole-dict override of these fields and broke that working case.
 
         Args:
             parser: The top-level parser (unchanged, passed through).
@@ -240,11 +209,10 @@ class SRLightningCLI(LightningCLI):
     def add_arguments_to_parser(self, parser: LightningArgumentParser) -> None:
         """Wire top-level ``optimizer:`` / ``lr_scheduler:`` / ``matmul_precision:`` keys.
 
-        Subclass mode (``subclass_mode_model=True``) means the module's init args
-        live under ``model.init_args.<arg>``, which is what these links must
-        target. Subclass mode exists so a YAML can name its Lightning module by
-        ``class_path`` — without it ``model_class`` is fixed and no config can
-        select :class:`~sisr.training.SRGANLightning`.
+        Subclass mode puts init args under ``model.init_args.<arg>``, which is
+        what these links target. It exists so a YAML can name its Lightning
+        module by ``class_path``; without it ``model_class`` is fixed and no
+        config could select ``SRGANLightning``.
         """
         parser.add_optimizer_args(link_to="model.init_args.optimizer")
         parser.add_lr_scheduler_args(link_to="model.init_args.lr_scheduler")
@@ -270,43 +238,30 @@ class SRLightningCLI(LightningCLI):
     def _parse_ckpt_path(self) -> None:
         """Reload ``--ckpt_path`` hyperparameters via ``_reconstruct_ckpt_hparams`` first.
 
-        Duplicates ``LightningCLI._parse_ckpt_path`` (``lightning/pytorch/cli.py``)
-        with two substitutions. First, the raw ``hyper_parameters`` dict is rebuilt
-        through :func:`_reconstruct_ckpt_hparams` before being handed to
-        ``parse_object``, so both the current nested format and checkpoints saved
-        before that fix (which reload with a jsonargparse ``SystemExit`` otherwise —
-        see that function's docstring) work through every subcommand that accepts
-        ``--ckpt_path`` (``fit`` resume, ``validate``, ``test``, ``export``).
+        Duplicates ``LightningCLI._parse_ckpt_path`` with two substitutions.
+        First, ``hyper_parameters`` is rebuilt through
+        :func:`_reconstruct_ckpt_hparams`, so legacy checkpoints reload rather
+        than exiting.
 
-        Second, under ``subclass_mode_model=True`` the module's fields are options
-        at ``model.init_args.<key>``, not ``model.<key>``, so the reconstructed
-        hparams are nested one level deeper — and that nested override MUST be
-        parsed through the *subcommand's own* parser/config branch
-        (``self._parser(subcommand)``, ``self.config[subcommand]``), never through
-        the top-level subcommand-dispatching one (``self.parser``, ``self.config``),
-        even though both expose the same ``model.init_args.<key>`` option path.
-        The top-level route parses without a syntax error, but per-field the
-        outcome is either a hard ``SystemExit`` (``model``, ``processor``: no
-        default, required) or a silent revert to the bare-annotation default
-        (any nested subclass field with a fallback, e.g. ``eval_config``) — see
-        below for which and why.
+        Second -- **and this is the trap** -- under ``subclass_mode_model=True``
+        the reconstructed override sits at ``model.init_args.<key>`` and MUST be
+        parsed through the *subcommand's own* parser and config branch
+        (``self._parser(subcommand)``, ``self.config[subcommand]``), never the
+        top-level ``self.parser`` / ``self.config``, though both expose the same
+        option path.
 
-        **The reason**: jsonargparse's subclass-merge
-        (``ActionTypeHint._check_type``) looks up the previous value as
-        ``cfg.get(self.dest)``, and ``self.dest`` is the bare name (``"model"``),
-        never subcommand-qualified. Through the subcommand's parser ``cfg`` is
-        already scoped, so the lookup finds the resolved value and merges onto
-        it, preserving sibling keys and subclass-only defaults. Through the
-        top-level parser ``cfg`` is unscoped, the value actually lives at
-        ``cfg["validate"]["model"]``, and the miss reads as "no previous value"
-        rather than an error — so jsonargparse rebuilds from schema defaults:
-        ``None`` for the required ``model``/``processor``, and the bare
-        annotation for any nested subclass field (``eval_config`` reverts to
-        base ``SREvalConfig``).
+        jsonargparse's subclass merge (``ActionTypeHint._check_type``) looks up
+        the previous value as ``cfg.get(self.dest)``, and ``self.dest`` is the
+        bare name, never subcommand-qualified. Scoped, the lookup hits and merges
+        onto the resolved value, keeping sibling keys and subclass-only defaults.
+        Unscoped, the value really lives at ``cfg["validate"]["model"]`` and the
+        miss reads as *no previous value* rather than an error -- so jsonargparse
+        rebuilds from schema defaults.
 
-        **So a resumed run either dies on "arguments are required" or silently
-        reverts to annotation defaults with nothing in the logs.** Re-inlining
-        this as ``self.parser`` "for simplicity" reintroduces exactly that.
+        **A resumed run then either dies on "arguments are required"
+        (``model``/``processor``, which have no default) or silently reverts a
+        nested subclass field to its bare annotation, with nothing in the logs.**
+        Re-inlining this as ``self.parser`` "for simplicity" reintroduces it.
         """
         if not self.config.get("subcommand"):
             return
@@ -331,10 +286,8 @@ class SRLightningCLI(LightningCLI):
     def subcommands() -> dict[str, set[str]]:
         """Register ``export`` alongside the stock ``fit``/``validate``/``test``/``predict``.
 
-        ``{"model", "datamodule"}`` is skipped from ``export``'s CLI-parsed
-        arguments the same way ``fit`` skips them — both are already wired
-        from the top-level ``model:`` / ``data:`` YAML keys, not re-specified
-        per-subcommand.
+        ``export`` skips ``{"model", "datamodule"}`` as ``fit`` does: both come
+        from the top-level ``model:`` / ``data:`` keys, not per-subcommand.
         """
         subcommands = LightningCLI.subcommands()
         subcommands["export"] = {"model", "datamodule"}
@@ -344,11 +297,8 @@ class SRLightningCLI(LightningCLI):
 def main() -> None:
     """Console-script entrypoint.
 
-    Invoked as ``sisr ...`` via the entry point registered in
-    ``pyproject.toml``, and also as ``python -m sisr.cli ...``.
-    ``freeze_support`` lives inside ``main`` (not the ``__main__`` block)
-    so it also runs under the console-script path, which bypasses
-    ``__main__``.
+    ``freeze_support`` sits inside ``main``, not the ``__main__`` block, so it
+    also runs under the console-script path, which bypasses ``__main__``.
     """
     if sys.platform == "win32":
         from multiprocessing import freeze_support

--- a/sisr/colorspace.py
+++ b/sisr/colorspace.py
@@ -1,37 +1,26 @@
 """BT.601 RGB <-> YCbCr conversion, full-range and studio-range.
 
-Two distinct ranges live here, deliberately kept apart:
+**Two ranges, never one.** Unifying them is the mistake this split guards against.
 
-* **Full-range** (:func:`rgb_to_ycbcr` / :func:`ycbcr_to_rgb`) is the
-  project's *training* chroma space — what :class:`~sisr.processors.SRProcessor`
-  subclasses (``YChannelProcessor``, ``YCbCrProcessor``) feed the model.
-  Changing these would silently renumber a trained model's inputs and
-  invalidate existing checkpoints, so they are frozen.
-* **Studio-range** (:func:`rgb_to_ycbcr_studio`) is the *metric* colorspace —
-  what MATLAB's ``rgb2ycbcr``, BasicSR's ``bgr2ycbcr(y_only=...)``, and every
-  published SR benchmark actually score against. It exists solely for
-  :class:`~sisr.training.lightning_module.SRLightning`'s PSNR/SSIM
-  computation and must never be used as a processor's colorspace.
+* **Full-range** (:func:`rgb_to_ycbcr` / :func:`ycbcr_to_rgb`) is the *training*
+  space every :class:`~sisr.processors.SRProcessor` feeds the model. Frozen:
+  changing it renumbers a trained model's inputs and invalidates checkpoints.
+* **Studio-range** (:func:`rgb_to_ycbcr_studio`) is the *metric* space MATLAB's
+  ``rgb2ycbcr``, BasicSR and every published SR benchmark score against. Scoring
+  only -- never a processor's colorspace.
 
-Do not "unify" these two — that is the one mistake this split guards against.
-These pure tensor functions live on their own so callers can convert
-colorspaces without depending on Lightning or model code.
+Pure tensor functions, so callers convert without importing Lightning or models.
 """
 
 import torch
 
-# BT.601 full-range RGB <-> YCbCr conversion (ITU-R Rec. BT.601-7).
-# Both colorspaces are normalised to [0, 1]. Cb and Cr have a +0.5 offset on
-# their stored representation so that signed chroma values in [-0.5, +0.5]
-# map onto unsigned [0, 1]. This is the *full-range* (a.k.a. "JPEG") variant
-# of BT.601 — distinct from the studio-range variant below, which scales Y to
-# [16/255, 235/255] and Cb/Cr to [16/255, 240/255].
+# BT.601-7 full-range ("JPEG") variant. Both spaces are [0, 1]; Cb/Cr carry a
+# +0.5 offset so signed chroma in [-0.5, +0.5] stores as unsigned [0, 1].
 
 _RGB_TO_Y = (0.299, 0.587, 0.114)
-# Ratios of MATLAB's published rgb2ycbcr studio-range matrix (see
-# rgb_to_ycbcr_studio below) over the chroma legal-range scale of 224 —
-# kept as literal ratios rather than pre-divided decimals so the MATLAB
-# source constants stay visible and transcription cannot silently drift.
+# MATLAB's published rgb2ycbcr matrix over the 224-level chroma range. Left as
+# literal ratios, not decimals: the source constants stay visible, so a
+# transcription slip cannot hide.
 _RGB_TO_CB = (-37.797 / 224, -74.203 / 224, 112 / 224)  # output offset +0.5
 _RGB_TO_CR = (112 / 224, -93.786 / 224, -18.214 / 224)  # output offset +0.5
 _YCBCR_TO_R = 1.402  # cr coefficient
@@ -39,14 +28,11 @@ _YCBCR_TO_G_CB = -0.344136  # cb coefficient
 _YCBCR_TO_G_CR = -0.714136  # cr coefficient
 _YCBCR_TO_B = 1.772  # cb coefficient
 
-# BT.601 studio-range ("limited"/"TV" range) rescale, applied on top of the
-# full-range YCbCr above. Luma occupies 219 of 255 levels ([16, 235]); chroma
-# occupies 224 of 255 levels ([16, 240], centered on 128) — the two scales
-# differ, so collapsing them to one constant would itself be a fidelity bug.
-# A full-range diff scales by exactly one of these two factors on conversion,
-# so PSNR computed in studio range sits a *constant*, algebraically exact
-# 20*log10(255/219) dB above full-range for Y (and 20*log10(255/224) dB for
-# Cb/Cr) — see tests/test_colorspace.py for the identity this predicts.
+# Studio ("limited"/"TV") rescale over the full-range values above. Luma spans
+# 219 of 255 levels, chroma 224 -- two different scales, so collapsing them to
+# one constant is itself a fidelity bug. The consequence: studio-range PSNR sits
+# a constant 20*log10(255/219) dB above full-range for Y, 20*log10(255/224) for
+# Cb/Cr. tests/test_colorspace.py asserts that identity.
 _STUDIO_Y_SCALE = 219 / 255
 _STUDIO_Y_OFFSET = 16 / 255
 _STUDIO_C_SCALE = 224 / 255
@@ -57,12 +43,10 @@ def rgb_to_ycbcr(img: torch.Tensor) -> torch.Tensor:
     """Convert a normalised RGB tensor to YCbCr (BT.601 full-range).
 
     Args:
-        img (torch.Tensor): RGB tensor of shape ``(B, 3, H, W)`` with
-            values in ``[0, 1]``.
+        img: RGB ``(B, 3, H, W)`` in ``[0, 1]``.
 
     Returns:
-        torch.Tensor: YCbCr tensor of shape ``(B, 3, H, W)`` in
-        ``[0, 1]`` with Cb/Cr offset by +0.5.
+        YCbCr ``(B, 3, H, W)`` in ``[0, 1]``, Cb/Cr offset by +0.5.
     """
     r, g, b = img[:, 0:1], img[:, 1:2], img[:, 2:3]
     y = _RGB_TO_Y[0] * r + _RGB_TO_Y[1] * g + _RGB_TO_Y[2] * b
@@ -75,12 +59,10 @@ def ycbcr_to_rgb(img: torch.Tensor) -> torch.Tensor:
     """Convert a YCbCr tensor to RGB (BT.601 full-range, clamped to [0, 1]).
 
     Args:
-        img (torch.Tensor): YCbCr tensor of shape ``(B, 3, H, W)`` with
-            Cb/Cr offset by +0.5.
+        img: YCbCr ``(B, 3, H, W)``, Cb/Cr offset by +0.5.
 
     Returns:
-        torch.Tensor: RGB tensor of shape ``(B, 3, H, W)`` clamped to
-        ``[0, 1]``.
+        RGB ``(B, 3, H, W)`` clamped to ``[0, 1]``.
     """
     y, cb, cr = img[:, 0:1], img[:, 1:2] - 0.5, img[:, 2:3] - 0.5
     r = y + _YCBCR_TO_R * cr
@@ -92,20 +74,17 @@ def ycbcr_to_rgb(img: torch.Tensor) -> torch.Tensor:
 def rgb_to_ycbcr_studio(img: torch.Tensor) -> torch.Tensor:
     """Convert a normalised RGB tensor to YCbCr (BT.601 studio-range) — metric only.
 
-    Rescales :func:`rgb_to_ycbcr`'s full-range output onto the studio
-    ("limited"/"TV") range MATLAB's ``rgb2ycbcr`` and the SR literature
-    report PSNR/SSIM against. This is a one-way conversion for scoring —
-    there is no ``ycbcr_to_rgb_studio``, since nothing reconstructs an
-    image from it. Do not feed this to a model; every :class:`SRProcessor`
-    trains in full-range (see module docstring).
+    Rescales :func:`rgb_to_ycbcr`'s output onto the range MATLAB's
+    ``rgb2ycbcr`` and the SR literature report PSNR/SSIM against. One-way:
+    nothing reconstructs an image from it, so there is no studio inverse.
+    **Never feed this to a model** -- every processor trains full-range.
 
     Args:
-        img (torch.Tensor): RGB tensor of shape ``(B, 3, H, W)`` with
-            values in ``[0, 1]``.
+        img: RGB ``(B, 3, H, W)`` in ``[0, 1]``.
 
     Returns:
-        torch.Tensor: YCbCr tensor of shape ``(B, 3, H, W)``, Y in
-        ``[16/255, 235/255]``, Cb/Cr in ``[16/255, 240/255]``.
+        YCbCr ``(B, 3, H, W)``: Y in ``[16/255, 235/255]``, Cb/Cr in
+        ``[16/255, 240/255]``.
     """
     full = rgb_to_ycbcr(img)
     y, cb, cr = full[:, 0:1], full[:, 1:2], full[:, 2:3]

--- a/sisr/export.py
+++ b/sisr/export.py
@@ -1,34 +1,27 @@
 """Bare-model ONNX export.
 
-Exports ``module.model`` — the wrapped :class:`~sisr.models.base.SRModel`,
-*without* the :class:`~sisr.processors.SRProcessor` — so the graph matches
-:meth:`SRLightning.forward` exactly (which is itself model-only; see
-``sisr/training/lightning_module.py``). This is a deliberate choice, not an
-oversight: a consumer of the exported graph is expected to have ``sisr``
-importable and call ``processor.extract`` / ``processor.reconstruct``
-themselves.
+Exports ``module.model`` **without** the processor, so the graph matches
+:meth:`SRLightning.forward`, which is itself model-only. Deliberate: a consumer
+is expected to have ``sisr`` importable and call ``processor.extract`` /
+``reconstruct`` itself.
 
-The exported graph also carries the same provenance metadata as the checkpoint
-sinks (:func:`sisr.training.metadata.build_metadata`), written one field per
-``onnx.ModelProto.metadata_props`` entry rather than a single opaque JSON blob —
-Netron renders per-field props as a readable table, which is most of the value.
-``metadata_props`` is string->string only, so non-string fields are JSON-encoded.
+**What that means per processor:**
 
-For :class:`~sisr.processors.RGBProcessor` architectures (SRResNet), those
-methods are identity functions, so the bare graph is already an end-to-end
-LR-RGB -> SR-RGB pipeline. Under
-:class:`~sisr.processors.RGBSignedOutputProcessor` the same graph emits
-``[-1, 1]`` and the consumer must apply ``(out + 1) / 2``; the input side is
-unchanged. For :class:`~sisr.processors.YChannelProcessor`
-architectures (SRCNN), the graph only covers Y -> Y: reconstructing an RGB
-image needs the LR image's Cb/Cr channels back (bicubic-upsampled to the SR
-size), which this export omits. A non-Python ONNX consumer of an SRCNN graph
-must reimplement that chroma path itself — see the README's ONNX section.
+- :class:`~sisr.processors.RGBProcessor` (SRResNet): both are identity, so the
+  bare graph is already end-to-end LR-RGB -> SR-RGB.
+- :class:`~sisr.processors.RGBSignedOutputProcessor`: the same graph emits
+  ``[-1, 1]``; the consumer applies ``(out + 1) / 2``. Input side unchanged.
+- :class:`~sisr.processors.YChannelProcessor` (SRCNN): **Y -> Y only.**
+  Rebuilding RGB needs the LR image's Cb/Cr bicubic-upsampled to the SR size,
+  which this omits -- a non-Python consumer must reimplement that chroma path.
 
-Requires the optional ``export`` extra (``onnx``, ``onnxruntime``). The
-import is gated inside :func:`to_onnx` so plain ``import sisr`` — and
-``import sisr.export`` itself — stays free of the dependency until export is
-actually invoked.
+The graph carries the same provenance metadata as the checkpoint sinks, one
+field per ``metadata_props`` entry rather than one blob, because Netron renders
+per-field props as a readable table. That map is string->string, so non-strings
+are JSON-encoded.
+
+Requires the ``export`` extra. The import is gated inside :func:`to_onnx`, so
+even ``import sisr.export`` stays free of the dependency until it is invoked.
 """
 
 from __future__ import annotations

--- a/sisr/losses/adversarial.py
+++ b/sisr/losses/adversarial.py
@@ -7,24 +7,21 @@ class AdversarialLoss(torch.nn.Module):
     """Non-saturating GAN objective over discriminator **logits**.
 
     Deliberately **not** an :class:`~sisr.losses.base.SRLoss`: that contract is
-    ``forward(pred, target)`` in model space, and the generator's term
-    ``-log D(G(I_LR))`` has no target at all. Bending it to fit would put a
-    dummy argument in the signature the whole loss library depends on. Being a
-    separate class also makes the objective testable without a training loop
-    and swappable from YAML (LSGAN, relativistic) without touching the module.
+    ``forward(pred, target)`` and the generator term ``-log D(G(I_LR))`` has no
+    target, so fitting it would put a dummy argument in the signature the whole
+    loss library depends on. Standing apart also makes it testable without a
+    training loop and swappable from YAML (LSGAN, relativistic).
 
-    Takes logits, not probabilities — see
-    :class:`~sisr.models.srgan.SRDiscriminator`. Parameter-free, so it adds
-    nothing to any ``state_dict``.
+    Takes **logits**, not probabilities. Parameter-free, so it adds nothing to
+    any ``state_dict``.
     """
 
     def generator_loss(self, logits_fake: torch.Tensor) -> torch.Tensor:
         """Generator's adversarial term: make the discriminator call fakes real.
 
-        The **non-saturating** form (``-log D(G(x))``, i.e. BCE against a
-        *real* target) rather than ``+log(1 - D(G(x)))`` — the latter's gradient
-        vanishes exactly when the discriminator is winning, which is when the
-        generator most needs signal.
+        The **non-saturating** form (BCE against a *real* target), not
+        ``+log(1 - D(G(x)))``, whose gradient vanishes exactly when the
+        discriminator is winning and the generator most needs signal.
 
         Args:
             logits_fake: Discriminator logits for generated images, ``(B, 1)``.

--- a/sisr/losses/base.py
+++ b/sisr/losses/base.py
@@ -10,31 +10,27 @@ from ..processors import SRProcessor
 class SRLoss(torch.nn.Module, abc.ABC):
     """A criterion that needs facts only the :class:`SRProcessor` knows.
 
-    :class:`~sisr.training.lightning_module.SRLightning` calls :meth:`bind`
-    exactly once at construction, passing the processor wired alongside the
-    model. Plain :class:`torch.nn.Module` criteria (``MSELoss``, ``L1Loss``,
-    :class:`~sisr.losses.pixel.CharbonnierLoss`) need no such adaptation and
-    are used directly — this base exists only for the losses that do.
+    ``SRLightning`` calls :meth:`bind` once at construction with the processor
+    wired alongside the model. Plain ``torch.nn.Module`` criteria (``MSELoss``,
+    ``CharbonnierLoss``) need no adaptation and are used directly; this base is
+    only for the losses that do.
 
-    A loss may optionally expose ``last_terms: dict[str, torch.Tensor]``, a
-    structural protocol :class:`SRLightning` checks via ``getattr`` rather
-    than ``isinstance``, so any criterion holding one participates in
-    per-term logging as ``loss/<stage>/<name>``
-    (:class:`~sisr.losses.composite.WeightedSumLoss` is the one that does).
-    The tensors are written in place across ordinary steps and only replaced
-    when the existing buffer cannot be reused (first use, a device/dtype
-    change, or leaving :func:`torch.inference_mode`).
+    **Optional structural protocol:** a loss exposing
+    ``last_terms: dict[str, torch.Tensor]`` gets per-term logging as
+    ``loss/<stage>/<name>``. ``SRLightning`` checks it with ``getattr``, not
+    ``isinstance``, so any criterion holding one participates. Those tensors are
+    written **in place** and replaced only when the buffer cannot be reused
+    (first use, device/dtype change, leaving :func:`torch.inference_mode`).
     """
 
     @abc.abstractmethod
     def bind(self, processor: SRProcessor) -> None:
         """Adopt the model's output space, or raise if it cannot be served.
 
-        Abstract rather than defaulted to a no-op, for the same reason
-        :attr:`SRProcessor.output_range` is: a wrong inherited default is
-        exactly the failure this declaration exists to prevent. It is also
-        the one place an impossible model/loss pairing can fail loudly
-        instead of silently computing the wrong quantity.
+        Abstract rather than a defaulted no-op: a wrong inherited default is
+        the failure this exists to prevent, and this is the one place an
+        impossible model/loss pairing fails loudly rather than silently
+        computing the wrong quantity.
 
         Args:
             processor: The processor wired alongside the model, supplying
@@ -52,7 +48,6 @@ class SRLoss(torch.nn.Module, abc.ABC):
     def describe(self) -> str:
         """One-line recipe for the TensorBoard HParams column.
 
-        Concrete with a class-name default: this is presentation, so a new
-        loss must not be forced to implement it.
+        Defaulted, not abstract -- presentation must not be a subclass burden.
         """
         return type(self).__name__

--- a/sisr/losses/pixel.py
+++ b/sisr/losses/pixel.py
@@ -24,16 +24,14 @@ def _check_reduction(reduction: str) -> str:
 class CharbonnierLoss(torch.nn.Module):
     """Charbonnier distance ``sqrt((pred - target)^2 + eps^2)``.
 
-    A differentiable variant of L1: the ``eps`` floor gives a finite gradient
-    at ``pred == target``, which is where ``|x|`` has none. That is the whole
-    reason to prefer it — at the default ``eps`` the *value* is numerically
-    close to L1 for typical residuals, so do not expect a PSNR change from
-    swapping one for the other.
+    A differentiable L1: the ``eps`` floor gives a finite gradient at
+    ``pred == target``, where ``|x|`` has none. That is the only reason to
+    prefer it -- the *value* is numerically close to L1 at the default, so
+    expect no PSNR change from swapping them.
 
-    ``eps`` is **squared inside the root**, which spans both conventions in
-    circulation: LapSRN's ``sqrt(diff^2 + eps^2)`` at ``eps=1e-3`` (the
-    default here, and the paper that brought Charbonnier to SISR), and
-    BasicSR's ``sqrt(diff^2 + 1e-12)`` at ``eps=1e-6``.
+    ``eps`` is **squared inside the root**, spanning both live conventions:
+    LapSRN's ``eps=1e-3`` (the default, and the paper that brought Charbonnier
+    to SISR) and BasicSR's ``eps=1e-6``.
 
     Args:
         eps: Intensity-scale floor, squared inside the root. Defaults to
@@ -58,24 +56,21 @@ class CharbonnierLoss(torch.nn.Module):
 class TotalVariationLoss(torch.nn.Module):
     """Total-variation loss: isotropic ``sqrt(dx^2 + dy^2 + eps^2)``, reduced per ``reduction``.
 
-    Ledig et al. Sec. 3.4 add this to the VGG22 content loss at weight ``2e-8``
-    for SRResNet-VGG22 — the one VGG variant reproducible without a
-    discriminator, so it is required for that recipe, not optional. Their
-    ``l_TV`` is a norm of the gradient *vector*, i.e. isotropic;
-    ``isotropic=False`` gives the common ``|dx| + |dy|`` reimplementation, which
-    is a **different function** (up to ``sqrt(2)`` larger on diagonal
-    structure), not a rescaling. Both difference grids are cropped to a common
-    ``(H-1, W-1)`` so the norm can combine them per pixel.
+    Required, not optional, for SRResNet-VGG22: Ledig et al. Sec. 3.4 add it to
+    the VGG22 content loss at weight ``2e-8``, and that is the one VGG variant
+    reproducible without a discriminator. Their ``l_TV`` is a norm of the
+    gradient *vector*; ``isotropic=False`` gives the common ``|dx| + |dy|``
+    reimplementation, a **different function** (up to ``sqrt(2)`` larger on
+    diagonals), not a rescaling. Both grids crop to ``(H-1, W-1)`` so the norm
+    combines them per pixel.
 
     Two traps before setting a weight:
 
-    - ``target`` is **ignored** — this is a regulariser, not a distance. The
-      uniform ``(pred, target)`` signature exists so ``WeightedSumLoss`` can
-      dispatch every term identically.
+    - ``target`` is **ignored** -- a regulariser, not a distance. The uniform
+      signature exists so ``WeightedSumLoss`` dispatches every term identically.
     - **The value scales with the intensity range.** The paper's ``2e-8``
-      presumes a ``[-1, 1]`` output range; under a ``[0, 1]`` processor the
-      same image gives exactly half the TV, so the effective weight differs
-      by 2x.
+      presumes ``[-1, 1]``; under a ``[0, 1]`` processor the same image gives
+      exactly half the TV, so the effective weight differs by 2x.
 
     Args:
         isotropic: Use the paper's ``sqrt(dx^2 + dy^2)`` norm. ``False``

--- a/sisr/models/base.py
+++ b/sisr/models/base.py
@@ -18,13 +18,10 @@ class SRModel(nn.Module, abc.ABC):
     _hparams: dict
 
     #: How the model expects its LR input: ``'pre_upsampled'`` if LR arrives
-    #: already resized to the HR grid (e.g. SRCNN, which is resolution-
-    #: preserving), or ``'native_lr'`` if the model consumes true low-
-    #: resolution and upsamples internally (e.g. SRResNet's sub-pixel conv).
-    #: Declared per-architecture rather than inferred (e.g. from ``'scale'
-    #: in hparams``) — that check happens to hold for both current
-    #: architectures but would silently break on a third that doesn't follow
-    #: the same pattern.
+    #: already on the HR grid (SRCNN), ``'native_lr'`` if the model upsamples
+    #: internally (SRResNet). Declared, never inferred -- a rule like
+    #: ``'scale' in hparams`` holds for both current architectures and would
+    #: silently break on a third.
     input_contract: ClassVar[Literal["pre_upsampled", "native_lr"]]
 
     @property
@@ -37,15 +34,13 @@ class SRModel(nn.Module, abc.ABC):
     def variant_tag(self) -> str:
         """Short token distinguishing this configuration from siblings of the same class.
 
-        Appears in artifact filenames, so a directory of weights can be read
-        without opening anything: ``SRCNN_x2_Y_915`` and ``SRResNet_x4_RGB_16B64F``
-        differ in exactly this token when the architecture and scale match.
+        Appears in artifact filenames, so a directory of weights reads without
+        opening anything: ``SRCNN_x2_Y_915``, ``SRResNet_x4_RGB_16B64F``.
 
-        Abstract, never defaulted, for the same reason ``input_contract`` is
-        declared rather than inferred: no rule over ``hparams`` produces a
-        readable tag for every architecture, and an inherited default would
-        silently label two different configurations identically. Keep it short,
-        stable, and filename-safe.
+        Abstract, never defaulted, for the same reason ``input_contract`` is:
+        no rule over ``hparams`` yields a readable tag for every architecture,
+        and an inherited default would label two configurations identically.
+        Keep it short, stable and filename-safe.
         """
 
     @abc.abstractmethod
@@ -53,12 +48,10 @@ class SRModel(nn.Module, abc.ABC):
         """Run the model on input ``x`` and return the SR output tensor."""
 
     def reset_parameters(self, **kwargs: Any) -> None:
-        """Optional paper-style weight init. Default: no-op (kwargs ignored).
+        """Optional paper-style weight init. Default: no-op.
 
-        Subclasses may declare specific kwargs (e.g. ``SRCNN``'s ``mean`` /
-        ``std``). The base accepts ``**kwargs`` so callers like
-        ``SRLightning`` can pass paper-init options
-        polymorphically without knowing the subclass signature — models that
-        don't override absorb the kwargs as no-ops.
+        ``**kwargs`` lets ``SRLightning`` pass paper-init options
+        polymorphically; subclasses declare what they read (``SRCNN``'s
+        ``mean``/``std``), and models that do not override absorb them.
         """
         pass

--- a/sisr/models/srgan/config.py
+++ b/sisr/models/srgan/config.py
@@ -14,20 +14,17 @@ class SRGANTrainingConfig(SRResNetTrainingConfig):
     """SRGAN training defaults. The generator is SRResNet, so ``scale=4`` is inherited.
 
     Args:
-        init_from: Path to a bare-weights ``.safetensors`` whose generator weights
-            initialise this run's generator. The paper scopes the MSE-init
-            trick to "when training the actual GAN", so a paper-faithful SRGAN
-            run starts from an MSE-trained SRResNet. Optional: unset trains
-            from scratch, which is what tests and smoke runs use.
+        init_from: Bare-weights ``.safetensors`` to initialise the generator
+            from. A paper-faithful SRGAN run starts from an MSE-trained
+            SRResNet -- the paper scopes that to "when training the actual
+            GAN". Unset trains from scratch, which tests and smoke runs use.
 
-        adversarial_weight: Weight on the adversarial term of the generator's
-            loss. Defaults to ``1e-3``, the paper's value. The content term is
-            whatever ``criterion`` the module was given, so the total is
-            ``content + adversarial_weight * adversarial``.
+        adversarial_weight: Weight on the generator's adversarial term;
+            ``1e-3`` is the paper's. Total is
+            ``content + adversarial_weight * adversarial``, where content is
+            whatever ``criterion`` the module was given.
 
-        d_steps_per_g_step: Goodfellow's ``k`` — discriminator updates per
-            generator update. Defaults to ``1``, which is Ledig's 1:1
-            alternation.
+        d_steps_per_g_step: Goodfellow's ``k``. ``1`` is Ledig's alternation.
 
     Raises:
         ValueError: If ``d_steps_per_g_step`` is below 1.
@@ -47,15 +44,14 @@ class SRGANTrainingConfig(SRResNetTrainingConfig):
 class SRGANEvalConfig(SRResNetEvalConfig):
     """SRGAN eval defaults — SRResNet's scoring, plus perceptual metrics.
 
-    Inherits ``crop_border=4``, ``psnr_channels=['RGB', 'Y']`` and
-    ``ssim_impl='daala'``, so an SRGAN number stays comparable to the SRResNet
-    baseline computed the same way.
+    Inherits SRResNet's border, channels and ``ssim_impl='daala'``, so an SRGAN
+    number stays comparable to the baseline computed the same way.
 
     Args:
-        perceptual_metrics: Overrides the base default to ``['lpips', 'dists']``.
-            An adversarial objective makes PSNR and SSIM **worse by design**, so
-            without these an SRGAN run has no metric that tracks what it is
-            optimising. ``'lpips'`` requires the ``[perceptual]`` extra.
+        perceptual_metrics: ``['lpips', 'dists']``. An adversarial objective
+            makes PSNR and SSIM **worse by design**, so without these a run has
+            no metric tracking what it optimises. ``'lpips'`` needs the
+            ``[perceptual]`` extra.
     """
 
     perceptual_metrics: list[str] = field(default_factory=lambda: ["lpips", "dists"])

--- a/sisr/models/srresnet/config.py
+++ b/sisr/models/srresnet/config.py
@@ -1,9 +1,7 @@
 """SRResNet-paper-faithful training and evaluation defaults.
 
-Subclassing :class:`~sisr.training.config.SRTrainingConfig` /
-:class:`~sisr.training.config.SREvalConfig` lets the SRResNet recipe live
-alongside the model architecture, so an SRResNet experiment YAML only has
-to point at these classes via ``class_path`` to inherit defaults.
+Subclassing the base configs keeps the recipe beside the architecture, so an
+experiment YAML inherits it by naming these classes in ``class_path``.
 
 Reference: Photo-Realistic Single Image Super-Resolution Using a
 Generative Adversarial Network (https://arxiv.org/pdf/1609.04802),
@@ -22,28 +20,20 @@ from sisr.training.config import SREvalConfig, SRTrainingConfig
 class SRResNetTrainingConfig(SRTrainingConfig):
     """SRResNet-paper-faithful training defaults.
 
-    The paper trains on full RGB using Adam (lr 1e-4) and no per-layer LRs.
-    Colorspace *and* intensity range are both selected at the YAML layer by
-    the processor: :class:`~sisr.processors.RGBSignedOutputProcessor` for
-    the paper's LR ``[0, 1]`` / HR ``[-1, 1]`` asymmetry,
-    :class:`~sisr.processors.RGBProcessor` for plain ``[0, 1]`` throughout.
+    Full RGB, Adam at lr 1e-4, no per-layer LRs. Colorspace *and* intensity
+    range are chosen by the processor in YAML:
+    :class:`~sisr.processors.RGBSignedOutputProcessor` for the paper's LR
+    ``[0, 1]`` / HR ``[-1, 1]`` asymmetry, :class:`~sisr.processors.RGBProcessor`
+    for plain ``[0, 1]``.
 
-    The paper does not specify a weight-initialization scheme.
-    ``init_strategy='paper'`` is reserved for a future PR that wires up a
-    project-chosen init (e.g. Kaiming-style for the PReLU activations) via
-    :meth:`SRResNet.reset_parameters`. Today the field defaults to
-    ``'default'`` so SRResNet ships with PyTorch's built-in init; flipping
-    to ``'paper'`` is currently a no-op because
-    :meth:`SRModel.reset_parameters` (the inherited base) does nothing.
-    The field exists now so a future PR can add the implementation without
-    a YAML schema change.
+    **The paper specifies no weight init**, so ``init_strategy`` defaults to
+    ``'default'``. Setting ``'paper'`` is a no-op today: the inherited
+    :meth:`SRModel.reset_parameters` does nothing. The field exists so an
+    implementation can land without a YAML schema change.
 
-    ``scale`` defaults to ``4``: unlike SRCNN (whose paper reports multiple
-    scales and whose model carries no ``scale`` hparam at all), the SRResNet
-    baseline this project reproduces (Ledig et al. §3.2) is fixed at a single
-    4x upscaling factor, matching ``SRResNet``'s own ``scale`` hparam. The
-    default is therefore validated, not just recorded — see
-    ``SRTrainingConfig.validate_against``.
+    ``scale`` defaults to ``4`` -- the baseline reproduced here is fixed at one
+    factor, unlike SRCNN, whose model carries no ``scale`` hparam at all. It is
+    validated against the model, not merely recorded.
     """
 
     init_strategy: Literal["default", "paper"] = "default"
@@ -52,13 +42,12 @@ class SRResNetTrainingConfig(SRTrainingConfig):
     def validate_against(self, model: SRModel, processor: SRProcessor) -> None:
         """Extend the base checks with SRResNet's ``in_out_channels``/processor correlation.
 
-        Raises a readable error before the base's forward probe would
-        otherwise surface the same defect as a cryptic Conv2d shape mismatch.
+        Fires before the base's forward probe, which would surface the same
+        defect as a cryptic Conv2d shape mismatch.
 
         Args:
-            model: The constructed :class:`~sisr.models.srresnet.SRResNet` instance.
-            processor: The :class:`~sisr.processors.base.SRProcessor` paired
-                with ``model``.
+            model: The constructed ``SRResNet``.
+            processor: The processor paired with it.
 
         Raises:
             ValueError: If ``model``'s ``in_out_channels`` doesn't match
@@ -81,25 +70,21 @@ class SRResNetTrainingConfig(SRTrainingConfig):
 class SRResNetEvalConfig(SREvalConfig):
     """SRResNet-paper-faithful eval defaults.
 
-    Reports PSNR on RGB and Y — Ledig et al. quote Y-channel only (the full
-    YCbCr aggregate reads optimistically high since chroma planes are far
-    smoother than luma); excludes the outer ``scale=4`` pixels before
-    computing PSNR / SSIM, matching the standard SR-evaluation convention;
-    and computes SSIM with the daala convention Ledig et al. themselves used,
-    rather than the field-standard Wang SSIM most SR papers report.
+    PSNR on RGB and Y (Ledig et al. quote Y only; the YCbCr aggregate reads
+    optimistically high, chroma being far smoother than luma), the field's
+    border convention, and the daala SSIM the paper itself used.
 
     Args:
-        crop_border: Overrides the base default to ``4`` (outer pixels
-            excluded before PSNR / SSIM at the standard ``x4`` scale).
-        psnr_channels: Overrides the base default to ``['RGB', 'Y']`` —
-            ``'Y'`` is the paper's own metric; ``'RGB'`` is a supplementary
-            aggregate.
-        ssim_impl: Overrides the base default to ``'daala'`` — Ledig et al.
-            computed SSIM with the daala package, whose gaussian sigma scales
-            with image height, not with Wang's fixed 11x11. PSNR is unaffected
-            (it is implementation-invariant); SSIM under this setting is
-            comparable to the paper and **not** to the wider SR literature,
-            which reports Wang. See :mod:`sisr.metrics.ssim`.
+        crop_border: ``None`` -- derive the field convention's ``scale`` pixels
+            from the model rather than pin a constant. Resolved by
+            ``SRLightning``; for this config that is 4.
+        psnr_channels: ``['RGB', 'Y']`` -- ``'Y'`` is the paper's metric,
+            ``'RGB'`` a supplementary aggregate.
+        ssim_impl: ``'daala'``, whose gaussian sigma scales with image height
+            rather than Wang's fixed 11x11. **SSIM under this setting is
+            comparable to the paper and not to the wider SR literature**, which
+            reports Wang. PSNR is unaffected, being implementation-invariant.
+            See :mod:`sisr.metrics.ssim`.
     """
 
     crop_border: int | None = None

--- a/sisr/processors/base.py
+++ b/sisr/processors/base.py
@@ -9,10 +9,8 @@ import torch
 class SRProcessor(abc.ABC):
     """Adapts dataset-format tensors (RGB float in [0, 1]) to/from model IO.
 
-    Partitioned by colorspace, not by model — the same processor instance
-    is shared across all models that train in that colorspace. Replaces
-    the per-batch colorspace logic that previously lived as standalone
-    functions in :mod:`sisr.colorspace`.
+    Partitioned by colorspace, not by model: one instance serves every model
+    training in that colorspace.
     """
 
     @abc.abstractmethod
@@ -22,17 +20,15 @@ class SRProcessor(abc.ABC):
     def extract_target(self, hr_rgb: torch.Tensor) -> torch.Tensor:
         """Convert dataset HR (RGB, ``[B, 3, H', W']``) into the model's *output* space.
 
-        The training loss is computed between ``model(extract(lr))`` and
-        ``extract_target(hr)``, so an implementation must be the exact
-        inverse of :meth:`reconstruct`.
+        The loss is computed between ``model(extract(lr))`` and
+        ``extract_target(hr)``, so this must be the exact inverse of
+        :meth:`reconstruct`.
 
-        Defaults to :meth:`extract`, which is correct for every processor
-        whose input and output spaces coincide — i.e. every pure colorspace
-        adapter, where the same conversion applies to LR and HR alike.
-        Override only when the model consumes and emits *different* ranges;
-        :class:`~sisr.processors.rgb.RGBSignedOutputProcessor` is the one
-        such case, and exists because the SRGAN paper specifies exactly that
-        asymmetry.
+        Defaults to :meth:`extract`, correct wherever input and output spaces
+        coincide -- every pure colorspace adapter. **Override only when the
+        model consumes and emits different ranges**;
+        :class:`~sisr.processors.rgb.RGBSignedOutputProcessor` is the one such
+        case, and exists because the SRGAN paper specifies that asymmetry.
 
         Args:
             hr_rgb: HR batch, RGB ``float32`` in ``[0, 1]``.
@@ -51,9 +47,9 @@ class SRProcessor(abc.ABC):
     def model_channels(self) -> int:
         """Number of channels ``extract`` produces — the model's IO channel count.
 
-        A fact only the processor knows (not a mirror of the model's own
-        config), used to validate a model/processor pairing at construction
-        time (see ``SRTrainingConfig.validate_against``).
+        A fact only the processor knows -- not a mirror of the model's config.
+        Validates a model/processor pairing at construction
+        (``SRTrainingConfig.validate_against``).
         """
 
     @property
@@ -61,16 +57,11 @@ class SRProcessor(abc.ABC):
     def output_range(self) -> tuple[float, float]:
         """The model's *output* intensity range, e.g. ``(0.0, 1.0)`` or ``(-1.0, 1.0)``.
 
-        A fact only the processor knows (mirrors ``model_channels``) —
-        abstract rather than defaulted, because a wrong inherited default is
-        exactly the failure this exists to prevent. Applying
-        :class:`~sisr.processors.rgb.RGBProcessor`'s ``[0, 1]`` reconstruction
-        logic to weights actually trained under
-        :class:`~sisr.processors.rgb.RGBSignedOutputProcessor` (``[-1, 1]``)
-        produces silently wrong images with no error — the same hazard the
-        README documents for ONNX consumers of that processor. Recorded in
-        checkpoint/export provenance metadata precisely so a downstream
-        consumer never has to guess it.
+        Abstract, never defaulted: a wrong inherited default is the failure
+        this exists to prevent. Reconstructing ``[-1, 1]``-trained weights with
+        ``[0, 1]`` logic produces silently wrong images and no error. Recorded
+        in checkpoint and export metadata so no downstream consumer has to
+        guess it.
         """
 
     @property
@@ -78,10 +69,8 @@ class SRProcessor(abc.ABC):
     def output_colorspace(self) -> Literal["RGB", "YCbCr", "Y"]:
         """Colorspace of the model's output planes.
 
-        A fact only the processor knows (mirrors :attr:`output_range`) —
-        abstract rather than defaulted, because a consumer cannot tell Y/Cb/Cr
-        planes from R/G/B ones by shape, and one that matters
-        (:class:`~sisr.losses.vgg.VGG19FeatureLoss`, which normalises with RGB
-        ImageNet statistics) would otherwise silently compute a meaningless
-        quantity.
+        Abstract for the same reason as :attr:`output_range`: nothing tells
+        Y/Cb/Cr planes from R/G/B ones by shape, and
+        :class:`~sisr.losses.vgg.VGG19FeatureLoss` normalises with RGB ImageNet
+        statistics -- it would silently compute a meaningless quantity.
         """

--- a/sisr/processors/rgb.py
+++ b/sisr/processors/rgb.py
@@ -37,21 +37,17 @@ class RGBProcessor(SRProcessor):
 class RGBSignedOutputProcessor(SRProcessor):
     """RGB in and out, with the model's *output* space in ``[-1, 1]``.
 
-    Ledig et al. §3.2: "We scaled the range of the LR input images to [0, 1]
-    and for the HR images to [-1, 1]. The MSE loss was thus calculated on
-    images of intensity range [-1, 1]." The asymmetry is the point — the
-    model consumes ``[0, 1]`` and emits ``[-1, 1]`` — which is why the target
-    mapping lives in :meth:`extract_target` rather than :meth:`extract`.
+    Ledig et al. §3.2 scale LR to ``[0, 1]`` and HR to ``[-1, 1]``. **The
+    asymmetry is the point**, which is why the target mapping lives in
+    :meth:`extract_target` rather than :meth:`extract`.
 
-    Practically this centres the regression target on zero, which matches
-    what a freshly initialised conv stack emits; against a ``[0, 1]`` target
-    the tail conv has to learn a +0.5 mean shift first. The 4x it also
-    applies to the MSE is *not* a second effect — Adam normalises by the
-    second moment, so a global loss scaling cancels out of the update. Only
-    the logged ``loss/train`` value differs (by exactly 4x).
+    It centres the regression target on zero, matching what a freshly
+    initialised conv stack emits; against ``[0, 1]`` the tail conv must learn a
+    +0.5 mean shift first. The 4x it also applies to the MSE is **not** a second
+    effect -- Adam normalises by the second moment, so a global loss scaling
+    cancels out of the update. Only the logged ``loss/train`` differs, by 4x.
 
-    Pair with an unscaled :class:`RGBProcessor` to reproduce runs recorded
-    before this processor existed.
+    Pair with :class:`RGBProcessor` to reproduce runs predating this class.
     """
 
     def extract(self, lr_rgb: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## What changed

Prose compaction across the four packages the earlier passes did not reach: root modules,
`losses/`, `models/`, `processors/`. **−137 prose lines, code unchanged** (2,990 → 2,991, one line
from a reflow).

| | before | after |
|---|---:|---:|
| prose : code, whole package | **1.639** | **1.593** |
| root modules | 1.74 | 1.52 |
| `models/` | 1.29 | 1.23 |
| `losses/` | 1.29 | 1.29 |
| `processors/` | 1.04 | 1.00 |

`sisr/models/srcnn/` is **deliberately untouched** — #219 and #220 both rewrite files in it, and a
prose diff on top would collide for no gain. It is the obvious next target once they land.

## Constraint ledger

Every removed block, classified. No constraint, failure mode, or `Args:`/`Returns:`/`Raises:`
entry was deleted; nothing was moved out of the codebase.

| file | cut | class |
|---|---|---|
| `colorspace.py` | `(torch.Tensor)` type prefixes in every `Args:`/`Returns:` | **deleted as restatement** — the signature already says it |
| `colorspace.py` | the studio-range PSNR offset derivation | **compressed to its conclusion**; the test that asserts the identity is named |
| `colorspace.py` | "these pure tensor functions live on their own so callers can…" | **compressed** — kept as one clause |
| `cli.py` | `_parse_ckpt_path`'s two-parser explanation | **compressed** — the *rule* (never `self.parser`), the mechanism (`cfg.get(self.dest)` is unqualified) and both failure modes all kept verbatim in substance |
| `cli.py` | `parse_arguments`' collision walk-through | **compressed**; the "catch, do not pre-scan" lesson kept as its own bolded rule |
| `cli.py` | `_CKPT_HPARAM_KEYS`' history of what old checkpoints stored | **deleted as narrative about what the code used to do** — the surviving rule is which keys are loadable |
| `cli.py` | `set_parsing_settings` rationale | **compressed**; the alternative (disabling the selector by name) kept |
| `artifacts.py` | "**Why it exists**" — four sentences on the pre-refactor shape | **deleted as narrative**; the one-owner rule kept |
| `artifacts.py` | "Why safetensors" | **compressed** — the consumer-exposure argument is the load-bearing half and stays |
| `export.py` | per-processor consequences, as prose | **compressed into a bulleted table**; the SRCNN Y→Y limitation kept, emphasised |
| `losses/base.py` | `last_terms` protocol paragraph | **compressed**; in-place-write rule and all three replacement triggers kept |
| `losses/pixel.py` | Charbonnier ε-convention paragraph | **compressed**; both live conventions kept |
| `losses/pixel.py` | TV isotropy + range-scaling traps | **compressed**; both traps kept as bullets, including the 2× weight consequence |
| `models/base.py` | `variant_tag` / `input_contract` "abstract not inferred" rationale | **compressed**; the rule and its reason kept |
| `processors/base.py` | `output_range` / `output_colorspace` rationale | **compressed**; the silent-wrong-image failure kept |
| `models/srresnet/config.py` | `init_strategy`, `scale` narrative | **compressed** |
| `models/srgan/config.py`, `processors/rgb.py` | `Args:` bodies restating the class docstring | **compressed** |

**Kept — unsure (0).** Nothing in this pass was a judgement call I could not settle; where a cut
felt close, the text was compressed rather than removed.

## One defect found, not moved

`SRResNetEvalConfig.crop_border` documented "Overrides the base default to `4`". The field has
been `None` since the border started deriving from `scale` (#217) — the docstring described a
value the code no longer holds. Corrected to state the sentinel and what it resolves to here.

## About the gate

**This does not reach the gate, and the gate's replacement number needs deciding with the
measurement in hand rather than before it.** `conventions.md` currently demands ≤ 1.00, which is
unreachable without deleting rules. The four packages in scope held 1,324 prose lines between
them; a pass that loses nothing took 10.4% of that, which is 137 lines and lands at **1.593**.

Reaching 1.40 needs 716 lines gone in total. The remaining 579 can only come from `training`,
`utils`, `metrics` and `datasets` — all already compacted once — so it is a *second* pass over
already-compacted code, not this one. That is a separate decision, and this PR does not presume
it: no gate value is changed here.

## Evidence

`ruff check`, `ruff format --check` and `mypy sisr/` all clean. Tests for every touched package
pass — no behaviour is in this diff, so CI's full run is the check that matters.
