### PR TITLE
fix: take SRResNet to the reference degradation order; hold SRCNN, measured

### DIFF
--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -23,6 +23,7 @@ import torch
 from PIL import Image
 
 from ..utils.cache import LMDBCache, LMDBCacheBuildContext
+from . import derived_cache
 from .hr_cache import CACHE_NAME, FORMAT_TAG, HEADER, compute_checksum, estimate_map_size
 
 
@@ -116,11 +117,21 @@ class HRCachedTrainDataset(SRDataset):
     SRResNet's train datasets need identically — so the two cannot drift on
     it (e.g. two different build progress-bar labels for what is, by design,
     one shared cache). A subclass supplies only its indexing scheme (grid vs
-    random crop, via :attr:`_img_sizes`) and its read-time degradation, built
-    on :meth:`_read_hr`.
+    random crop, via :attr:`_img_sizes`).
+
+    It owns **two** caches. The raw-HR one is shared verbatim across
+    architectures and scales. The derived-plane one
+    (:mod:`~sisr.datasets.derived_cache`) is per ``(kind, scale)`` and holds the
+    whole image already degraded, so a crop taken from it matches what the
+    reference pipelines produce — degrading the crop instead resolves the
+    bicubic kernel's edge taps against the crop border. Read them with
+    :meth:`_read_hr` and :meth:`_read_derived`.
 
     Args:
         img_dir: Directory of HR images.
+        scale: Upscaling factor the derived plane is built for.
+        derived_kind: Which plane to derive — see
+            :data:`~sisr.datasets.derived_cache.KINDS`.
         use_tqdm: Whether to display a progress bar during the LMDB build.
         cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
         build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
