### PR TITLE
fix: modcrop SRCNN's validation HR, matching the authors' degradation order

### DIFF
--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -31,6 +31,38 @@ from .base import HRCachedTrainDataset, SRDataset
 from .hr_cache import process_hr_image as _process_hr_image
 
 
+def _modcrop_extent(length: int, scale: int) -> int:
+    """Returns the largest multiple of *scale* not exceeding *length*.
+
+    The single owner of the authors' ``modcrop`` convention, in the one form
+    both callers need: :func:`_grid_dims` wants the cropped extent as a number,
+    :func:`_modcrop` wants to slice by it. Before this existed the convention
+    was spelled out at two sites and absent from a third, which is how SRCNN
+    came to be degraded one way at training time and another at evaluation.
+    """
+    return length - (length % scale)
+
+
+def _modcrop(arr: np.ndarray, scale: int) -> np.ndarray:
+    """Crops *arr* so both spatial axes are whole multiples of *scale*.
+
+    The authors' released ``demo_SR.m`` applies this to the ground truth
+    **before** the bicubic round trip::
+
+        im_gnd = modcrop(im, up_scale);
+        im_l   = imresize(im_gnd, 1/up_scale, 'bicubic');
+        im_b   = imresize(im_l,   up_scale,   'bicubic');
+
+    Without it, an image whose height is not a multiple of *scale* is
+    downsampled to ``h // scale`` rows and stretched back over ``h``, so the LR
+    sampling grid does not align with the HR one. At x3 most standard benchmark
+    images are affected -- 481x321 and 512x512 both are -- so this is the
+    common case, not the corner.
+    """
+    h, w = arr.shape[:2]
+    return arr[: _modcrop_extent(h, scale), : _modcrop_extent(w, scale)]
+
+
 def _grid_dims(
     height: int, width: int, scale: int, sub_img_size: int, stride: int
 ) -> tuple[int, int]:
@@ -39,9 +71,12 @@ def _grid_dims(
     Single source of truth for the deterministic patch grid: :func:`_iter_patch_origins`
     and :meth:`TrainDataset.__getitem__`'s O(1) index -> origin lookup both derive
     positions from this, so they can never silently disagree and misalign an index.
+
+    The extent comes from :func:`_modcrop_extent`, the same function the
+    validation loader crops by, so the two cannot drift apart again.
     """
-    h_crop = height - (height % scale)
-    w_crop = width - (width % scale)
+    h_crop = _modcrop_extent(height, scale)
+    w_crop = _modcrop_extent(width, scale)
     n_rows = len(range(0, h_crop - sub_img_size + 1, stride))
     n_cols = len(range(0, w_crop - sub_img_size + 1, stride))
     return n_rows, n_cols
@@ -209,6 +244,12 @@ class ValidationDataset(SRDataset):
     produced by bicubic-downsampling and bicubic-upsampling back to the
     original size.
 
+    **The HR image is modcropped first** (:func:`_modcrop`), matching the
+    authors' released order and what :class:`TrainDataset`'s grid already did.
+    So the HR served here is up to ``scale - 1`` pixels smaller per axis than
+    the file on disk -- that is the reference the paper's numbers are computed
+    against.
+
     Args:
         img_dir (str | Path): Directory containing the high-resolution
             images.
@@ -235,10 +276,12 @@ class ValidationDataset(SRDataset):
 
         Returns:
             A ``(lr_tensor, hr_tensor)`` tuple of ``float32`` tensors
-            with shape ``(C, H, W)`` and values in ``[0, 1]``.
+            with shape ``(C, H, W)`` and values in ``[0, 1]``. Both are
+            modcropped to a whole multiple of ``scale``, so ``H``/``W`` may be
+            up to ``scale - 1`` smaller than the source file's.
         """
         path = self.img_paths[idx]
-        arr = self._load_rgb(path)  # HWC uint8 RGB
+        arr = _modcrop(self._load_rgb(path), self.scale)  # HWC uint8 RGB
         lr_arr = _degrade(arr, self.scale)
 
         return self._to_tensor(lr_arr), self._to_tensor(arr)

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -340,3 +340,72 @@ def test_srcnn_validation_skips_non_image_files(tiny_rgb_image_dir: Path):
     ds = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2)
     assert len(ds) == 3  # only the 3 PNGs
     assert all(p.suffix == ".png" for p in ds.img_paths)
