### PR TITLE
refactor: one scale resolution, and it always returns an int

### DIFF
--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -145,9 +145,12 @@ class SRTrainingConfig:
                 ``init_std`` is not positive; or if ``init_strategy`` is
                 neither ``'default'`` nor ``'paper'``.
         """
-        if self.scale is not None and self.scale < 1:
+        if self.scale is not None and (
+            not isinstance(self.scale, int) or isinstance(self.scale, bool) or self.scale < 1
+        ):
             raise ValueError(
-                f"training_config.scale must be a positive int; got {self.scale}. "
+                f"training_config.scale must be a positive int; got {self.scale!r} "
+                f"({type(self.scale).__name__}). "
                 "It is not only provenance: for an architecture that declares no `scale` "
                 "hparam of its own (SRCNN, deliberately -- it is resolution-preserving) "
                 "nothing else checks it, and eval_config.crop_border derives from it, so a "

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -100,7 +100,7 @@ class SRLightning(lightning.LightningModule):
         # Resolved here, once, BEFORE the scorer is built -- the scorer and
         # every artifact's sisr_meta must record the number actually used.
         if self.eval_config.crop_border is None:
-            self.eval_config.crop_border = self._resolved_scale(
+            self.eval_config.crop_border = self.resolved_scale(
                 "eval_config.crop_border is None (derive the border from the scale)"
             )
         # The scoring path's one owner: crop, colorspace split, both
@@ -887,11 +887,27 @@ class SRLightning(lightning.LightningModule):
         _, sr_rgb = self._forward_lr(batch)
         return sr_rgb
 
-    def _resolved_scale(self, why: str) -> int:
+    def resolved_scale(self, why: str) -> int:
         """The run's upscaling factor, from the training config or the model.
+
+        The single implementation of the three-step resolution --
+        ``training_config.scale``, else the model's ``scale`` hparam, else
+        raise. :func:`~sisr.training.metadata.build_metadata` carried its own
+        copy and the two had already diverged: this one coerces to ``int``, that
+        one did not, so one config could write a ``str`` into artifact
+        provenance and an ``int`` into the evaluation crop border.
+
+        Public rather than underscored precisely because it has a second module
+        as a caller. A private helper with an outside caller is how a helper
+        quietly becomes unchangeable: the underscore says "free to change" and
+        the second caller says otherwise.
 
         Args:
             why: What needed the scale, for the error message.
