### PR TITLE
chore: ask for the evidence at filing time, not after a round trip

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Something behaves differently from what it documents.
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A fix here ships the test that catches it, proven **RED before and GREEN after** — a test
+        that passes both ways documents nothing. You do not have to write that test, but the more
+        precisely you can say what "wrong" looks like, the sooner one exists.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: The behaviour, not the diagnosis.
+      placeholder: Resuming with --ckpt_path into a run directory that has not saved yet raises FileNotFoundError before the first step.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: >
+        The command and the config. Trim the config to the keys that matter if it is long, but
+        say which template it started from — a default that was overridden is often the answer.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Traceback or wrong output
+      description: Paste it whole. A trimmed traceback usually loses the frame that matters.
+      render: text
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: A release, or the commit SHA if you are on a branch.
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: >
+        OS, Python, torch, and whether you are on CUDA, CPU, or MPS. Under WSL, say so — the
+        multiprocessing start method differs from Windows and it changes worker behaviour.
+      value: |
+        - OS:
+        - Python:
+        - torch:
+        - Accelerator:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: touches
+    attributes:
+      label: Does this involve any of these?
+      description: Each has its own trap, and saying so early saves a round trip.
+      options:
+        - label: A metric number (PSNR, SSIM, LPIPS, DISTS)
+        - label: Colorspace conversion, or Y-channel output
+        - label: The LMDB cache, or dataset building
+        - label: Checkpoints, resuming, or the exported artifact
+        - label: torch.compile

--- a/.github/ISSUE_TEMPLATE/2_performance.yml
+++ b/.github/ISSUE_TEMPLATE/2_performance.yml
@@ -1,0 +1,66 @@
+name: Performance
+description: Something is slower than it should be, or a speed-up is worth making.
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **A throughput number without its conditions is a lead, not a result.** Two mistakes have
+        cost real time on this project and both are invisible in the number itself:
+
+        - **A mean over a short run hides one-time cost** — worker spawn, cache warm, autotune —
+          and can invert the conclusion. Report **medians with warm-up excluded**, and say how
+          many iterations you discarded.
+        - **A rate read by polling a metrics file is quantised by the logging cadence**, and the
+          quantisation forges precision: repeated windows agree to five significant figures while
+          resolving almost nothing. If you polled, divide the step delta by `log_every_n_steps`
+          and say how many logging intervals your window actually spanned.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What is slow
+      description: Which operation, and where you measured it — a step, a validation cycle, cache build, export.
+    validations:
+      required: true
+
+  - type: textarea
+    id: numbers
+    attributes:
+      label: The measurement
+      description: >
+        Medians, warm-up excluded. If you are proposing a change rather than reporting a
+        regression, "after" can be an estimate — say so.
+      value: |
+        |            | before | after |
+        | ---------- | ------ | ----- |
+        | ms/op or ops/s |    |       |
+
+        - Iterations discarded as warm-up:
+        - Iterations measured:
+        - Polled from a metrics file? If yes, logging intervals spanned:
+    validations:
+      required: true
+
+  - type: textarea
+    id: provenance
+    attributes:
+      label: Where it was measured
+      description: >
+        Which dataset (a synthetic or absent one makes the number synthetic), which accelerator,
+        and the host's power state — on a laptop off mains the same run has measured roughly half
+        its plugged-in rate, which is more than enough to invent or hide an effect.
+      value: |
+        - Dataset:
+        - Accelerator:
+        - Power state (mains / battery, and any performance mode):
+        - Precision (fp32 / bf16 / amp):
+        - Commit or version:
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you think would help
+      description: Optional. A profile or a flame graph is worth more than a guess, if you have one.

--- a/.github/ISSUE_TEMPLATE/3_reproduction_discrepancy.yml
+++ b/.github/ISSUE_TEMPLATE/3_reproduction_discrepancy.yml
@@ -1,0 +1,70 @@
+name: Reproduction discrepancy
+description: A metric does not match the published number it should.
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Two numbers here are comparable only if they were produced the same way.** Most reports
+        of a mismatch turn out to be a convention difference rather than a defect, and the fields
+        below are the ones that decide which. Please fill them even if they seem pedantic —
+        without them the report cannot be acted on.
+
+  - type: input
+    id: paper
+    attributes:
+      label: Which paper, table and row
+      placeholder: Ledig et al. 2017, Table 2, SRGAN-VGG54
+    validations:
+      required: true
+
+  - type: textarea
+    id: numbers
+    attributes:
+      label: Their number and yours
+      value: |
+        | dataset | published | measured here | delta |
+        | ------- | --------- | ------------- | ----- |
+        |         |           |               |       |
+    validations:
+      required: true
+
+  - type: textarea
+    id: convention
+    attributes:
+      label: How the metric was computed
+      description: >
+        These four decide comparability more often than the model does. **SSIM has two live
+        conventions in this repo** and they do not agree: the SRResNet line defaults to `daala`,
+        which is what Ledig et al. used, and everything else to `wang`, which is what most of the
+        SR literature reports. PSNR-Y likewise differs by a constant offset between the
+        studio-range and full-range definitions.
+      value: |
+        - Metric and channel (e.g. PSNR-Y, SSIM-Y, LPIPS):
+        - SSIM convention, if applicable (wang / daala):
+        - Border cropped before scoring, in pixels:
+        - Scale factor:
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: What produced your number
+      description: >
+        The config, the checkpoint or weights, and the step it came from. If it was read off a
+        training curve rather than a scored evaluation pass, say so — the two are not the same
+        measurement, and a checkpoint's filename does not always name the step a curve uses.
+      render: shell
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Already ruled out
+      description: Tick what you have checked. Nothing here is required; it just saves a round trip.
+      options:
+        - label: The LR images were produced by this repo's degradation, not another resize
+        - label: The comparison uses the same crop border on both sides
+        - label: The model reached the step the published result was trained to

