### PR TITLE
refactor: route every metric tag through the grammar's declared owner

### DIFF
--- a/sisr/metrics/scoring.py
+++ b/sisr/metrics/scoring.py
@@ -63,6 +63,64 @@ def metric_tag(family: str, scope: str, key: str) -> str:
     return f"{family}/{scope}/{key}"
 
 
+#: A metric value as it travels to ``pl_module.log``. The validation path
+#: produces 0-dim tensors straight from the metric functions; the benchmark
+#: path means its per-image buffer first and so produces plain floats. Both are
+#: legal ``log`` arguments, and ``Scores`` is only a carrier -- it never does
+#: arithmetic on them -- so it accepts either rather than forcing one side to
+#: convert for the type checker's benefit.
+ScoreValue = torch.Tensor | float
+
+
+def perceptual_tag(name: str, scope: str) -> str:
+    """Build a perceptual metric's tag: ``{name}/{scope}``.
+
+    The second rule of the grammar, and deliberately a different shape:
+    LPIPS/DISTS carry no colorspace key, so they get their own family root
+    rather than a key slot under the PSNR/SSIM scheme. That shape is already
+    published, so it is preserved here rather than normalised -- which is
+    exactly why it needs an owner too. A caller re-deriving "the tag grammar"
+    from :func:`metric_tag` alone silently gets this family wrong.
+
+    Args:
+        name: Perceptual metric name, e.g. ``'lpips'``.
+        scope: ``'val'`` for the validation loop, else a benchmark dataset name.
+
+    Returns:
+        The TensorBoard tag.
+    """
+    return f"{name}/{scope}"
+
+
+def expected_tags(eval_config: SREvalConfig, scope: str) -> list[str]:
+    """Every tag a run under *eval_config* will log at *scope*.
+
+    The values-free half of the grammar: :meth:`Scores.tagged` answers "which
+    tags exist" **with** numbers, this answers it without any. Both derive from
+    :func:`metric_tag` and :func:`perceptual_tag`, so a caller that needs to
+    know the tag namespace before a single batch has been scored -- seeding
+    TensorBoard's HParams columns, or validating a checkpoint monitor -- asks
+    the owner instead of re-deriving the grammar from f-strings.
+
+    That re-derivation is not hypothetical: the checkpoint monitor validator,
+    whose whole job is knowing which tags will exist, had its own copy. When
+    the two disagree the failure is silent -- a correct monitor is rejected, or
+    an incorrect one accepted and the run keeps its worst checkpoint.
+
+    Args:
+        eval_config: The evaluation settings the run will score under.
+        scope: ``'val'`` for the validation loop, else a benchmark dataset name.
+
+    Returns:
+        Every tag, PSNR then SSIM then perceptual, in the order
+        :meth:`Scores.tagged` produces them.
+    """
+    tags = [metric_tag("psnr", scope, k) for k in eval_config.psnr_keys]
+    tags += [metric_tag("ssim", scope, k) for k in eval_config.ssim_keys]
+    tags += [perceptual_tag(name, scope) for name in eval_config.perceptual_keys]
+    return tags
+
+
 class Scores:
     """Metric values for one scored pair, before any tag prefixing.
 
@@ -76,15 +134,15 @@ class Scores:
 
     def __init__(
         self,
-        psnr: dict[str, torch.Tensor],
-        ssim: dict[str, torch.Tensor],
-        perceptual: dict[str, torch.Tensor],
+        psnr: dict[str, ScoreValue],
+        ssim: dict[str, ScoreValue],
+        perceptual: dict[str, ScoreValue],
     ) -> None:
         self.psnr = psnr
         self.ssim = ssim
         self.perceptual = perceptual
 
-    def tagged(self, scope: str) -> dict[str, torch.Tensor]:
+    def tagged(self, scope: str) -> dict[str, ScoreValue]:
         """Flatten to ``tag -> value`` under ``scope``.
 
         Perceptual metrics carry no colorspace key, so they tag as