+
+        Returns:
+            The factor, always an ``int`` -- a model hparam is free-form and is
+            not otherwise type-checked.
 
         Raises:
             ValueError: If neither ``training_config.scale`` nor the model's own

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -143,17 +143,14 @@ def build_metadata(
     model = module.model
     processor = module.processor
 
-    scale = module.training_config.scale
-    if scale is None:
-        scale = model.hparams.get("scale")
-    if scale is None:
-        raise ValueError(
-            f"Cannot describe a {type(model).__name__} artifact without a scale: "
-            f"training_config.scale is None and the model declares no 'scale' "
-            f"hyperparameter. A reader cannot use the file without it -- for a "
-            f"pre-upsampled architecture the scale is what they must resize the input "
-            f"by before feeding it. Set training_config.scale in your config."
-        )
+    # One resolver, shared with SRLightning's own crop-border derivation. A
+    # second copy here is what let artifact provenance record a str while the
+    # evaluation border recorded an int, from one config.
+    scale = module.resolved_scale(
+        f"Cannot describe a {type(model).__name__} artifact without a scale. A reader "
+        f"cannot use the file without it -- for a pre-upsampled architecture the scale "
+        f"is what they must resize the input by before feeding it"
+    )
 
     meta = _envelope("sr_model", global_step, epoch, monitor, monitor_value, batch_step)
     meta["model"] = {

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -370,3 +370,13 @@ def test_training_config_rejects_unknown_init_strategy():
         SRTrainingConfig(init_strategy="Paper")
     with pytest.raises(ValueError, match="init_strategy"):
         SRTrainingConfig(init_strategy="xavier")
+
+
+def test_training_config_rejects_a_non_integer_scale_with_an_actionable_message():
+    """A str scale hit `self.scale < 1` and raised a bare TypeError naming no
+    config key -- the exact unhelpful failure this validation exists to remove.
+    bool is excluded on purpose: `isinstance(True, int)` is True, and
+    `scale: true` in YAML is not an upscaling factor."""
+    for bad in ("4", 4.0, True, [4]):
+        with pytest.raises(ValueError, match="scale"):
+            SRTrainingConfig(scale=bad)

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -374,3 +374,53 @@ def test_build_metadata_refuses_an_artifact_that_cannot_state_its_scale():
 
     with pytest.raises(ValueError, match="without a scale"):
         build_metadata(module)
+
+
+# ---------------------------------------------------------------------------
+# One scale resolution, one type
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_scale_is_an_int_whatever_the_hparam_holds():
+    """`_resolved_scale` coerced with int(); build_metadata's copy did not. The
+    same fact, recorded two ways from one run: a str in artifact provenance and
+    an int in the evaluation crop border.
+
+    Artifact provenance is what a downstream consumer reads to know what the
+    file means -- for a pre-upsampled architecture the scale is what they must
+    resize the input by -- so a type that varies with how the config was
+    written is not a good property for it to have."""
+    model = SRResNet(scale=2, hidden_channel=8, num_residual_blocks=1)
+    model.hparams["scale"] = "2"  # the route config validation cannot reach
+    lit = SRLightning(
+        model=model,
+        processor=RGBSignedOutputProcessor(),
+        training_config=SRTrainingConfig(),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    meta = build_metadata(lit)
+    assert meta["io"]["scale"] == 2
+    assert isinstance(meta["io"]["scale"], int), (
+        f"artifact provenance recorded {meta['io']['scale']!r}, a "
+        f"{type(meta['io']['scale']).__name__}"
+    )
+
+
+def test_both_scale_paths_are_the_same_function():
+    """Two implementations of one three-step resolution is how they came to
+    disagree on type in the first place. `metadata` must not carry a copy."""
+    import inspect
+
+    import sisr.training.metadata as metadata
+
+    src = inspect.getsource(metadata.build_metadata)
+    assert "resolved_scale" in src, "build_metadata must call the shared resolver"
+    assert 'hparams.get("scale")' not in src, "build_metadata still re-derives the scale"
+
+
+def test_resolved_scale_is_public_api():
+    """It gains a second module as a caller, so the underscore has to go --
+    a private helper with an outside caller is how a helper quietly becomes
+    unchangeable."""
+    assert hasattr(SRLightning, "resolved_scale")
+    assert not hasattr(SRLightning, "_resolved_scale")


### PR DESCRIPTION
**Stack position 4 of 12 · review group: metric-path P2 · base: `refactor/metric-tag-single-owner` (#248)**

Closes #236. Last of the metric-path group.

### The duplication and the divergence

| | `SRLightning._resolved_scale` | `metadata.build_metadata` |
|---|---|---|
| resolution | config → model hparam → raise | *identical* |
| coercion | `int(scale)` | **none** |

One config, one fact, two recorded types: a `str` in artifact provenance and an `int` in the
evaluation crop border.

`build_metadata` now calls the resolver, which **loses its underscore** in the same change —
the issue's own note, and the same reasoning #232 applies one module over.

### Where the string actually comes from

The issue framed this as `scale: "4"` in YAML. Two commits down this stack, `scale` became
type-checked, so that route is now closed at construction. **The remaining route is the model's
own `scale` hparam**, which is free-form and type-checked by nothing — so the test sources the
string from there. Same defect, the route that is still open.

### A defect introduced earlier in this stack, fixed here

The `scale` validation added in #244 compared with `<`:

```
SRTrainingConfig(scale='4')
-> TypeError: '<' not supported between instances of 'str' and 'int'
```

A bare `TypeError` naming no config key — precisely the failure that validation exists to
remove. It now type-checks first, **excluding `bool` explicitly**: `isinstance(True, int)` is
`True`, and `scale: true` in YAML is not an upscaling factor.

Fixed here rather than by rewriting the earlier commit, because scale's *type* is this change's
subject and rewriting would have rebuilt three PRs' worth of stack for it.

### Evidence

- 4 tests proven RED first (3 for #236, 1 for the `TypeError`).
- One of them is structural: it asserts `build_metadata` no longer contains
  `hparams.get("scale")`, so a re-introduced copy fails rather than silently diverging again.
- `871 passed, 2 skipped` (the 2 are Windows-only liveness paths).
- `mypy` clean over 48 files; `ruff check` + `format --check` clean.