+
+
+# ---------------------------------------------------------------------------
+# modcrop: the authors' degradation order
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def non_divisible_image_dir(tmp_path: Path) -> Path:
+    """One 481x321 image -- BSD100's exact size, where 481 % 3 == 1.
+
+    The shared fixture is 36x36, divisible by 2/3/4, so it cannot see this
+    defect at all. At x3 most standard benchmark images are NOT divisible,
+    so the affected case is the common one rather than the corner.
+    """
+    rng = np.random.default_rng(seed=7)
+    arr = rng.integers(0, 256, size=(321, 481, 3), dtype=np.uint8)
+    Image.fromarray(arr).save(tmp_path / "bsd_like.png")
+    return tmp_path
+
+
+def test_validation_hr_is_cropped_to_a_multiple_of_scale(non_divisible_image_dir: Path):
+    """The released demo_SR.m applies `modcrop` to the ground truth BEFORE the
+    bicubic round trip:
+
+        im_gnd = modcrop(im, up_scale);
+        im_l   = imresize(im_gnd, 1/up_scale, 'bicubic');
+        im_b   = imresize(im_l,   up_scale,   'bicubic');
+
+    Without it a 481-wide image is downsampled to 160 columns and stretched
+    back over 481, so the LR grid does not align with the HR one."""
+    ds = ValidationDataset(img_dir=non_divisible_image_dir, scale=3)
+    lr, hr = ds[0]
+    assert hr.shape[-2:] == (321, 480), "HR must be modcropped to a multiple of scale"
+    assert lr.shape == hr.shape, "SRCNN is pre-upsampled: LR and HR share a size"
+
+
+def test_validation_lr_matches_the_authors_degradation_order(non_divisible_image_dir: Path):
+    """Byte-exact against modcrop-then-degrade, computed independently here."""
+    from sisr.datasets.srcnn import _degrade
+
+    arr = np.array(Image.open(next(non_divisible_image_dir.iterdir())).convert("RGB"))
+    h, w = arr.shape[:2]
+    expected_hr = arr[: h - h % 3, : w - w % 3]
+    expected_lr = _degrade(expected_hr, 3)
+
+    lr, hr = ValidationDataset(img_dir=non_divisible_image_dir, scale=3)[0]
+    got_hr = (hr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+    got_lr = (lr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+    assert np.array_equal(got_hr, expected_hr)
+    assert np.array_equal(got_lr, expected_lr)
+
+
+def test_train_and_validation_share_one_modcrop_implementation():
+    """The convention had three sites and two answers. It must now have one
+    owner that the training grid and the validation loader both call."""
+    from sisr.datasets.srcnn import _modcrop, _modcrop_extent
+
+    assert _modcrop_extent(481, 3) == 480
+    assert _modcrop_extent(321, 3) == 321  # already a multiple -- unchanged
+    assert _modcrop(np.zeros((321, 481, 3), np.uint8), 3).shape == (321, 480, 3)
+
+
+def test_validation_untouched_when_already_divisible(tiny_rgb_image_dir: Path):
+    """36x36 divides by 2, 3 and 4, so no shipped-size behaviour changes."""
+    for scale in (2, 3, 4):
+        lr, hr = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=scale)[0]
+        assert hr.shape[-2:] == (36, 36)
+        assert lr.shape == hr.shape


### PR DESCRIPTION
**Stack position 2 of 12 · review group: metric-path P2 · base: `fix/config-field-validation` (#244)**

Closes #242.

### Primary source: checked, not assumed

The issue's acceptance required confirming against the authors' released demo rather than
trusting the convention. Done — and it says exactly what was hoped:

```matlab
im_gnd = modcrop(im, up_scale);
im_l   = imresize(im_gnd, 1/up_scale, 'bicubic');
im_b   = imresize(im_l,   up_scale,   'bicubic');
```

`modcrop` is applied to the **ground truth**, **before** the round trip. So the reference the
metric is computed against is the cropped image, and the HR this dataset serves had to change
too — not just the LR.

*(Correction to the issue: it said the demo was "already in hand from the earlier
evaluation-geometry work". It was not on disk; it was fetched from the public release for this.)*

### Measured

481x321 at x3 — BSD100's exact size, where `481 % 3 == 1`:

```
ours     -> downsampled to 160 cols, stretched back over 481
modcrop  -> 480 cols
max |diff| = 59 / 255      mean = 2.87
```

### One deliberate deviation from the issue's proposal

The issue proposed putting the modcrop **inside `_degrade`**, reasoning that the training
grid's own crop would then become redundant. **I did not do that, and the measurement is why.**

`_degrade` is also called **per sub-image** in the training path. Modcropping there would crop
the *patch*, shrinking a 33x33 sub-image to 32x32 at scales 2 and 4 — silently changing the
training patch size. The authors modcrop the **image**, never the patch.

So the convention gets a single owner, `_modcrop_extent`, which both `_grid_dims` (training)
and `ValidationDataset` (evaluation) derive from. Same guarantee the issue wanted — the two
cannot drift again — without changing the training grid.

### A second, deeper divergence, filed not fixed: #245

While confirming the above I measured something the issue did not cover. We degrade an
*extracted patch*; the authors degrade the *image* and then extract. Bicubic support reaches
past a patch boundary, so these differ:

| scale | max\|diff\| | 4 px border mean | interior mean |
|---:|---:|---:|---:|
| 2 | 3 | 0.663 | 0.424 |
| **3** | **5** | **0.831** | **0.000** |
| 4 | 8 | 1.574 | 0.450 |

At x3 the interior is bit-identical and the whole difference is the border — the signature of
the kernel reaching outside the patch. Filed as **#245** rather than fixed here: it changes
SRCNN's *training* data and the data path is 98.94% decode-dominated, so it needs a throughput
measurement, not just a correctness one.

**This means "train and eval degrade identically" now holds for the modcrop convention and
still does not hold on that second axis.** #245 is the remainder.

### Evidence

- 3 tests proven RED before the fix; 1 more green on both sides, guarding that the
  already-divisible case does not move.
- `474 passed` across `tests/datasets` and `tests/training`.
- Nothing published moves: there is no SRCNN run in this project yet.
