### PR TITLE
fix: reject config values that silently produce an incomparable number

### DIFF
--- a/sisr/metrics/scoring.py
+++ b/sisr/metrics/scoring.py
@@ -134,6 +134,13 @@ class SRScorer:
                 config never passed through ``SRLightning``, which resolves the
                 derive-from-scale sentinel; scoring against an unresolved border
                 would silently pick a different region than the run intends.
+                Also if it is negative -- reachable only past
+                ``SREvalConfig.__post_init__``, via the sentinel resolution's
+                direct assignment -- or if twice the border would consume an
+                image's shorter axis. The oversized case cannot be caught at
+                config time because no image is in scope there, so it is caught
+                here, where the tensor is, and names both the border and the
+                size rather than surfacing as a torch shape error.
         """
         n = self.eval_config.crop_border
         if n is None:
@@ -142,8 +149,24 @@ class SRScorer:
                 "meaning 'crop the model's scale', resolved by SRLightning at construction "
                 "-- build the scorer from a module's eval_config, or set an explicit int."
             )
-        if n <= 0:
+        if n < 0:
+            raise ValueError(
+                f"eval_config.crop_border is {n} at scoring time. SREvalConfig rejects a "
+                "negative border at construction, but SRLightning ASSIGNS this field when it "
+                "resolves the derive-from-scale sentinel, which bypasses that check -- so a "
+                "non-positive `scale` lands here. Scoring would silently return the FULL "
+                "image, because 'no crop' and 'a negative crop' are the same branch."
+            )
+        if n == 0:
             return tensors
+        for t in tensors:
+            h, w = t.shape[-2:]
+            if 2 * n >= min(h, w):
+                raise ValueError(
+                    f"eval_config.crop_border={n} removes {2 * n} px from each axis of a "
+                    f"{h}x{w} image, leaving nothing to score. Lower crop_border, or drop "
+                    "the images smaller than it from the evaluation set."
+                )
         return tuple(t[..., n:-n, n:-n] for t in tensors)
 
     def metric_tensors(

--- a/sisr/models/srgan/config.py
+++ b/sisr/models/srgan/config.py
@@ -35,9 +35,31 @@ class SRGANTrainingConfig(SRResNetTrainingConfig):
     d_steps_per_g_step: int = 1
 
     def __post_init__(self) -> None:
-        """Reject settings this training mode cannot honour."""
+        """Reject settings this training mode cannot honour.
+
+        ``super()`` first: this override previously replaced its parent's
+        checks outright, which left the base class's ``compile_mode`` /
+        ``compile_backend`` guard dead for **every** SRGAN config -- the
+        longest-running configuration here, and so the most expensive place to
+        lose a startup check.
+
+        Raises:
+            ValueError: If ``d_steps_per_g_step`` is below 1, if
+                ``adversarial_weight`` is negative, or for anything the
+                inherited validation rejects.
+        """
+        super().__post_init__()
         if self.d_steps_per_g_step < 1:
             raise ValueError(f"d_steps_per_g_step must be >= 1; got {self.d_steps_per_g_step}.")
+        if self.adversarial_weight < 0:
+            raise ValueError(
+                f"adversarial_weight must be >= 0; got {self.adversarial_weight}. "
+                "The generator minimises `content + adversarial_weight * adversarial`, so a "
+                "negative weight inverts the adversarial term and trains the generator to "
+                "look MORE fake to the discriminator. Zero is legitimate -- it is the "
+                "content-only ablation. Fix "
+                "model.training_config.init_args.adversarial_weight in your YAML."
+            )
 
 
 @dataclass

--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -124,12 +124,70 @@ class SRTrainingConfig:
     compile_mode: str | None = None
 
     def __post_init__(self) -> None:
-        """Reject a compile mode that nothing will apply.
+        """Reject a compile mode that nothing will apply, and values that mean nothing.
+
+        Every check here names the YAML key to fix, matching
+        :class:`SREvalConfig`'s style. They exist because each of these fields
+        reached something that accepted it silently: a negative ``scale``
+        resolves ``eval_config.crop_border`` to a negative border and scores
+        uncropped, a negative ``layer_lrs`` entry trains that layer in the
+        wrong direction, and ``init_strategy`` dispatches on ``== "paper"``, so
+        any other spelling means "default" with nothing saying so.
+
+        ``init_mean`` is deliberately unconstrained -- a negative mean is a
+        legitimate gaussian.
 
         Raises:
             ValueError: If ``compile_mode`` is set without
-                ``compile_backend='inductor'``.
+                ``compile_backend='inductor'``; if ``scale`` is set and is not
+                a positive int; if any ``layer_lrs`` entry (or either half of
+                a ``[weight_lr, bias_lr]`` pair) is not positive; if
+                ``init_std`` is not positive; or if ``init_strategy`` is
+                neither ``'default'`` nor ``'paper'``.
         """