@@ -99,7 +157,7 @@ class Scores:
         """
         tags = {metric_tag("psnr", scope, k): v for k, v in self.psnr.items()}
         tags |= {metric_tag("ssim", scope, k): v for k, v in self.ssim.items()}
-        tags |= {f"{name}/{scope}": v for name, v in self.perceptual.items()}
+        tags |= {perceptual_tag(name, scope): v for name, v in self.perceptual.items()}
         return tags
 
 

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -26,6 +26,7 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 from .. import artifacts
 from ..metrics.perceptual import PERCEPTUAL_METRICS
+from ..metrics.scoring import Scores, expected_tags, perceptual_tag
 from .metadata import build_component_metadata, build_metadata
 
 if TYPE_CHECKING:  # `SRLightning` is referenced in annotations only, and a
@@ -386,9 +387,12 @@ class BenchmarkImageLogger(Callback):
             # pooling) and agreeing with validation_step only because this loop
             # slices one image at a time.
             scores = _sr(pl_module).scorer.score(sr[i : i + 1], hr_cropped[i : i + 1])
-            psnr_dict = {key: value.item() for key, value in scores.psnr.items()}
-            ssim_dict = {key: value.item() for key, value in scores.ssim.items()}
-            perceptual_dict = {name: value.item() for name, value in scores.perceptual.items()}
+            # float(), not .item(): Scores carries either tensors (this path,
+            # straight from the scorer) or plain floats (the means _flush_buffer
+            # builds). Exact for a 0-dim tensor, and total over both.
+            psnr_dict = {key: float(value) for key, value in scores.psnr.items()}
+            ssim_dict = {key: float(value) for key, value in scores.ssim.items()}
+            perceptual_dict = {name: float(value) for name, value in scores.perceptual.items()}
             self._buffer[dataset_name].append(
                 BenchmarkSample(filename, psnr_dict, ssim_dict, perceptual_dict)
             )
@@ -444,30 +448,20 @@ class BenchmarkImageLogger(Callback):
             if not samples:
                 continue
 
-            psnr_keys = samples[0].psnr.keys()
-            ssim_keys = samples[0].ssim.keys()
-
-            for key in psnr_keys:
-                mean_psnr = sum(s.psnr[key] for s in samples) / len(samples)
-                pl_module.log(
-                    f"psnr/{dataset_name}/{key}",
-                    mean_psnr,
-                    add_dataloader_idx=False,
-                    sync_dist=True,
-                )
-            for key in ssim_keys:
-                mean_ssim = sum(s.ssim[key] for s in samples) / len(samples)
-                pl_module.log(
-                    f"ssim/{dataset_name}/{key}",
-                    mean_ssim,
-                    add_dataloader_idx=False,
-                    sync_dist=True,
-                )
-            for name in samples[0].perceptual:
-                mean = sum(s.perceptual[name] for s in samples) / len(samples)
-                pl_module.log(
-                    f"{name}/{dataset_name}", mean, add_dataloader_idx=False, sync_dist=True
-                )
+            # Mean each family, then let Scores.tagged apply the grammar --
+            # the same call validation_step's own emission goes through. The
+            # perceptual family's different tag shape comes along for free,
+            # which is the part a hand-rolled f-string kept getting to own.
+            n = len(samples)
+            means = Scores(
+                psnr={k: sum(s.psnr[k] for s in samples) / n for k in samples[0].psnr},
+                ssim={k: sum(s.ssim[k] for s in samples) / n for k in samples[0].ssim},
+                perceptual={
+                    k: sum(s.perceptual[k] for s in samples) / n for k in samples[0].perceptual
+                },
+            )
+            for tag, mean in means.tagged(dataset_name).items():
+                pl_module.log(tag, mean, add_dataloader_idx=False, sync_dist=True)
 
         self._buffer.clear()
 
@@ -914,17 +908,16 @@ class _SRCheckpointBase(_RollingSaveMixin, ModelCheckpoint):
             return
 
         eval_config = _sr(pl_module).eval_config
-        higher_better = {f"psnr/val/{key}" for key in eval_config.psnr_keys}
-        higher_better |= {f"ssim/val/{key}" for key in eval_config.ssim_keys}
-        higher_better |= {
-            f"{name}/val" for name in eval_config.perceptual_keys if not PERCEPTUAL_METRICS[name]
-        }
+        # "Which tags will this run log?" is exactly expected_tags' question, and
+        # it is the grammar's owner. Re-deriving it here is what let the emitted
+        # set and the accepted set drift apart, silently.
+        valid_metrics = set(expected_tags(eval_config, "val"))
         lower_better = {
-            f"{name}/val" for name in eval_config.perceptual_keys if PERCEPTUAL_METRICS[name]
+            perceptual_tag(name, "val")
+            for name in eval_config.perceptual_keys
+            if PERCEPTUAL_METRICS[name]
         }
-
         label = type(self).__name__
-        valid_metrics = higher_better | lower_better
         if self.monitor not in valid_metrics:
             raise MisconfigurationException(
                 f"`{label}(monitor_metric={self.monitor!r})` does not match any "

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -18,7 +18,7 @@ from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 
 from ..losses import SRLoss
-from ..metrics.scoring import SRScorer, metric_tag
+from ..metrics.scoring import SRScorer, expected_tags, metric_tag
 from ..models.base import SRModel
 from ..processors import SRProcessor
 from .config import SREvalConfig, SRTrainingConfig
@@ -792,11 +792,10 @@ class SRLightning(lightning.LightningModule):
         ]
         if not tb_loggers:
             return
-        metrics = {
-            **{f"psnr/val/{k}": 0.0 for k in self.eval_config.psnr_keys},
-            **{f"ssim/val/{k}": 0.0 for k in self.eval_config.ssim_keys},
-            **{f"{name}/val": 0.0 for name in self.eval_config.perceptual_keys},
-        }
+        # The tag set comes from the grammar's owner, not from f-strings here:
+        # these columns are only populated if they match the scalars
+        # validation_step actually logs, and it logs Scores.tagged("val").
+        metrics = dict.fromkeys(expected_tags(self.eval_config, "val"), 0.0)
         for tb in tb_loggers:
             tb.log_hyperparams(self._tb_hparams, metrics)
 

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -2649,3 +2649,96 @@ def test_an_explicit_prefix_still_wins_over_the_derived_identity(tmp_path: Path)
 
     names = sorted(p.name for p in tmp_path.glob(f"*{SRWeightsCheckpoint.FILE_EXTENSION}"))
     assert names and all(n.startswith("myrun_s") for n in names), names
+
+
+# ---------------------------------------------------------------------------
+# The metric-tag grammar has one owner
+# ---------------------------------------------------------------------------
+
+
+def _grammar_eval_config():
+    from sisr.training import SREvalConfig
+
+    return SREvalConfig(psnr_channels=["RGB", "Y"], ssim_channels=["RGB", "Y"])
+
+
+def _scores_for(cfg):
+    import torch
+
+    from sisr.metrics.scoring import Scores
+
+    return Scores(
+        psnr={k: torch.tensor(0.0) for k in cfg.psnr_keys},
+        ssim={k: torch.tensor(0.0) for k in cfg.ssim_keys},
+        perceptual={k: torch.tensor(0.0) for k in cfg.perceptual_keys},
+    )
+
+
+def test_expected_tags_agrees_with_what_scores_emit():
+    """`expected_tags` answers "which tags will exist?" without values;
+    `Scores.tagged` answers it with them. Two derivations of one grammar is the
+    drift `metric_tag`'s docstring says routing through it prevents."""
+    from sisr.metrics.scoring import expected_tags
+
+    cfg = _grammar_eval_config()
+    cfg_p = _grammar_eval_config()
+    cfg_p.perceptual_metrics = ["lpips", "dists"]
+    for c in (cfg, cfg_p):
+        for scope in ("val", "Set5"):
+            assert set(expected_tags(c, scope)) == set(_scores_for(c).tagged(scope))
+
+
+def test_monitor_validator_follows_the_grammar_when_it_moves(monkeypatch):
+    """`_validate_monitor` exists to refuse a monitor naming a metric nothing
+    will log -- the failure it prevents is a run that silently keeps its WORST
+    checkpoint. It answered "which tags will exist?" by re-deriving the grammar
+    in raw f-strings instead of asking the function that owns it.
+
+    Move the grammar in its one documented owner. The emitter follows it; the
+    validator must too, or it rejects a monitor the run really does emit."""
+    from types import SimpleNamespace
+
+    import sisr.metrics.scoring as scoring
+    from sisr.training.callbacks import SRCheckpoint
+
+    monkeypatch.setattr(scoring, "metric_tag", lambda f, s, k: f"{f}.{s}.{k}")
+
+    cfg = _grammar_eval_config()
+    emitted = set(_scores_for(cfg).tagged("val"))
+    assert "psnr.val.Y" in emitted, "the moved grammar must actually be in effect"
+
+    module = SimpleNamespace(eval_config=cfg)
+    for tag in sorted(emitted):
+        ckpt = SRCheckpoint(monitor_metric=tag, mode="max", dirpath="/tmp/x")
+        ckpt._validate_monitor(module)  # must not raise: the run WILL log this tag
+
+
+def test_benchmark_means_are_tagged_by_the_grammar_owner(monkeypatch):
+    """`_flush_buffer` hand-rolled `psnr/{set}/{key}` with raw f-strings, which
+    is exactly what `Scores.tagged(dataset_name)` already returns -- the
+    perceptual family's different shape included. Move the grammar and the
+    benchmark hierarchy must move with the validation one."""
+    import sisr.metrics.scoring as scoring
+
+    monkeypatch.setattr(scoring, "metric_tag", lambda f, s, k: f"{f}.{s}.{k}")
+    logged: dict[str, float] = {}
+
+    from types import SimpleNamespace
+
+    from sisr.training.callbacks import BenchmarkImageLogger, BenchmarkSample
+
+    cfg = _grammar_eval_config()
+    module = SimpleNamespace(eval_config=cfg, log=lambda t, v, **kw: logged.__setitem__(t, v))
+    cb = BenchmarkImageLogger.__new__(BenchmarkImageLogger)
+    cb._buffer = {
+        "Set5": [
+            BenchmarkSample(
+                filename="a",
+                psnr={k: 1.0 for k in cfg.psnr_keys},
+                ssim={k: 1.0 for k in cfg.ssim_keys},
+                perceptual={},
+            )
+        ]
+    }
+    cb._flush_buffer(module)
+    assert "psnr.Set5.Y" in logged, f"benchmark tags did not follow the grammar: {sorted(logged)}"


