### PR TITLE
feat: document per-step scalar logging cost and add an opt-out

### DIFF
--- a/sisr/training/config.py
+++ b/sisr/training/config.py
@@ -102,6 +102,35 @@ class SRTrainingConfig:
             to eager on SRResNet**, so a compiled run does not reproduce an
             eager one. Staying at ``None`` is the standing recommendation.
 
+        scalar_logging: Which per-step scalars a training step records.
+            ``self.log`` costs real host time on **every** step, and
+            ``log_every_n_steps`` gates the *flush*, not the accumulate, so the
+            existing cadence knob does not touch it. Those scalars are the run's
+            evidence, so this is opt-in and never silently applied.
+
+            - ``'all'`` (default) -- unchanged behaviour, every scalar below.
+            - ``'essential'`` -- keeps only the objective each optimiser
+              actually steps on: ``loss/train``, plus ``loss/train/d`` under
+              manual optimization. **Stops recording:** ``loss/train/content``
+              and ``loss/train/adv`` on the adversarial path, and every
+              per-term tag a composite criterion exposes through
+              ``last_terms`` (``loss/train/<term>``). Validation scalars are
+              untouched -- they are per-cycle, not per-step.
+
+            **What this is measured to be worth, so the trade is visible
+            here rather than inferred.** On an RTX 5060 Laptop: one ``self.log``
+            call costs **1.132 ms on a 6.167 ms SRCNN step (18.4%)**, and is
+            **below the noise floor of a 36 ms SRResNet step**. But that 1.132 ms
+            is ``loss/train`` itself — the objective, which ``'essential'``
+            keeps — so on both *shipped* configs this knob recovers nothing
+            measurable. It pays only for a criterion with many terms, where the
+            decomposition is several extra calls per step. Treat it as a lever
+            for that case, not as a general speedup.
+
+            **Two runs that logged different scalar sets are not
+            interchangeable**, which is why this lives on the training config
+            and so reaches ``hparams`` and the checkpoint, rather than on a
+            callback.
         compile_mode: ``torch.compile``'s ``mode``, applied alongside
             ``compile_backend``. ``None`` (default) leaves inductor on its own
             default. **Requires ``compile_backend='inductor'``** — ``mode`` is
@@ -122,6 +151,7 @@ class SRTrainingConfig:
     scale: int | None = None
     compile_backend: str | None = None
     compile_mode: str | None = None
+    scalar_logging: Literal["all", "essential"] = "all"
 
     def __post_init__(self) -> None:
         """Reject a compile mode that nothing will apply, and values that mean nothing.
@@ -191,6 +221,12 @@ class SRTrainingConfig:
                 "Fix model.training_config.init_args.init_strategy in your YAML."
             )
 
+        if self.scalar_logging not in ("all", "essential"):
+            raise ValueError(
+                f"training_config.scalar_logging must be 'all' or 'essential'; got "
+                f"{self.scalar_logging!r}. Fix "
+                f"model.training_config.init_args.scalar_logging in your YAML."
+            )
         if self.compile_mode is not None and self.compile_backend != "inductor":
             raise ValueError(
                 f"compile_mode={self.compile_mode!r} needs compile_backend='inductor'; got "

--- a/sisr/training/gan_module.py
+++ b/sisr/training/gan_module.py
@@ -418,8 +418,12 @@ class SRGANLightning(SRLightning):
         self.untoggle_optimizer(opt_g)
 
         self.log("loss/train", g_loss, prog_bar=True, on_step=True)
-        self.log("loss/train/content", content, on_step=True)
-        self.log("loss/train/adv", adversarial, on_step=True)
+        # The decomposition, not the objective: dropped by scalar_logging='essential'.
+        # loss/train and loss/train/d stay unconditionally -- they are what the two
+        # optimisers actually step on, and a run without them has no objective trace.
+        if self.training_config.scalar_logging != "essential":
+            self.log("loss/train/content", content, on_step=True)
+            self.log("loss/train/adv", adversarial, on_step=True)
         self._log_loss_terms("train")
 
     def _time_schedulers(self) -> list[torch.optim.lr_scheduler.LRScheduler]:

--- a/sisr/training/lightning_module.py
+++ b/sisr/training/lightning_module.py
@@ -655,6 +655,11 @@ class SRLightning(lightning.LightningModule):
         criterion exposing that mapping participates. Empty (and so a no-op)
         for every scalar loss.
 
+        Skipped for the training stage under
+        ``training_config.scalar_logging='essential'`` — these are the per-step
+        scalars that knob exists to drop. Validation still logs them: they are
+        per-cycle, so they cost nothing per step.
+
         Args:
             stage: ``"train"`` or ``"val"`` — the middle tag segment.
         """
@@ -662,6 +667,8 @@ class SRLightning(lightning.LightningModule):
         if not terms:
             return
         on_step = stage == "train"
+        if on_step and self.training_config.scalar_logging == "essential":
+            return
         for name, value in terms.items():
             self.log(
                 f"loss/{stage}/{name}",

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -59,6 +59,7 @@ def test_sr_training_config_field_names():
         "scale",
         "compile_backend",
         "compile_mode",
+        "scalar_logging",
     }
 
 
