### PR TITLE
fix: honour SRResNet's padding everywhere, and reject one that cannot work

### DIFF
--- a/sisr/models/srresnet/model.py
+++ b/sisr/models/srresnet/model.py
@@ -50,21 +50,42 @@ class SRResidualBlock(torch.nn.Module):
         return identity + x
 
 
+#: Kernel size of the sub-pixel upsample convolution. Fixed by the architecture
+#: rather than exposed, but named so the padding check can see it.
+_UPSAMPLE_KERNEL = 3
+
+
 class SRUpsampleBlock(torch.nn.Module):
     """Sub-pixel convolution upsampling block: conv -> PixelShuffle -> PReLU.
+
+    The conv must be **shape-preserving**: ``PixelShuffle`` turns
+    ``(C*scale**2, H, W)`` into ``(C, H*scale, W*scale)``, so any spatial size
+    the conv loses is multiplied by ``scale`` in the output. It does not have to
+    be the literal string ``'same'`` -- ``p == (kernel_size - 1) // 2`` is the
+    same map for an odd kernel -- and :class:`SRResNet` enforces exactly that
+    before constructing one. This used to hardcode ``'same'`` and ignore the
+    ``padding`` its parent recorded.
 
     Args:
         channels: Input channel count.
         scale: Upscaling factor. Defaults to ``2``.
         kernel_size: Kernel size for the conv layer. Defaults to ``3``.
+        padding: Padding for the conv layer. Must be shape-preserving.
+            Defaults to ``'same'``.
     """
 
