### PR TITLE
fix: test_dataloader raises before setup instead of reporting nothing to do

### DIFF
--- a/sisr/training/datamodule.py
+++ b/sisr/training/datamodule.py
@@ -216,7 +216,10 @@ class SRDataModule(lightning.LightningDataModule):
         self._predict_spec = predict_dataset
         self._train_dl_kwargs = train_dataloader_kwargs or {}
         self._val_dl_kwargs = val_dataloader_kwargs or {"batch_size": 1, "num_workers": 1}
-        self._test_dl_kwargs = test_dataloader_kwargs or self._val_dl_kwargs
+        # dict(...), not the object itself: unset, this used to BE
+        # _val_dl_kwargs, so the first thing to mutate either would silently
+        # change both loaders.
+        self._test_dl_kwargs = test_dataloader_kwargs or dict(self._val_dl_kwargs)
         self._predict_dl_kwargs = predict_dataloader_kwargs or {"batch_size": 1, "num_workers": 0}
 
         self._train_ds: Dataset | None = None
@@ -331,10 +334,31 @@ class SRDataModule(lightning.LightningDataModule):
     def test_dataloader(self) -> list[DataLoader]:
         """Test loaders only — for ``cli test --ckpt_path <path>`` final eval.
 
+        Separates "not configured" from "not set up", the way
+        :meth:`predict_dataloader` already does. Returning ``[]`` for both made
+        them indistinguishable, and a ``test`` run that reached the second
+        evaluated nothing and reported success. This is the final evaluation
+        path, so the number that does not get produced is the one someone would
+        publish.
+
         Returns:
             List of one DataLoader per entry in ``test_datasets``, in
-            insertion order. Empty when no test sets are configured.
+            insertion order. Empty when no test sets are configured — that
+            state is legitimate and stays silent.
+
+        Raises:
+            RuntimeError: If test sets are configured but ``setup`` has not
+                instantiated them. Lightning calls ``setup()`` itself; a direct
+                caller has to.
         """
