### PR TITLE
docs: state that the HR cache checksum keys on name and size only

### DIFF
--- a/sisr/datasets/hr_cache.py
+++ b/sisr/datasets/hr_cache.py
@@ -62,6 +62,12 @@ def compute_checksum(img_paths: Sequence[Path]) -> str:
     parameter enters this hash — the cache stores whole raw images, unaffected
     by anything derived from them at read time.
 
+    **It keys on name and size only**, so replacing an image with a different
+    one of the same byte length under the same name does not invalidate the
+    cache. That is accepted, not an oversight: keying on ``st_mtime_ns`` too
+    would make every ``git checkout`` or ``rsync`` re-decode the whole dataset.
+    If you have edited an image in place, delete the cache directory.
+
     Returns:
         A hex-encoded SHA-256 digest string.
     """

--- a/tests/datasets/test_hr_cache.py
+++ b/tests/datasets/test_hr_cache.py
@@ -257,3 +257,34 @@ def test_existing_cache_reopens_without_rebuild_via_either_architecture(
     mock_srresnet.assert_not_called()
     mock_srcnn.assert_not_called()
     assert built._cache.path == reopened_srresnet._cache.path == reopened_srcnn._cache.path
+
+
+def test_checksum_keys_on_name_and_size_only(tmp_path):
+    """Pins the accepted property: two different images of the same name and
+    byte length hash identically. Here so nobody adds mtime without reading the
+    docstring's reason first."""
+    import numpy as np
+    from PIL import Image
+
+    from sisr.datasets.hr_cache import compute_checksum
+
+    path = tmp_path / "img.png"
+    rng = np.random.default_rng(0)
+
+    # Two different images; PNG is lossless, so equal byte length is not
+    # guaranteed -- search until two differ in content but not in size.
+    first = None
+    for _ in range(200):
+        arr = rng.integers(0, 256, (16, 16, 3), dtype=np.uint8)
+        Image.fromarray(arr).save(path)
+        size, digest = path.stat().st_size, compute_checksum([path])
+        if first is None:
+            first = (size, digest, arr)
+            continue
+        if size == first[0] and not np.array_equal(arr, first[2]):
+            assert digest == first[1], (
+                "a different image of the same name and byte size must hash "
+                "identically -- this property is accepted, see the docstring"
+            )
+            return
+    pytest.skip("no same-size pair found in 200 tries; the property is unchanged")


### PR DESCRIPTION
**Stack position 13 of 13 · base: `feat/progress-bar-callback` (#257)**

No issue — the settled decision from the last review round, written down where the code is.

`compute_checksum` keys on **name and size only**, so replacing an image with a different one of
the same byte length under the same name does not invalidate the cache. Accepted rather than
fixed: keying on `st_mtime_ns` too would make every `git checkout` or `rsync` re-decode the whole
dataset.

Two commits, per the repo's doc-only rule: the docstring, then a test pinning the property so
nobody adds mtime without reading the reason first. The test searches for a same-byte-length PNG
pair rather than assuming one, and skips if it cannot find one, so it cannot flake.
