### PR TITLE
fix: an unbound VGG loss refuses to compute instead of assuming [0, 1]

### DIFF
--- a/sisr/losses/vgg.py
+++ b/sisr/losses/vgg.py
@@ -171,8 +171,15 @@ class _VGGFeatureLoss(SRLoss):
         self.distance = distance
         self.grayscale_to_rgb = grayscale_to_rgb
         self.allow_non_rgb = allow_non_rgb
-        # Identity until bind(); a [0, 1] processor needs no mapping anyway.
-        self._gain, self._offset = 1.0, 0.0
+        # Sentinel, NOT the identity. An identity default would make "never
+        # bound" and "bound to a [0, 1] processor" indistinguishable at
+        # runtime, and the wrong one of those trains on features that mean
+        # something other than the recipe says. SRProcessor.output_range --
+        # the value bind() reads -- is abstract rather than defaulted for
+        # exactly this reason, and its consumer must not undo that by handing
+        # itself a fallback.
+        self._gain: float | None = None
+        self._offset: float | None = None
         # persistent=False: constants, and a distributable checkpoint should not
         # carry them.
         self.register_buffer(
@@ -188,7 +195,15 @@ class _VGGFeatureLoss(SRLoss):
         return applied
 
     def bind(self, processor: SRProcessor) -> None:
-        """Derive the affine map from the model's output range into ``[0, 1]``."""
+        """Derive the affine map from the model's output range into ``[0, 1]``.
+
+        Until this runs the loss refuses to compute -- see :meth:`_features`.
+
+        Raises:
+            ValueError: If the processor emits a channel count or colorspace
+                this loss has no published recipe for, or a non-increasing
+                ``output_range``.
+        """
         channels = processor.model_channels
         if channels != 3 and not self.grayscale_to_rgb:
             raise ValueError(
@@ -215,7 +230,25 @@ class _VGGFeatureLoss(SRLoss):
         self._offset = -low / (high - low)
 
     def _features(self, x: torch.Tensor) -> torch.Tensor:
-        """Map into ``[0, 1]``, normalise, and take the truncated VGG's output."""
+        """Map into ``[0, 1]``, normalise, and take the truncated VGG's output.
+
+        Raises:
+            RuntimeError: If :meth:`bind` has not run, so the model's output
+                range is unknown. Both shipped paths bind, so this is reachable
+                only through a container that is not itself an
+                :class:`~sisr.losses.base.SRLoss`.
+        """
+        if self._gain is None or self._offset is None:
+            raise RuntimeError(
+                f"{type(self).__name__} was never bound to a processor, so it does not know "
+                "what range the model emits. Reconstructing [-1, 1] output with [0, 1] logic "
+                "feeds ImageNet normalisation data it was not designed for: training proceeds, "
+                "the number looks plausible, and the features mean something other than the "
+                "recipe says. Either put this term inside a WeightedSumLoss (which forwards "
+                "bind() to its SRLoss terms) or hand it to SRLightning as the criterion "
+                "(which binds it directly). A plain nn.ModuleList or a custom composite does "
+                "neither -- call bind(processor) yourself if you need one."
+            )
         x = x * self._gain + self._offset
         if x.shape[1] == 1:
             x = x.expand(-1, 3, -1, -1)

--- a/tests/losses/test_vgg.py
+++ b/tests/losses/test_vgg.py
@@ -196,6 +196,10 @@ def test_feature_scale_squares_into_an_mse_and_is_linear_in_an_l1():
                 layer="vgg22", feature_scale=0.5, distance=distance, weights=None
             )
         scaled._vgg.load_state_dict(unscaled._vgg.state_dict())
+        # An unbound loss now refuses to compute; both sides get the same
+        # binding so the ratio still isolates feature_scale.
+        unscaled.bind(RGBProcessor())
+        scaled.bind(RGBProcessor())
 
         ratio = scaled(x, target).item() / unscaled(x, target).item()
 
@@ -208,6 +212,9 @@ def test_before_activation_changes_the_features(vgg22):
         pre = VGG19FeatureLoss(layer="vgg22", before_activation=True, weights=None)
     pre._vgg.load_state_dict(vgg22._vgg.state_dict(), strict=True)
     x, target = torch.rand(1, 3, 32, 32), torch.rand(1, 3, 32, 32)
+    # Same binding on both, so the difference isolates before_activation.
+    pre.bind(RGBProcessor())
+    vgg22.bind(RGBProcessor())
 
     assert pre(x, target).item() != pytest.approx(vgg22(x, target).item())
 
@@ -329,3 +336,62 @@ def test_to_empty_with_recurse_false_leaves_the_vgg_weights_untouched(vgg22):
     assert len(after) == len(before)
     for b, a in zip(before, after, strict=True):
         assert torch.equal(b, a)
+
+
+# ---------------------------------------------------------------------------
+# "never bound" must be loud, not silently [0, 1]
+# ---------------------------------------------------------------------------
+
+
+def test_unbound_vgg_loss_refuses_to_compute(vgg22: VGG19FeatureLoss):
+    """__init__ set _gain=1.0, _offset=0.0 -- the identity -- so an unbound loss
+    silently behaved as though the model emits [0, 1], and "never bound" was
+    indistinguishable at runtime from "bound to a [0, 1] processor".
+
+    The identical question is already answered the other way one seam over:
+    SRProcessor.output_range is abstract rather than defaulted, and says why --
+    "a wrong inherited default is the failure this exists to prevent". The
+    consumer of that carefully-abstract value must not hand itself a default."""
+    with pytest.raises(RuntimeError, match="bind"):
+        vgg22(torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+
+
+def test_unbound_error_names_both_live_paths(vgg22: VGG19FeatureLoss):
+    """Whoever hits this has written a custom composite and needs to know the
+    contract exists, so the message has to say what to do about it."""
+    with pytest.raises(RuntimeError) as excinfo:
+        vgg22(torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+    message = str(excinfo.value)
+    assert "WeightedSumLoss" in message
+    assert "bind" in message
+
+
+def test_bound_directly_is_unaffected(vgg22: VGG19FeatureLoss):
+    """Shipped path 1: an SRLoss handed to SRLightning as the criterion."""
+    vgg22.bind(RGBProcessor())
+    assert torch.isfinite(vgg22(torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16)))
+
+
+def test_bound_through_weighted_sum_is_unaffected(vgg22: VGG19FeatureLoss):
+    """Shipped path 2: nested in WeightedSumLoss, which forwards bind() to its
+    SRLoss terms. This is how the flagship reproduction's content loss is wired."""
+    from sisr.losses import WeightedSumLoss
+
+    composite = WeightedSumLoss(terms={"vgg": vgg22}, weights={"vgg": 1.0})
+    composite.bind(RGBSignedOutputProcessor())
+    assert torch.isfinite(composite(torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16)))
+
+
+def test_signed_range_processor_actually_changes_the_mapping(vgg22: VGG19FeatureLoss):
+    """The bug's consequence, pinned: [-1, 1] and [0, 1] must not agree. If they
+    did, the silent default would have been harmless and this is all theatre."""
+    x = torch.rand(1, 3, 16, 16) * 2 - 1
+    y = torch.rand(1, 3, 16, 16) * 2 - 1
+    vgg22.bind(RGBProcessor())
+    as_unit = vgg22(x, y)
+    vgg22.bind(RGBSignedOutputProcessor())
+    as_signed = vgg22(x, y)
+    assert not torch.isclose(as_unit, as_signed), (
+        "a [-1, 1] model scored through [0, 1] logic must differ -- otherwise "
+        "the silently-wrong default cost nothing"
+    )


### PR DESCRIPTION
**Stack position 5 of 12 · review group: correctness · base: `refactor/one-scale-resolution` (#249)**

Closes #239. First of the correctness group.

### The asymmetry, in one line each

```python
# sisr/processors/base.py -- abstract, never defaulted
output_range: "a wrong inherited default is the failure this exists to prevent"

# sisr/losses/vgg.py -- the consumer of that value, before this PR
self._gain, self._offset = 1.0, 0.0     # the identity
```

`SRProcessor.output_range` is abstract precisely so nobody inherits a wrong range.
`SRLoss.bind` is abstract for the same stated reason. And then the loss handed itself the
identity anyway — making **"never bound"** and **"bound to a `[0, 1]` processor"**
indistinguishable at runtime.

### It does not fire on any shipped path

`SRLightning` binds an `SRLoss` criterion; `WeightedSumLoss.bind` forwards to its `SRLoss`
terms. Both live paths bind, and both have a test here proving they still do.

It bites through a container that is **not** itself an `SRLoss` — a plain `nn.ModuleList`, or a
user's own composite. Paired with `RGBSignedOutputProcessor` (range `[-1, 1]`), the loss feeds
`[-1, 1]` data through ImageNet normalisation designed for `[0, 1]`. Training proceeds, the
number looks plausible, and the features mean something other than the recipe says.

That is the flagship reproduction's content loss.

### The test that stops this being theatre

Four tests cover the mechanism. A fifth pins the **consequence**:

```python
def test_signed_range_processor_actually_changes_the_mapping(vgg22):
    vgg22.bind(RGBProcessor());            as_unit   = vgg22(x, y)
    vgg22.bind(RGBSignedOutputProcessor()); as_signed = vgg22(x, y)
    assert not torch.isclose(as_unit, as_signed)
```

If `[0, 1]` and `[-1, 1]` logic agreed, the silent default would have cost nothing and none of
this would be worth doing. They do not agree.

### Two existing tests edited, and why that is not a smell

`test_feature_scale_squares_into_an_mse_and_is_linear_in_an_l1` and
`test_before_activation_changes_the_features` both called the loss **unbound**, relying on the
identity. Each now binds **identically on both sides** of its comparison, so each still
isolates exactly the one variable it was written to isolate. The contract changed on purpose;
these are the two call sites that were exercising the removed default.

### Evidence

- 2 tests proven RED before the change; 3 more green on both sides as guards.
- `495 passed` across `tests/training` and `tests/losses`.
- `mypy` clean; `ruff check` + `format --check` clean.