@@ -380,3 +381,14 @@ def test_training_config_rejects_a_non_integer_scale_with_an_actionable_message(
     for bad in ("4", 4.0, True, [4]):
         with pytest.raises(ValueError, match="scale"):
             SRTrainingConfig(scale=bad)
+
+
+def test_scalar_logging_defaults_to_all_and_rejects_anything_else():
+    """The knob is opt-in: an existing config must behave exactly as before, and a
+    typo must not silently produce a run with a different evidence set."""
+    from sisr.training.config import SRTrainingConfig
+
+    assert SRTrainingConfig().scalar_logging == "all"
+    assert SRTrainingConfig(scalar_logging="essential").scalar_logging == "essential"
+    with pytest.raises(ValueError, match="scalar_logging must be 'all' or 'essential'"):
+        SRTrainingConfig(scalar_logging="minimal")

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -30,6 +30,7 @@ from sisr.training import (
     SREvalConfig,
     SRLightning,
     SRPredictionWriter,
+    SRTrainingConfig,
 )
 
 
@@ -321,6 +322,51 @@ def test_fast_dev_run_logs_per_term_loss_tags_for_a_composite_criterion(
 
     metrics = set(trainer.callback_metrics)
     assert {"loss/train", "loss/train/vgg22", "loss/train/tv"} <= metrics
+    assert {"loss/val", "loss/val/vgg22", "loss/val/tv"} <= metrics
+
+
+@pytest.mark.filterwarnings("ignore::lightning.pytorch.utilities.warnings.PossibleUserWarning")
+def test_scalar_logging_essential_drops_the_per_step_terms_and_keeps_validation(
+    tiny_rgb_image_dir: Path,
+):
+    """The opt-out must remove exactly the per-step decomposition and nothing else.
+
+    Ships its own mutation: `loss/train` and every validation tag are asserted
+    still present, so a change that simply stopped logging would fail here rather
+    than look like a successful opt-out.
+    """
+    with pytest.warns(UserWarning, match="randomly initialised"):
+        vgg = VGG19FeatureLoss(layer="vgg22", weights=None)
+    model = SRCNN(num_channels=3, num_filters=(8, 4), kernel_sizes=(3, 1, 3), padding="same")
+    module = SRLightning(
+        model=model,
+        processor=RGBProcessor(),
+        training_config=SRTrainingConfig(scalar_logging="essential"),
+        eval_config=SREvalConfig(crop_border=0),
+        criterion=WeightedSumLoss(
+            terms={"vgg22": vgg, "tv": TotalVariationLoss()},
+            weights={"vgg22": 1.0, "tv": 2.0e-8},
+        ),
+        optimizer=functools.partial(torch.optim.SGD, lr=1e-4),
+    )
+    trainer = lightning.Trainer(
+        fast_dev_run=True,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+    trainer.fit(module, datamodule=_make_datamodule(tiny_rgb_image_dir))
+
+    metrics = set(trainer.callback_metrics)
+    assert "loss/train" in metrics, "the objective itself must survive the opt-out"
+    assert not {"loss/train/vgg22", "loss/train/tv"} & metrics, (
+        "per-step term tags must be gone under scalar_logging='essential'"
+    )
+    # Validation is per-cycle, not per-step, so it costs nothing and is untouched.
     assert {"loss/val", "loss/val/vgg22", "loss/val/tv"} <= metrics
 
 


### PR DESCRIPTION
Closes #117. Stacked on #262.

**Read the measurement before the code — it does not support this issue's
premise, and I have shipped the change anyway with that stated at the knob.**

## What was measured

Real Lightning fit loops, CUDA-synced per step, warmup-excluded medians, on
mains with the GPU otherwise idle.

| configuration | step | `self.log` cost |
|---|---:|---|
| **SRCNN b128, 33x33 Y, scalar MSE** | 6.167 ms | **+1.132 ms — 18.4% of the step** |
| **SRResNet b16, 96x96, composite (mse + tv)** | 36.102 ms | **below noise** |

For SRResNet the three configurations came back at 36.102 / 36.199 / 36.268
ms/step for `all` / `essential` / logging stubbed out entirely — the deltas are
*negative*, i.e. the whole effect is under the noise floor.

The 1.132 ms figure **reproduces the older 1.18 ms measurement** on current
code, which is worth knowing on its own: that figure predated the graph-path
retirement and its stated framing no longer existed.

## Why the knob cannot recover it

The 1.132 ms is the cost of **one** `self.log` call, and on SRCNN that call is
`loss/train` — the objective. `'essential'` keeps it, correctly: this issue's
own position is that these scalars are the run's evidence and must never be
silently removed.

So on both shipped configs the opt-out saves nothing measurable. It pays only
for a criterion with many terms, where the decomposition is several extra calls
per step. That is stated in the docstring, at the knob, rather than left to be
discovered.

## What ships

`training_config.scalar_logging: Literal["all", "essential"] = "all"`.

- **`'all'`** — unchanged. Every existing config behaves exactly as before.
- **`'essential'`** — keeps `loss/train` (and `loss/train/d` under manual
  optimization); drops `loss/train/content`, `loss/train/adv`, and every
  `loss/train/<term>` a composite criterion exposes via `last_terms`.
- Validation is untouched — per-cycle, not per-step.

It lives on the **training config**, not a callback: it changes what a run
*records*, and two runs that logged different scalar sets must not silently look
comparable. The training config reaches `hparams` and the checkpoint; a callback
does not.

## RED -> GREEN

`test_scalar_logging_essential_drops_the_per_step_terms_and_keeps_validation`,
run against the pre-change modules:

```
AssertionError: per-step term tags must be gone under scalar_logging='essential'
assert not ({'loss/train/tv', 'loss/train/vgg22'} & {...})
```

GREEN after. It ships its own mutation — `loss/train` and every validation tag
are asserted still present, so a change that merely stopped logging would fail
here rather than look like a successful opt-out. Plus a field-validation test
(a typo must not silently produce a run with a different evidence set).

Full suite: **1,086 passed, 2 skipped** (both Windows-only liveness paths).

## The call this leaves you

The knob is implemented, tested, default-off and honest about its own value. If
you would rather not carry a config field that recovers nothing on either
shipped architecture, dropping this PR and keeping only the measurement is a
defensible read of the same evidence — the numbers are recorded either way.
