### PR TITLE
fix: abort a failed LMDB write transaction instead of leaving it to the GC

### DIFF
--- a/sisr/utils/cache.py
+++ b/sisr/utils/cache.py
@@ -129,13 +129,26 @@ class LMDBCacheBuildContext:
     def write_batch(self, pairs: Sequence[tuple[str, bytes]]) -> None:
         """Writes a batch of key-value pairs in a single transaction.
 
+        Context-managed, so a failed put aborts the transaction immediately.
+        Uncontext-managed it was aborted only by garbage collection, which
+        means it survived exactly as long as the raised exception's traceback
+        -- and anything that logs with ``exc_info=True``, stores the exception,
+        wraps and re-raises it, or merely holds it while a ``tqdm`` bar and a
+        pool of futures are still live keeps the write lock held. That is
+        precisely the state :meth:`parallel_build` is in when a job fails.
+
+        The environment here is owned by the caller and outlives this method,
+        and ``parallel_build`` calls it in a loop, so nothing else bounds it.
+        A ``put`` raising ``MapFullError`` partway through is a known,
+        designed-for event -- ``hr_cache.estimate_map_size`` exists because of
+        it.
+
         Args:
             pairs: Sequence of ``(key, value)`` tuples to write.
         """
-        txn = self.env.begin(write=True)
-        for key, value in pairs:
-            txn.put(key.encode(), value)
-        txn.commit()
+        with self.env.begin(write=True) as txn:
+            for key, value in pairs:
+                txn.put(key.encode(), value)
 
     def parallel_build(
         self,
@@ -170,47 +183,49 @@ class LMDBCacheBuildContext:
 
         pbar = tqdm(total=n_items, desc=desc, unit="item") if self.use_tqdm else None
 
-        # <= 1 effective worker: skip the pool. Its spawn/import cost, plus the
-        # hazard of nesting one inside a test/xdist worker, isn't worth it here.
-        if num_workers <= 1:
-            for i in range(n_items):
-                args = (items[i],)
-                if process_args is not None:
-                    args = args + tuple(process_args[i])
-                self.write_batch(process_fn(*args))
-                if pbar is not None:
-                    pbar.update(1)
-            if pbar is not None:
-                pbar.close()
-            return
-
-        next_submit = 0
-        with ProcessPoolExecutor(max_workers=num_workers) as executor:
-            pending: set[Future] = set()
-
-            def _submit() -> None:
-                nonlocal next_submit
-                if next_submit < n_items:
-                    args = (items[next_submit],)
+        # finally, not the success path: an exception used to leave the bar
+        # open, which corrupts every subsequent line of terminal output.
+        try:
+            # <= 1 effective worker: skip the pool. Its spawn/import cost, plus
+            # the hazard of nesting one inside a test/xdist worker, isn't worth
+            # it here.
+            if num_workers <= 1:
+                for i in range(n_items):
+                    args = (items[i],)
                     if process_args is not None:
-                        args = args + tuple(process_args[next_submit])
-                    pending.add(executor.submit(process_fn, *args))
-                    next_submit += 1
-
-            for _ in range(num_workers):
-                _submit()
-
-            while pending:
-                done, _ = wait(pending, return_when=FIRST_COMPLETED)
-                for future in done:
-                    pending.discard(future)
-                    self.write_batch(future.result())
+                        args = args + tuple(process_args[i])
+                    self.write_batch(process_fn(*args))
                     if pbar is not None:
                         pbar.update(1)
+                return
+
+            next_submit = 0
+            with ProcessPoolExecutor(max_workers=num_workers) as executor:
+                pending: set[Future] = set()
+
+                def _submit() -> None:
+                    nonlocal next_submit
+                    if next_submit < n_items:
+                        args = (items[next_submit],)
+                        if process_args is not None:
+                            args = args + tuple(process_args[next_submit])
+                        pending.add(executor.submit(process_fn, *args))
+                        next_submit += 1
+
+                for _ in range(num_workers):
                     _submit()
 
-        if pbar is not None:
-            pbar.close()
+                while pending:
+                    done, _ = wait(pending, return_when=FIRST_COMPLETED)
+                    for future in done:
+                        pending.discard(future)
+                        self.write_batch(future.result())
+                        if pbar is not None:
+                            pbar.update(1)
+                        _submit()
+        finally:
+            if pbar is not None:
+                pbar.close()
 
 
 class LMDBCache:

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1359,3 +1359,84 @@ def test_close_is_safe_before_the_environment_is_ever_opened(tmp_path: Path):
     cache.close()
     cache.close()
     assert cache._env is None
+
+
+# ---------------------------------------------------------------------------
+# A failed write_batch must not hold the write lock
+# ---------------------------------------------------------------------------
+
+
+def test_failed_write_batch_leaves_the_env_writable_while_the_exception_is_held(tmp_path):
+    """The transaction was aborted only by garbage collection, so it survived
+    exactly as long as the exception's traceback did.
+
+    The weak version of this test -- let the `except` block exit, then write --
+    PASSES today and proves nothing: refcounting has already collected the
+    transaction by then. Holding a reference is what a real caller does. Anything
+    that logs with exc_info=True, stores the exception, wraps and re-raises it,
+    or holds it while a tqdm bar and a pool of futures are still live keeps the
+    write lock held -- which is exactly the state parallel_build is in when a
+    job fails.
+
+    MapFullError mid-build is a designed-for event here: hr_cache.estimate_map_size
+    exists because of it."""
+    import lmdb
+
+    from sisr.utils.cache import LMDBCacheBuildContext
+
+    # Big enough that a small write always fits, small enough that the
+    # oversized batch below cannot: the abort has to be what frees the lock,
+    # not spare capacity.
+    env = lmdb.open(str(tmp_path / "db"), map_size=1 << 20, subdir=True)
+    try:
+        ctx = LMDBCacheBuildContext(env)
+        ctx.write_batch([("small", b"x")])  # a normal write first
+
+        held = None
+        try:
+            ctx.write_batch([(f"big{i}", b"y" * 4096) for i in range(1024)])
+        except lmdb.MapFullError as exc:
+            held = exc  # the traceback -- and the failed txn -- stay alive
+
+        assert held is not None, "the oversized batch was expected to exhaust the map"
+        # With `held` still referenced, the aborted-by-GC path cannot have run.
+        ctx.write_batch([("after", b"z")])
+        with env.begin() as txn:
+            assert txn.get(b"after") == b"z"
+    finally:
+        env.close()
+
+
+def test_parallel_build_closes_the_progress_bar_on_the_failure_path(tmp_path, monkeypatch):
+    """pbar.close() was called only on the success path, in both branches. An
+    exception left the bar open, which corrupts subsequent terminal output."""
+    import lmdb
+
+    from sisr.utils import cache as cache_mod
+    from sisr.utils.cache import LMDBCacheBuildContext
+
+    closed: list[bool] = []
+
+    class _Bar:
+        def __init__(self, *a, **k):
+            pass
+
+        def update(self, _n):
+            pass
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setattr(cache_mod, "tqdm", _Bar)
+
+    def _boom(_item):
+        raise RuntimeError("job failed")
+
+    env = lmdb.open(str(tmp_path / "db2"), map_size=1 << 20, subdir=True)
+    try:
+        ctx = LMDBCacheBuildContext(env, use_tqdm=True)
+        with pytest.raises(RuntimeError, match="job failed"):
+            ctx.parallel_build(items=[1], process_fn=_boom, num_workers=1)
+        assert closed, "the progress bar was left open on the exception path"
+    finally:
+        env.close()


### PR DESCRIPTION
**Stack position 7 of 12 · review group: correctness · base: `fix/srresnet-padding-honoured` (#251)**

Closes #240. Last of the correctness group.

### The asymmetry

`cache.py` opens six LMDB transactions. Four were context-managed. The two that were not were
**both the write transactions** — where aborting on failure is the thing that matters.

`_build`'s is defensible: it sits inside `try: ... finally: env.close()`, and closing the
environment invalidates the transaction. It is bounded. **`write_batch`'s is not** — its
environment is owned by the caller and outlives it, and `parallel_build` calls it in a loop,
once per completed job.

### Why the test's exact shape is the point

The issue was explicit that the weak version of this test proves nothing, and it is right.
Uncontext-managed, the transaction is aborted **only by garbage collection**, so it survives
exactly as long as the exception's traceback:

| scenario | next write |
|---|---|
| `except` block exits, traceback released | **succeeds** — refcounting collected it |
| a reference to the exception is still held | **blocked** |

So the test holds the exception. Proven RED with that shape:

```
lmdb.Error: Attempt to start a write transaction while another write
transaction is active on the same thread. This would deadlock.
```

A retained traceback is not exotic — anything that logs with `exc_info=True`, stores the
exception, wraps and re-raises it, or merely holds it while a `tqdm` bar and a pool of futures
are still live is in that state. **That is exactly the state `parallel_build` is in when a job
fails.** And a `put` raising `MapFullError` partway through is a designed-for event here:
`hr_cache.estimate_map_size` exists because of it and says so.

*(The test's map sizing was tuned after the first attempt: at 16 KB the post-abort write failed
for genuine exhaustion rather than for the lock, which would have made it pass for the wrong
reason. It was re-proven RED at the final sizing.)*

### Also here

`parallel_build` called `pbar.close()` only on the success path, in **both** branches, so an
exception left the bar open and corrupted every subsequent line of terminal output. Now a
`try/finally` covering both.

### Evidence

- 2 tests, both proven RED, and the first re-proven RED after its sizing changed.
- `138 passed, 2 skipped` across `tests/utils` and `tests/datasets` (the 2 are Windows-only).
- `mypy` clean; `ruff` clean.
