### PR TITLE
refactor: promote metadata.class_path, which had an outside caller already

### DIFF
--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -29,7 +29,7 @@ from ..models.srgan import SRDiscriminator, SRGANEvalConfig, SRGANTrainingConfig
 from ..processors import SRProcessor
 from .config import SREvalConfig
 from .lightning_module import SRLightning
-from .metadata import _class_path, build_metadata
+from .metadata import build_metadata, class_path
 
 #: ``(section, key)`` of every ``build_metadata`` field ``init_from`` validates —
 #: the properties that decide whether one run's generator weights mean anything in
@@ -532,11 +532,11 @@ class SRGANLightning(SRLightning):
         """
         super().on_save_checkpoint(checkpoint)
         checkpoint["sisr_meta"]["discriminator"] = {
-            "class_path": _class_path(self.discriminator),
+            "class_path": class_path(self.discriminator),
             "init_args": dict(self.discriminator.hparams),
         }
         checkpoint["sisr_meta"]["adversarial"] = {
-            "loss": _class_path(self.adversarial_loss),
+            "loss": class_path(self.adversarial_loss),
             "weight": self.training_config.adversarial_weight,
             "d_steps_per_g_step": self.training_config.d_steps_per_g_step,
         }

--- a/sisr/training/metadata.py
+++ b/sisr/training/metadata.py
@@ -55,8 +55,24 @@ def _to_plain(obj: Any) -> Any:
     return obj
 
 
-def _class_path(obj: Any) -> str:
-    """Dotted ``module.ClassName`` path for an instance's class — the YAML's own shape."""
+def class_path(obj: Any) -> str:
+    """Dotted ``module.ClassName`` path for an instance's class — the YAML's own shape.
+
+    Public because a second module needs it: ``gan_module`` describes the
+    discriminator and the adversarial loss the same way ``build_metadata``
+    describes the generator, and provenance readers must see one spelling of a
+    class path across every component of a run. It was underscored with an
+    outside caller, which is how a helper quietly becomes unchangeable -- the
+    underscore says "free to change" and the second caller says otherwise.
+
+    Args:
+        obj: Any instance. Its **class** is described, not the instance.
+
+    Returns:
+        ``"package.module.ClassName"`` -- the same shape a config's
+        ``class_path`` key takes, so a recorded value can be pasted straight
+        back into YAML.
+    """
     cls = type(obj)
     return f"{cls.__module__}.{cls.__qualname__}"
 
@@ -154,15 +170,15 @@ def build_metadata(
 
     meta = _envelope("sr_model", global_step, epoch, monitor, monitor_value, batch_step)
     meta["model"] = {
-        "class_path": _class_path(model),
+        "class_path": class_path(model),
         "init_args": _to_plain(model.hparams),
         "variant": model.variant_tag,
     }
     meta["processor"] = {
-        "class_path": _class_path(processor),
+        "class_path": class_path(processor),
     }
     meta["criterion"] = {
-        "class_path": _class_path(module.criterion),
+        "class_path": class_path(module.criterion),
         "description": module.criterion_description,
     }
     meta["io"] = {
@@ -216,7 +232,7 @@ def build_component_metadata(
     meta = _envelope("component", global_step, epoch, monitor, monitor_value, batch_step)
     meta["component"] = {
         "name": attribute,
-        "class_path": _class_path(component),
+        "class_path": class_path(component),
         "init_args": _to_plain(getattr(component, "hparams", {})),
         # Duck-typed: a co-trained component need not be an SRModel, and one
         # without a tag simply contributes nothing to the filename.

--- a/tests/training/test_metadata.py
+++ b/tests/training/test_metadata.py
@@ -424,3 +424,29 @@ def test_resolved_scale_is_public_api():
     unchangeable."""
     assert hasattr(SRLightning, "resolved_scale")
     assert not hasattr(SRLightning, "_resolved_scale")
+
+
+def test_class_path_is_public_api():
+    """`gan_module` imported it across a module boundary while its name said
+    "free to change". That combination is the problem: the underscore says one
+    thing and the second caller says another, and nothing reconciles them --
+    which is how a helper quietly becomes unchangeable.
+
+    Promoted rather than removed, matching the identical call one module over
+    for the scale resolver. Two private helpers in one stack going opposite ways
+    would be the worse outcome."""
+    import sisr.training.metadata as metadata
+
+    assert hasattr(metadata, "class_path")
+    assert not hasattr(metadata, "_class_path")
+
+
+def test_gan_module_imports_no_private_symbol_from_metadata():
+    """The structural half: a re-introduced private import fails here."""
+    import inspect
+
+    import sisr.training.gan_module as gan_module
+
+    src = inspect.getsource(gan_module)
+    assert "from .metadata import _class_path" not in src
+    assert "import _" not in src.split("class ")[0], "no private cross-module import"


### PR DESCRIPTION
**Stack position 9 of 12 · review group: hygiene / UX · base: `refactor/collect-batch-extractions` (#253)**

Closes #232.

### Which direction, and why

The issue said either direction is fine — promote it, or remove the need. **Promoted**, for two
reasons:

1. `gan_module` does not merely want a comparison against `build_metadata`'s output. It
   describes the **discriminator** and the **adversarial loss** the same way `build_metadata`
   describes the generator, and a provenance reader must see one spelling of a class path
   across every component of a run. That is a real interface.
2. **This stack already made the identical call one module over** — `_resolved_scale` lost its
   underscore in #249 for exactly this reason. Two private helpers going opposite ways in one
   stack would be the worse outcome.

Being public, it gets a real docstring rather than a one-liner: what it describes (the
instance's *class*, not the instance) and why the shape matters (a recorded value pastes
straight back into a config's own `class_path` key).

### Evidence

- 2 tests proven RED. One is structural: a re-introduced private cross-module import fails it,
  rather than only the current instance being fixed.
- `417 passed` in `tests/training`.
- `mypy` clean; `ruff` clean. No behaviour change.