--- a/.github/ISSUE_TEMPLATE/4_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/4_enhancement.yml
@@ -1,0 +1,45 @@
+name: Enhancement
+description: Something this should do that it does not.
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What you are trying to do
+      description: The problem, not a proposed API. What is awkward today is the part worth knowing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like instead
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of change is this
+      description: >
+        A new architecture is a subclass plus its config dataclasses and a YAML, and needs no new
+        Lightning module. A new *training paradigm* — adversarial, distillation, multi-stage — is
+        the case that may justify one.
+      options:
+        - A new architecture
+        - A new training paradigm
+        - A new loss or metric
+        - Data loading or caching
+        - Config, CLI, or export surface
+        - Documentation
+        - Something else
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you considered instead
+      description: >
+        Optional, but the most useful field on this form. A rejected alternative is the part that
+        does not survive in a diff.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Blank issues stay on: a maintainer filing a one-line note should not have to
+# fight a form. The forms exist to catch what an outside report usually omits.
+blank_issues_enabled: true
+# Discussions is not enabled on this repo, so nothing here points at it.
+contact_links:
+  - name: How do I configure this?
+    url: https://github.com/YeapJieShen/single-image-super-resolution/blob/main/docs/configuration.md
+    about: Every config key, what it does, and which are load-bearing.
+  - name: Does it reproduce the paper?
+    url: https://github.com/YeapJieShen/single-image-super-resolution/blob/main/docs/reproduction.md
+    about: The measured tables, and exactly where this departs from what the papers specify.
+  - name: How to contribute
+    url: https://github.com/YeapJieShen/single-image-super-resolution/blob/main/CONTRIBUTING.md
+    about: Branch naming, the four CI checks, and the evidence a change has to carry.


### PR DESCRIPTION
## What changed

Four issue forms plus `config.yml`. The community profile reported `issue_template` missing;
it will not after this.

## Why

The PR template already carries this project's evidence bar. **Nothing carried it on the way in**,
so a report routinely arrived without the one fact that decides whether it is real — and for a
reproduction framework that fact is usually a convention, not a bug.

Forms rather than markdown templates, for one reason: **a form can mark a field `required`**. A
markdown prompt asking for medians is a prompt; a required field is a harness. The evidence field
is precisely the one that gets deleted along with the rest of the comment block.

## The forms

| form | labels | what it refuses to be filed without |
|---|---|---|
| Bug report | `bug`, `needs-triage` | what/expected/repro/version/environment |
| Performance | `enhancement`, `needs-triage` | the numbers, and where they were measured |
| Reproduction discrepancy | `bug`, `needs-triage` | paper+table+row, both numbers, the metric convention, what produced yours |
| Enhancement | `enhancement`, `needs-triage` | problem, proposal, kind of change |

**Reproduction discrepancy is the one worth the most here.** Two numbers in this project are
comparable only if produced the same way, so the form asks for the metric and channel, the SSIM
convention, the crop border and the scale — and says outright that SSIM has two live conventions
which do not agree, the SRResNet line defaulting to `daala` (what Ledig et al. used) and
everything else to `wang` (what most of the literature reports). Most mismatch reports are that,
not a defect.

**Performance** carries both measurement traps as prose, because both are invisible in the number
itself: a mean over a short run hides worker spawn, cache warm and autotune and can invert the
conclusion; and a rate polled from a metrics file is quantised by `log_every_n_steps`, so
repeated windows agree to five significant figures while resolving almost nothing. It asks for
the number of logging intervals spanned, which is the thing that makes that visible. It also asks
for the host's power state — off mains the same run has measured roughly half its plugged-in
rate, which is more than enough to invent or hide an effect.

## Two deliberate omissions

**Blank issues stay enabled.** A maintainer filing a one-line note should not have to fight a
form; these are for reports from outside.

**No code of conduct.** It is the profile's other gap and it is not a harness — which covenant,
who enforces it, and what contact address gets published are policy choices with a real decision
behind them. It should not ride along on this.

## One thing this found

**Discussions is not enabled on this repo.** My first draft pointed a contact link at
`/discussions`, which would have shipped a 404 on the new-issue page. The links now point at
`docs/configuration.md`, `docs/reproduction.md` and `CONTRIBUTING.md`, all verified to exist at
those paths. Enabling Discussions is a repo-settings change and is yours to make, not something
to flip as a side effect of this.

## Evidence

No behaviour, so there is no test to be RED. What was checkable was checked:

- All five files parse as YAML.
- All four forms validate against GitHub's issue-form schema — element types, `markdown` blocks
  carrying no `id`/`validations`, `dropdown` options as strings, `checkboxes` options as
  `{label}` mappings, id character set, and no duplicate ids within a form.
- Every label named by a form already exists in the repo (`bug`, `enhancement`, `needs-triage`) —
  a form naming a missing label silently fails to apply it.
- Every `contact_links` URL resolves to a file present at that path on `main`.

The forms render only once they are on the default branch, so the final check is the new-issue
page after merge.

Closes #228