### PR DESCRIPTION
**Stack position 3 of 12 · review group: metric-path P2 · base: `fix/srcnn-validation-modcrop` (#246)**

Closes #230.

### The grammar has two rules, not one

The issue said "route the three sites through `metric_tag`". That is not sufficient on its
own, and the reason is the bug's own shape: perceptual metrics tag as `{name}/{scope}`, with
no colorspace key, because LPIPS/DISTS have no colorspace decomposition. **A caller
re-deriving "the tag grammar" from `metric_tag` alone silently gets that family wrong — which
is exactly what `_flush_buffer` did.**

So this adds a second owner, `perceptual_tag`, and `expected_tags` built from both:

| function | answers |
|---|---|
| `metric_tag` | `{family}/{scope}/{key}` — one tag |
| `perceptual_tag` | `{name}/{scope}` — one tag, different shape, already published |
| `Scores.tagged` | which tags exist, **with** values |
| `expected_tags` | which tags exist, **without** values |

That last one is what the three bypass sites needed and did not have.

### The three sites

| site | was | now |
|---|---|---|
| `on_train_start` HParams seeding | three f-string dict comprehensions | `expected_tags(eval_config, "val")` |
| `_flush_buffer` benchmark means | hand-rolled per family, perceptual special-cased | mean each family, then `Scores.tagged(dataset_name)` |
| `_validate_monitor` | rebuilt the whole namespace | `expected_tags` + `perceptual_tag` for the direction split |

### The test that keeps it fixed

The issue asked for "a test that fails if the emitted tag set and the validator's accepted set
disagree — prove it RED by changing the grammar in one place." That is what the three tests do:
they **move the grammar in its owner** and assert the other sites follow.

Proven RED. Before the fix, with the grammar moved:

```
benchmark tags did not follow the grammar:
  ['psnr/Set5/RGB', 'psnr/Set5/Y', 'ssim/Set5/RGB', 'ssim/Set5/Y']
  expected 'psnr.Set5.Y'
```

### One type widening, deliberately

`Scores` values become `Tensor | float`. The validation path carries 0-dim tensors straight
from the metric functions; the benchmark path carries means it computed itself. `Scores` is a
carrier and never does arithmetic on them, so it accepts both rather than forcing one side to
convert for the type checker. The single site that assumed tensors now uses `float()` — exact
for a 0-dim tensor, total over both.

### Evidence

- 3 tests proven RED before the change.
- `599 passed` across `tests/training` and `tests/metrics`.
- `mypy`: clean over 48 source files. `ruff check` + `ruff format --check`: clean.
- **No behaviour change while the grammar is unchanged** — which is the point. It is invisible
  today and load-bearing the moment the grammar moves.