-    def __init__(self, channels: int, scale: int = 2, kernel_size: int = 3):
+    def __init__(
+        self,
+        channels: int,
+        scale: int = 2,
+        kernel_size: int = 3,
+        padding: str | int = "same",
+    ):
         super().__init__()
 
         self.upsample = torch.nn.Sequential(
             torch.nn.Conv2d(
-                channels, channels * (scale**2), kernel_size=kernel_size, padding="same"
+                channels, channels * (scale**2), kernel_size=kernel_size, padding=padding
             ),
             torch.nn.PixelShuffle(scale),
             torch.nn.PReLU(),
@@ -94,7 +115,10 @@ class SRResNet(SRModel):
         hidden_channel: Feature channel count used in the residual/upsample blocks.
         kernel_sizes: Kernel sizes for the head, residual, and tail conv layers.
         num_residual_blocks: Number of residual blocks in the network.
-        padding: Padding for the conv layers. Defaults to ``'same'``.
+        padding: Padding for the conv layers, applied to **every** convolution
+            including the upsample block's. Must be shape-preserving --
+            ``'same'``, or ``(k - 1) // 2`` for every kernel this model builds
+            (see :meth:`_check_padding`). Defaults to ``'same'``.
     """
 
     #: Consumes true low-resolution input and upsamples internally (sub-pixel conv).
@@ -113,6 +137,7 @@ class SRResNet(SRModel):
 
         self._check_scale(scale)
         self._check_architecture(kernel_sizes, num_residual_blocks)
+        self._check_padding(padding, kernel_sizes)
 
         self._hparams = {
             "scale": scale,
@@ -148,7 +173,12 @@ class SRResNet(SRModel):
 
         self.upsample = torch.nn.Sequential(
             *[
-                SRUpsampleBlock(channels=hidden_channel, scale=2)
+                SRUpsampleBlock(
+                    channels=hidden_channel,
+                    scale=2,
+                    kernel_size=_UPSAMPLE_KERNEL,
+                    padding=padding,
+                )
                 for _ in range(int(math.log2(scale)))
             ]
         )
@@ -156,6 +186,51 @@ class SRResNet(SRModel):
         self.tail = torch.nn.Conv2d(
             hidden_channel, in_out_channels, kernel_size=kernel_sizes[2], padding=padding
         )
+
+    @staticmethod
+    def _check_padding(padding: str | int, kernel_sizes: tuple[int, ...]) -> None:
+        """Rejects a padding that would not preserve each conv's spatial size.
+
+        Every convolution here must be shape-preserving, for two independent
+        reasons: the residual blocks add ``x`` to their own output, and
+        ``PixelShuffle`` multiplies any size the upsample conv loses by
+        ``scale``. Anything else either fails inside ``forward`` with a raw
+        shape error or -- worse -- succeeds and returns a map that is no longer
+        ``scale`` times the input.
+
+        Measured on the paper's kernels before this check existed:
+        ``padding=0`` raised from the residual skip, and ``padding=1`` silently
+        turned a 24x24 input into 30x30 at ``scale=2``.
+
+        The rule is shape-preservation, not the literal string ``'same'``, so
+        ``padding=1`` with all-3 kernels stays legal.
+
+        Args:
+            padding: The requested padding.
+            kernel_sizes: ``(head, residual, tail)`` kernels.
+
+        Raises:
+            ValueError: If *padding* is not ``'same'`` and is not
+                ``(k - 1) // 2`` for every kernel the model builds, including
+                the upsample block's.
+        """
+        if padding == "same":
+            return
+        if not isinstance(padding, int) or isinstance(padding, bool):
+            raise ValueError(
+                f"padding must be 'same' or an int; got {padding!r} ({type(padding).__name__})."
+            )
+        for kernel in (*kernel_sizes, _UPSAMPLE_KERNEL):
+            if kernel % 2 == 0 or padding != (kernel - 1) // 2:
+                raise ValueError(
+                    f"padding={padding} is not shape-preserving for a kernel of size "
+                    f"{kernel} (this model builds kernels {(*kernel_sizes, _UPSAMPLE_KERNEL)}, "
+                    f"the last being the upsample block's). Every convolution here must "
+                    f"preserve its spatial size: the residual blocks add x to their own "
+                    f"output, and PixelShuffle multiplies whatever the upsample conv loses "
+                    f"by scale. Use 'same', or {(kernel - 1) // 2} if every kernel is "
+                    f"{kernel}."
+                )
 
     def _check_scale(self, scale: int) -> None:
         """Validates that scale is a positive power of 2."""

--- a/tests/models/srresnet/test_model.py
+++ b/tests/models/srresnet/test_model.py
@@ -154,3 +154,82 @@ def test_variant_tag_is_blocks_and_width():
     """The two knobs that move capacity, and the two a reader wants off `ls`."""
     assert SRResNet(scale=4).variant_tag == "16B64F"
     assert SRResNet(scale=4, num_residual_blocks=8, hidden_channel=32).variant_tag == "8B32F"
+
+
+# ---------------------------------------------------------------------------
+# padding is honoured everywhere, or rejected -- never recorded and ignored
+# ---------------------------------------------------------------------------
+
+
+def test_every_conv_agrees_with_the_recorded_padding_hparam():
+    """`padding` threaded into head, residual blocks and tail; SRUpsampleBlock
+    hardcoded 'same'. _hparams goes verbatim into checkpoint and ONNX
+    provenance as model.init_args, so a file claimed padding: 1 while one of
+    its convolutions was built 'same'. This project treats artifact metadata as
+    what a downstream consumer trusts to know what a file means."""
+    model = SRResNet(
+        scale=2, hidden_channel=8, num_residual_blocks=1, kernel_sizes=(3, 3, 3), padding=1
+    )
+    recorded = model.hparams["padding"]
+    for name, module in model.named_modules():
+        if isinstance(module, torch.nn.Conv2d):
+            assert module.padding == (recorded, recorded), (
+                f"{name} was built with padding={module.padding}, but the model records "
+                f"padding={recorded!r}"
+            )
+
+
+def test_same_padding_reaches_the_upsample_conv_too():
+    """The 'same' case must keep working -- it is what every shipped config uses."""
+    model = SRResNet(scale=2, hidden_channel=8, num_residual_blocks=1)
+    assert model.hparams["padding"] == "same"
+    for name, module in model.named_modules():
+        if isinstance(module, torch.nn.Conv2d):
+            assert module.padding == "same", f"{name} did not receive 'same'"
+
+
+def test_padding_that_would_break_the_scale_factor_is_rejected():
+    """padding=1 with the paper's 9-3-9 kernels RUNS and silently returns
+    30x30 from a 24x24 input at scale 2 -- the head and tail each shrink by 6,
+    so the model is no longer xscale. Nothing raised and nothing warned."""
+    with pytest.raises(ValueError, match="padding"):
+        SRResNet(
+            scale=2, hidden_channel=8, num_residual_blocks=1, kernel_sizes=(9, 3, 9), padding=1
+        )
+
+
+def test_padding_that_breaks_the_residual_skip_is_rejected():
+    """padding=0 made the residual block's output smaller than its input, so
+    `x + block(x)` failed on shape -- a raw RuntimeError from inside forward,
+    several frames from the config that caused it."""
+    with pytest.raises(ValueError, match="padding"):
+        SRResNet(scale=2, hidden_channel=8, num_residual_blocks=1, padding=0)
+
+
+def test_shape_preserving_int_padding_is_accepted_and_scales_correctly():
+    """The rule is shape-preservation, not the literal string 'same': p ==
+    (k-1)//2 preserves the map for an odd kernel, so padding=1 with all-3
+    kernels is legitimate and must still upscale by exactly `scale`."""
+    model = SRResNet(
+        scale=2, hidden_channel=8, num_residual_blocks=1, kernel_sizes=(3, 3, 3), padding=1
+    )
+    out = model(torch.zeros(1, 3, 24, 24))
+    assert out.shape == (1, 3, 48, 48)
+
+
+def test_padding_that_is_neither_same_nor_an_int_is_rejected():
+    """'valid' is the other string torch accepts, and it is not shape-preserving
+    for any kernel above 1. bool is excluded separately: isinstance(True, int)
+    is True, and `padding: true` is not a pixel count."""
+    for bad in ("valid", 1.5, True, None):
+        with pytest.raises(ValueError, match="padding"):
+            SRResNet(scale=2, hidden_channel=8, num_residual_blocks=1, padding=bad)
+
+
+def test_even_kernel_cannot_be_shape_preserving_with_int_padding():
+    """An even kernel has no p making the conv shape-preserving, so no int
+    padding can be accepted for one -- (k-1)//2 would silently lose a pixel."""
+    with pytest.raises(ValueError, match="padding"):
+        SRResNet(
+            scale=2, hidden_channel=8, num_residual_blocks=1, kernel_sizes=(4, 4, 4), padding=1
+        )


### PR DESCRIPTION
**Stack position 6 of 12 · review group: correctness · base: `fix/vgg-loss-requires-bind` (#250)**

Closes #241.

### The judgement call, settled by measurement

The issue flagged that the fix needed a judgement — and guessed `same` might be genuinely
required by `PixelShuffle`. Measured first, on `SRResNet(scale=2)` with the paper's 9-3-9
kernels:

| `padding` | result |
|---|---|
| `'same'` | OK — 24x24 → 48x48 |
| `0` | **`RuntimeError`** — the residual skip adds a 16-wide tensor to a 12-wide one |
| `1` | **"works", returns 30x30 from 24x24 at scale 2** |

So the knob was broken for *every* value but `same`: one raised from several frames inside
`forward`, the other silently produced a model that is no longer `xscale` (head and tail each
shrink by 6 with a 9-kernel and `padding=1`).

### So the accepted set is a rule, not a value

Every convolution must be **shape-preserving**, for two independent reasons: the residual
blocks add `x` to their own output, and `PixelShuffle` multiplies whatever the upsample conv
loses by `scale`. That means `'same'`, **or** `(k - 1) // 2` for every kernel the model builds —
the upsample block's included.

```
padding=1, kernel_sizes=(3,3,3)  ->  legal, and still 24x24 -> 48x48
padding=1, kernel_sizes=(9,3,9)  ->  ValueError naming the kernel it cannot preserve
padding=0, any                   ->  ValueError, not a RuntimeError from inside forward
padding='same'                   ->  unchanged
```

This keeps the knob meaningful rather than reducing it to a one-value field, and it is why
`SRUpsampleBlock` now **takes** `padding` instead of hardcoding it — which is what makes
`_hparams["padding"]` describe what was actually constructed.

### Why the recorded hparam mattered even though nothing hits it

`_hparams` goes verbatim into checkpoint and ONNX provenance as `model.init_args`. A file
could claim `padding: 0` while one of its convolutions was built `same`. This project treats
artifact metadata as the thing a downstream consumer trusts to know what a file means.

### Evidence

- 3 tests proven RED; 2 more green on both sides (the `'same'` path, and the legitimate
  `padding=1` + all-3-kernels case that must not be caught by the new rule).
- The acceptance test walks **every `Conv2d` in the built model** and asserts it agrees with
  the recorded hparam — the upsample block included, which is the one that used to disagree.
- **All 14 shipped SRResNet/SRGAN generator configs** pass the new rule unchanged.
- `507 passed` across `tests/models` and `tests/training`; `mypy`, `ruff` clean.
