### PR TITLE
feat: a progress bar that shows the whole run name and only the wanted metrics

### DIFF
--- a/sisr/cli.py
+++ b/sisr/cli.py
@@ -33,10 +33,12 @@ from typing import Any, Literal
 import torch
 from jsonargparse import set_parsing_settings
 from lightning.pytorch import Trainer
+from lightning.pytorch.callbacks import Callback, ProgressBar
 from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCLI
 
 from .export import to_onnx
 from .training import SRDataModule, SREvalConfig, SRLightning, SRTrainingConfig
+from .training.callbacks import SRProgressBar
 
 # The only keys a checkpoint's hyper_parameters can restore. Legacy checkpoints also
 # carry 'model/*'/'processor'/'criterion', which were TensorBoard-only and never part
@@ -168,6 +170,63 @@ class SRLightningCLI(LightningCLI):
         # trainer_class. No caller does that, and forbidding it would mean restating
         # LightningCLI's whole signature here.
         super().__init__(*args, trainer_class=trainer_class, **kwargs)  # type: ignore[misc]
+
+    @staticmethod
+    def _with_default_progress_bar(
+        config_callbacks: list[Any] | None,
+        callbacks: list[Callback],
+        enable_progress_bar: bool = True,
+    ) -> list[Callback]:
+        """Append :class:`SRProgressBar` unless a progress bar is already configured.
+
+        Lightning installs its own bar when none is given, and that bar
+        truncates the run name to four characters. So the project's bar has to
+        be supplied by default or it fixes nothing -- but it must **not** be
+        supplied unconditionally: ``Trainer`` raises
+        ``MisconfigurationException`` for two progress bars, and
+        ``LightningCLI._instantiate_trainer`` merges ``trainer_defaults`` by
+        appending. Passing it through ``trainer_defaults`` would therefore turn
+        any config that names its own progress bar into a hard startup failure.
+
+        ``enable_progress_bar=False`` is the third way this can go wrong:
+        ``Trainer`` refuses a progress-bar callback outright when the bar is
+        disabled, so a default injected regardless would break every run that
+        turns it off -- which is what the existing suite caught.
+
+        Args:
+            config_callbacks: Callbacks declared in the config's ``trainer``
+                section, which may be ``None``.
+            callbacks: Callbacks Lightning assembled separately.
+            enable_progress_bar: The trainer's own setting. ``False`` means no
+                bar at all, so nothing is added.
+
+        Returns:
+            *callbacks*, with an ``SRProgressBar`` appended only when the bar
+            is enabled and neither list already holds one.
+        """
+        if not enable_progress_bar:
+            return callbacks
+        existing = [*(config_callbacks or []), *callbacks]
+        if any(isinstance(cb, ProgressBar) for cb in existing):
+            return callbacks
+        return [*callbacks, SRProgressBar()]
+
+    def _instantiate_trainer(self, config: dict[str, Any], callbacks: list[Callback]) -> Trainer:
+        """Build the trainer, defaulting the progress bar to this project's.
+
+        Args:
+            config: The parsed ``trainer`` config section.
+            callbacks: Callbacks Lightning assembled for this run.
+
+        Returns:
+            The constructed trainer.
+        """
+        callbacks = self._with_default_progress_bar(
+            config.get("callbacks"),
+            callbacks,
+            enable_progress_bar=config.get("enable_progress_bar", True) is not False,
+        )
+        return super()._instantiate_trainer(config, callbacks)
 
     def parse_arguments(self, parser: LightningArgumentParser, args: ArgsType) -> None:
         """Parse CLI arguments, turning a known jsonargparse crash into an actionable error.

--- a/sisr/training/callbacks.py
+++ b/sisr/training/callbacks.py
@@ -21,7 +21,12 @@ import lightning
 import torch
 import torch.nn.functional
 import torchvision
-from lightning.pytorch.callbacks import BasePredictionWriter, Callback, ModelCheckpoint
+from lightning.pytorch.callbacks import (
+    BasePredictionWriter,
+    Callback,
+    ModelCheckpoint,
+    TQDMProgressBar,
+)
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 from .. import artifacts
@@ -1360,3 +1365,109 @@ class SRPredictionWriter(BasePredictionWriter):
             filename = img_paths[sample_idx].stem
             out_path = self.output_dir / f"{filename}.png"
             torchvision.utils.save_image(prediction[i].clamp(0.0, 1.0), out_path)
+
+
+#: Metric families the progress bar can be narrowed to. ``loss`` covers every
+#: ``loss/...`` tag (train, val, and the discriminator's on an adversarial run);
+#: the rest are the scored families, taken from the metric layer rather than
+#: restated, so a new perceptual metric is selectable the day it exists.
+PROG_BAR_FAMILIES: frozenset[str] = frozenset({"loss", "psnr", "ssim"}) | frozenset(
+    PERCEPTUAL_METRICS
+)
+
+
+class SRProgressBar(TQDMProgressBar):
+    """Progress bar showing the whole run name, and only the metrics asked for.
+
+    Exists for two reasons, both of which need a callback this project owns --
+    there was none, so neither was reachable from a config.
+
+    **The run name.** Lightning's ``get_standard_metrics`` truncates
+    unconditionally::
+
+        if isinstance(version, str):
+            version = version[-4:]      # "vgg54-scaled" -> "aled"
+
+    That rule is written for integer-ish versions (``version_10`` -> ``_10``).
+    This project names runs after what they *are*, so two runs differing
+    anywhere but their last four characters are indistinguishable in the bar --
+    exactly when you most want to know which one you are watching.
+
+    **The metric set.** Every entry in the bar comes from a ``prog_bar=True``
+    at a log call, spread over five sites, with no way to turn any of them off.
+    On an adversarial run that is five metrics plus ``v_num``, which wraps the
+    line and pushes PSNR/SSIM to the far end. Placement was thought about --
+    ``prog_bar`` is a display choice and stays with the caller -- but
+    configurability was not.
+
+    **Nothing about what is logged changes.** ``prog_bar`` controls display
+    only; every metric still reaches TensorBoard and ``metrics.csv`` exactly as
+    before. This changes what a human reads mid-run, never what a result is
+    computed from.
+
+    Args:
+        metrics: Families to display, from :data:`PROG_BAR_FAMILIES`. ``None``
+            (default) shows everything logged with ``prog_bar=True``, so no
+            shipped config changes what it displays. ``['psnr', 'ssim']`` gives
+            the scored view; ``['loss']`` suits an adversarial run, where
+            PSNR/SSIM get worse by design. ``v_num`` is not a family and always
+            survives.
+        refresh_rate: Batches between bar refreshes, as ``TQDMProgressBar``.
+        process_position: Row offset when several bars are shown.
+
+    Raises:
+        ValueError: If any entry of *metrics* is not a known family.
+    """
+
+    def __init__(
+        self,
+        metrics: list[str] | None = None,
+        refresh_rate: int = 1,
+        process_position: int = 0,
+    ) -> None:
+        super().__init__(refresh_rate=refresh_rate, process_position=process_position)
+        if metrics is not None:
+            unknown = [m for m in metrics if m not in PROG_BAR_FAMILIES]
+            if unknown:
+                raise ValueError(
+                    f"SRProgressBar.metrics entries must be one of "
+                    f"{sorted(PROG_BAR_FAMILIES)}; got unsupported {unknown}. A typo would "
+                    f"otherwise show an empty bar, which reads as 'nothing is being logged' "
+                    f"rather than 'that family does not exist'. Fix the callback's "
+                    f"init_args.metrics in your YAML."
+                )
+        self.metrics = metrics
+
+    def get_metrics(
+        self, trainer: lightning.Trainer, pl_module: lightning.LightningModule
+    ) -> dict[str, int | str | float | dict[str, float]]:
+        """The bar's items: the full version, plus the selected metric families.
+
+        Args:
+            trainer: The running trainer.
+            pl_module: The module being trained. Unused; part of the hook.
+
+        Returns:
+            What to render, in the order Lightning would have rendered it.
+        """
+        items = super().get_metrics(trainer, pl_module)
+
+        # Undo get_standard_metrics' truncation. Lightning derives v_num from a
+        # private helper that reports a version only when every logger agrees on
+        # one; that rule is reproduced here from the public `.version`
+        # attribute rather than by importing the private symbol, which is the
+        # same cross-boundary fragility this package avoids in its own modules
+        # -- and worse here, since it can vanish in a Lightning minor release.
+        # If v_num is absent, or the loggers disagree, whatever Lightning
+        # decided stands.
+        if "v_num" in items:
+            versions = {logger.version for logger in trainer.loggers}
+            if len(versions) == 1 and (version := versions.pop()) not in ("", None):
+                items["v_num"] = version
+
+        if self.metrics is None:
+            return items
+        allowed = set(self.metrics)
+        # A key with no "/" is not one of our tags (v_num, and anything
+        # Lightning adds later); those are never filtered out.
+        return {k: v for k, v in items.items() if "/" not in k or k.split("/")[0] in allowed}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1313,3 +1313,57 @@ def test_ckpt_path_reload_survives_subclass_mode(tmp_path, monkeypatch):
     # annotation coerces it — more evidence the value came through the config
     # machinery rather than being read off the checkpoint dict directly.
     assert cli.model.training_config.example_input_shape == (3, 32, 32)
+
+
+def test_cli_supplies_the_project_progress_bar_by_default():
+    """The callback is useless unwired: Lightning installs its own bar unless
+    something replaces it, so the truncated run name would survive in every
+    existing config."""
+    from sisr.cli import SRLightningCLI
+    from sisr.training.callbacks import SRProgressBar
+
+    out = SRLightningCLI._with_default_progress_bar(None, [])
+    assert [type(cb) for cb in out] == [SRProgressBar]
+
+
+def test_cli_progress_bar_default_yields_to_a_configured_one():
+    """It must NOT be supplied unconditionally. Trainer raises for two progress
+    bars, and LightningCLI._instantiate_trainer merges trainer_defaults by
+    APPENDING -- so wiring it that way would turn any config naming its own
+    progress bar into a hard startup failure rather than an override."""
+    from lightning.pytorch.callbacks import TQDMProgressBar
+
+    from sisr.cli import SRLightningCLI
+    from sisr.training.callbacks import SRProgressBar
+
+    mine = TQDMProgressBar()
+    # declared in the config's trainer.callbacks
+    assert SRLightningCLI._with_default_progress_bar([mine], []) == []
+    # or assembled by Lightning separately
+    assert SRLightningCLI._with_default_progress_bar(None, [mine]) == [mine]
+    # a project bar the user configured explicitly also counts
+    theirs = SRProgressBar(metrics=["psnr"])
+    assert SRLightningCLI._with_default_progress_bar([theirs], []) == []
+
+
+def test_cli_progress_bar_default_keeps_other_callbacks():
+    """Only the progress bar is defaulted; nothing else is touched."""
+    from lightning.pytorch.callbacks import LearningRateMonitor
+
+    from sisr.cli import SRLightningCLI
+    from sisr.training.callbacks import SRProgressBar
+
+    lr = LearningRateMonitor()
+    out = SRLightningCLI._with_default_progress_bar(None, [lr])
+    assert out[0] is lr
+    assert isinstance(out[1], SRProgressBar)
+
+
+def test_cli_progress_bar_default_respects_enable_progress_bar_false():
+    """Trainer refuses a progress-bar callback outright when the bar is
+    disabled, so a default injected regardless breaks every run that turns it
+    off. Caught by the existing suite, not by this test -- which is why the
+    test exists now."""
+    from sisr.cli import SRLightningCLI
+
+    assert SRLightningCLI._with_default_progress_bar(None, [], enable_progress_bar=False) == []

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -2742,3 +2742,82 @@ def test_benchmark_means_are_tagged_by_the_grammar_owner(monkeypatch):
     }
     cb._flush_buffer(module)
     assert "psnr.Set5.Y" in logged, f"benchmark tags did not follow the grammar: {sorted(logged)}"
+
+
+# ---------------------------------------------------------------------------
+# SRProgressBar: full run name, and a configurable metric set
+# ---------------------------------------------------------------------------
+
+
+def _bar_trainer(version, pbar_metrics):
+    """Minimal stand-in: get_metrics reads only loggers and progress_bar_metrics."""
+    from types import SimpleNamespace
+
+    logger = SimpleNamespace(version=version, name="n", save_dir=".", group_separator="/")
+    return SimpleNamespace(loggers=[logger], progress_bar_metrics=dict(pbar_metrics))
+
+
+_BAR_METRICS = {
+    "loss/train": 0.0177,
+    "loss/train/d": 0.0217,
+    "loss/val": 0.0049,
+    "psnr/val/RGB": 24.50,
+    "ssim/val/RGB": 0.827,
+}
+
+
+def test_progress_bar_shows_the_whole_run_name():
+    """Lightning's get_standard_metrics truncates unconditionally --
+    `version = version[-4:]`, a rule written for integer-ish versions like
+    'version_10' -> '_10'. This project names runs after what they ARE, so
+    'vgg54-scaled' rendered as 'aled', and two runs differing anywhere but the
+    last four characters were indistinguishable in the bar."""
+    from sisr.training.callbacks import SRProgressBar
+
+    items = SRProgressBar().get_metrics(_bar_trainer("vgg54-scaled", _BAR_METRICS), None)
+    assert items["v_num"] == "vgg54-scaled"
+
+
+def test_progress_bar_default_shows_todays_metric_set():
+    """No shipped config may change what it displays."""
+    from sisr.training.callbacks import SRProgressBar
+
+    items = SRProgressBar().get_metrics(_bar_trainer("run", _BAR_METRICS), None)
+    assert set(items) == {"v_num", *_BAR_METRICS}
+
+
+def test_progress_bar_can_be_narrowed_to_psnr_and_ssim():
+    """The requested view: only what is being watched, plus which run it is."""
+    from sisr.training.callbacks import SRProgressBar
+
+    bar = SRProgressBar(metrics=["psnr", "ssim"])
+    items = bar.get_metrics(_bar_trainer("vgg54-scaled", _BAR_METRICS), None)
+    assert set(items) == {"v_num", "psnr/val/RGB", "ssim/val/RGB"}
+
+
+def test_progress_bar_can_drop_psnr_and_ssim_for_an_adversarial_run():
+    """On a GAN variant PSNR/SSIM get worse by design, so the losses are what
+    is worth watching -- the filter has to subtract, not only select."""
+    from sisr.training.callbacks import SRProgressBar
+
+    items = SRProgressBar(metrics=["loss"]).get_metrics(_bar_trainer("g", _BAR_METRICS), None)
+    assert set(items) == {"v_num", "loss/train", "loss/train/d", "loss/val"}
+
+
+def test_progress_bar_rejects_an_unknown_metric_family():
+    """A typo would silently show an empty bar, which reads as "nothing is
+    being logged" rather than "you asked for a family that does not exist"."""
+    from sisr.training.callbacks import SRProgressBar
+
+    SRProgressBar(metrics=["psnr", "ssim", "loss", "lpips", "dists"])  # all valid
+    with pytest.raises(ValueError, match="metrics"):
+        SRProgressBar(metrics=["psnr", "pnsr"])
+
+
+def test_progress_bar_keeps_v_num_even_when_it_is_filtered_out():
+    """v_num is not a metric family and must survive any selection -- knowing
+    which run you are watching is the reason the bar was wrong to begin with."""
+    from sisr.training.callbacks import SRProgressBar
+
+    items = SRProgressBar(metrics=["psnr"]).get_metrics(_bar_trainer("abc-def", _BAR_METRICS), None)
+    assert items["v_num"] == "abc-def"


