### PR TITLE
fix: take SRCNN to the reference degradation order too

### DIFF
--- a/sisr/datasets/base.py
+++ b/sisr/datasets/base.py
@@ -131,11 +131,7 @@ class HRCachedTrainDataset(SRDataset):
         img_dir: Directory of HR images.
         scale: Upscaling factor the derived plane is built for.
         derived_kind: Which plane to derive — see
-            :data:`~sisr.datasets.derived_cache.KINDS` — or ``None`` to build
-            no derived cache at all. ``None`` is not a convenience: a plane
-            that pushes the working set past RAM makes shuffled training
-            I/O-bound, which is measurably far worse than the per-item work
-            it removes. See :mod:`sisr.datasets.srcnn`.
+            :data:`~sisr.datasets.derived_cache.KINDS`.
         use_tqdm: Whether to display a progress bar during the LMDB build.
         cache_dir: Defaults to ``img_dir / '.lmdb_cache'``.
         build_num_workers: ``None`` (default) uses ``min(os.cpu_count() or
@@ -151,7 +147,7 @@ class HRCachedTrainDataset(SRDataset):
         self,
         img_dir: str | Path,
         scale: int,
-        derived_kind: str | None,
+        derived_kind: str,
         use_tqdm: bool = False,
         cache_dir: str | Path | None = None,
         build_num_workers: int | None = None,
@@ -178,25 +174,21 @@ class HRCachedTrainDataset(SRDataset):
         # above: that cache's checksum deliberately ignores every derivation
         # parameter, so a scale-dependent plane stored there would never be
         # invalidated by a scale change.
-        self._derived = (
-            None
-            if derived_kind is None
-            else LMDBCache(
-                cache_dir=cache_dir,
-                name=derived_cache.cache_name(derived_kind, scale),
-                checksum=derived_cache.compute_checksum(self.img_paths, derived_kind, scale),
-                length=len(self.img_paths),
-                map_size=derived_cache.estimate_map_size(self._img_sizes, derived_kind, scale),
-                metadata={"format": derived_cache.cache_name(derived_kind, scale)},
-                build_fn=lambda ctx: ctx.parallel_build(
-                    items=self.img_paths,
-                    process_fn=derived_cache.process_derived_image,
-                    process_args=[(i, derived_kind, scale) for i in range(len(self.img_paths))],
-                    num_workers=self.build_num_workers,
-                    desc=f"Building {derived_kind} cache (x{scale})",
-                ),
-                use_tqdm=use_tqdm,
-            )
+        self._derived = LMDBCache(
+            cache_dir=cache_dir,
+            name=derived_cache.cache_name(derived_kind, scale),
+            checksum=derived_cache.compute_checksum(self.img_paths, derived_kind, scale),
+            length=len(self.img_paths),
+            map_size=derived_cache.estimate_map_size(self._img_sizes, derived_kind, scale),
+            metadata={"format": derived_cache.cache_name(derived_kind, scale)},
+            build_fn=lambda ctx: ctx.parallel_build(
+                items=self.img_paths,
+                process_fn=derived_cache.process_derived_image,
+                process_args=[(i, derived_kind, scale) for i in range(len(self.img_paths))],
+                num_workers=self.build_num_workers,
+                desc=f"Building {derived_kind} cache (x{scale})",
+            ),
+            use_tqdm=use_tqdm,
         )
 
     def _compute_checksum(self) -> str:
@@ -282,11 +274,6 @@ class HRCachedTrainDataset(SRDataset):
             KeyError: If the backing LMDB entry is missing (a corrupt or
                 incomplete cache).
         """
-        if self._derived is None:
-            raise RuntimeError(
-                f"{type(self).__name__} was built with derived_kind=None, so there is "
-                f"no derived plane to read. Either pass a kind or derive at read time."
-            )
         key = f"{self._derived_kind}_{img_idx:08d}"
         with self._derived.get_buffer(key) as buf:
             if buf is None:

--- a/sisr/datasets/derived_cache.py
+++ b/sisr/datasets/derived_cache.py
@@ -16,6 +16,15 @@ So the derived plane gets its own database, whose *name* and *checksum* both
 carry kind, scale and :data:`IMRESIZE_VERSION`. A stale one is unreachable
 rather than silently wrong.
 
+**Sizing matters more than it looks.** A shuffling training loader touches the
+whole cache, so what governs throughput is whether the raw-HR cache *plus* this
+plane fits in page cache. ``'lr'`` costs ``1/scale**2`` of the HR pixels and is
+negligible; ``'bicubic'`` is HR-sized and roughly doubles the working set.
+Crossing available RAM is a step change, not a gradient — measured at a **21x**
+throughput loss on the far side, with the GPU idle and the loop I/O-bound. Size
+the box against the dataset before choosing ``'bicubic'``; see
+:mod:`sisr.datasets.srcnn`.
+
 Deliberately torch-free, for the same reason :mod:`~sisr.datasets.hr_cache` is:
 :func:`process_derived_image` is the function pickled to ``ProcessPoolExecutor``
 build workers, and a spawned worker re-imports *its own defining module*.

--- a/sisr/datasets/srcnn.py
+++ b/sisr/datasets/srcnn.py
@@ -10,21 +10,28 @@ image once and slicing its deterministic sub-images out at load time is far
 cheaper than re-decoding, and it decouples that cache from the sub-image
 grid (``subimg_size``, ``stride``): neither affects the raw bytes stored.
 
-**The training path still degrades each extracted patch, and that is a known
-fidelity gap held open deliberately.** The authors' released ``demo_SR.m``
-degrades the whole image first — ``modcrop``, ``imresize`` down, ``imresize``
-up — and only then extracts, which leaves a measurable difference in a 4px
-patch border at x3.
+**The whole image is degraded once and both sub-images are sliced from the
+result**, which is the order the authors' released ``demo_SR.m`` uses —
+``modcrop`` then ``imresize`` down then up, and only then patch extraction.
+Degrading an already-extracted patch instead resolves the bicubic kernel's
+edge taps against the patch border: at x3 the interior is bit-identical and
+the entire difference is a 4px border, 43% of a 33x33 patch. The degraded
+plane is cached separately by :mod:`~sisr.datasets.derived_cache`, whose key
+*does* carry ``scale``.
 
-Caching that whole-image plane is what :mod:`~sisr.datasets.derived_cache`
-exists for, and SRResNet uses it. **SRCNN deliberately does not.** Its
-formulation is pre-upsampled, so the degraded plane is HR-sized rather than
-1/scale^2 of it: caching it doubles the working set, and once that exceeds RAM
-a shuffled training loader becomes I/O-bound. Measured on a 12 GB box,
-real training loop: **21.60 it/s degrading per patch against 1.02 it/s reading a
-cached plane** — a 21x regression, because the working set went from 6.3 GB to
-12.6 GB. The correctness gain is real and the cost is worse; the trade is
-recorded on the issue rather than taken silently.
+**🚨 This plane needs RAM, and running short of it is catastrophic rather than
+gradual.** SRCNN is pre-upsampled, so the degraded plane is HR-sized rather
+than ``1/scale**2`` of it — caching it roughly **doubles the working set** a
+shuffling loader touches. While that set fits in page cache the cost is a
+memory read; once it does not, every item becomes a disk seek. Measured on a
+12 GB box with a 12.6 GB working set: a real training loop fell from **21.6 to
+1.0 it/s, a 21x regression**, with the GPU at 13% and 36% iowait.
+
+**Budget roughly two bytes of RAM per HR pixel in the dataset, plus headroom.**
+For DIV2K-800 that is ~12.6 GB, so a 16 GB machine is the practical floor and
+12 GB is not enough. The symptom is unmistakable once you look for it: low GPU
+utilisation with high iowait and sustained disk read. It cannot be seen in a
+per-item benchmark, because per-item *work* is not what changed.
 :class:`ValidationDataset` generates LR pairs on the fly for full images.
 
 LR degradation uses MATLAB-compatible antialiased bicubic resizing (see
@@ -105,14 +112,15 @@ class TrainDataset(HRCachedTrainDataset):
     Every HR image is decoded once into an LMDB cache (uint8 RGB, whole) — see
     :mod:`~sisr.datasets.base` for why. Each ``__getitem__`` maps its flat index
     to a source image and a deterministic ``(top, left)`` grid position in O(1),
-    slices the ``subimg_size`` square HR sub-image, and degrades it to LR.
+    and slices the ``subimg_size`` square out of **both** whole-image planes at
+    that position — the degraded one already computed over the whole image, so
+    no kernel ever reaches past a patch edge.
     **The grid is derived from exactly one place** (:func:`_grid_dims`), so
     indices can never silently misalign.
 
-    ``subimg_size`` and ``scale`` stay coupled while the degradation is per
-    patch: ``33 % scale`` shifts each patch's own LR sampling grid, so x3 is
-    better behaved than x2 or x4. See the module docstring for why the fix that
-    would remove that coupling is not applied here.
+    Because the degradation now happens before extraction, ``subimg_size`` and
+    ``scale`` are no longer coupled: there is no per-patch sampling grid left to
+    shift, so ``33 % scale`` stops mattering.
 
     **The checksum keys only on the file manifest** (plus a format tag), not on
     ``subimg_size``/``stride``/``scale`` — none of those affect the bytes
@@ -154,9 +162,7 @@ class TrainDataset(HRCachedTrainDataset):
         super().__init__(
             img_dir,
             scale=scale,
-            # No derived plane: HR-sized, so caching it doubles the working set
-            # and makes shuffled training I/O-bound. Measured in the module docstring.
-            derived_kind=None,
+            derived_kind="bicubic",
             use_tqdm=use_tqdm,
             cache_dir=cache_dir,
             build_num_workers=build_num_workers,
@@ -199,9 +205,11 @@ class TrainDataset(HRCachedTrainDataset):
         Locates *idx*'s source image and grid position in O(1) via
         :attr:`_img_offsets`/:attr:`_img_n_cols`, slices the HR sub-image out
         of that image's cached raw bytes (via
-        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`), and derives
-        LR from it with :func:`_degrade` — numerically identical to computing
-        both at build time, just performed at load time instead.
+        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_hr`) and the LR
+        sub-image out of the whole-image degraded plane (via
+        :meth:`~sisr.datasets.base.HRCachedTrainDataset._read_derived`) at the
+        same position. Both planes are modcropped identically, so the two
+        slices are aligned by construction.
 
         Args:
             idx (int): Zero-based sub-image index.
@@ -228,7 +236,10 @@ class TrainDataset(HRCachedTrainDataset):
                 top : top + self.sub_img_size, left : left + self.sub_img_size, :
             ].copy()
 
-        lr_subimg = _degrade(hr_subimg, self.scale)
+        with self._read_derived(img_idx) as plane:
+            lr_subimg = plane[
+                top : top + self.sub_img_size, left : left + self.sub_img_size, :
+            ].copy()
 
         return self._to_tensor(lr_subimg), self._to_tensor(hr_subimg)
 

--- a/tests/datasets/test_srcnn.py
+++ b/tests/datasets/test_srcnn.py
@@ -411,21 +411,21 @@ def test_validation_untouched_when_already_divisible(tiny_rgb_image_dir: Path):
         assert lr.shape == hr.shape
 
 
-def test_train_lr_is_still_degraded_per_patch_and_that_is_deliberate(
+def test_train_lr_is_sliced_from_the_whole_image_degradation_not_degraded_per_patch(
     shared_srcnn_train_ds: TrainDataset,
 ):
-    """SRCNN keeps the per-patch degradation, against the authors' order, on purpose.
+    """The authors' ``demo_SR.m`` degrades the image and *then* extracts.
 
-    Caching the whole-image plane is what fixes the fidelity gap and is what
-    SRResNet does. SRCNN is pre-upsampled, so that plane is HR-sized: caching it
-    took the working set from 6.3 GB to 12.6 GB on a 12 GB box and a real
-    training loop went from 21.60 it/s to 1.02 it/s. This test pins the trade so
-    the slow variant is not reintroduced by someone reading only the issue.
+    Ships its own mutation: the patch-wise order is computed here too, and the
+    test fails if the dataset returns that instead. Without it the assertion
+    would pass on either implementation wherever the two happen to agree.
     """
     from sisr.datasets.derived_cache import derive
     from sisr.datasets.srcnn import _degrade
 
     ds = shared_srcnn_train_ds
+    # An interior patch: at the image corner the out-of-patch taps and the
+    # out-of-image taps coincide, so the two orders agree there.
     n_cols = ds._img_n_cols[0]
     idx = n_cols + 1
     row, col = divmod(idx - ds._img_offsets[0], n_cols)
@@ -434,26 +434,44 @@ def test_train_lr_is_still_degraded_per_patch_and_that_is_deliberate(
 
     lr, hr = ds[idx]
     got = (lr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
-    hr_arr = (hr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
 
-    assert np.array_equal(got, _degrade(hr_arr, ds.scale)), "LR must be the patch's own degradation"
-
-    # And it genuinely differs from the authors' order, so the gap is real and open.
     whole = np.array(Image.open(ds.img_paths[0]).convert("RGB"))
     plane = derive(whole, "bicubic", ds.scale)
-    assert not np.array_equal(
-        got, plane[top : top + ds.sub_img_size, left : left + ds.sub_img_size]
-    ), "if these ever match, the fidelity gap is closed and this test should go"
+    expected = plane[top : top + ds.sub_img_size, left : left + ds.sub_img_size]
+    assert np.array_equal(got, expected)
+
+    hr_arr = (hr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+    patchwise = _degrade(hr_arr, ds.scale)
+    assert not np.array_equal(got, patchwise), (
+        "dataset still degrades the extracted patch — the bicubic kernel's edge "
+        "taps resolve against the patch border instead of the real neighbours"
+    )
 
 
-def test_srcnn_train_dataset_builds_no_derived_cache(tmp_path: Path):
-    """The opt-out must be real: no second database, and a clear error if read."""
-    rng = np.random.default_rng(seed=23)
-    Image.fromarray(rng.integers(0, 256, size=(64, 64, 3), dtype=np.uint8)).save(tmp_path / "a.png")
-    ds = TrainDataset(img_dir=tmp_path, subimg_size=33, stride=11, scale=3, build_num_workers=1)
-    assert ds._derived is None
-    with pytest.raises(RuntimeError, match="derived_kind=None"):
-        with ds._read_derived(0):
-            pass
-    dbs = {p.name.split("_")[0] for p in (tmp_path / ".lmdb_cache").iterdir() if p.is_dir()}
-    assert dbs == {"hr"}, f"expected only the raw-HR database, found {dbs}"
+def test_subimg_size_and_scale_are_no_longer_coupled(tmp_path: Path):
+    """``33 % scale`` mattered only because ``_degrade`` ran per patch, giving each
+    patch its own LR sampling grid. Degrading the whole image first removes the
+    per-patch grid, so a size indivisible by scale is no longer a special case."""
+    from sisr.datasets.derived_cache import derive
+
+    rng = np.random.default_rng(seed=21)
+    arr = rng.integers(0, 256, size=(64, 64, 3), dtype=np.uint8)
+    for scale in (2, 3, 4):
+        # One directory per scale: the raw-HR cache hashes the manifest only, so
+        # all three would share a database and LMDB refuses a second handle.
+        img_dir = tmp_path / f"x{scale}"
+        img_dir.mkdir()
+        Image.fromarray(arr).save(img_dir / "a.png")
+        ds = TrainDataset(
+            img_dir=img_dir, subimg_size=33, stride=11, scale=scale, build_num_workers=1
+        )
+        n_cols = ds._img_n_cols[0]
+        idx = n_cols + 1
+        row, col = divmod(idx, n_cols)
+        top, left = row * ds.stride, col * ds.stride
+        lr, _ = ds[idx]
+        got = (lr.permute(1, 2, 0).numpy() * 255).round().astype(np.uint8)
+        plane = derive(arr, "bicubic", scale)
+        assert np.array_equal(got, plane[top : top + 33, left : left + 33]), (
+            f"scale {scale}: 33 % {scale} == {33 % scale} must not change anything"
+        )


### PR DESCRIPTION
Closes #245. Stacked on #262.

Takes SRCNN to the same reference degradation order #260 gave SRResNet, reverting
the hold I placed on it — and documents what that hold was actually about.

## Why the hold is lifted

It was never a correctness objection. The order is right: the authors' released
`demo_SR.m` is explicit (`modcrop` -> `imresize` down -> `imresize` up, *then*
extraction), and degrading an extracted patch resolves the bicubic kernel's edge
taps against the patch border. At x3 the patch interior is bit-identical and the
**entire** difference is a 4px border — 43% of a 33x33 patch.

The objection was **memory**, and memory is a property of the box, not of the
code. SRCNN is pre-upsampled, so its degraded plane is HR-sized rather than
`1/scale**2` of it, and caching it roughly doubles the working set a shuffling
loader touches. Measured on a 12 GB box against a 12.6 GB working set:

| | before | after |
|---|---:|---:|
| real training loop, 400 steps | 21.60 it/s | **1.02 it/s** |

GPU at 13%, 36% iowait, 992 MB/s sustained read. That is a **step change at the
point the working set stops fitting in page cache**, not a gradient — so it is a
sizing requirement, not a reason to ship the wrong degradation.

## 🚨 Read before merging: this needs RAM

**Budget roughly two bytes of RAM per HR pixel in the training set, plus
headroom.** For DIV2K-800 that is ~12.6 GB, so **16 GB is the practical floor and
12 GB is not enough.** On a box below it, SRCNN training will be I/O-bound and
roughly 20x slower, silently — there is no error, only a slow run.

Both `datasets/srcnn.py` and `datasets/derived_cache.py` now state this where the
choice is made, and name the symptom (low GPU utilisation, high iowait, sustained
disk read) because **it cannot be seen in a per-item benchmark** — per-item
*work* is not what changes.

I did not add a runtime memory check. A host-specific guard shipping in a public
framework is something this project has declined before, and the honest version
of it would have to read total RAM and estimate a working set on every platform.
Say the word if you would rather have an opportunistic warning that degrades to
silence where it cannot measure.

## What ships

- SRCNN slices both sub-images out of whole-image planes at the same grid
  position; no kernel reaches past a patch edge.
- `derived_kind` is required again on the shared base — the `None` opt-out had no
  remaining caller, and speculative generality is what the deletion test rejects.
- The `sub_img_size` / `scale` coupling **dissolves**: with no per-patch sampling
  grid left to shift, `33 % scale` stops mattering. There is a test for it across
  x2 / x3 / x4.

## Tests

The whole-image-order tests come back, including the one that ships its own
mutation — it recomputes the *old* per-patch order and fails if the dataset
returns it, so it cannot pass on either implementation.

Full suite: **1,084 passed, 2 skipped** (both Windows-only liveness paths).