+        if self.scale is not None and self.scale < 1:
+            raise ValueError(
+                f"training_config.scale must be a positive int; got {self.scale}. "
+                "It is not only provenance: for an architecture that declares no `scale` "
+                "hparam of its own (SRCNN, deliberately -- it is resolution-preserving) "
+                "nothing else checks it, and eval_config.crop_border derives from it, so a "
+                "non-positive scale becomes a non-positive border and the metric is computed "
+                "on the uncropped image. Fix model.training_config.init_args.scale in your YAML."
+            )
+
+        if self.layer_lrs is not None:
+            for i, lr in enumerate(self.layer_lrs):
+                pair = [lr] if isinstance(lr, int | float) else list(lr)
+                if any(v <= 0 for v in pair):
+                    raise ValueError(
+                        f"training_config.layer_lrs[{i}]={lr!r} must be positive "
+                        "(every entry, and both halves of a [weight_lr, bias_lr] pair). "
+                        "These are absolute learning rates handed straight to the optimizer: "
+                        "a negative one ascends the loss for that layer and a zero freezes it "
+                        "silently. Only the list's LENGTH is checked when the optimizer is "
+                        "built. Fix model.training_config.init_args.layer_lrs in your YAML."
+                    )
+
+        if self.init_std <= 0:
+            raise ValueError(
+                f"training_config.init_std must be positive; got {self.init_std}. "
+                "It reaches torch.nn.init.normal_ as the gaussian's standard deviation. "
+                "(init_mean is unconstrained -- a negative mean is legitimate.) "
+                "Fix model.training_config.init_args.init_std in your YAML."
+            )
+
+        if self.init_strategy not in ("default", "paper"):
+            raise ValueError(
+                f"training_config.init_strategy must be 'default' or 'paper'; got "
+                f"{self.init_strategy!r}. The dispatch tests `== 'paper'`, so any other "
+                "spelling -- 'Paper' included -- silently selects PyTorch's default init "
+                "while the config reads as though the paper's runs. This is a "
+                "paper-reproduction framework, so that difference is the whole point of the "
+                "field. The Literal annotation is enforced by jsonargparse at the CLI and by "
+                "nothing in Python, so a directly-constructed config had no guard at all. "
+                "Fix model.training_config.init_args.init_strategy in your YAML."
+            )
+
         if self.compile_mode is not None and self.compile_backend != "inductor":
             raise ValueError(
                 f"compile_mode={self.compile_mode!r} needs compile_backend='inductor'; got "
@@ -267,17 +325,30 @@ class SREvalConfig:
     def __post_init__(self) -> None:
         """Validate all channel/metric fields at construction.
 
-        Covers ``psnr_channels``, ``ssim_channels``, ``ssim_impl``,
-        ``perceptual_metrics`` and ``lpips_net``.
+        Covers ``crop_border``, ``psnr_channels``, ``ssim_channels``,
+        ``ssim_impl``, ``perceptual_metrics`` and ``lpips_net``.
 
         Raises:
-            ValueError: If any entry of either channel field is not a
+            ValueError: If ``crop_border`` is negative (``None`` and ``0`` are
+                both legitimate, and mean different things); if any entry of
+                either channel field is not a
                 supported colorspace or single-channel name (see
                 ``_CHANNEL_SUBNAMES``), if ``ssim_impl`` is not ``'wang'`` or
                 ``'daala'``, if any entry of ``perceptual_metrics`` is not a
                 supported metric (see ``PERCEPTUAL_METRICS``), or if
                 ``lpips_net`` is not ``'alex'``, ``'vgg'`` or ``'squeeze'``.
         """
+        if self.crop_border is not None and self.crop_border < 0:
+            raise ValueError(
+                f"SREvalConfig.crop_border must be None or >= 0; got {self.crop_border}. "
+                "`None` is the sentinel meaning 'derive the border from the model's scale', "
+                "so a negative value is exactly what someone reaches for to mean 'auto' -- "
+                "and it does not mean that: the slice guard treats anything <= 0 as 'no "
+                "crop', so a negative border silently scores the FULL image and produces a "
+                "number comparable to no published result. Fix "
+                "model.eval_config.init_args.crop_border in your YAML."
+            )
+
         valid = tuple(_CHANNEL_SUBNAMES)
         for field_name in ("psnr_channels", "ssim_channels"):
             invalid = [c for c in getattr(self, field_name) if c not in valid]

--- a/tests/metrics/test_scoring_contract.py
+++ b/tests/metrics/test_scoring_contract.py
@@ -157,3 +157,43 @@ def test_the_two_ssim_conventions_genuinely_differ():
     wang, daala = score("wang"), score("daala")
     for tag in (t for t in wang if t.startswith("ssim/")):
         assert wang[tag] != pytest.approx(daala[tag], rel=1e-6), tag
+
+
+# --- crop_border: the two failures that reach a number, not an exception ---
+
+
+def test_crop_rejects_a_negative_border_forced_past_config_validation():
+    """SRLightning ASSIGNS eval_config.crop_border after construction, which
+    bypasses __post_init__ entirely -- so config validation alone cannot be the
+    only guard. A negative border makes the slice guard `n <= 0` return the
+    tensors uncropped: a number that looks valid and is comparable to nothing."""
+    from sisr.metrics.scoring import SRScorer
+    from sisr.training import SREvalConfig
+
+    cfg = SREvalConfig(crop_border=0)
+    cfg.crop_border = -4  # what _resolved_scale would have written for scale=-4
+    scorer = SRScorer(cfg)
+    with pytest.raises(ValueError, match="crop_border"):
+        scorer.crop(torch.zeros(1, 3, 32, 32))
+
+
+def test_crop_rejects_a_border_that_would_consume_the_whole_image():
+    """Oversized borders currently surface as a bare torch RuntimeError several
+    frames down, naming no config key. Every sibling field gets an actionable
+    message; this one should too, and it names the image size because that is
+    the half of the problem the config cannot know."""
+    from sisr.metrics.scoring import SRScorer
+    from sisr.training import SREvalConfig
+
+    scorer = SRScorer(SREvalConfig(crop_border=99))
+    with pytest.raises(ValueError, match=r"crop_border"):
+        scorer.crop(torch.zeros(1, 3, 8, 8))
+
+
+def test_crop_accepts_a_border_that_leaves_at_least_one_pixel():
+    """The boundary stays usable: 3 px off each side of an 8x8 leaves 2x2."""
+    from sisr.metrics.scoring import SRScorer
+    from sisr.training import SREvalConfig
+
+    (out,) = SRScorer(SREvalConfig(crop_border=3)).crop(torch.zeros(1, 3, 8, 8))
+    assert out.shape == (1, 3, 2, 2)

--- a/tests/models/srgan/test_config.py
+++ b/tests/models/srgan/test_config.py
@@ -43,3 +43,28 @@ def test_eval_config_perceptual_metrics_independent_per_instance():
     b = SRGANEvalConfig()
     a.perceptual_metrics.append("x")
     assert b.perceptual_keys == ["lpips", "dists"]
+
+
+def test_srgan_training_config_runs_its_parents_post_init():
+    """SRGANTrainingConfig.__post_init__ overrode its parent's without calling
+    super(), so the compile_mode/compile_backend guard was dead for every SRGAN
+    config -- the longest-running configuration in the project, and so the most
+    expensive place to lose a startup check. An audit found this the only
+    __post_init__ in the package that skipped its parent."""
+    with pytest.raises(ValueError, match="compile_mode"):
+        SRGANTrainingConfig(compile_mode="max-autotune", compile_backend=None)
+
+
+def test_srgan_training_config_rejects_negative_adversarial_weight():
+    """A negative weight inverts the generator's adversarial objective: it would
+    train to look MORE fake. Zero is legitimate -- it is the content-only
+    ablation the golden-mse run uses."""
+    SRGANTrainingConfig(adversarial_weight=0.0)  # valid -- must not raise
+    with pytest.raises(ValueError, match="adversarial_weight"):
+        SRGANTrainingConfig(adversarial_weight=-1e-3)
+
+
+def test_srgan_training_config_keeps_its_own_validation():
+    """super() must be added without losing what was already there."""
+    with pytest.raises(ValueError, match="d_steps_per_g_step"):
+        SRGANTrainingConfig(d_steps_per_g_step=0)

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -307,3 +307,66 @@ def test_validate_against_rejects_scale_mismatch():
     model = SRResNet(scale=4, num_residual_blocks=1)
     with pytest.raises(ValueError, match="scale"):
         cfg.validate_against(model, RGBProcessor())
+
+
+# --- Field validation: a nonsense value must not reach a published number ---
+
+
+def test_eval_config_rejects_negative_crop_border():
+    """A negative border silently scores UNCROPPED: the slice guard is `n <= 0`,
+    so -4 and 0 produce byte-identical numbers and neither errors. `None` is the
+    derive-from-scale sentinel, so -1 is exactly what someone reaches for when
+    they mean "auto" — it must not be a valid way to ask for that."""
+    SREvalConfig(crop_border=0)  # valid -- must not raise
+    SREvalConfig(crop_border=4)  # valid -- must not raise
+    SREvalConfig(crop_border=None)  # the derive-from-scale sentinel
+    with pytest.raises(ValueError, match="crop_border"):
+        SREvalConfig(crop_border=-1)
+    with pytest.raises(ValueError, match="crop_border"):
+        SREvalConfig(crop_border=-4)
+
+
+def test_training_config_rejects_non_positive_scale():
+    """`scale` is unvalidated, and for an architecture with no `scale` hparam
+    (SRCNN, deliberately) `validate_against` checks nothing either. It then
+    resolves `crop_border`, so a negative scale becomes a negative border and
+    the score is silently uncropped."""
+    SRTrainingConfig(scale=4)  # valid -- must not raise
+    SRTrainingConfig(scale=None)  # unset is legitimate
+    for bad in (-3, 0):
+        with pytest.raises(ValueError, match="scale"):
+            SRTrainingConfig(scale=bad)
+
+
+def test_training_config_rejects_non_positive_layer_lrs():
+    """Length is checked when the optimizer is built; the values never are.
+    A negative LR trains every layer in the wrong direction."""
+    SRTrainingConfig(layer_lrs=[1e-4, [1e-4, 1e-5]])  # valid -- must not raise
+    with pytest.raises(ValueError, match="layer_lrs"):
+        SRTrainingConfig(layer_lrs=[-1e-4, -1e-4, -1e-4])
+    with pytest.raises(ValueError, match="layer_lrs"):
+        SRTrainingConfig(layer_lrs=[1e-4, [1e-4, -1e-5]])
+    with pytest.raises(ValueError, match="layer_lrs"):
+        SRTrainingConfig(layer_lrs=[0.0])
+
+
+def test_training_config_rejects_non_positive_init_std():
+    """Reaches torch.nn.init.normal_ as-is. init_mean stays unconstrained."""
+    SRTrainingConfig(init_std=0.001, init_mean=-1.0)  # valid -- must not raise
+    for bad in (-0.001, 0.0):
+        with pytest.raises(ValueError, match="init_std"):
+            SRTrainingConfig(init_std=bad)
+
+
+def test_training_config_rejects_unknown_init_strategy():
+    """The dispatch is `== "paper"`, so ANY other string means "default".
+    'Paper' therefore produces a run that looks configured for the paper's
+    initialisation and is not, with nothing saying so. The Literal annotation
+    is enforced by jsonargparse at the CLI and by nothing in Python, so a
+    directly-constructed config — every test, every script — has no guard."""
+    SRTrainingConfig(init_strategy="paper")  # valid -- must not raise
+    SRTrainingConfig(init_strategy="default")  # valid -- must not raise
+    with pytest.raises(ValueError, match="init_strategy"):
+        SRTrainingConfig(init_strategy="Paper")
+    with pytest.raises(ValueError, match="init_strategy"):
+        SRTrainingConfig(init_strategy="xavier")


### PR DESCRIPTION
**Stack position 1 of 12 · review group: metric-path P2**

Closes #233, #238, #243.

### Why these three are one PR

They are one chain, not three fixes. `crop_border` accepting a negative value is the
defect; `scale` accepting a negative value is *how it gets there*; and #243 is the same
shape one class over — a validation that exists and does not run.

```
training_config.scale = -3         (unvalidated)
  -> SRCNN declares no `scale` hparam, so validate_against compares nothing
  -> SRLightning resolves eval_config.crop_border = -3
  -> SRScorer.crop: `if n <= 0: return tensors`
  -> every PSNR/SSIM scored on the FULL image, no error, no warning
```

That last number looks valid and is comparable to nothing.

### What changed

| field | before | now |
|---|---|---|
| `eval_config.crop_border` | `-4` scored uncropped, identical to `0` | raises, naming the YAML key |
| `training_config.scale` | `-3` / `0` accepted | must be a positive int when set |
| `layer_lrs` | length checked at optimizer build, values never | every entry, and both halves of a pair, must be positive |
| `init_std` | `-0.001` reached `torch.nn.init.normal_` | must be positive (`init_mean` stays free) |
| `init_strategy` | `'Paper'` silently selected PyTorch's default init | must be `'default'` or `'paper'` |
| `adversarial_weight` | `-1e-3` inverted the generator's objective | must be `>= 0` (zero is the content-only ablation) |
| `SRGANTrainingConfig.__post_init__` | replaced its parent's; the `compile_mode` guard never ran | calls `super()` first |

### Two guards, deliberately

`SRLightning` **assigns** `eval_config.crop_border` when it resolves the derive-from-scale
sentinel, which bypasses `__post_init__` entirely. So config validation cannot be the only
guard — `SRScorer.crop` refuses a negative border as well, and the oversized case (which
config time cannot see, because no image is in scope there) raises where the tensor is,
naming both the border and the image size instead of a bare torch `RuntimeError`.

### Evidence

- **9 tests, each proven RED on this branch's parent** before the fix.
- `683 passed` across `tests/training`, `tests/metrics`, `tests/models`.
- **All 34 config objects** across the shipped templates and the run-config mirror still
  construct unchanged — no shipped config changes behaviour.

### On #243

Not from the review passes — found while reading `__post_init__` for this PR. Measured:
`SRGANTrainingConfig(compile_mode='max-autotune', compile_backend=None)` did not raise,
while the identical construction on the parent did. An audit of every `__post_init__` in
the package found this the **only** override skipping its parent.