### PR DESCRIPTION
**Stack position 12 of 12 · review group: hygiene / UX · base: `fix/test-dataloader-raises` (#256)**

Closes #237. Last of the stack.

### Before / after

```
before:  v_num=aled, loss/train/d=0.0217, loss/train=0.0177, loss/val=0.0049,
         psnr/val/RGB=24.50, ssim/val/RGB=0.827

after :  v_num=vgg54-scaled, loss/train/d=0.0217, loss/train=0.0177, ...    (default)
after :  v_num=vgg54-scaled, psnr/val/RGB=24.50, ssim/val/RGB=0.827         (metrics: [psnr, ssim])
```

Both verified against a real `TensorBoardLogger`, not only in unit tests.

### 1. The run name

Lightning truncates unconditionally — `version = version[-4:]`, a rule written for integer-ish
versions (`version_10` → `_10`). This project names runs after what they *are*, so
`vgg54-scaled` rendered as `aled` and two runs differing anywhere but their last four
characters were indistinguishable — exactly when you most want to know which you are watching.

### 2. The metric set

`metrics` takes a list of families, defaulting to `None` = **exactly what is shown today**, so
no shipped config changes what it displays.

| setting | bar shows |
|---|---|
| `None` (default) | everything logged `prog_bar=True`, as now |
| `['psnr', 'ssim']` | the scored view |
| `['loss']` | an adversarial run, where PSNR/SSIM get worse by design |

The filter **subtracts as well as selects**, per the request. An unknown family raises rather
than silently rendering an empty bar, which would read as "nothing is being logged".

### The wiring is the subtle part

An unwired callback fixes nothing — Lightning installs its own bar unless something replaces
it. But **`trainer_defaults` is the wrong mechanism**, and I verified why rather than assuming:

```python
# LightningCLI._instantiate_trainer
config[key] += value if isinstance(value, list) else [value]   # APPENDS
```

```
Trainer(callbacks=[SRProgressBar(), TQDMProgressBar()])
-> MisconfigurationException: You added multiple progress bar callbacks
```

So `trainer_defaults` would turn any config naming its own progress bar into a **hard startup
failure** rather than an override. `SRLightningCLI._instantiate_trainer` injects the default
only when no progress bar is already configured.

**A third case was caught by the existing suite, not anticipated by me:**
`enable_progress_bar=False` — `Trainer` refuses a progress-bar callback outright when the bar
is disabled, so three CLI tests failed. Fixed, and it now has its own test.

### One deliberate non-dependency

Lightning's private `_version` helper is **not** imported. Its rule — report a version only
when every logger agrees on one — is reproduced from the public `.version` attribute instead.
A private third-party symbol can vanish in a minor release, and this stack has a PR about
exactly that smell in our own modules.

### Risk

**None to any number.** `prog_bar` controls display only; every metric still reaches
TensorBoard and `metrics.csv` exactly as before.

### Evidence

- 6 tests for the bar + 4 for the wiring, all proven RED first.
- `473 passed` across `tests/training` and `tests/test_cli.py`.
- `mypy` clean; `ruff` clean.