+        if self._test_specs and not self._test_ds:
+            raise RuntimeError(
+                f"SRDataModule.test_dataloader() called before setup('test') instantiated "
+                f"the {len(self._test_specs)} configured test set(s) "
+                f"({', '.join(self._test_specs)}). Lightning calls setup() itself; a direct "
+                f"caller has to. Returning an empty list here would make a `test` run "
+                f"evaluate nothing and report success."
+            )
         return [
             DataLoader(ds, shuffle=False, **self._test_dl_kwargs) for ds in self._test_ds.values()
         ]

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -535,3 +535,79 @@ def test_accepted_init_args_gives_up_quietly_on_an_unresolvable_class(class_path
     reports the original constructor error, rather than replacing a real
     failure with an import error raised while composing the message."""
     assert _accepted_init_args(class_path) is None
+
+
+# ---------------------------------------------------------------------------
+# test_dataloader must not fail silently
+# ---------------------------------------------------------------------------
+
+
+def _make_dm_no_test_sets(image_dir: Path) -> SRDataModule:
+    """Same shape as _make_dm, with test_datasets left unset."""
+    return SRDataModule(
+        train_dataset={
+            "class_path": "sisr.datasets.srcnn.TrainDataset",
+            "init_args": {
+                "img_dir": str(image_dir),
+                "subimg_size": 33,
+                "stride": 14,
+                "scale": 2,
+                "use_tqdm": False,
+                "cache_dir": str(image_dir / ".lmdb_cache_nt"),
+                "build_num_workers": 1,
+            },
+        },
+        val_dataset={
+            "class_path": "sisr.datasets.srcnn.ValidationDataset",
+            "init_args": {"img_dir": str(image_dir), "scale": 2},
+        },
+        val_dataloader_kwargs={"batch_size": 1, "num_workers": 0},
+        # test_datasets and test_dataloader_kwargs both deliberately unset
+    )
+
+
+def test_test_dataloader_before_setup_raises_when_test_sets_are_configured(
+    tiny_rgb_image_dir: Path,
+):
+    """Its two siblings raise; this one returned [] silently, and it is the one
+    whose failure matters most.
+
+    The two states were indistinguishable: "configured with Set5, setup() never
+    run" and "configured with no test sets at all" both gave []. A `test` run in
+    the first state evaluates NOTHING and reports success -- and that is the
+    final evaluation path, so the number that never gets produced is the one
+    someone would publish."""
+    dm = _make_dm(tiny_rgb_image_dir)
+    with pytest.raises(RuntimeError, match="setup"):
+        dm.test_dataloader()
+
+
+def test_test_dataloader_still_returns_empty_when_no_test_sets_configured(
+    tiny_rgb_image_dir: Path,
+):
+    """That state is legitimate and must stay silent -- a fit run with no
+    benchmark sets is a normal thing to configure. It must not become an error
+    just because the other state now is one."""
+    dm = _make_dm_no_test_sets(tiny_rgb_image_dir)
+    assert dm.test_dataloader() == []
+    dm.setup(stage="test")
+    assert dm.test_dataloader() == []
+
+
+def test_test_dataloader_after_setup_is_unchanged(tiny_rgb_image_dir: Path):
+    """The working path must keep working: one loader per entry, in order."""
+    dm = _make_dm(tiny_rgb_image_dir)
+    dm.setup(stage="test")
+    loaders = dm.test_dataloader()
+    assert len(loaders) == 2
+    assert all(isinstance(dl, DataLoader) for dl in loaders)
+
+
+def test_val_and_test_dataloader_kwargs_are_not_the_same_object(tiny_rgb_image_dir: Path):
+    """`self._test_dl_kwargs is self._val_dl_kwargs` was True whenever
+    test_dataloader_kwargs was unset -- the same dict object, not a copy.
+    Nothing mutates them today, so it costs nothing now and couples the two
+    loaders silently the first time anything does."""
+    dm = _make_dm_no_test_sets(tiny_rgb_image_dir)
+    assert dm._test_dl_kwargs == dm._val_dl_kwargs
+    assert dm._test_dl_kwargs is not dm._val_dl_kwargs


### PR DESCRIPTION
**Stack position 11 of 12 · review group: hygiene / UX · base: `chore/remove-mutation-artifact` (#255)**

Closes #235.

### The asymmetry

| call before `setup()` | before | now |
|---|---|---|
| `train_dataloader()` | `RuntimeError`, naming the stage | unchanged |
| `val_dataloader()` | `RuntimeError`, likewise | unchanged |
| `test_dataloader()` | **`[]`, silently** | `RuntimeError` when test sets are configured |

`_require` exists for exactly this, and its message reads *"Lightning calls setup() itself; a
direct caller has to."* The one loader that skipped it was the one whose failure was silent.

### Why silent is the wrong failure here specifically

The two states were indistinguishable:

```
configured with Set5, setup() never run  ->  []
configured with no test sets at all      ->  []
```

A `test` run reaching the first **evaluates nothing and reports success**. That is the final
evaluation path — the number that does not get produced is the one someone would publish.

`predict_dataloader` already had the fix's shape: separate "not configured" from "not set up".
`test_dataloader` now uses `_test_specs` (what the config asked for) against `_test_ds` (what
`setup` built).

**"No test sets configured" still returns `[]`** and has its own test, so it cannot become an
error by accident.

### Also here, latent

`self._test_dl_kwargs is self._val_dl_kwargs` was `True` whenever `test_dataloader_kwargs` was
unset — the same dict object, not a copy. Nothing mutates them today, so it cost nothing and
would have coupled the two loaders silently the first time anything did. Now a `dict()` copy,
with a test on identity rather than equality.

### Evidence

- 2 tests proven RED; 2 more green on both sides (the legitimate `[]`, and the post-setup path).
- `463 passed` across `tests/training` and `tests/test_cli.py`.
- `mypy` clean; `ruff` clean.
