### PR TITLE
chore: delete a mutation-testing artifact and cover what it sat inside

### DIFF
--- a/sisr/training/probe.py
+++ b/sisr/training/probe.py
@@ -168,8 +168,6 @@ def _first_probe_dataset(dm: Any) -> tuple[str, Any] | None:
     test_datasets = getattr(dm, "test_datasets", None)
     if test_datasets:
         return "test_datasets", next(iter(test_datasets.values()))
-    return None  # mutated: unreachable no-op
-
     return None
 
 

--- a/tests/training/test_probe.py
+++ b/tests/training/test_probe.py
@@ -203,3 +203,80 @@ def test_a_datamodule_with_no_probeable_dataset_yields_no_sample():
     with probe_pair(_DM()) as probe:
         assert probe.sample is None
         assert probe.train_lr() is None
+
+
+# ---------------------------------------------------------------------------
+# _first_probe_dataset: the priority order the contract check depends on
+# ---------------------------------------------------------------------------
+
+
+def test_no_unreachable_statement_survives_in_probe():
+    """A dead `return None` after a `return None`, under a comment left over
+    from a mutation experiment. It went in with the commit that created the
+    module rather than as a deliberate marker, and an AST sweep of the package
+    found it the ONLY unreachable statement -- a one-off, not a pattern."""
+    import ast
+    import inspect
+
+    import sisr.training.probe as probe
+
+    tree = ast.parse(inspect.getsource(probe))
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(body, list):
+            continue
+        for i, stmt in enumerate(body[:-1]):
+            assert not isinstance(stmt, ast.Return | ast.Raise), (
+                f"unreachable statement after {type(stmt).__name__} at line {body[i + 1].lineno}"
+            )
+
+
+def test_first_probe_dataset_priority_is_train_then_val_then_test():
+    """train > val > first test set -- whichever loader would actually run
+    first for the live stage, so the contract check fires for a bare
+    `validate`/`test` invocation and not only for `fit`."""
+    from types import SimpleNamespace
+
+    from sisr.training.probe import _first_probe_dataset
+
+    train, val, t5 = object(), object(), object()
+
+    assert _first_probe_dataset(
+        SimpleNamespace(train_dataset=train, val_dataset=val, test_datasets={"Set5": t5})
+    ) == ("train_dataset", train)
+    assert _first_probe_dataset(
+        SimpleNamespace(train_dataset=None, val_dataset=val, test_datasets={"Set5": t5})
+    ) == ("val_dataset", val)
+    assert _first_probe_dataset(
+        SimpleNamespace(train_dataset=None, val_dataset=None, test_datasets={"Set5": t5})
+    ) == ("test_datasets", t5)
+
+
+def test_first_probe_dataset_returns_none_when_nothing_is_set():
+    """All three unset, and an empty test_datasets dict, are both "nothing to
+    probe" rather than an error."""
+    from types import SimpleNamespace
+
+    from sisr.training.probe import _first_probe_dataset
+
+    assert _first_probe_dataset(SimpleNamespace()) is None
+    assert (
+        _first_probe_dataset(
+            SimpleNamespace(train_dataset=None, val_dataset=None, test_datasets={})
+        )
+        is None
+    )
+
+
+def test_first_probe_dataset_takes_the_first_test_set_in_insertion_order():
+    """`next(iter(...))` on a dict -- insertion order, so the YAML's first
+    entry wins rather than an arbitrary one."""
+    from types import SimpleNamespace
+
+    from sisr.training.probe import _first_probe_dataset
+
+    first, second = object(), object()
+    dm = SimpleNamespace(
+        train_dataset=None, val_dataset=None, test_datasets={"Set5": first, "Set14": second}
+    )
+    assert _first_probe_dataset(dm) == ("test_datasets", first)


### PR DESCRIPTION
**Stack position 10 of 12 · review group: hygiene / UX · base: `refactor/promote-class-path` (#254)**

Closes #234.

```diff
     if test_datasets:
         return "test_datasets", next(iter(test_datasets.values()))
-    return None  # mutated: unreachable no-op
-
     return None
```

Established before removing it, per the issue: it went in with the commit that created the
module rather than as a deliberate marker, it is **not** an anchor the mutation audit expects,
and an AST sweep of `sisr/` found it the **only** unreachable statement in the package.

### The half that is worth more than the deletion

`_first_probe_dataset` had **no direct test**, and it decides the `train > val > test` priority
that makes the contract check fire for a bare `validate`/`test` invocation rather than only for
`fit`. Four tests now pin:

- the priority order, each level in turn
- `None` for "all three unset" **and** for an empty `test_datasets` dict
- that `next(iter(...))` takes the YAML's **first** test set, not an arbitrary one

### The regression guard is a sweep, not an assertion about one line

`test_no_unreachable_statement_survives_in_probe` walks the module's AST for any statement
following a `return`/`raise` in the same block. A re-introduced dead statement **anywhere in
the file** fails it, not just this one. Proven RED.

### Evidence

- `15 passed` in `tests/training/test_probe.py` (11 before).
- `mypy` clean; `ruff` clean.