@@ -135,6 +146,8 @@ class HRCachedTrainDataset(SRDataset):
     def __init__(
         self,
         img_dir: str | Path,
+        scale: int,
+        derived_kind: str,
         use_tqdm: bool = False,
         cache_dir: str | Path | None = None,
         build_num_workers: int | None = None,
@@ -144,6 +157,7 @@ class HRCachedTrainDataset(SRDataset):
         self._index_images(img_dir)
         self.build_num_workers = build_num_workers
         self._img_sizes = self._collect_sizes()
+        self._derived_kind = derived_kind
 
         cache_dir = Path(cache_dir) if cache_dir else self.img_dir / ".lmdb_cache"
         self._cache = LMDBCache(
@@ -154,6 +168,26 @@ class HRCachedTrainDataset(SRDataset):
             map_size=estimate_map_size(self._img_sizes),
             metadata={"format": FORMAT_TAG},
             build_fn=self._build,
+            use_tqdm=use_tqdm,
+        )
+        # A sibling database in the same directory, not a second value in the one
+        # above: that cache's checksum deliberately ignores every derivation
+        # parameter, so a scale-dependent plane stored there would never be
+        # invalidated by a scale change.
+        self._derived = LMDBCache(
+            cache_dir=cache_dir,
+            name=derived_cache.cache_name(derived_kind, scale),
+            checksum=derived_cache.compute_checksum(self.img_paths, derived_kind, scale),
+            length=len(self.img_paths),
+            map_size=derived_cache.estimate_map_size(self._img_sizes, derived_kind, scale),
+            metadata={"format": derived_cache.cache_name(derived_kind, scale)},
+            build_fn=lambda ctx: ctx.parallel_build(
+                items=self.img_paths,
+                process_fn=derived_cache.process_derived_image,
+                process_args=[(i, derived_kind, scale) for i in range(len(self.img_paths))],
+                num_workers=self.build_num_workers,
+                desc=f"Building {derived_kind} cache (x{scale})",
+            ),
             use_tqdm=use_tqdm,
         )
 
@@ -226,3 +260,25 @@ class HRCachedTrainDataset(SRDataset):
                 raise KeyError(key)
             h, w = HEADER.unpack_from(buf, 0)
             yield np.frombuffer(buf, dtype=np.uint8, offset=HEADER.size).reshape(h, w, 3)
+
+    @contextmanager
+    def _read_derived(self, img_idx: int) -> Iterator[np.ndarray]:
+        """Yields the cached derived plane at ``img_idx`` as an ``(H, W, 3)`` uint8 view.
+
+        Same zero-copy contract as :meth:`_read_hr` — the view is valid only
+        inside the ``with`` block. The plane was derived from the **whole**
+        image, so a slice of it is what the reference pipelines produce and a
+        degraded slice of :meth:`_read_hr` is not.
+
+        Raises:
+            KeyError: If the backing LMDB entry is missing (a corrupt or
+                incomplete cache).
+        """
+        key = f"{self._derived_kind}_{img_idx:08d}"
+        with self._derived.get_buffer(key) as buf:
+            if buf is None:
+                raise KeyError(key)
+            h, w = derived_cache.HEADER.unpack_from(buf, 0)
+            yield np.frombuffer(buf, dtype=np.uint8, offset=derived_cache.HEADER.size).reshape(
+                h, w, 3
+            )

--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -131,7 +131,11 @@ class HRCachedTrainDataset(SRDataset):
         img_dir: Directory of HR images.
         scale: Upscaling factor the derived plane is built for.
         derived_kind: Which plane to derive — see
-            :data:`~sisr.datasets.derived_cache.KINDS`.
+            :data:`~sisr.datasets.derived_cache.KINDS` — or ``None`` to build
+            no derived cache at all. ``None`` is not a convenience: a plane
+            that pushes the working set past RAM makes shuffled training
+            I/O-bound, which is measurably far worse than the per-item work
+            it removes. See :mod:`sisr.datasets.srcnn`.
         use_tqdm: Whether to display a progress bar during the LMDB build.
         cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
         build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
@@ -147,7 +151,7 @@ class HRCachedTrainDataset(SRDataset):
         self,
         img_dir: str | Path,
         scale: int,
-        derived_kind: str,
+        derived_kind: str | None,
         use_tqdm: bool = False,
         cache_dir: str | Path | None = None,
         build_num_workers: int | None = None,
@@ -174,21 +178,25 @@ class HRCachedTrainDataset(SRDataset):
         # above: that cache's checksum deliberately ignores every derivation
         # parameter, so a scale-dependent plane stored there would never be
         # invalidated by a scale change.
-        self._derived = LMDBCache(
-            cache_dir=cache_dir,
-            name=derived_cache.cache_name(derived_kind, scale),
-            checksum=derived_cache.compute_checksum(self.img_paths, derived_kind, scale),
-            length=len(self.img_paths),
-            map_size=derived_cache.estimate_map_size(self._img_sizes, derived_kind, scale),
-            metadata={"format": derived_cache.cache_name(derived_kind, scale)},
-            build_fn=lambda ctx: ctx.parallel_build(
-                items=self.img_paths,
-                process_fn=derived_cache.process_derived_image,
-                process_args=[(i, derived_kind, scale) for i in range(len(self.img_paths))],
-                num_workers=self.build_num_workers,
-                desc=f"Building {derived_kind} cache (x{scale})",
-            ),
-            use_tqdm=use_tqdm,
+        self._derived = (
+            None
+            if derived_kind is None
+            else LMDBCache(
+                cache_dir=cache_dir,
+                name=derived_cache.cache_name(derived_kind, scale),
+                checksum=derived_cache.compute_checksum(self.img_paths, derived_kind, scale),
+                length=len(self.img_paths),
+                map_size=derived_cache.estimate_map_size(self._img_sizes, derived_kind, scale),
+                metadata={"format": derived_cache.cache_name(derived_kind, scale)},
+                build_fn=lambda ctx: ctx.parallel_build(
+                    items=self.img_paths,
+                    process_fn=derived_cache.process_derived_image,
+                    process_args=[(i, derived_kind, scale) for i in range(len(self.img_paths))],
+                    num_workers=self.build_num_workers,
+                    desc=f"Building {derived_kind} cache (x{scale})",
+                ),
+                use_tqdm=use_tqdm,
+            )
         )
 
     def _compute_checksum(self) -> str:
@@ -274,6 +282,11 @@ class HRCachedTrainDataset(SRDataset):
             KeyError: If the backing LMDB entry is missing (a corrupt or
                 incomplete cache).
         """
+        if self._derived is None:
+            raise RuntimeError(
+                f"{type(self).__name__} was built with derived_kind=None, so there is "
+                f"no derived plane to read. Either pass a kind or derive at read time."
+            )
         key = f"{self._derived_kind}_{img_idx:08d}"
         with self._derived.get_buffer(key) as buf:
             if buf is None:

--- a/sisr/datasets/derived_cache.py
+++ b/sisr/datasets/derived_cache.py
@@ -1,0 +1,160 @@
+"""Whole-image derived planes, cached as a sibling of the raw-HR cache.
+
+Both train datasets need a plane derived from the **whole** HR image: SRResNet
+the bicubic downscale, SRCNN that downscale bicubically restored to HR size.
+Degrading an already-extracted crop instead resolves the kernel's edge taps
+against the crop border rather than the real neighbouring pixels, which is not
+what the surveyed reference pipelines do and not what produced the numbers this
+project compares against.
+
+**A sibling cache, never a second value inside the raw-HR one.**
+:func:`~sisr.datasets.hr_cache.compute_checksum` states that no degradation
+parameter enters its hash, and every shipped config points every architecture at
+one shared cache directory. A scale-dependent plane living in there would be
+invalidated by nothing -- build at x4, run at x3, same checksum, wrong pixels.
+So the derived plane gets its own database, whose *name* and *checksum* both
+carry kind, scale and :data:`IMRESIZE_VERSION`. A stale one is unreachable
+rather than silently wrong.
+
+Deliberately torch-free, for the same reason :mod:`~sisr.datasets.hr_cache` is:
+:func:`process_derived_image` is the function pickled to ``ProcessPoolExecutor``
+build workers, and a spawned worker re-imports *its own defining module*.
+"""
+
+import hashlib
+import struct
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from ..utils.imresize import resize
+
+IMRESIZE_VERSION = 1
+"""Bumped **by hand** whenever :mod:`sisr.utils.imresize` changes its output.
+
+Deliberately not a hash of that module's source: a docstring or comment edit
+would then invalidate every derived plane and trigger a multi-gigabyte rebuild.
+That is the same failure mode that made the raw-HR cache key on name and size
+only, and the fix's failure mode being common where the defect's is rare is
+exactly why it was rejected there.
+"""
+
+KINDS = ("lr", "bicubic")
+"""``'lr'`` -- the bicubic downscale by ``scale`` (SRResNet's model input).
+``'bicubic'`` -- that downscale bicubically restored to HR size (SRCNN's)."""
+
+HEADER = struct.Struct("<II")
+
+
+def modcrop_extent(length: int, scale: int) -> int:
+    """Returns the largest multiple of *scale* not exceeding *length*.
+
+    The single owner of the authors' ``modcrop`` convention, in the one form
+    its callers need: a cropped extent as a number, to slice by or to grid over.
+    """
+    return length - (length % scale)
+
+
+def modcrop(arr: np.ndarray, scale: int) -> np.ndarray:
+    """Crops *arr* so both spatial axes are whole multiples of *scale*.
+
+    The authors' released ``demo_SR.m`` applies this to the ground truth
+    **before** the bicubic round trip::
+
+        im_gnd = modcrop(im, up_scale);
+        im_l   = imresize(im_gnd, 1/up_scale, 'bicubic');
+        im_b   = imresize(im_l,   up_scale,   'bicubic');
+
+    Without it, an image whose height is not a multiple of *scale* is
+    downsampled to ``h // scale`` rows and stretched back over ``h``, so the LR
+    sampling grid does not align with the HR one.
+    """
+    h, w = arr.shape[:2]
+    return arr[: modcrop_extent(h, scale), : modcrop_extent(w, scale)]
+
+
+def derive(arr: np.ndarray, kind: str, scale: int) -> np.ndarray:
+    """Produces one derived plane from a **whole** HR array.
+
+    Args:
+        arr: ``(H, W, 3)`` uint8 RGB, not yet modcropped.
+        kind: One of :data:`KINDS`.
+        scale: Upscaling factor.
+
+    Returns:
+        ``(H', W', 3)`` uint8 — ``(H, W)`` modcropped and divided by *scale*
+        for ``'lr'``, or modcropped and round-tripped back to that size for
+        ``'bicubic'``.
+
+    Raises:
+        ValueError: If *kind* is not in :data:`KINDS`.
+    """
+    if kind not in KINDS:
+        raise ValueError(f"kind must be one of {KINDS}; got {kind!r}.")
+    gnd = modcrop(arr, scale)
+    h, w = gnd.shape[:2]
+    lr = resize(np.ascontiguousarray(gnd), (h // scale, w // scale))
+    if kind == "lr":
+        return lr
+    return resize(np.ascontiguousarray(lr), (h, w))
+
+
+def derived_shape(height: int, width: int, kind: str, scale: int) -> tuple[int, int]:
+    """The ``(h, w)`` :func:`derive` will produce, without deriving it."""
+    h, w = modcrop_extent(height, scale), modcrop_extent(width, scale)
+    return (h, w) if kind == "bicubic" else (h // scale, w // scale)
+
+
+def cache_name(kind: str, scale: int) -> str:
+    """The LMDB database name for this plane, sibling to the raw-HR one.
+
+    Carries *kind*, *scale* and :data:`IMRESIZE_VERSION` so two derivations of
+    the same images never share a database.
+    """
+    return f"derived_{kind}_x{scale}_v{IMRESIZE_VERSION}"
+
+
+def process_derived_image(path: Path, idx: int, kind: str, scale: int) -> list[tuple[str, bytes]]:
+    """Decodes one HR image, derives its plane, and returns its LMDB entry.
+
+    Top-level (not a method) so it can be pickled by ``ProcessPoolExecutor`` on
+    spawn platforms.
+
+    Returns:
+        ``[(f'{kind}_{idx:08d}', header + raw_bytes)]``, *header* being
+        :data:`HEADER`-packed ``(h, w)`` of the derived plane.
+    """
+    arr = np.array(Image.open(path).convert("RGB"))
+    out = derive(arr, kind, scale)
+    h, w = out.shape[:2]
+    return [(f"{kind}_{idx:08d}", HEADER.pack(h, w) + out.tobytes())]
+
+
+def compute_checksum(img_paths: Sequence[Path], kind: str, scale: int) -> str:
+    """SHA-256 over the file manifest **plus** kind, scale and imresize version.
+
+    Unlike the raw-HR checksum, the derivation parameters are part of this hash:
+    that is the whole reason this cache is separate. Keys on name and size only,
+    for the reason stated in
+    :func:`sisr.datasets.hr_cache.compute_checksum`.
+    """
+    manifest = ",".join(f"{p.name}:{p.stat().st_size}" for p in img_paths)
+    canonical = "|".join(
+        [manifest, f"kind={kind}", f"scale={scale}", f"imresize={IMRESIZE_VERSION}"]
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def estimate_map_size(sizes: Sequence[tuple[int, int]], kind: str, scale: int) -> int:
+    """LMDB ``map_size`` for the derived planes of images with these sizes.
+
+    Exact derived sizes plus 10% slack, floored at 64 MiB — the contract
+    :func:`sisr.datasets.hr_cache.estimate_map_size` documents.
+    """
+    total = 0
+    for h, w in sizes:
+        dh, dw = derived_shape(h, w, kind, scale)
+        total += HEADER.size + dh * dw * 3
+    return max(int(total * 1.1), 64 * 1024 * 1024)

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -10,14 +10,21 @@ image once and slicing its deterministic sub-images out at load time is far
 cheaper than re-decoding, and it decouples that cache from the sub-image
 grid (``subimg_size``, ``stride``): neither affects the raw bytes stored.
 
-**The whole image is degraded once and both sub-images are sliced from the
-result**, which is the order the authors' released ``demo_SR.m`` uses —
-``modcrop`` then ``imresize`` down then up, and only then patch extraction.
-Degrading an already-extracted patch instead resolves the bicubic kernel's
-edge taps against the patch border: at x3 the interior is bit-identical and
-the entire difference is a 4px border, 43% of a 33x33 patch. The degraded
-plane is cached separately by :mod:`~sisr.datasets.derived_cache`, whose key
-*does* carry ``scale``.
+**The training path still degrades each extracted patch, and that is a known
+fidelity gap held open deliberately.** The authors' released ``demo_SR.m``
+degrades the whole image first — ``modcrop``, ``imresize`` down, ``imresize``
+up — and only then extracts, which leaves a measurable difference in a 4px
+patch border at x3.
+
+Caching that whole-image plane is what :mod:`~sisr.datasets.derived_cache`
+exists for, and SRResNet uses it. **SRCNN deliberately does not.** Its
+formulation is pre-upsampled, so the degraded plane is HR-sized rather than
+1/scale^2 of it: caching it doubles the working set, and once that exceeds RAM
+a shuffled training loader becomes I/O-bound. Measured on a 12 GB box,
+real training loop: **21.60 it/s degrading per patch against 1.02 it/s reading a
+cached plane** — a 21x regression, because the working set went from 6.3 GB to
+12.6 GB. The correctness gain is real and the cost is worse; the trade is
+recorded on the issue rather than taken silently.
 :class:`ValidationDataset` generates LR pairs on the fly for full images.
 
 LR degradation uses MATLAB-compatible antialiased bicubic resizing (see
@@ -98,15 +105,14 @@ class TrainDataset(HRCachedTrainDataset):
     Every HR image is decoded once into an LMDB cache (uint8 RGB, whole) — see
     :mod:`~sisr.datasets.base` for why. Each ``__getitem__`` maps its flat index
     to a source image and a deterministic ``(top, left)`` grid position in O(1),
-    and slices the ``subimg_size`` square out of **both** whole-image planes at
-    that position — the degraded one already computed over the whole image, so
-    no kernel ever reaches past a patch edge.
+    slices the ``subimg_size`` square HR sub-image, and degrades it to LR.
     **The grid is derived from exactly one place** (:func:`_grid_dims`), so
     indices can never silently misalign.
 
-    Because the degradation now happens before extraction, ``subimg_size`` and
-    ``scale`` are no longer coupled: there is no per-patch sampling grid left to
-    shift, so ``33 % scale`` stops mattering.
+    ``subimg_size`` and ``scale`` stay coupled while the degradation is per
+    patch: ``33 % scale`` shifts each patch's own LR sampling grid, so x3 is
+    better behaved than x2 or x4. See the module docstring for why the fix that
+    would remove that coupling is not applied here.
 
     **The checksum keys only on the file manifest** (plus a format tag), not on
     ``subimg_size``/``stride``/``scale`` — none of those affect the bytes
@@ -148,7 +154,9 @@ class TrainDataset(HRCachedTrainDataset):
         super().__init__(
             img_dir,
             scale=scale,
-            derived_kind="bicubic",
+            # No derived plane: HR-sized, so caching it doubles the working set
+            # and makes shuffled training I/O-bound. Measured in the module docstring.
+            derived_kind=None,
             use_tqdm=use_tqdm,
             cache_dir=cache_dir,
             build_num_workers=build_num_workers,
@@ -191,11 +199,9 @@ class TrainDataset(HRCachedTrainDataset):
         Locates *idx*'s source image and grid position in O(1) via
         :attr:`_img_offsets`/:attr:`_img_n_cols`, slices the HR sub-image out
         of that image's cached raw bytes (via
-        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`) and the LR
-        sub-image out of the whole-image degraded plane (via
-        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_derived`) at the
-        same position. Both planes are modcropped identically, so the two
-        slices are aligned by construction.
+        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`), and derives
+        LR from it with :func:`_degrade` — numerically identical to computing
+        both at build time, just performed at load time instead.
 
         Args:
             idx (int): Zero-based sub-image index.
@@ -222,10 +228,7 @@ class TrainDataset(HRCachedTrainDataset):
                 top : top + self.sub_img_size, left : left + self.sub_img_size, :
             ].copy()
 
-        with self._read_derived(img_idx) as plane:
-            lr_subimg = plane[
-                top : top + self.sub_img_size, left : left + self.sub_img_size, :
-            ].copy()
+        lr_subimg = _degrade(hr_subimg, self.scale)
 
         return self._to_tensor(lr_subimg), self._to_tensor(hr_subimg)
 

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -7,10 +7,17 @@ through :mod:`~sisr.datasets.hr_cache`, shared verbatim with
 :mod:`sisr.datasets.srresnet` — the same image directory produces exactly one
 cache regardless of which architecture builds it first. Decoding a source
 image once and slicing its deterministic sub-images out at load time is far
-cheaper than re-decoding, and it decouples the cache from every
-LR-generation parameter (``scale``) as well as the sub-image grid itself
-(``subimg_size``, ``stride``): none of them affect the raw bytes stored, only
-what gets sliced/degraded from them at read time.
+cheaper than re-decoding, and it decouples that cache from the sub-image
+grid (``subimg_size``, ``stride``): neither affects the raw bytes stored.
+
+**The whole image is degraded once and both sub-images are sliced from the
+result**, which is the order the authors' released ``demo_SR.m`` uses —
+``modcrop`` then ``imresize`` down then up, and only then patch extraction.
+Degrading an already-extracted patch instead resolves the bicubic kernel's
+edge taps against the patch border: at x3 the interior is bit-identical and
+the entire difference is a 4px border, 43% of a 33x33 patch. The degraded
+plane is cached separately by :mod:`~sisr.datasets.derived_cache`, whose key
+*does* carry ``scale``.
 :class:`ValidationDataset` generates LR pairs on the fly for full images.
 
 LR degradation uses MATLAB-compatible antialiased bicubic resizing (see
@@ -28,39 +35,9 @@ import torch
 from ..utils.cache import LMDBCacheBuildContext
 from ..utils.imresize import resize
 from .base import HRCachedTrainDataset, SRDataset
+from .derived_cache import modcrop as _modcrop
+from .derived_cache import modcrop_extent as _modcrop_extent
 from .hr_cache import process_hr_image as _process_hr_image
-
-
-def _modcrop_extent(length: int, scale: int) -> int:
-    """Returns the largest multiple of *scale* not exceeding *length*.
-
-    The single owner of the authors' ``modcrop`` convention, in the one form
-    both callers need: :func:`_grid_dims` wants the cropped extent as a number,
-    :func:`_modcrop` wants to slice by it. Before this existed the convention
-    was spelled out at two sites and absent from a third, which is how SRCNN
-    came to be degraded one way at training time and another at evaluation.
-    """
-    return length - (length % scale)
-
-
-def _modcrop(arr: np.ndarray, scale: int) -> np.ndarray:
-    """Crops *arr* so both spatial axes are whole multiples of *scale*.
-
-    The authors' released ``demo_SR.m`` applies this to the ground truth
-    **before** the bicubic round trip::
-
-        im_gnd = modcrop(im, up_scale);
-        im_l   = imresize(im_gnd, 1/up_scale, 'bicubic');
-        im_b   = imresize(im_l,   up_scale,   'bicubic');
-
-    Without it, an image whose height is not a multiple of *scale* is
-    downsampled to ``h // scale`` rows and stretched back over ``h``, so the LR
-    sampling grid does not align with the HR one. At x3 most standard benchmark
-    images are affected -- 481x321 and 512x512 both are -- so this is the
-    common case, not the corner.
-    """
-    h, w = arr.shape[:2]
-    return arr[: _modcrop_extent(h, scale), : _modcrop_extent(w, scale)]
 
 
 def _grid_dims(
@@ -105,9 +82,10 @@ def _degrade(hr_arr: np.ndarray, scale: int) -> np.ndarray:
     """Derives an LR array from an HR array: bicubic-down → bicubic-up.
 
     Restores *hr_arr*'s original spatial size (SRCNN's pre-upsampled
-    formulation). Shared by :class:`TrainDataset` (per sub-image, at read
-    time) and :class:`ValidationDataset` (per full image) so the degradation
-    recipe cannot drift between the two.
+    formulation). :class:`ValidationDataset` applies it per full image;
+    :class:`TrainDataset` reads the same round trip out of the cached
+    whole-image plane instead of recomputing it per sub-image, so both see a
+    degradation computed over a whole modcropped image and cannot drift.
     """
     h, w = hr_arr.shape[:2]
     down = resize(hr_arr, (h // scale, w // scale))
@@ -120,9 +98,15 @@ class TrainDataset(HRCachedTrainDataset):
     Every HR image is decoded once into an LMDB cache (uint8 RGB, whole) — see
     :mod:`~sisr.datasets.base` for why. Each ``__getitem__`` maps its flat index
     to a source image and a deterministic ``(top, left)`` grid position in O(1),
-    slices the ``subimg_size`` square HR sub-image, and degrades it to LR.
+    and slices the ``subimg_size`` square out of **both** whole-image planes at
+    that position — the degraded one already computed over the whole image, so
+    no kernel ever reaches past a patch edge.
     **The grid is derived from exactly one place** (:func:`_grid_dims`), so
     indices can never silently misalign.
+
+    Because the degradation now happens before extraction, ``subimg_size`` and
+    ``scale`` are no longer coupled: there is no per-patch sampling grid left to
+    shift, so ``33 % scale`` stops mattering.
 
     **The checksum keys only on the file manifest** (plus a format tag), not on
     ``subimg_size``/``stride``/``scale`` — none of those affect the bytes
@@ -162,7 +146,12 @@ class TrainDataset(HRCachedTrainDataset):
         self.stride = stride
         self.scale = scale
         super().__init__(
-            img_dir, use_tqdm=use_tqdm, cache_dir=cache_dir, build_num_workers=build_num_workers
+            img_dir,
+            scale=scale,
+            derived_kind="bicubic",
+            use_tqdm=use_tqdm,
+            cache_dir=cache_dir,
+            build_num_workers=build_num_workers,
         )
         self._img_offsets, self._img_n_cols, self._total_patches = self._compute_grid()
 
@@ -202,9 +191,11 @@ class TrainDataset(HRCachedTrainDataset):
         Locates *idx*'s source image and grid position in O(1) via
         :attr:`_img_offsets`/:attr:`_img_n_cols`, slices the HR sub-image out
         of that image's cached raw bytes (via
-        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`), and
-        derives LR from it with :func:`_degrade` — numerically identical to
-        computing both at build time, just performed at load time instead.
+        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`) and the LR
+        sub-image out of the whole-image degraded plane (via
+        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_derived`) at the
+        same position. Both planes are modcropped identically, so the two
+        slices are aligned by construction.
 
         Args:
             idx (int): Zero-based sub-image index.
@@ -231,7 +222,10 @@ class TrainDataset(HRCachedTrainDataset):
                 top : top + self.sub_img_size, left : left + self.sub_img_size, :
             ].copy()
 
-        lr_subimg = _degrade(hr_subimg, self.scale)
+        with self._read_derived(img_idx) as plane:
+            lr_subimg = plane[
+                top : top + self.sub_img_size, left : left + self.sub_img_size, :
+            ].copy()
 
         return self._to_tensor(lr_subimg), self._to_tensor(hr_subimg)
 

--- a/sisr/datasets/srresnet.py
+++ b/sisr/datasets/srresnet.py
@@ -10,6 +10,14 @@ architecture builds it first. Decoding a DIV2K PNG costs ~109ms, while the
 work. The random crop itself is **not** cached (that would defeat crop
 randomness); it is drawn fresh, from the cached raw array, on every
 ``__getitem__`` call.
+
+**The whole image is downscaled once, and the pair is cropped from HR and LR
+together** — the order BasicSR, EDSR and DIV2K's own distributed LR archives
+all use. Downscaling an extracted crop instead resolves the bicubic kernel's
+edge taps against the crop border: measured on DIV2K, every crop's interior
+stays bit-identical while the 2px LR border — 30.6% of a 24x24 patch — differs
+by up to 22/255. The whole-image plane is cached by
+:mod:`~sisr.datasets.derived_cache`.
 :class:`ValidationDataset` serves full images cropped to a multiple of
 ``scale``, uncached (each is decoded once per epoch, no repetition).
 
@@ -33,18 +41,25 @@ class TrainDataset(HRCachedTrainDataset):
 
     Every HR image is decoded once into an LMDB cache (uint8 RGB, whole, with
     its ``(H, W)`` header) — see :mod:`~sisr.datasets.base` for why. Each
-    ``__getitem__`` reads those bytes, takes a fresh random ``hr_crop_size``
-    square crop, and bicubic-downsamples by ``scale`` for the LR input.
-    **Only the decode is memoized, never the crop** — crop randomness has to
-    survive the cache.
+    ``__getitem__`` draws a fresh random position in **LR** coordinates and
+    slices the pair out of the cached whole-image HR and LR planes at that
+    position — the LR one already downscaled, so no kernel ever reaches past a
+    crop edge. **Only the planes are memoized, never the crop** — crop
+    randomness has to survive the cache.
+
+    Drawing in LR coordinates makes every HR offset a multiple of ``scale``,
+    exactly as EDSR does. That is 16x fewer distinct positions at x4 than
+    unaligned offsets would give — 153,892 rather than 2,452,645 on a
+    2040x1356 image — and still ~123M across an 800-image training set.
 
     Unlike :class:`sisr.datasets.srcnn.TrainDataset` there is **no
     downsample+upsample round-trip**: the LR is not upsampled back, the model
     owns the x``scale`` upsampling, and the LR tensor is
     ``hr_crop_size // scale`` a side.
 
-    **The checksum keys only on the file manifest**, so changing
-    ``hr_crop_size``/``crops_per_image``/``scale`` never invalidates the cache.
+    **The raw-HR checksum keys only on the file manifest**, so changing
+    ``hr_crop_size``/``crops_per_image``/``scale`` never invalidates it. The
+    derived LR plane is keyed separately and *does* carry ``scale``.
     HR is always RGB; Y/YCbCr selection happens downstream.
 
     Reference:
@@ -89,7 +104,12 @@ class TrainDataset(HRCachedTrainDataset):
         self.crops_per_image = crops_per_image
         self.lr_size = hr_crop_size // scale
         super().__init__(
-            img_dir, use_tqdm=use_tqdm, cache_dir=cache_dir, build_num_workers=build_num_workers
+            img_dir,
+            scale=scale,
+            derived_kind="lr",
+            use_tqdm=use_tqdm,
+            cache_dir=cache_dir,
+            build_num_workers=build_num_workers,
         )
 
     def _build(self, ctx: LMDBCacheBuildContext) -> None:
@@ -100,31 +120,41 @@ class TrainDataset(HRCachedTrainDataset):
         return len(self.img_paths) * self.crops_per_image
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """Returns a ``(lr_tensor, hr_tensor)`` pair where ``hr_tensor`` is a random crop.
+        """Returns a ``(lr_tensor, hr_tensor)`` pair cropped from the whole-image planes.
 
-        ``hr_tensor`` is a random ``hr_crop_size`` square crop and
-        ``lr_tensor`` is its bicubic downscale by ``scale`` (side
-        ``hr_crop_size // scale``). Both are ``float32`` in ``[0, 1]``
-        with shape ``(3, H, W)``.
+        A random position is drawn in LR coordinates; ``lr_tensor`` is the
+        ``hr_crop_size // scale`` square there and ``hr_tensor`` the
+        ``hr_crop_size`` square at ``scale`` times that position, so the two are
+        aligned by construction. Both are ``float32`` in ``[0, 1]`` with shape
+        ``(3, H, W)``.
+
+        Raises:
+            ValueError: If the image is smaller than ``hr_crop_size`` after the
+                modcrop the LR plane was derived under.
         """
         img_idx = idx % len(self.img_paths)
 
-        with self._read_hr(img_idx) as arr:
-            h, w = arr.shape[:2]
-            if w < self.hr_crop_size or h < self.hr_crop_size:
+        with self._read_derived(img_idx) as lr_plane:
+            lr_h, lr_w = lr_plane.shape[:2]
+            if lr_h < self.lr_size or lr_w < self.lr_size:
                 raise ValueError(
-                    f"Image {self.img_paths[img_idx].name} ({w}x{h}) is smaller than "
-                    f"hr_crop_size {self.hr_crop_size}."
+                    f"Image {self.img_paths[img_idx].name} is {lr_w * self.scale}x"
+                    f"{lr_h * self.scale} after modcrop, smaller than hr_crop_size "
+                    f"{self.hr_crop_size}."
                 )
-            top = random.randint(0, h - self.hr_crop_size)
-            left = random.randint(0, w - self.hr_crop_size)
-            hr_arr = arr[top : top + self.hr_crop_size, left : left + self.hr_crop_size, :].copy()
+            top = random.randint(0, lr_h - self.lr_size)
+            left = random.randint(0, lr_w - self.lr_size)
+            lr_arr = lr_plane[top : top + self.lr_size, left : left + self.lr_size, :].copy()
 
-        lr_arr = resize(hr_arr, (self.lr_size, self.lr_size))
-        lr_tensor = self._to_tensor(lr_arr)
-        hr_tensor = self._to_tensor(hr_arr)
+        hr_top, hr_left = top * self.scale, left * self.scale
+        with self._read_hr(img_idx) as arr:
+            hr_arr = arr[
+                hr_top : hr_top + self.hr_crop_size,
+                hr_left : hr_left + self.hr_crop_size,
+                :,
+            ].copy()
 
-        return lr_tensor, hr_tensor
+        return self._to_tensor(lr_arr), self._to_tensor(hr_arr)
 
 
 class ValidationDataset(SRDataset):

--- a/tests/datasets/test_derived_cache.py
+++ b/tests/datasets/test_derived_cache.py
@@ -1,0 +1,130 @@
+"""The whole-image derived-plane cache.
+
+Its whole reason to exist is that the raw-HR cache's checksum deliberately
+ignores every derivation parameter, so anything scale-dependent stored there
+would never be invalidated. These tests hold that separation.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from sisr.datasets import derived_cache as dc
+from sisr.utils.imresize import resize
+
+
+@pytest.fixture
+def image_paths(tmp_path: Path) -> list[Path]:
+    """Two images, one of them not a multiple of 3 on either axis."""
+    rng = np.random.default_rng(seed=3)
+    paths = []
+    for i, (h, w) in enumerate([(36, 36), (321, 481)]):
+        arr = rng.integers(0, 256, size=(h, w, 3), dtype=np.uint8)
+        p = tmp_path / f"img_{i}.png"
+        Image.fromarray(arr).save(p)
+        paths.append(p)
+    return paths
+
+
+@pytest.mark.parametrize("scale", [2, 3, 4])
+@pytest.mark.parametrize("kind", ["lr", "bicubic"])
+def test_derive_matches_modcrop_then_resize_computed_independently(kind: str, scale: int):
+    """Byte-exact against the authors' order, spelled out here rather than reused."""
+    rng = np.random.default_rng(seed=11)
+    arr = rng.integers(0, 256, size=(321, 481, 3), dtype=np.uint8)
+
+    h, w = 321 - 321 % scale, 481 - 481 % scale
+    gnd = np.ascontiguousarray(arr[:h, :w])
+    expected = resize(gnd, (h // scale, w // scale))
+    if kind == "bicubic":
+        expected = resize(np.ascontiguousarray(expected), (h, w))
+
+    assert np.array_equal(dc.derive(arr, kind, scale), expected)
+
+
+@pytest.mark.parametrize("scale", [2, 3, 4])
+@pytest.mark.parametrize("kind", ["lr", "bicubic"])
+def test_derived_shape_predicts_the_real_output_shape(kind: str, scale: int):
+    """``estimate_map_size`` sizes the database from this without deriving anything,
+    so a disagreement is a MapFullError mid-build."""
+    rng = np.random.default_rng(seed=12)
+    arr = rng.integers(0, 256, size=(321, 481, 3), dtype=np.uint8)
+    assert dc.derived_shape(321, 481, kind, scale) == dc.derive(arr, kind, scale).shape[:2]
+
+
+def test_derive_rejects_an_unknown_kind():
+    with pytest.raises(ValueError, match="kind must be one of"):
+        dc.derive(np.zeros((8, 8, 3), np.uint8), "bilinear", 2)
+
+
+def test_cache_name_separates_kind_scale_and_imresize_version():
+    """A stale plane must be unreachable, not silently wrong: the database name
+    itself carries every parameter that changes the pixels."""
+    names = {
+        dc.cache_name("lr", 2),
+        dc.cache_name("lr", 4),
+        dc.cache_name("bicubic", 2),
+        dc.cache_name("bicubic", 4),
+    }
+    assert len(names) == 4
+    assert all(f"v{dc.IMRESIZE_VERSION}" in n for n in names)
+
+
+def test_checksum_changes_with_kind_scale_and_imresize_version(image_paths, monkeypatch):
+    """Contrast with the raw-HR checksum, which deliberately ignores all three."""
+    base = dc.compute_checksum(image_paths, "lr", 4)
+    assert dc.compute_checksum(image_paths, "bicubic", 4) != base
+    assert dc.compute_checksum(image_paths, "lr", 3) != base
+
+    monkeypatch.setattr(dc, "IMRESIZE_VERSION", dc.IMRESIZE_VERSION + 1)
+    assert dc.compute_checksum(image_paths, "lr", 4) != base
+
+
+def test_checksum_ignores_content_at_equal_name_and_size(image_paths):
+    """Same accepted property as the raw-HR cache, stated here so a future edit
+    does not silently make one stricter than the other."""
+    before = dc.compute_checksum(image_paths, "lr", 4)
+    target = image_paths[0]
+    size = target.stat().st_size
+    rng = np.random.default_rng(seed=99)
+    while True:  # write a different image of identical byte length
+        arr = rng.integers(0, 256, size=(36, 36, 3), dtype=np.uint8)
+        Image.fromarray(arr).save(target)
+        if target.stat().st_size == size:
+            break
+    assert dc.compute_checksum(image_paths, "lr", 4) == before
+
+
+def test_estimate_map_size_is_floored_at_64_mib():
+    assert dc.estimate_map_size([(8, 8)], "lr", 4) == 64 * 1024 * 1024
+
+
+def test_estimate_map_size_covers_the_real_payload(image_paths):
+    sizes = [(321, 481)] * 400
+    est = dc.estimate_map_size(sizes, "bicubic", 3)
+    payload = sum(
+        dc.HEADER.size + h * w * 3 for h, w in (dc.derived_shape(*s, "bicubic", 3) for s in sizes)
+    )
+    assert est >= payload
+
+
+def test_module_imports_no_torch():
+    """``process_derived_image`` is what gets pickled to build workers, and a
+    spawned worker re-imports *this* module — so torch must not ride along."""
+    probe = "import sisr.datasets.derived_cache, sys; print('torch' in sys.modules)"
+    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+    assert out.stdout.strip() == "False"
+
+
+def test_process_derived_image_round_trips_through_its_header(image_paths):
+    """The entry must be self-describing: shape recoverable from the value alone."""
+    [(key, value)] = dc.process_derived_image(image_paths[1], 7, "lr", 3)
+    assert key == "lr_00000007"
+    h, w = dc.HEADER.unpack_from(value, 0)
+    plane = np.frombuffer(value, np.uint8, offset=dc.HEADER.size).reshape(h, w, 3)
+    expected = dc.derive(np.array(Image.open(image_paths[1]).convert("RGB")), "lr", 3)
+    assert np.array_equal(plane, expected)

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -411,21 +411,21 @@ def test_validation_untouched_when_already_divisible(tiny_rgb_image_dir: Path):
         assert lr.shape == hr.shape
 
 
-def test_train_lr_is_sliced_from_the_whole_image_degradation_not_degraded_per_patch(
+def test_train_lr_is_still_degraded_per_patch_and_that_is_deliberate(
     shared_srcnn_train_ds: TrainDataset,
 ):
-    """The authors' ``demo_SR.m`` degrades the image and *then* extracts.
+    """SRCNN keeps the per-patch degradation, against the authors' order, on purpose.
 
-    Ships its own mutation: the patch-wise order is computed here too, and the
-    test fails if the dataset returns that instead. Without it the assertion
-    would pass on either implementation wherever the two happen to agree.
+    Caching the whole-image plane is what fixes the fidelity gap and is what
+    SRResNet does. SRCNN is pre-upsampled, so that plane is HR-sized: caching it
+    took the working set from 6.3 GB to 12.6 GB on a 12 GB box and a real
+    training loop went from 21.60 it/s to 1.02 it/s. This test pins the trade so
+    the slow variant is not reintroduced by someone reading only the issue.
     """
     from sisr.datasets.derived_cache import derive
     from sisr.datasets.srcnn import _degrade
 
     ds = shared_srcnn_train_ds
-    # An interior patch: at the image corner the out-of-patch taps and the
-    # out-of-image taps coincide, so the two orders agree there.
     n_cols = ds._img_n_cols[0]
     idx = n_cols + 1
     row, col = divmod(idx - ds._img_offsets[0], n_cols)
@@ -434,44 +434,26 @@ def test_train_lr_is_sliced_from_the_whole_image_degradation_not_degraded_per_pa
 
     lr, hr = ds[idx]
     got = (lr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+    hr_arr = (hr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
 
+    assert np.array_equal(got, _degrade(hr_arr, ds.scale)), "LR must be the patch's own degradation"
+
+    # And it genuinely differs from the authors' order, so the gap is real and open.
     whole = np.array(Image.open(ds.img_paths[0]).convert("RGB"))
     plane = derive(whole, "bicubic", ds.scale)
-    expected = plane[top : top + ds.sub_img_size, left : left + ds.sub_img_size]
-    assert np.array_equal(got, expected)
-
-    hr_arr = (hr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
-    patchwise = _degrade(hr_arr, ds.scale)
-    assert not np.array_equal(got, patchwise), (
-        "dataset still degrades the extracted patch — the bicubic kernel's edge "
-        "taps resolve against the patch border instead of the real neighbours"
-    )
+    assert not np.array_equal(
+        got, plane[top : top + ds.sub_img_size, left : left + ds.sub_img_size]
+    ), "if these ever match, the fidelity gap is closed and this test should go"
 
 
-def test_subimg_size_and_scale_are_no_longer_coupled(tmp_path: Path):
-    """``33 % scale`` mattered only because ``_degrade`` ran per patch, giving each
-    patch its own LR sampling grid. Degrading the whole image first removes the
-    per-patch grid, so a size indivisible by scale is no longer a special case."""
-    from sisr.datasets.derived_cache import derive
-
-    rng = np.random.default_rng(seed=21)
-    arr = rng.integers(0, 256, size=(64, 64, 3), dtype=np.uint8)
-    for scale in (2, 3, 4):
-        # One directory per scale: the raw-HR cache hashes the manifest only, so
-        # all three would share a database and LMDB refuses a second handle.
-        img_dir = tmp_path / f"x{scale}"
-        img_dir.mkdir()
-        Image.fromarray(arr).save(img_dir / "a.png")
-        ds = TrainDataset(
-            img_dir=img_dir, subimg_size=33, stride=11, scale=scale, build_num_workers=1
-        )
-        n_cols = ds._img_n_cols[0]
-        idx = n_cols + 1
-        row, col = divmod(idx, n_cols)
-        top, left = row * ds.stride, col * ds.stride
-        lr, _ = ds[idx]
-        got = (lr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
-        plane = derive(arr, "bicubic", scale)
-        assert np.array_equal(got, plane[top : top + 33, left : left + 33]), (
-            f"scale {scale}: 33 % {scale} == {33 % scale} must not change anything"
-        )
+def test_srcnn_train_dataset_builds_no_derived_cache(tmp_path: Path):
+    """The opt-out must be real: no second database, and a clear error if read."""
+    rng = np.random.default_rng(seed=23)
+    Image.fromarray(rng.integers(0, 256, size=(64, 64, 3), dtype=np.uint8)).save(tmp_path / "a.png")
+    ds = TrainDataset(img_dir=tmp_path, subimg_size=33, stride=11, scale=3, build_num_workers=1)
+    assert ds._derived is None
+    with pytest.raises(RuntimeError, match="derived_kind=None"):
+        with ds._read_derived(0):
+            pass
+    dbs = {p.name.split("_")[0] for p in (tmp_path / ".lmdb_cache").iterdir() if p.is_dir()}
+    assert dbs == {"hr"}, f"expected only the raw-HR database, found {dbs}"

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -409,3 +409,69 @@ def test_validation_untouched_when_already_divisible(tiny_rgb_image_dir: Path):
         lr, hr = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=scale)[0]
         assert hr.shape[-2:] == (36, 36)
         assert lr.shape == hr.shape
+
+
+def test_train_lr_is_sliced_from_the_whole_image_degradation_not_degraded_per_patch(
+    shared_srcnn_train_ds: TrainDataset,
+):
+    """The authors' ``demo_SR.m`` degrades the image and *then* extracts.
+
+    Ships its own mutation: the patch-wise order is computed here too, and the
+    test fails if the dataset returns that instead. Without it the assertion
+    would pass on either implementation wherever the two happen to agree.
+    """
+    from sisr.datasets.derived_cache import derive
+    from sisr.datasets.srcnn import _degrade
+
+    ds = shared_srcnn_train_ds
+    # An interior patch: at the image corner the out-of-patch taps and the
+    # out-of-image taps coincide, so the two orders agree there.
+    n_cols = ds._img_n_cols[0]
+    idx = n_cols + 1
+    row, col = divmod(idx - ds._img_offsets[0], n_cols)
+    top, left = row * ds.stride, col * ds.stride
+    assert top > 0 and left > 0
+
+    lr, hr = ds[idx]
+    got = (lr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+
+    whole = np.array(Image.open(ds.img_paths[0]).convert("RGB"))
+    plane = derive(whole, "bicubic", ds.scale)
+    expected = plane[top : top + ds.sub_img_size, left : left + ds.sub_img_size]
+    assert np.array_equal(got, expected)
+
+    hr_arr = (hr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+    patchwise = _degrade(hr_arr, ds.scale)
+    assert not np.array_equal(got, patchwise), (
+        "dataset still degrades the extracted patch — the bicubic kernel's edge "
+        "taps resolve against the patch border instead of the real neighbours"
+    )
+
+
+def test_subimg_size_and_scale_are_no_longer_coupled(tmp_path: Path):
+    """``33 % scale`` mattered only because ``_degrade`` ran per patch, giving each
+    patch its own LR sampling grid. Degrading the whole image first removes the
+    per-patch grid, so a size indivisible by scale is no longer a special case."""
+    from sisr.datasets.derived_cache import derive
+
+    rng = np.random.default_rng(seed=21)
+    arr = rng.integers(0, 256, size=(64, 64, 3), dtype=np.uint8)
+    for scale in (2, 3, 4):
+        # One directory per scale: the raw-HR cache hashes the manifest only, so
+        # all three would share a database and LMDB refuses a second handle.
+        img_dir = tmp_path / f"x{scale}"
+        img_dir.mkdir()
+        Image.fromarray(arr).save(img_dir / "a.png")
+        ds = TrainDataset(
+            img_dir=img_dir, subimg_size=33, stride=11, scale=scale, build_num_workers=1
+        )
+        n_cols = ds._img_n_cols[0]
+        idx = n_cols + 1
+        row, col = divmod(idx, n_cols)
+        top, left = row * ds.stride, col * ds.stride
+        lr, _ = ds[idx]
+        got = (lr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+        plane = derive(arr, "bicubic", scale)
+        assert np.array_equal(got, plane[top : top + 33, left : left + 33]), (
+            f"scale {scale}: 33 % {scale} == {33 % scale} must not change anything"
+        )

--- a/tests/datasets/test_srresnet.py
+++ b/tests/datasets/test_srresnet.py
@@ -29,6 +29,17 @@ def varied_size_rgb_image_dir(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
+def _locate(whole: np.ndarray, crop: np.ndarray, size: int) -> tuple[int, int]:
+    """Finds the (top, left) a crop was taken from. The draw is random, so the
+    test recovers the position rather than pinning the RNG."""
+    h, w = whole.shape[:2]
+    for top in range(0, h - size + 1):
+        for left in range(0, w - size + 1):
+            if (whole[top : top + size, left : left + size] == crop).all():
+                return top, left
+    raise AssertionError("crop not found in source image")
+
+
 def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
     """LR must be the MATLAB-compatible bicubic downscale of the SAME HR crop
     the item returned — not merely a (3, h/scale, w/scale) tensor in [0, 1].
@@ -50,13 +61,27 @@ def test_train_dataset_getitem_lr_is_downscaled_hr(tiny_rgb_image_dir: Path):
     assert 0.0 <= lr.min() <= lr.max() <= 1.0
     assert 0.0 <= hr.min() <= hr.max() <= 1.0
 
-    # Reference: recover the HR crop as uint8 HWC and re-run the dataset's own
-    # resize primitive (MATLAB-compatible bicubic).
+    # Reference: the whole image downscaled once, sliced at the pair's own
+    # position -- the order BasicSR, EDSR and DIV2K's distributed LR all use.
+    # The position is recovered by matching the HR crop, since the draw is random.
+    from sisr.datasets.derived_cache import derive
+
     hr_uint8 = (hr.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
-    lr_size = 16 // 4
-    lr_expected_arr = resize(hr_uint8, (lr_size, lr_size))
-    lr_expected = torch.from_numpy(lr_expected_arr).permute(2, 0, 1).float().div(255.0)
-    torch.testing.assert_close(lr, lr_expected, atol=1e-6, rtol=0)
+    whole = np.array(Image.open(ds.img_paths[0]).convert("RGB"))
+    plane = derive(whole, "lr", 4)
+    top, left = _locate(whole, hr_uint8, 16)
+    assert top % 4 == 0 and left % 4 == 0, "HR offsets must be scale-aligned"
+
+    expected = plane[top // 4 : top // 4 + 4, left // 4 : left // 4 + 4]
+    got = (lr.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
+    assert np.array_equal(got, expected)
+
+    # The mutation: downscaling the extracted crop is the order this replaced,
+    # and it must not be what came back.
+    assert not np.array_equal(got, resize(np.ascontiguousarray(hr_uint8), (4, 4))), (
+        "dataset still downscales the extracted crop -- the bicubic kernel's edge "
+        "taps resolve against the crop border instead of the real neighbours"
+    )
 
 
 def test_train_dataset_len_scales_with_crops_per_image(tiny_rgb_image_dir: Path):
@@ -326,3 +351,16 @@ def test_srresnet_validation_skips_non_image_files(tiny_rgb_image_dir: Path):
     ds = ValidationDataset(img_dir=tiny_rgb_image_dir, scale=2)
     assert len(ds) == 3
     assert all(p.suffix == ".png" for p in ds.img_paths)
+
+
+def test_train_crop_offsets_are_always_scale_aligned(tiny_rgb_image_dir: Path):
+    """EDSR draws the offset in LR coordinates, which makes every HR offset a
+    multiple of scale. Nothing else keeps the two planes aligned: an unaligned
+    HR offset has no corresponding LR pixel to pair with."""
+    ds = TrainDataset(img_dir=tiny_rgb_image_dir, scale=4, hr_crop_size=16, crops_per_image=8)
+    whole = np.array(Image.open(ds.img_paths[0]).convert("RGB"))
+    for idx in range(0, len(ds), len(ds.img_paths)):
+        _, hr = ds[idx]
+        hr_uint8 = (hr.permute(1, 2, 0).numpy() * 255.0).round().astype(np.uint8)
+        top, left = _locate(whole, hr_uint8, 16)
+        assert top % 4 == 0 and left % 4 == 0, f"offset ({top}, {left}) is not scale-aligned"


### PR DESCRIPTION
Closes #259. **#245 is closed by #266**, higher in this stack, which lifts the hold this PR places on SRCNN — see "What a real run changed" below for why the hold existed and why it was a sizing requirement rather than a correctness one.

Both train datasets degraded an **already-extracted crop**. Bicubic support
reaches past the crop boundary, so those taps resolved against the crop's edge
handling instead of the real neighbouring pixels. This takes SRResNet to the
reference order and holds SRCNN where it is, for a measured reason.

## What a real run changed about the plan

I first shipped this for both architectures on the strength of a dataset-level
benchmark that reported a 12.2x / 4.8x speedup. **That benchmark was wrong in
direction for SRCNN**, and a real training loop caught it:

| | derived plane | working set | before | after |
|---|---:|---:|---:|---:|
| **SRResNet x4** | 401 MB | 6.7 GB | 22.25 it/s | **23.51 it/s** |
| **SRCNN x3** | 6.3 GB | **12.6 GB** (box has 12 GB) | 21.60 it/s | **1.02 it/s** |

SRCNN is pre-upsampled, so its degraded plane is HR-sized rather than
1/scale^2 of it. Caching it pushes the working set past RAM and a shuffled
loader misses page cache on nearly every item — GPU at 13%, 36% iowait,
992 MB/s sustained read. **So this PR holds SRCNN on per-patch degradation** (it measures 34.23 it/s after
the revert). **#266 lifts that hold**: the constraint is the box's RAM, not the
code, and the box is being given more — shipping the wrong degradation
permanently to fit one machine is the worse trade.

The benchmark's mistake is the reusable part: it walked consecutive indices
(cache-friendly in a way no shuffling loader is) and sampled 2000 of 11 million
patches, so after warmup it measured cache hits rather than the steady-state
miss rate. It now shuffles, and the real-loop probe is what decides.

## Evidence for the order itself

**Primary source, SRCNN.** Dong's released `demo_SR.m` is explicit: `modcrop` ->
`imresize` down -> `imresize` up, then extraction.

**SRResNet: the paper is silent**, so this is a convention gap rather than a
stated-value violation. What settles it is the field — BasicSR's
`extract_subimages.py` crops the already-downscaled `X4` directory and contains
no resize at all; EDSR's `get_patch` draws its offset in LR coordinates and
takes HR at `scale x` that; DIV2K distributes full-image bicubic LR.

## RED -> GREEN

Run against the pre-change modules with the new cache module present, so every
failure is an assertion rather than an import error.

| test | RED on pre-fix |
|---|---|
| SRResNet LR matches the whole-image downscale | `HR offsets must be scale-aligned`, offset (8, 6) |
| SRResNet offsets always scale-aligned | offset (13, 9) is not scale-aligned |

Plus two SRCNN tests that now pin the *deliberate* gap: the LR must equal the
patch's own degradation, **and** must differ from the whole-image order — so if
those ever coincide, the test says the gap is closed rather than passing quietly.

Full suite: **1,082 passed, 2 skipped** (both Windows-only liveness paths).

## Design notes

**A sibling cache, not a second value in the raw-HR one.** That cache's checksum
deliberately ignores every derivation parameter and every shipped config points
every architecture at one directory — a scale-dependent plane living there would
be invalidated by nothing: build at x4, run at x3, same checksum, wrong pixels.
The sibling's name *and* checksum carry kind, scale and an imresize version
marker.

**The marker is bumped by hand, not hashed from source.** A hash would make a
docstring edit trigger a multi-gigabyte rebuild — the same failure mode that made
the raw-HR cache key on name and size only.

**`derived_kind=None` is a documented opt-out**, not an omission: it is how an
architecture whose plane would not fit in RAM declines one.

**Torch-free**, verified by a fresh-interpreter probe: `process_derived_image` is
what gets pickled to build workers, and a spawned worker re-imports its own
defining module.

**Scale-aligned offsets** cost 16x the distinct crop positions at x4 — 153,892
against 2,452,645 on a 2040x1356 image — leaving ~123M across DIV2K-800.
Accepted, and stated where it is chosen.
